### PR TITLE
[Feature] Add context manager to allow main process first.

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -190,10 +190,6 @@ class Accelerator:
         Lets the local main process go inside a with block.
 
         The other processes will enter the with block after the main process exits.
-
-        Examples: >>> accelerator = Accelerator() >>> cache_fname = Path("cache.txt") >>> with
-        accelerator.local_main_process_first(): >>> if cache_fname.exists(): >>> data = cache_fname,read_text() # Load
-        from cache >>> else: >>> data = "data" # Time consuming operation >>> cache_fname.write_text(data)
         """
         yield from self._goes_first(self.is_local_main_process)
 
@@ -203,10 +199,6 @@ class Accelerator:
         Lets the main process go first inside a with block.
 
         The other processes will enter the with block after the main process exits.
-
-        Examples: >>> accelerator = Accelerator() >>> cache_fname = Path("cache.txt") >>> with
-        accelerator.main_process_first(): >>> if cache_fname.exists(): >>> data = cache_fname,read_text() # Load from
-        cache >>> else: >>> data = "data" # Time consuming operation >>> cache_fname.write_text(data)
         """
         yield from self._goes_first(self.is_main_process)
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -202,13 +202,13 @@ class Accelerator:
         """
         yield from self._goes_first(self.is_main_process)
 
-    def _goes_first(self, is_master):
-        if not is_master:
+    def _goes_first(self, is_main):
+        if not is_main:
             self.wait_for_everyone()
 
         yield
 
-        if is_master:
+        if is_main:
             self.wait_for_everyone()
 
     def print(self, *args, **kwargs):


### PR DESCRIPTION
This feature is useful when downloading or processing data. 

Example

```python
accelerator = Accelerator() 
cache_fname = Path("cache.txt") 

with accelerator.main_process_first():  ## or accelerator.local_main_process_first()
    if cache_fname.exists(): 
        data = cache_fname.read_text() # Load from cache 
    else:
         data = "data" # Time consuming operation 
         cache_fname.write_text(data)  # Cache the data
```

This syntaxis is much more concise and contributes with more semantic than the older one:

```python
if not accelerator.is_main_process:  # or is_local_main_process
    accelerator.wait_for_everybody()

if cache_fname.exists(): 
    data = cache_fname.read_text() # Load from cache 
else:
     data = "data" # Time consuming operation 
     cache_fname.write_text(data)  # Cache the data

if accelerator.is_main_process:  # or is_local_main_process
    accelerator.wait_for_everybody()
```