### PR TITLE
Fix port in config creation

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -46,7 +46,7 @@ def get_cluster_input():
             main_process_ip = _ask_field(
                 "What is the IP address of the machine that will host the main process? ",
             )
-            main_process_ip = _ask_field(
+            main_process_port = _ask_field(
                 "What is the port you will use to communicate with the main process? ",
                 lambda x: int(x),
             )


### PR DESCRIPTION
This PR fixes how the port information provided by the user in `accelerate config` is stored. Previously, it was erasing the IP address of the main process.

Fixes #49