### PR TITLE
Central dataloader

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -82,7 +82,7 @@ class Accelerator:
 
             Will default to :obj:`["torch"]` for PyTorch versions <=1.5.1 and :obj:`["generator"]` for PyTorch versions
             >= 1.6.
-        main_dataloader (:obj:`bool`, `optional`, defaults to :obj:`False`):
+        central_dataloader (:obj:`bool`, `optional`, defaults to :obj:`False`):
             If set to :obj:`True`, the datalaoder prepared by the Accelerator is only iterated through on the main
             process and then the batches are split and broadcast to each process.
         kwargs_handlers (list of kwargs handlers, `optional`)
@@ -103,7 +103,7 @@ class Accelerator:
         cpu: bool = False,
         deepspeed_plugin: DeepSpeedPlugin = None,
         rng_types: Optional[List[Union[str, RNGType]]] = None,
-        main_dataloader: bool = False,
+        central_dataloader: bool = False,
         kwargs_handlers: Optional[List[KwargsHandler]] = None,
     ):
         if deepspeed_plugin is None:  # init from env variables
@@ -117,7 +117,7 @@ class Accelerator:
 
         self.device_placement = device_placement
         self.split_batches = split_batches
-        self.main_dataloader = main_dataloader
+        self.central_dataloader = central_dataloader
 
         # Kwargs handlers
         self.ddp_handler = None
@@ -389,7 +389,7 @@ class Accelerator:
             split_batches=self.split_batches,
             put_on_device=self.device_placement,
             rng_types=self.rng_types.copy(),
-            main_dataloader=self.main_dataloader,
+            central_dataloader=self.central_dataloader,
         )
 
     def prepare_optimizer(self, optimizer):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -82,6 +82,9 @@ class Accelerator:
 
             Will default to :obj:`["torch"]` for PyTorch versions <=1.5.1 and :obj:`["generator"]` for PyTorch versions
             >= 1.6.
+        main_dataloader (:obj:`bool`, `optional`, defaults to :obj:`False`):
+            If set to :obj:`True`, the datalaoder prepared by the Accelerator is only iterated through on the main
+            process and then the batches are split and broadcast to each process.
         kwargs_handlers (list of kwargs handlers, `optional`)
             A list of :obj:`KwargHandler` to customize how the objects related to distributed training or mixed
             precision are created. See :doc:`kwargs` for more information.
@@ -100,6 +103,7 @@ class Accelerator:
         cpu: bool = False,
         deepspeed_plugin: DeepSpeedPlugin = None,
         rng_types: Optional[List[Union[str, RNGType]]] = None,
+        main_dataloader: bool = False,
         kwargs_handlers: Optional[List[KwargsHandler]] = None,
     ):
         if deepspeed_plugin is None:  # init from env variables
@@ -113,6 +117,7 @@ class Accelerator:
 
         self.device_placement = device_placement
         self.split_batches = split_batches
+        self.main_dataloader = main_dataloader
 
         # Kwargs handlers
         self.ddp_handler = None
@@ -384,6 +389,7 @@ class Accelerator:
             split_batches=self.split_batches,
             put_on_device=self.device_placement,
             rng_types=self.rng_types.copy(),
+            main_dataloader=self.main_dataloader,
         )
 
     def prepare_optimizer(self, optimizer):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -83,7 +83,7 @@ class Accelerator:
             Will default to :obj:`["torch"]` for PyTorch versions <=1.5.1 and :obj:`["generator"]` for PyTorch versions
             >= 1.6.
         central_dataloader (:obj:`bool`, `optional`, defaults to :obj:`False`):
-            If set to :obj:`True`, the datalaoder prepared by the Accelerator is only iterated through on the main
+            If set to :obj:`True`, the dataloader prepared by the Accelerator is only iterated through on the main
             process and then the batches are split and broadcast to each process.
         kwargs_handlers (list of kwargs handlers, `optional`)
             A list of :obj:`KwargHandler` to customize how the objects related to distributed training or mixed

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -82,7 +82,7 @@ class Accelerator:
 
             Will default to :obj:`["torch"]` for PyTorch versions <=1.5.1 and :obj:`["generator"]` for PyTorch versions
             >= 1.6.
