### PR TITLE
Add defaults for compute_environmnent

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -42,13 +42,13 @@ def load_config_from_file(config_file):
     config_file = config_file if config_file is not None else default_config_file
     with open(config_file, "r", encoding="utf-8") as f:
         if config_file.endswith(".json"):
-            if json.load(f)["compute_environment"] == ComputeEnvironment.LOCAL_MACHINE:
+            if json.load(f).get("compute_environment", ComputeEnvironment.LOCAL_MACHINE):
                 config_class = ClusterConfig
             else:
                 config_class = SageMakerConfig
             return config_class.from_json_file(json_file=config_file)
         else:
-            if yaml.safe_load(f)["compute_environment"] == ComputeEnvironment.LOCAL_MACHINE:
+            if yaml.safe_load(f).get("compute_environment", ComputeEnvironment.LOCAL_MACHINE):
                 config_class = ClusterConfig
             else:
                 config_class = SageMakerConfig
@@ -73,7 +73,10 @@ class BaseConfig:
     def from_json_file(cls, json_file=None):
         json_file = default_json_config_file if json_file is None else json_file
         with open(json_file, "r", encoding="utf-8") as f:
-            return cls(**json.load(f))
+            config_dict = json.load(f)
+        if "compute_environment" not in config_dict:
+            config_dict["compute_environment"] = ComputeEnvironment.LOCAL_MACHINE
+        return cls(**config_dict)
 
     def to_json_file(self, json_file):
         with open(json_file, "w", encoding="utf-8") as f:
@@ -84,7 +87,10 @@ class BaseConfig:
     def from_yaml_file(cls, yaml_file=None):
         yaml_file = default_yaml_config_file if yaml_file is None else yaml_file
         with open(yaml_file, "r", encoding="utf-8") as f:
-            return cls(**yaml.safe_load(f))
+            config_dict = yaml.safe_load(f)
+        if "compute_environment" not in config_dict:
+            config_dict["compute_environment"] = ComputeEnvironment.LOCAL_MACHINE
+        return cls(**config_dict)
 
     def to_yaml_file(self, yaml_file):
         with open(yaml_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
#17 introduced a breaking change since it requires configs to now have a `"compute_environment"` field. This is fixed by re-running `accelerate config` but we can also be nice to the user and make sure it works for old configs as well :-)

This PR does that.