### PR TITLE
Add notebook/colab example

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ For instance, here is how you would run the GLUE example on the MRPC task (from 
 accelerate launch examples/nlp_example.py
 ```
 
+## Launching your training from a notebook
+
+🤗 Accelerate also provides a `notebook_launcher` function you can use in a notebook to launch a distributed training. This is especially useful for Colab or Kaggle notebooks with a TPU backend. Just define your training loop in a `training_function` then in your last cell, add:
+
+```python
+from accelerate import notebook_launcher
+
+notebook_launcher(training_function)
+```
+
+An example can be found in [this notebook](https://github.com/huggingface/notebooks/blob/master/examples/accelerate/simple_nlp_example.ipynb). [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/notebooks/blob/master/examples/accelerate/simple_nlp_example.ipynb)
+
+Note that this launcher does not work in Jupyter Notebook on a machine with multiple GPUs (yet). This feature will be released in a later version.
+
 ## Why should I use 🤗 Accelerate?
 
 You should use 🤗 Accelerate when you want to easily run your training scripts in a distributed environment without having to renounce full control over your training loop. This is not a high-level framework above PyTorch, just a thin wrapper so you don't have to learn a new library, In fact the whole API of 🤗 Accelerate is in one class, the `Accelerator` object.

--- a/docs/source/launcher.rst
+++ b/docs/source/launcher.rst
@@ -19,6 +19,9 @@ Colab](https://colab.research.google.com/) and [Kaggle kernels](https://www.kagg
 but support for training on several GPUs (if the machine on which you are running your notebook has them) is planned
 for a future release.
 
+An example can be found in `this notebook
+<https://github.com/huggingface/notebooks/blob/master/examples/accelerate/simple_nlp_example.ipynb>`__.
+
 .. warning::
 
     If you are training on Colab or a Kaggle kernel with TPUs, your :obj:`Accelerator` object should only be defined


### PR DESCRIPTION
This PR adds references in the main README and in the documentation to an example of notebook that can be used to fine-tune an NLP model on TPU in Colab.

cc @philschmid 