### PR TITLE
Don't error on non-Tensors objects in move to device

### DIFF
--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -105,10 +105,7 @@ def send_to_device(tensor, device):
     elif isinstance(tensor, dict):
         return type(tensor)({k: send_to_device(v, device) for k, v in tensor.items()})
     elif not hasattr(tensor, "to"):
-        raise TypeError(
-            f"Can't send the values of type {type(tensor)} to device {device}, only of nested list/tuple/dicts "
-            "of tensors or objects having a `to` method."
-        )
+        return tensor
     return tensor.to(device)
 
 


### PR DESCRIPTION
As pointed out in #12, users may have some non-Tensor objects in their dataloaders, which is perfectly fine. `accelerate` should not error on those when trying to send a batch on the proper device but just do a noop.

Fixes #12