### PR TITLE
[Docs] Machine config is yaml not json

### DIFF
--- a/docs/source/quicktour.rst
+++ b/docs/source/quicktour.rst
@@ -152,7 +152,7 @@ just run
 
     accelerate config
 
-on your machine and reply to the questions asked. This will save a `default_config.json` file in your cache folder for
+on your machine and reply to the questions asked. This will save a `default_config.yaml` file in your cache folder for
 🤗 Accelerate. That cache folder is (with decreasing order of priority):
 
     - The content of your environment variable ``HF_HOME`` suffixed with `accelerate`.
@@ -176,7 +176,7 @@ Note that if you specified a location for the config file in the previous step, 
 
 .. code-block:: bash
 
-    accelerate test --config_file path_to_config.json
+    accelerate test --config_file path_to_config.yaml
 
 
 Now that this is done, you can run your script with the following command:
@@ -190,7 +190,7 @@ If you stored the config file in a non-default location, you can indicate it to 
 
 .. code-block:: bash
 
-    accelerate launch --config_file path_to_config.json path_to_script.py --args_for_the_script
+    accelerate launch --config_file path_to_config.yaml path_to_script.py --args_for_the_script
 
 You can also override any of the arguments determined by your config file, see TODO: insert ref here.
 

--- a/src/accelerate/commands/config/__init__.py
+++ b/src/accelerate/commands/config/__init__.py
@@ -48,7 +48,7 @@ def config_command_parser(subparsers=None):
         "--config_file",
         default=None,
         help=(
-            "The path to use to store the config file. Will default to a file named default_config.json in the cache "
+            "The path to use to store the config file. Will default to a file named default_config.yaml in the cache "
             "location, which is the content of the environment `HF_HOME` suffixed with 'accelerate', or if you don't have "
             "such an environment variable, your cache directory ('~/.cache' or the content of `XDG_CACHE_HOME`) suffixed "
             "with 'huggingface'."

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -28,7 +28,7 @@ hf_cache_home = os.path.expanduser(
     os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
 )
 cache_dir = os.path.join(hf_cache_home, "accelerate")
-default_json_config_file = os.path.join(cache_dir, "default_config.json")
+default_json_config_file = os.path.join(cache_dir, "default_config.yaml")
 default_yaml_config_file = os.path.join(cache_dir, "default_config.yaml")
 
 # For backward compatibility: the default config is the json one if it's the only existing file.

--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -30,7 +30,7 @@ def test_command_parser(subparsers=None):
         "--config_file",
         default=None,
         help=(
-            "The path to use to store the config file. Will default to a file named default_config.json in the cache "
+            "The path to use to store the config file. Will default to a file named default_config.yaml in the cache "
             "location, which is the content of the environment `HF_HOME` suffixed with 'accelerate', or if you don't have "
             "such an environment variable, your cache directory ('~/.cache' or the content of `XDG_CACHE_HOME`) suffixed "
             "with 'huggingface'."


### PR DESCRIPTION
I think the default config is in `.yaml` format not in `.json`. Was a bit confused when reading the docs.