### PR TITLE
make deepspeed optimizer match parameters of passed optimizer

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -302,10 +302,7 @@ class Accelerator:
         if self.distributed_type == DistributedType.MULTI_GPU:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
             model = torch.nn.parallel.DistributedDataParallel(
-                model,
-                device_ids=[self.local_process_index],
-                output_device=self.local_process_index,
-                **kwargs,
+                model, device_ids=[self.local_process_index], output_device=self.local_process_index, **kwargs
             )
         elif self.distributed_type == DistributedType.MULTI_CPU:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
@@ -354,7 +351,7 @@ class Accelerator:
                 defaults = optimizer.defaults
                 params = []
                 for group in optimizer.param_groups:
-                    params.extend(group['params'])
+                    params.extend(group["params"])
 
                 optimizer = deepspeed.ops.adam.DeepSpeedCPUAdam(
                     params,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -352,8 +352,12 @@ class Accelerator:
             is_adamw = isinstance(optimizer, torch.optim.AdamW)
             if (is_adam or is_adamw) and deepspeed_plugin.offload_optimizer_device == "cpu":
                 defaults = optimizer.defaults
+                params = []
+                for group in optimizer.param_groups:
+                    params.extend(group['params'])
+
                 optimizer = deepspeed.ops.adam.DeepSpeedCPUAdam(
-                    model.parameters(),
+                    params,
                     lr=defaults["lr"],
                     bias_correction=True,
                     betas=defaults["betas"],


### PR DESCRIPTION
I am trying to do some prompt tuning with deepspeed+accelerate, and by default, when using deepspeed, all model parameters are updated. Instead, I'd like to only update the ones that I put in the original optimizer.