### PR TITLE
Support for multi-GPU in notebook_launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ notebook_launcher(training_function)
 
 An example can be found in [this notebook](https://github.com/huggingface/notebooks/blob/master/examples/accelerate/simple_nlp_example.ipynb). [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/notebooks/blob/master/examples/accelerate/simple_nlp_example.ipynb)
 
-Note that this launcher does not work in Jupyter Notebook on a machine with multiple GPUs (yet). This feature will be released in a later version.
-
 ## Why should I use 🤗 Accelerate?
 
 You should use 🤗 Accelerate when you want to easily run your training scripts in a distributed environment without having to renounce full control over your training loop. This is not a high-level framework above PyTorch, just a thin wrapper so you don't have to learn a new library, In fact the whole API of 🤗 Accelerate is in one class, the `Accelerator` object.

--- a/docs/source/launcher.rst
+++ b/docs/source/launcher.rst
@@ -15,16 +15,15 @@ Notebook Launcher
 =======================================================================================================================
 
 Launch your training function inside a notebook. Currently supports launching a training with TPUs on [Google
-Colab](https://colab.research.google.com/) and [Kaggle kernels](https://www.kaggle.com/code), or training on one GPU,
-but support for training on several GPUs (if the machine on which you are running your notebook has them) is planned
-for a future release.
+Colab](https://colab.research.google.com/) and [Kaggle kernels](https://www.kaggle.com/code), as well as training on
+several GPUs (if the machine on which you are running your notebook has them).
 
 An example can be found in `this notebook
 <https://github.com/huggingface/notebooks/blob/master/examples/accelerate/simple_nlp_example.ipynb>`__.
 
 .. warning::
 
-    If you are training on Colab or a Kaggle kernel with TPUs, your :obj:`Accelerator` object should only be defined
-    inside the training function. This is because the initialization should be done inside the launcher only.
+    Your :obj:`Accelerator` object should only be defined inside the training function. This is because the
+    initialization should be done inside the launcher only.
 
 .. autofunction:: accelerate.notebook_launcher

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -199,9 +199,8 @@ Launching training from a notebook
 -----------------------------------------------------------------------------------------------------------------------
 
 In Accelerate 0.3.0, a new :class:`~accelerate.notebook_launcher` has been introduced to help you launch your training
-function from a notebook. Currently supports launching a training with TPUs on Colab, or training on one GPU, but
-support for training on several GPUs (if the machine on which you are running your notebook has them) is planned for a
-future release.
+function from a notebook. This launcher supports launching a training with TPUs on Colab or Kaggle, as well as training
+on several GPUs (if the machine on which you are running your notebook has them).
 
 Just define a function responsible for your whole training and/or evaluation in a cell of the notebook, then execute a
 cell with the following code:
@@ -214,8 +213,8 @@ cell with the following code:
 
 .. warning::
 
-    If you are training on Colab with TPUs, your :obj:`Accelerator` object should only be defined inside the training
-    function. This is because the initialization should be done inside the launcher only.
+    Your :obj:`Accelerator` object should only be defined inside the training function. This is because the
+    initialization should be done inside the launcher only.
 
 
 Training on TPU

--- a/src/accelerate/notebook_launcher.py
+++ b/src/accelerate/notebook_launcher.py
@@ -14,7 +14,6 @@
 
 import os
 import sys
-import warnings
 
 import torch
 from torch.multiprocessing import start_processes
@@ -68,9 +67,9 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False):
         else:
             # No need for a distributed launch otherwise as it's either CPU or one GPU.
             if torch.cuda.is_available():
-                print(f"Launching training on one GPU.")
+                print("Launching training on one GPU.")
             else:
-                print(f"Launching training on CPU.")
+                print("Launching training on CPU.")
             function(*args)
 
     else:
@@ -115,7 +114,7 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False):
         else:
             # No need for a distributed launch otherwise as it's either CPU or one GPU.
             if torch.cuda.is_available():
