### PR TITLE
Fix fp16 by converting outputs back to FP32

### DIFF
--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -345,6 +345,19 @@ If you are using gradient clipping in your script, you should replace the calls 
 :obj:`torch.nn.utils.clip_grad_norm_` or :obj:`torch.nn.utils.clip_grad_value_` with :obj:`accelerator.clip_grad_norm_`
 and :obj:`accelerator.clip_grad_value_` respectively.
 
+Mixed Precision training
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you are running your training in Mixed Precision with Accelerate, you will get the best result with your loss being
+computed inside your model (like in Transformer models for instance). Every computation outside of the model will be
+executed in full precision (which is generally what you want for loss computation, expecially if it involves a
+softmax). However you might want to put your loss computation inside the `accelerator.autocast` context manager:
+
+.. codeblock::
+
+    with accelerator.autocast():
+        loss = complex_loss_function(outputs, target):
+
 
 Internal mechanism
 -----------------------------------------------------------------------------------------------------------------------

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -556,7 +556,7 @@ class Accelerator:
     @contextmanager
     def autocast(self):
         """
-        Will apply automatic mixed precision inside the block inside thics context manager, if it is enabled. Nothing
+        Will apply automatic mixed-precision inside the block inside this context manager, if it is enabled. Nothing
         different will happen otherwise.
         """
         if self.native_amp:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -28,6 +28,7 @@ from .state import AcceleratorState, DistributedType, is_deepspeed_available
 from .utils import (
     DeepSpeedPlugin,
     RNGType,
+    convert_outputs_to_fp32,
     extract_model_from_parallel,
     gather,
     pad_across_processes,
@@ -295,6 +296,7 @@ class Accelerator:
             model = torch.nn.parallel.DistributedDataParallel(model, **kwargs)
         if self.native_amp:
             model.forward = torch.cuda.amp.autocast()(model.forward)
+            model.forward = convert_outputs_to_fp32(model.forward)
         return model
 
     def _prepare_deepspeed(self, *args):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -552,3 +552,17 @@ class Accelerator:
                 state_dict[k] = state_dict[k].float()
 
         return state_dict
+
+    @contextmanager
+    def autocast(self):
+        """
+        Will apply automatic mixed precision inside the block inside thics context manager, if it is enabled. Nothing
+        different will happen otherwise.
+        """
+        if self.native_amp:
+            autocast_context = torch.cuda.amp.autocast()
+            autocast_context.__enter__()
+            yield
+            autocast_context.__exit__()
+        else:
+            yield


### PR DESCRIPTION
As was pointed out in #101, there is currently a bug in mixed precision training: the outputs are properly computed in mixed precision but are returned in FP16, and the loss computation is not inside a `torch.cuda.amp.autocast` context manager so is executed in full FP16, which is generally unstable (especially for softmax).

This was not discovered with Transformers models as the loss is computed inside the model, which is generally a better idea if one wants to use mixed precision with Accelerate.

To fix the problem, this PR:
- automatically converts the outputs of the model to FP32 so that the loss is executed in full precision (generally a better idea)
- adds a context manager `accelerator.autocast` for more complex loss functions that should be executed in mixed precision (as with all things accelerate, this context manager always work, it just does nothing if FP16 is not activated).