-        central_dataloader (:obj:`bool`, `optional`, defaults to :obj:`False`):
+        dispatch_batches (:obj:`bool`, `optional`, defaults to :obj:`False`):
             If set to :obj:`True`, the dataloader prepared by the Accelerator is only iterated through on the main
             process and then the batches are split and broadcast to each process.
         kwargs_handlers (list of kwargs handlers, `optional`)
@@ -103,7 +103,7 @@ class Accelerator:
         cpu: bool = False,
         deepspeed_plugin: DeepSpeedPlugin = None,
         rng_types: Optional[List[Union[str, RNGType]]] = None,
-        central_dataloader: bool = False,
+        dispatch_batches: bool = False,
         kwargs_handlers: Optional[List[KwargsHandler]] = None,
     ):
         if deepspeed_plugin is None:  # init from env variables
@@ -117,7 +117,7 @@ class Accelerator:
 
         self.device_placement = device_placement
         self.split_batches = split_batches
-        self.central_dataloader = central_dataloader
+        self.dispatch_batches = dispatch_batches
 
         # Kwargs handlers
         self.ddp_handler = None
@@ -389,7 +389,7 @@ class Accelerator:
             split_batches=self.split_batches,
             put_on_device=self.device_placement,
             rng_types=self.rng_types.copy(),
-            central_dataloader=self.central_dataloader,
+            dispatch_batches=self.dispatch_batches,
         )
 
     def prepare_optimizer(self, optimizer):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -381,7 +381,7 @@ class DataLoaderDispatcher(DataLoader):
             batch = send_to_device(batch, state.device)
             # Broadcast the batch before splitting it.
             batch = broadcast(batch, from_process=0)
-            
+
             batch_size = find_batch_size(batch) // state.num_processes
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
 