-                print(f"Launching training on one GPU.")
+                print("Launching training on one GPU.")
             else:
-                print(f"Launching training on CPU.")
+                print("Launching training on CPU.")
             function(*args)

--- a/src/accelerate/notebook_launcher.py
+++ b/src/accelerate/notebook_launcher.py
@@ -22,7 +22,7 @@ from .state import AcceleratorState
 from .utils import PrepareForLaunch
 
 
-def notebook_launcher(function, args=(), num_processes=None, use_fp16=False):
+def notebook_launcher(function, args=(), num_processes=None, use_fp16=False, use_port="29500"):
     """
     Launches a training function, using several processes if it's possible in the current environment (TPU with
     multiple cores for instance).
@@ -37,7 +37,9 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False):
             The number of processes to use for training. Will default to 8 in Colab/Kaggle if a TPU is available, to
             the number of GPUs available otherwise.
         use_fp16 (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            If :obj:`True`, will use mixed precision training on multi-GPU .
+            If :obj:`True`, will use mixed precision training on multi-GPU.
+        use_port (:obj:`str`, `optional`, defaults to :obj:`"29500"`):
+            The port to use to communicate between processes when launching a multi-GPU training.
     """
     # Are we in a google colab or a Kaggle Kernel?
     if "IPython" in sys.modules:
@@ -98,7 +100,7 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False):
             # process here (the other ones will be set be the launcher).
             os.environ["WORLD_SIZE"] = str(num_processes)
             os.environ["MASTER_ADDR"] = "127.0.0.1"
-            os.environ["MASTER_PORT"] = "29500"
+            os.environ["MASTER_PORT"] = use_port
             os.environ["USE_FP16"] = str(use_fp16)
 
             launcher = PrepareForLaunch(function, distributed_type="MULTI_GPU")

--- a/src/accelerate/notebook_launcher.py
+++ b/src/accelerate/notebook_launcher.py
@@ -100,7 +100,7 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False, use
             # process here (the other ones will be set be the launcher).
             os.environ["WORLD_SIZE"] = str(num_processes)
             os.environ["MASTER_ADDR"] = "127.0.0.1"
-            os.environ["MASTER_PORT"] = use_port
+            os.environ["MASTER_PORT"] = str(use_port)
             os.environ["USE_FP16"] = str(use_fp16)
 
             launcher = PrepareForLaunch(function, distributed_type="MULTI_GPU")

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -14,6 +14,7 @@
 
 import importlib
 import inspect
+import os
 import random
 from enum import Enum
 from typing import List, Optional, Union
@@ -252,15 +253,23 @@ def save(obj, f):
 
 class PrepareForLaunch:
     """
-    Prepare a function that launches a script.
+    Prepare a function that will launched in a distributed setup.
+
+    Args:
+        launcher (:obj:`Callable`):
+            The function to launch.
+        distributed_type (:class:`~accelerate.state.DistributedType`):
+            The distributed type to prepare for.
     """
 
-    def __init__(self, launcher):
+    def __init__(self, launcher, distributed_type="NO"):
         self.launcher = launcher
+        self.distributed_type = DistributedType(distributed_type)
 
-    def __call__(self, index):
-        launcher_sig = inspect.signature(self.launcher)
-        if len(launcher_sig.parameters) == 0:
-            self.launcher()
-        else:
-            self.launcher(index)
+    def __call__(self, index, *args):
+        if self.distributed_type == DistributedType.MULTI_GPU:
+            # Prepare the environment for torch.distributed
+            os.environ["LOCAL_RANK"] = str(index)
+            os.environ["RANK"] = str(index)
+
+        self.launcher(*args)

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import importlib
-import inspect
 import os
 import random
 from enum import Enum


### PR DESCRIPTION
This PR adds support for multi-GPU training in the `notebook_launcher` and cleans a bit the API.

The same constraints as for TPU are applicable: no defining `accelerator` outside of the training function **and** CUDA has to be uninitiliazed until inside the trainnig function or the forking process is not happy.

Fixes #36