### PR TITLE
Add YAML config support

### DIFF
--- a/src/accelerate/commands/config.py
+++ b/src/accelerate/commands/config.py
@@ -81,7 +81,7 @@ class LaunchConfig:
 
     def to_yaml_file(self, yaml_file):
         with open(yaml_file, "w", encoding="utf-8") as f:
-            yaml.dump(self.to_dict(), f)
+            yaml.safe_dump(self.to_dict(), f)
 
 
 def config_command_parser(subparsers=None):


### PR DESCRIPTION
This PR adds support and defaults toward a YAML config while retaining backward compatibility: it's possible to pass along a json config file and if a default JSON config was created by the user, it will still be used.

However new configs created will default to the YAML format.