### PR TITLE
Use proper size

### DIFF
--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -198,10 +198,10 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
     new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
     if pad_first:
         indices = tuple(
-            slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(size))
+            slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(new_size))
         )
     else:
-        indices = tuple(slice(0, old_size[dim]) if i == dim else slice(None) for i in range(len(size)))
+        indices = tuple(slice(0, old_size[dim]) if i == dim else slice(None) for i in range(len(new_size)))
     new_tensor[indices] = tensor
     return new_tensor
 


### PR DESCRIPTION
The `size` used inside the `pad_across_processes` function was wrong, this PR fixes that.