### PR TITLE
Pass along kwargs to backward

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -387,16 +387,16 @@ class Accelerator:
     def prepare_optimizer(self, optimizer):
         return AcceleratedOptimizer(optimizer, device_placement=self.device_placement, scaler=self.scaler)
 
-    def backward(self, loss):
+    def backward(self, loss, **kwargs):
         """
         Use :obj:`accelerator.backward(loss)` in lieu of :obj:`loss.backward()`.
         """
         if self.distributed_type == DistributedType.DEEPSPEED:
-            self.deepspeed_engine.backward(loss)
+            self.deepspeed_engine.backward(loss, **kwargs)
         elif self.scaler is not None:
-            self.scaler.scale(loss).backward()
+            self.scaler.scale(loss).backward(**kwargs)
         else:
-            loss.backward()
+            loss.backward(**kwargs)
 
     def unscale_gradients(self, optimizer=None):
         """

--- a/src/accelerate/deepspeed_utils.py
+++ b/src/accelerate/deepspeed_utils.py
@@ -20,7 +20,7 @@ if is_deepspeed_available():
     from deepspeed import DeepSpeedEngine
 
 if is_apex_available():
-    from apex import amp
+    import amp
 
 
 class DeepSpeedEngineWrapper(DeepSpeedEngine):

--- a/src/accelerate/deepspeed_utils.py
+++ b/src/accelerate/deepspeed_utils.py
@@ -20,7 +20,7 @@ if is_deepspeed_available():
     from deepspeed import DeepSpeedEngine
 
 if is_apex_available():
-    import amp
+    from apex import amp
 
 
 class DeepSpeedEngineWrapper(DeepSpeedEngine):


### PR DESCRIPTION
This PR allows the use of all keyword arguments for the `backward` method.

Fixes #103