### PR TITLE
fix rng_types in accelerator

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -150,7 +150,8 @@ class Accelerator:
         self._models = []
 
         # RNG Types
-        if rng_types is None:
+        self.rng_types = rng_types
+        if self.rng_types is None:
             self.rng_types = ["torch"] if version.parse(torch.__version__) <= version.parse("1.5.1") else ["generator"]
 
     @property


### PR DESCRIPTION
The lines 152--154 in `accelerator.py` have the risk of causing `AttributeError: 'Accelerator' object has no attribute 'rng_types'` (ex. line 392 in `accelerator.py`)

So this PR:
- Define `self.rng_types` in advance.