### PR TITLE
Fix `OptimWrapper` init

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -52,6 +52,7 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         self.optimizer = optimizer
         self.scaler = scaler
         self.state = AcceleratorState()
+        self.device_placement = device_placement
 
         # Handle device placement
         if device_placement:


### PR DESCRIPTION
The `device_placement` was not initialized in the `OptimWrapper` init, this PR fixes that.
Fixes #126 