### PR TITLE
[DeepSpeed] allow untested optimizers deepspeed

### DIFF
--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -388,4 +388,5 @@ class DeepSpeedPlugin:
                 },
             },
             "steps_per_print": float("inf"),  # this will stop deepspeed from logging @ stdout
+            "zero_allow_untested_optimizer": True,
         }


### PR DESCRIPTION
Similar to how it's done in `transformers`, I think we should always allow untested optimizers, e.g. for AdamW.

See: https://github.com/huggingface/transformers/blob/b6ddb08a664565848c4741e0ff949a4d12989e83/src/transformers/deepspeed.py#L342

cc @stas00 @vasudevgupta7 