### PR TITLE
Fix DataLoader length when split_batches=True

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -104,6 +104,8 @@ class BatchSamplerShard(BatchSampler):
         self.drop_last = batch_sampler.drop_last
 
     def __len__(self):
+        if self.split_batches:
+            return len(self.batch_sampler)
         if len(self.batch_sampler) % self.num_processes == 0:
             return len(self.batch_sampler) // self.num_processes
         length = len(self.batch_sampler) // self.num_processes


### PR DESCRIPTION
As pointed out by #119, the dataloader length is incorrect when `split_batches=True` (even if the length of the iterator is the right one). This PR fixes that by fixing the length of the batch sampler used.