### PR TITLE
Fix load from config

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -44,7 +44,7 @@ def load_config_from_file(config_file):
         if config_file.endswith(".json"):
             if (
                 json.load(f).get("compute_environment", ComputeEnvironment.LOCAL_MACHINE)
-                is ComputeEnvironment.LOCAL_MACHINE
+                == ComputeEnvironment.LOCAL_MACHINE
             ):
                 config_class = ClusterConfig
             else:
@@ -53,7 +53,7 @@ def load_config_from_file(config_file):
         else:
             if (
                 yaml.safe_load(f).get("compute_environment", ComputeEnvironment.LOCAL_MACHINE)
-                is ComputeEnvironment.LOCAL_MACHINE
+                == ComputeEnvironment.LOCAL_MACHINE
             ):
                 config_class = ClusterConfig
             else:


### PR DESCRIPTION
When testing the key dictionary for `"compute_environment"`, the result gotten from the config file is a string, so it needs to be compared with an `==` to the enum value.