### PR TITLE
Add optimizer not stepped property

### DIFF
--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -358,6 +358,20 @@ softmax). However you might want to put your loss computation inside the `accele
     with accelerator.autocast():
         loss = complex_loss_function(outputs, target):
 
+Another caveat with Mixed Precision training is that the gradient will skip a few updates at the beginning and
+sometimes during training: because of the dynamic loss scaling strategy, there are points at training where the
+gradients have overflown, and the loss scaling factor is reduced to avoid this happening again at the next step.
+
+This means that you may update your learning rate scheduler when there was no update, which is fine in general, but may
+have an impace when you have very little training data, or if the first learning rate values of your scheduler are very
+important. In this case, you can skip the learning rate scheduler updates when the optimizer step was not done like
+this:
+
+.. codeblock::
+
+    if not accelerator.optimizer_step_was_skipped:
+        lr_scheduler.step()
+
 
 Internal mechanism
 -----------------------------------------------------------------------------------------------------------------------

--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -359,11 +359,11 @@ softmax). However you might want to put your loss computation inside the `accele
         loss = complex_loss_function(outputs, target):
 
 Another caveat with Mixed Precision training is that the gradient will skip a few updates at the beginning and
-sometimes during training: because of the dynamic loss scaling strategy, there are points at training where the
+sometimes during training: because of the dynamic loss scaling strategy, there are points during training where the
 gradients have overflown, and the loss scaling factor is reduced to avoid this happening again at the next step.
 
 This means that you may update your learning rate scheduler when there was no update, which is fine in general, but may
-have an impace when you have very little training data, or if the first learning rate values of your scheduler are very
+have an impact when you have very little training data, or if the first learning rate values of your scheduler are very
 important. In this case, you can skip the learning rate scheduler updates when the optimizer step was not done like
 this:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -566,3 +566,14 @@ class Accelerator:
             autocast_context.__exit__()
         else:
             yield
+
+    @property
+    def optimizer_step_was_skipped(self):
+        """
+        Whether or not the optimizer update was skipped (because of gradient overflow in mixed precision), in which
+        case the learning rate should not be changed.
+        """
+        for optimizer in self._optimizers:
+            if optimizer.is_overflow:
+                return True
+        return False

--- a/src/accelerate/deepspeed_utils.py
+++ b/src/accelerate/deepspeed_utils.py
@@ -89,7 +89,7 @@ class DeepSpeedOptimizerWrapper(AcceleratedOptimizer):
 
     @property
     def is_overflow(self):
-        """This must be called before lr_scheduler.step() when using deepspeed with fp16"""
+        """Whether or not the optimizer step was done, or skipped because of gradient overflow."""
         overflow = False
         if hasattr(self.optimizer, "overflow"):
             overflow = self.optimizer.overflow


### PR DESCRIPTION
This PR adds a property to check whether or not the optimizer step was skipped in Mixed Precision or DeepSpeed training. This is not necessary to use in most cases, but could be important if there are not many training steps.