### PR TITLE
Add customization point for init_process_group kwargs

### DIFF
--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -125,7 +125,7 @@ def training_function(config, args):
     lr_scheduler = get_linear_schedule_with_warmup(
         optimizer=optimizer,
         num_warmup_steps=100,
-        num_training_steps=len(train_dataloader) * num_epochs,
+        num_training_steps=(len(train_dataloader) * num_epochs) // gradient_accumulation_steps,
     )
 
     # Now we train the model

--- a/src/accelerate/kwargs_handlers.py
+++ b/src/accelerate/kwargs_handlers.py
@@ -14,6 +14,8 @@
 
 import copy
 from dataclasses import dataclass
+from datetime import timedelta
+from typing import Optional
 
 
 class KwargsHandler:
@@ -71,3 +73,16 @@ class GradScalerKwargs(KwargsHandler):
     backoff_factor: float = 0.5
     growth_interval: int = 2000
     enabled: bool = True
+
+
+@dataclass
+class InitProcessGroupKwargs(KwargsHandler):
+    """
+    Use this object in your :class:`~accelerate.Accelerator` to customize the initialization of the distributed
+    processes. Please refer to the documentation of this `method
+    <https://pytorch.org/docs/stable/distributed.html#torch.distributed.init_process_group>`__ for more information on
+    each argument.
+    """
+
+    init_method: Optional[str] = None
+    timeout: timedelta = timedelta(seconds=1800)

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -138,7 +138,9 @@ class AcceleratorState:
 
     _shared_state = {}
 
-    def __init__(self, fp16: bool = None, cpu: bool = False, deepspeed_plugin=None, _from_accelerator: bool = False):
+    def __init__(
+        self, fp16: bool = None, cpu: bool = False, deepspeed_plugin=None, _from_accelerator: bool = False, **kwargs
+    ):
         self.__dict__ = self._shared_state
         if not getattr(self, "initialized", False):
             self.backend = None
@@ -161,7 +163,7 @@ class AcceleratorState:
                 ), "DeepSpeed is not available => install it using `pip3 install deepspeed` or build it from source"
                 self.distributed_type = DistributedType.DEEPSPEED
                 if not torch.distributed.is_initialized():
-                    torch.distributed.init_process_group(backend="nccl")
+                    torch.distributed.init_process_group(backend="nccl", **kwargs)
                     self.backend = "nccl"
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
@@ -175,7 +177,7 @@ class AcceleratorState:
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
-                    torch.distributed.init_process_group(backend="nccl")
+                    torch.distributed.init_process_group(backend="nccl", **kwargs)
                     self.backend = "nccl"
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
@@ -213,7 +215,7 @@ class AcceleratorState:
                             "please try exporting rank 0's hostname as MASTER_ADDR"
                         )
                 if not torch.distributed.is_initialized():
-                    torch.distributed.init_process_group(backend, rank=rank, world_size=size)
+                    torch.distributed.init_process_group(backend, rank=rank, world_size=size, **kwargs)
                     self.backend = backend
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()


### PR DESCRIPTION
As pointed out it #223, users sometimes need to customize some of the kwargs of the `init_process_group` method of the torch distributed package. This PR enables that.

Fixes #223