### PR TITLE
Fix `accelerate test` with no config file

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -39,7 +39,8 @@ else:
 
 
 def load_config_from_file(config_file):
-    config_file = config_file if config_file is not None else default_config_file
+    config_file_exists = config_file is not None and os.path.isfile(config_file)
+    config_file = config_file if config_file_exists else default_config_file
     with open(config_file, "r", encoding="utf-8") as f:
         if config_file.endswith(".json"):
             if (


### PR DESCRIPTION
When I run `accelerate test`, I get this error:
```
Traceback (most recent call last):
  File ".../bin/accelerate-launch", line 33, in <module>
    sys.exit(load_entry_point('accelerate', 'console_scripts', 'accelerate-launch')())
  File ".../accelerate/src/accelerate/commands/launch.py", line 319, in main
    launch_command(args)
  File ".../accelerate/src/accelerate/commands/launch.py", line 285, in launch_command
    defaults = load_config_from_file(args.config_file)
  File ".../accelerate/src/accelerate/commands/config/config_args.py", line 43, in load_config_from_file
    with open(config_file, "r", encoding="utf-8") as f:
FileNotFoundError: [Errno 2] No such file or directory: 'None'
```

Looks like this command (executed by `accelerate test`)
`Running:  accelerate-launch --config_file=None .../accelerate/src/accelerate/test_utils/test_script.py`

results in a string `"None"` instead of a `None`, so I fixed it.