@@ -452,6 +452,8 @@ def prepare_data_loader(
 
         This does not support :obj:`BatchSampler` with varying batch size yet.
     """
+    if central_dataloader and not put_on_device:
+        raise ValueError("Using `central_dataloader=True` requires `put_on_device=True`.")
     # Grab defaults from AcceleratorState
     state = AcceleratorState()
     if num_processes is None:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -23,6 +23,7 @@ from .state import AcceleratorState, DistributedType, is_tpu_available
 from .utils import (
     RNGType,
     broadcast,
+    broadcast_object_list,
     concatenate,
     find_batch_size,
     get_data_structure,
@@ -339,7 +340,7 @@ class DataLoaderDispatcher(DataLoader):
             else:
                 batch_info = [None, stop_iteration]
 
-            torch.distributed.broadcast_object_list(batch_info)
+            broadcast_object_list(batch_info)
             stop_iteration = batch_info[1]
             if stop_iteration:
                 # If drop_last is False and split_batches is False, we may have a remainder to take care of.
@@ -349,7 +350,7 @@ class DataLoaderDispatcher(DataLoader):
                         batch_info = [get_data_structure(batch), False]
                     else:
                         batch_info = [None, True]
-                    torch.distributed.broadcast_object_list(batch_info)
+                    broadcast_object_list(batch_info)
                     stop_iteration = batch_info[1]
                     if stop_iteration:
                         continue

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -343,7 +343,6 @@ class DataLoaderDispatcher(DataLoader):
 
             broadcast_object_list(batch_info)
             stop_iteration = batch_info[1]
-            print(f"Process {state.process_index} after broadcast_object_list, stop: {stop_iteration}")
             if stop_iteration:
                 # If drop_last is False and split_batches is False, we may have a remainder to take care of.
                 if not self.split_batches and not self.drop_last:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -357,9 +357,12 @@ class DataLoaderDispatcher(DataLoader):
                 else:
                     continue
 
-            if state.process_index != 0:
-                batch = initialize_tensors(batch_info[0])
-            batch = send_to_device(batch, state.device)
+            if state.distributed_type != DistributedType.TPU:
+                if state.process_index != 0:
+                    batch = initialize_tensors(batch_info[0])
+                batch = send_to_device(batch, state.device)
+            else:
+                batch = None
             batch = broadcast(batch, from_process=0)
 
             batch_size = find_batch_size(batch) // state.num_processes

--- a/src/accelerate/test_utils/test_script.py
+++ b/src/accelerate/test_utils/test_script.py
@@ -113,7 +113,9 @@ def central_dl_preparation_check():
     length = 32 * state.num_processes
 
     dl = DataLoader(range(length), batch_size=8)
-    dl = prepare_data_loader(dl, state.device, state.num_processes, state.process_index, put_on_device=True, central_dataloader=True)
+    dl = prepare_data_loader(
+        dl, state.device, state.num_processes, state.process_index, put_on_device=True, central_dataloader=True
+    )
     result = []
     for batch in dl:
         result.append(gather(batch))
@@ -140,7 +142,9 @@ def central_dl_preparation_check():
         print("Non-shuffled central dataloader passing.")
 
     dl = DataLoader(range(length), batch_size=8, shuffle=True)
-    dl = prepare_data_loader(dl, state.device, state.num_processes, state.process_index, put_on_device=True, central_dataloader=True)
+    dl = prepare_data_loader(
+        dl, state.device, state.num_processes, state.process_index, put_on_device=True, central_dataloader=True
+    )
     result = []
     for batch in dl:
         result.append(gather(batch))
@@ -156,7 +160,7 @@ def central_dl_preparation_check():
         state.process_index,
         put_on_device=True,
         split_batches=True,
-        central_dataloader=True
+        central_dataloader=True,
     )
     result = []
     for batch in dl:

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -374,7 +374,7 @@ def broadcast(tensor, from_process: int = 0):
         The same data structure as :obj:`tensor` with all tensors broadcasted to the proper device.
     """
     if AcceleratorState().distributed_type == DistributedType.TPU:
-        raise _tpu_broadcast(tensor, src=from_process, name="accelerate.utils.broadcast")
+        return _tpu_broadcast(tensor, src=from_process, name="accelerate.utils.broadcast")
     elif AcceleratorState().distributed_type == DistributedType.MULTI_GPU:
         return _gpu_broadcast(tensor, src=from_process)
     elif AcceleratorState().distributed_type == DistributedType.MULTI_CPU:

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -357,7 +357,7 @@ def _tpu_broadcast(tensor, src=0, name="broadcast tensor"):
         return honor_type(tensor, (_tpu_broadcast(t, name=f"{name}_{i}") for i, t in enumerate(tensor)))
     elif isinstance(tensor, dict):
         return type(tensor)({k: _tpu_broadcast(v, name=f"{name}_{k}") for k, v in tensor.items()})
-    return xm.mesh_reduce(name, t, lambda x: x[src])
+    return xm.mesh_reduce(name, tensor, lambda x: x[src])
 
 
 def broadcast(tensor, from_process: int = 0):

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -317,7 +317,7 @@ def _gpu_gather(tensor):
         torch.distributed.all_gather(output_tensors, tensor)
         return torch.cat(output_tensors, dim=0)
 
-    return recursively_apply(tensor, _gpu_gather_one, error_on_other_type=True)
+    return recursively_apply(_gpu_gather_one, tensor, error_on_other_type=True)
 
 
 _cpu_gather = _gpu_gather


### PR DESCRIPTION
This PR adds a new API called central dataloader. The main concept is that the dataloader passed along to the `accelerator.prepare` method will behave like this: they will only be iterated on the main process, which will then dispatch the batches on all the other processes.

This solves two different problems:
- it makes sure all processes have the same underlying data (a feat usually achieved by synchronizing random number generators) when there is some random events out of the script control that can change the data: for instance we are streaming a dataset and there could be timeouts on some of the processes but not all
- when using an IterableDataset, it avoids iterating through (and thus processing) the data number of processes times, which saves CPU resources and make sure the GPUs are maxed.

The cost is a new synchronization at each batch, to broadcast the batch gathered on process 0 to the other processes.

The feature is activated by passing `central_dataloader=True` to the `Accelerator` at its creation. It is compatible with `split_batches=True` (in which case one batch of the dataloader on process 0 is split on each process, instead of iterating through the central dataloader to get `num_processes` batches and sending each to their right process). It requires `put_on_device=True`.