### PR TITLE
Fix example name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ accelerate launch my_script.py --args_to_my_script
 For instance, here is how you would run the GLUE example on the MRPC task (from the root of the repo):
 
 ```bash
-accelerate launch examples/nlp_example.py --task_name mrpc --model_name_or_path bert-base-cased
+accelerate launch examples/nlp_example.py
 ```
 
 ## Why should I use 🤗 Accelerate?

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ and answer the questions asked. This will generate a config file that will be us
 accelerate launch my_script.py --args_to_my_script
 ``` 
 
-For instance, here is how you would run the GLUE example on the MRPC task (from the root of the repo):
+For instance, here is how you would run the GLUE example of the huggingface/transformers repo on the MRPC task (from the root of the repo):
 
 ```bash
 accelerate launch examples/glue_example.py --task_name mrpc --model_name_or_path bert-base-cased

--- a/README.md
+++ b/README.md
@@ -267,10 +267,10 @@ and answer the questions asked. This will generate a config file that will be us
 accelerate launch my_script.py --args_to_my_script
 ``` 
 
-For instance, here is how you would run the GLUE example of the huggingface/transformers repo on the MRPC task (from the root of the repo):
+For instance, here is how you would run the GLUE example on the MRPC task (from the root of the repo):
 
 ```bash
-accelerate launch examples/glue_example.py --task_name mrpc --model_name_or_path bert-base-cased
+accelerate launch examples/nlp_example.py --task_name mrpc --model_name_or_path bert-base-cased
 ```
 
 ## Why should I use 🤗 Accelerate?


### PR DESCRIPTION
Changes `glue_example` to `nlp_example` as that's the name of the script.