### PR TITLE
fix: use `store_true` on argparse in nlp example

### DIFF
--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -162,8 +162,8 @@ def training_function(config, args):
 
 def main():
     parser = argparse.ArgumentParser(description="Simple example of training script.")
-    parser.add_argument("--fp16", type=bool, default=False, help="If passed, will use FP16 training.")
-    parser.add_argument("--cpu", type=bool, default=False, help="If passed, will train on the CPU.")
+    parser.add_argument("--fp16", action="store_true", help="If passed, will use FP16 training.")
+    parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
     args = parser.parse_args()
     config = {"lr": 2e-5, "num_epochs": 3, "correct_bias": True, "seed": 42, "batch_size": 16}
     training_function(config, args)


### PR DESCRIPTION
In example, it makes error when using the commands below.

```bash
python ./nlp_example.py --cpu
python ./nlp_example.py --fp16
```

So fixed the argparse option as `--store_true`, which is also same in `cv_example.py`

https://github.com/huggingface/accelerate/blob/c5c73e02389af9be0ff5e928ea0e94527b434846/examples/cv_example.py#L189-L190