### PR TITLE
Add Accelerator.free_memory

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import gc
 from typing import List, Optional, Union
 
 import torch
@@ -337,6 +338,15 @@ class Accelerator:
                 Where to save the content of :obj:`obj`.
         """
         save(obj, f)
+
+    def free_memory(self):
+        """
+        Will release all references to the internal objects stored and call the garbage collector. You should call this
+        method between two trainings with different models/optimizers.
+        """
+        self._optimizers = []
+        gc.collect()
+        torch.cuda.empty_cache()
 
     def _get_named_parameters(self, *args):
         named_parameters = {}


### PR DESCRIPTION
This PR adds a `free_memory` to the `Accelerator` class, to free memory between two different trainings. This cleans up the internal list to the optimizers, but we will also add other objects stored in the future (for instance #82 adds a reference to the model for deespeed).

Fixes #84