### PR TITLE
Unwrap optimizer before unscaling

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -413,8 +413,10 @@ class Accelerator:
                 optimizer = self._optimizers
             elif not isinstance(optimizer, (tuple, list)):
                 optimizer = [optimizer]
-            for optimizer in optimizer:
-                self.scaler.unscale_(optimizer)
+            for opt in optimizer:
+                while isinstance(opt, AcceleratedOptimizer):
+                    opt = opt.optimizer
+                self.scaler.unscale_(opt)
 
     def clip_grad_norm_(self, parameters, max_norm, norm_type=2):
         """


### PR DESCRIPTION
As mentioned in #113, the `unscale_gradients` method of `Accelerator` is unscaling the wrapped optimizer and not the inner one, which results in gradients being unscaled twice.

This PR fixes that.

Fixes #113