### PR TITLE
fix fp16 covert back to fp32 for issue: unsupported operand type(s) for /: 'dict' and 'int'

### DIFF
--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -151,7 +151,7 @@ def convert_to_fp32(tensor):
     if isinstance(tensor, (list, tuple)):
         return honor_type(tensor, (convert_to_fp32(t) for t in tensor))
     elif isinstance(tensor, dict):
-        return type(tensor)({k: convert_to_fp32(v) for k, v in tensor.items()})
+        return type(tensor)(**{k: convert_to_fp32(v) for k, v in tensor.items()})
     elif not hasattr(tensor, "dtype") or tensor.dtype != torch.float16:
         return tensor
     return tensor.float()


### PR DESCRIPTION
The details about this PR is [huggingface/transformers:#13232](https://github.com/huggingface/transformers/issues/13232)


I test the official example scripts: https://github.com/huggingface/transformers/examples/pytorch/translation/run_translation_no_trainer.py 
when using `fp16` mode via the `accelerate` repo.

However, it has been corrupted as follows:
![image](https://user-images.githubusercontent.com/26213546/131208144-f366f4f5-6ff6-4b33-8436-14a93c142b54.png)

I checked the `outputs.loss` and found it is a `dict` object with keys `dict_keys(['loss', 'logits', 'past_key_values', 'encoder_last_hidden_state'])`.

I tracked the problem to this function：`convert_to_fp32` in `accelerate/utils.py`
```python
def convert_to_fp32(tensor):
    if isinstance(tensor, (list, tuple)):
        return honor_type(tensor, (convert_to_fp32(t) for t in tensor))
    elif isinstance(tensor, dict):
        return type(tensor)({k: convert_to_fp32(v) for k, v in tensor.items()}). # problem line
    elif not hasattr(tensor, "dtype") or tensor.dtype != torch.float16:
        return tensor
    return tensor.float()
```

For the problem line, it's actually implemented as `Seq2SeqLMOutput({k: convert_to_fp32(v) for k, v in tensor.items()})`. 

**It means all parameters are passed to the first member variable `loss`. So that the `outputs.loss` is a dict.**

**I think the `**` should be added., i.e., `type(tensor)(**{k: convert_to_fp32(v) for k, v in tensor.items()})`**
