### PR TITLE
Add utility to pad tensor across processes to max length

### DIFF
--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -130,6 +130,13 @@ do with the :meth:`~accelerate.Accelerator.gather` method.
     Any instruction using your training dataloader length (for instance if you need the number of total training steps
     to create a learning rate scheduler) should go after the call to :meth:`~accelerate.Accelerator.prepare`.
 
+.. Warning::
+
+    The :meth:`~accelerate.Accelerator.gather` method requires the tensors to be all the same size on each process. If
+    you have tensors of different sizes on each process (for instance when dynamically padding to the maximum length in
+    a batch), you should use the :meth:`~accelerate.Accelerator.pad_across_processes` method to pad you tensor to the
+    biggest size across processes.
+
 
 Launching your distributed script
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -22,7 +22,7 @@ from .data_loader import prepare_data_loader
 from .kwargs_handlers import DistributedDataParallelKwargs, GradScalerKwargs, KwargsHandler
 from .optimizer import AcceleratedOptimizer
 from .state import AcceleratorState, DistributedType
-from .utils import RNGType, extract_model_from_parallel, gather, save, wait_for_everyone
+from .utils import RNGType, extract_model_from_parallel, gather, pad_across_processes, save, wait_for_everyone
 
 
 class Accelerator:
@@ -288,6 +288,23 @@ class Accelerator:
             tensors.
         """
         return gather(tensor)
+
+    def pad_across_processes(self, tensor, dim=0, pad_index=0, pad_first=False):
+        """
+        Recursively pad the tensors in a nested list/tuple/dictionary of tensors from all devices to the same size so
+        they can safely be gathered.
+
+        Args:
+            tensor (nested list/tuple/dictionary of :obj:`torch.Tensor`):
+                The data to gather.
+            dim (:obj:`int`, `optional`, defaults to 0):
+                The dimension on which to pad.
+            pad_index (:obj:`int`, `optional`, defaults to 0):
+                The value with which to pad.
+            pad_first (:obj:`bool`, `optional`, defaults to :obj:`False`):
+                Whether to pad at the beginning or the end.
+        """
+        return pad_across_processes(tensor, dim=dim, pad_index=pad_index, pad_first=pad_first)
 
     def unwrap_model(self, model):
         """

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -21,7 +21,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 from accelerate.commands.config import LaunchConfig, default_config_file
 from accelerate.state import DistributedType
@@ -68,9 +67,7 @@ def launch_command_parser(subparsers=None):
     parser.add_argument(
         "--machine_rank", type=int, default=0, help="The rank of the machine on which this script is launched."
     )
-    parser.add_argument(
-        "--main_process_ip", type=str, default=None, help="The IP address of the machine of rank 0."
-    )
+    parser.add_argument("--main_process_ip", type=str, default=None, help="The IP address of the machine of rank 0.")
     parser.add_argument(
         "--main_process_port",
         type=int,


### PR DESCRIPTION
This PR solves the problem of having predictions of different sizes across processes (for instance when doing padding to the maximum length of a batch) that can't be gathered (the script will hang).
To do this it introduces a new method called `pad_across_processes` that will pad a tensor (or nested list/tuple/dict of tensors) to the maximum length across processes on a given dimension.