### PR TITLE
Honor namedtuples in inputs/outputs

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -17,6 +17,7 @@ import torch
 from packaging import version
 
 from .state import AcceleratorState, DistributedType, is_tpu_available
+from .utils import honor_type
 
 
 if is_tpu_available():
@@ -25,7 +26,7 @@ if is_tpu_available():
 
 def move_to_device(state, device):
     if isinstance(state, (list, tuple)):
-        return type(state)(move_to_device(t, device) for t in state)
+        return honor_type(state, (move_to_device(t, device) for t in state))
     elif isinstance(state, dict):
         return type(state)({k: move_to_device(v, device) for k, v in state.items()})
     elif isinstance(state, torch.Tensor):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from collections import namedtuple
+
+import torch
+
+from accelerate.utils import send_to_device
+
+
+TestNamedTuple = namedtuple("TestNamedTuple", "a b")
+
+
+class UtilsTester(unittest.TestCase):
+    def test_send_to_device(self):
+        tensor = torch.randn(5, 2)
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+
+        result1 = send_to_device(tensor, device)
+        self.assertTrue(torch.equal(result1.cpu(), tensor))
+
+        result2 = send_to_device((tensor, [tensor, tensor]), device)
+        self.assertIsInstance(result2, tuple)
+        self.assertTrue(torch.equal(result2[0].cpu(), tensor))
+        self.assertIsInstance(result2[1], list)
+        self.assertTrue(torch.equal(result2[1][0].cpu(), tensor))
+        self.assertTrue(torch.equal(result2[1][1].cpu(), tensor))
+
+        result2 = send_to_device({"a": tensor, "b": [tensor, tensor]}, device)
+        self.assertIsInstance(result2, dict)
+        self.assertTrue(torch.equal(result2["a"].cpu(), tensor))
+        self.assertIsInstance(result2["b"], list)
+        self.assertTrue(torch.equal(result2["b"][0].cpu(), tensor))
+        self.assertTrue(torch.equal(result2["b"][1].cpu(), tensor))
+
+        result3 = send_to_device(TestNamedTuple(a=tensor, b=[tensor, tensor]), device)
+        self.assertIsInstance(result3, TestNamedTuple)
+        self.assertTrue(torch.equal(result3.a.cpu(), tensor))
+        self.assertIsInstance(result3.b, list)
+        self.assertTrue(torch.equal(result3.b[0].cpu(), tensor))
+        self.assertTrue(torch.equal(result3.b[1].cpu(), tensor))


### PR DESCRIPTION
This PR adds support for namedtuples in inputs/outputs of models and dataloaders.

There is sadly no direct check to know if a Python object is a namedtuple, and nametuple can't be instantiated from a generator like regular tuples and lists, the generator needs to be unpacked. Sadly list and tuples don't want that kind of unpacking, so I had to add a utility function that does the distinction depending on the type of object received.

Fixes #65