### PR TITLE
[WIP] Add bfloat16 support #243

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # VSCode
 .vscode
+
+# IntelliJ
+.idea

--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -73,7 +73,7 @@ class PetsDataset(Dataset):
 
 def training_function(config, args):
     # Initialize accelerator
-    accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu)
+    accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu, mixed_precision=args.mix_precision)
 
     # Sample hyper-parameters for learning rate, batch size, seed and a few other HPs
     lr = config["lr"]
@@ -187,6 +187,15 @@ def main():
     parser = argparse.ArgumentParser(description="Simple example of training script.")
     parser.add_argument("--data_dir", required=True, help="The data folder on disk.")
     parser.add_argument("--fp16", action="store_true", help="If passed, will use FP16 training.")
+    parser.add_argument(
+        "--mixed_precision",
+        type=str,
+        default="no",
+        choices=["no", "fp16", "bf16"],
+        help="Whether to use mixed precision. Choose"
+        "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
+        "and an Nvidia Ampere GPU.",
+    )
     parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
     args = parser.parse_args()
     config = {"lr": 3e-2, "num_epochs": 3, "seed": 42, "batch_size": 64, "image_size": 224}

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -51,7 +51,7 @@ EVAL_BATCH_SIZE = 32
 
 def training_function(config, args):
     # Initialize accelerator
-    accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu)
+    accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu, mixed_precision=args.mixed_precision)
 
     # Sample hyper-parameters for learning rate, batch size, seed and a few other HPs
     lr = config["lr"]
@@ -163,6 +163,15 @@ def training_function(config, args):
 def main():
     parser = argparse.ArgumentParser(description="Simple example of training script.")
     parser.add_argument("--fp16", action="store_true", help="If passed, will use FP16 training.")
+    parser.add_argument(
+        "--mixed_precision",
+        type=str,
+        default="no",
+        choices=["no", "fp16", "bf16"],
+        help="Whether to use mixed precision. Choose"
+        "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
+        "and an Nvidia Ampere GPU.",
+    )
     parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
     args = parser.parse_args()
     config = {"lr": 2e-5, "num_epochs": 3, "correct_bias": True, "seed": 42, "batch_size": 16}

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -219,6 +219,13 @@ class Accelerator:
         return self.local_process_index == 0
 
     @property
+    def use_fp16(self):
+        if self.mixed_precision != "no":
+            return True
+        else:
+            return False
+
+    @property
     def mixed_precision(self):
         if self.distributed_type == DistributedType.DEEPSPEED:
             if self.state.deepspeed_plugin.deepspeed_config["fp16"]["enabled"]:

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -108,14 +108,17 @@ def get_cluster_input():
             lambda x: str(x).lower(),
             default="no",
         )
+        fp16 = False
     else:
         mixed_precision = "No"
+        fp16 = False
 
     return ClusterConfig(
         compute_environment=ComputeEnvironment.LOCAL_MACHINE,
         distributed_type=distributed_type,
         num_processes=num_processes,
         mixed_precision=mixed_precision,
+        fp16=fp16,
         machine_rank=machine_rank,
         num_machines=num_machines,
         main_process_ip=main_process_ip,

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -103,20 +103,19 @@ def get_cluster_input():
     )
 
     if distributed_type != DistributedType.TPU:
-        fp16 = _ask_field(
-            "Do you wish to use FP16 (mixed precision)? [yes/NO]: ",
-            _convert_yes_no_to_bool,
-            default=False,
-            error_message="Please enter yes or no.",
+        mixed_precision = _ask_field(
+            "Do you wish to use FP16 or BF16 (mixed precision)? [NO/fp16/bf16]: ",
+            lambda x: str(x).lower(),
+            default="no",
         )
     else:
-        fp16 = False
+        mixed_precision = "No"
 
     return ClusterConfig(
         compute_environment=ComputeEnvironment.LOCAL_MACHINE,
         distributed_type=distributed_type,
         num_processes=num_processes,
-        fp16=fp16,
+        mixed_precision=mixed_precision,
         machine_rank=machine_rank,
         num_machines=num_machines,
         main_process_ip=main_process_ip,

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -67,7 +67,7 @@ class BaseConfig:
     compute_environment: ComputeEnvironment
     distributed_type: Union[DistributedType, SageMakerDistributedType]
     fp16: bool
-    mixed_precision: str = "no"
+    mixed_precision: str
 
     def to_dict(self):
         result = self.__dict__

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -66,7 +66,7 @@ def load_config_from_file(config_file):
 class BaseConfig:
     compute_environment: ComputeEnvironment
     distributed_type: Union[DistributedType, SageMakerDistributedType]
-    fp16: bool
+    mixed_precision: str
 
     def to_dict(self):
         result = self.__dict__

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -66,7 +66,8 @@ def load_config_from_file(config_file):
 class BaseConfig:
     compute_environment: ComputeEnvironment
     distributed_type: Union[DistributedType, SageMakerDistributedType]
-    mixed_precision: str
+    fp16: bool
+    mixed_precision: str = "no"
 
     def to_dict(self):
         result = self.__dict__

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -98,6 +98,12 @@ class BaseConfig:
             config_dict = yaml.safe_load(f)
         if "compute_environment" not in config_dict:
             config_dict["compute_environment"] = ComputeEnvironment.LOCAL_MACHINE
+        if "mixed_precision" not in config_dict:
+            if "fp16" in config_dict and config_dict["fp16"]:
+                config_dict["mixed_precision"] = "fp16"
+            else:
+                config_dict["mixed_precision"] = "no"
+
         return cls(**config_dict)
 
     def to_yaml_file(self, yaml_file):

--- a/src/accelerate/commands/config/sagemaker.py
+++ b/src/accelerate/commands/config/sagemaker.py
@@ -139,11 +139,11 @@ def get_sagemaker_input():
             lambda x: int(x),
             default=2,
         )
-    fp16 = _ask_field(
-        "Do you wish to use FP16 (mixed precision)? [yes/NO]: ",
-        _convert_yes_no_to_bool,
-        default=False,
-        error_message="Please enter yes or no.",
+
+    mixed_precision = _ask_field(
+        "Do you wish to use FP16 or BF16 (mixed precision)? [No/FP16/BF16]: ",
+        lambda x: str(x),
+        default="No",
     )
 
     return SageMakerConfig(
@@ -153,6 +153,6 @@ def get_sagemaker_input():
         profile=aws_profile,
         region=aws_region,
         iam_role_name=iam_role_name,
-        fp16=fp16,
+        mixed_precision=mixed_precision,
         num_machines=num_machines,
     )

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -418,13 +418,16 @@ def launch_command(args):
 
                 # Those args are handled separately
                 if (
-                    name not in ["compute_environment", "mixed_precision", "distributed_type"]
+                    name not in ["compute_environment", "fp16", "mixed_precision", "distributed_type"]
                     and getattr(args, name, None) is None
                 ):
                     setattr(args, name, attr)
 
         if not args.mixed_precision:
-            args.mixed_precision = defaults.mixed_precision
+            if args.fp16:
+                args.mixed_precision = "fp16"
+            else:
+                args.mixed_precision = defaults.mixed_precision
     else:
         if args.num_processes is None:
             args.num_processes = 1

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -66,6 +66,11 @@ def parse_flag_from_env(key, default=False):
     return strtobool(value) == 1  # As its name indicates `strtobool` actually returns an int...
 
 
+def parse_choice_from_env(key, default="no"):
+    value = os.environ.get(key, str(default))
+    return value
+
+
 class DistributedType(str, Enum):
     """
     Represents a type of distributed environment.
@@ -133,18 +138,25 @@ class AcceleratorState:
         - **num_processes** (:obj:`int`) -- The number of processes currently launched in parallel.
         - **process_index** (:obj:`int`) -- The index of the current process.
         - **local_process_index** (:obj:`int`) -- The index of the current process on the current server.
-        - **use_fp16** (:obj:`bool`) -- Whether or not the current script will use mixed precision.
+        - **mixed_precision** (:obj:`str`) -- Whether or not the current script will use mixed precision. If
+          you are using mixed precision, define if you want to use FP16 or BF16 (bfloat16) as the floating point.
     """
 
     _shared_state = {}
 
     def __init__(
-        self, fp16: bool = None, cpu: bool = False, deepspeed_plugin=None, _from_accelerator: bool = False, **kwargs
+        self,
+        mixed_precision: str = "no",
+        cpu: bool = False,
+        deepspeed_plugin=None,
+        _from_accelerator: bool = False,
+        **kwargs,
     ):
         self.__dict__ = self._shared_state
         if not getattr(self, "initialized", False):
             self.backend = None
             self.deepspeed_plugin = None
+            mixed_precision = mixed_precision.lower()
             if not _from_accelerator:
                 raise ValueError(
                     "Please make sure to properly initialize your accelerator via `accelerator = Accelerator()` "
@@ -156,7 +168,7 @@ class AcceleratorState:
                 self.process_index = xm.get_ordinal()
                 self.local_process_index = xm.get_local_ordinal()
                 self.device = xm.xla_device()
-                self.use_fp16 = False
+                self.mixed_precision = "no"
             elif os.environ.get("USE_DEEPSPEED", "false") == "true" and not cpu:
                 assert (
                     is_deepspeed_available()
@@ -170,9 +182,14 @@ class AcceleratorState:
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
                 self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
-                self.use_fp16 = False  # deepspeed handles fp16 using deepspeed_config
-                fp16 = parse_flag_from_env("USE_FP16", False) if fp16 is None else fp16
-                deepspeed_plugin.deepspeed_config.update({"fp16": {"enabled": fp16}})
+                self.mixed_precision = "no"  # deepspeed handles mixed_precision using deepspeed_config
+                mixed_precision = (
+                    parse_choice_from_env("MIXED_PRECISION", "no") if mixed_precision == "no" else mixed_precision
+                )
+                if mixed_precision == "fp16":
+                    deepspeed_plugin.deepspeed_config.update({"fp16": {"enabled": True}})
+                elif mixed_precision == "bf16":
+                    deepspeed_plugin.deepspeed_config.update({"bfloat16": {"enabled": True}})
                 self.deepspeed_plugin = deepspeed_plugin
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
@@ -184,7 +201,10 @@ class AcceleratorState:
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
                 self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
-                self.use_fp16 = parse_flag_from_env("USE_FP16", False) if fp16 is None else fp16
+                self.mixed_precision = (
+                    parse_choice_from_env("MIXED_PRECISION", "no") if mixed_precision == "no" else mixed_precision
+                )
+
             elif get_int_from_env(["PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "WORLD_SIZE"], 1) > 1:
                 self.distributed_type = DistributedType.MULTI_CPU
                 if is_ccl_available() and get_int_from_env(["CCL_WORKER_COUNT"], 0) > 0:
@@ -221,24 +241,32 @@ class AcceleratorState:
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = local_rank
                 self.device = torch.device("cpu")
-                self.use_fp16 = False
+                self.mixed_precision = "no"
             else:
                 self.distributed_type = DistributedType.NO
                 self.num_processes = 1
                 self.process_index = self.local_process_index = 0
                 self.device = torch.device("cuda" if torch.cuda.is_available() and not cpu else "cpu")
-                self.use_fp16 = parse_flag_from_env("USE_FP16", False) if fp16 is None else fp16
+                self.mixed_precision = (
+                    parse_choice_from_env("MIXED_PRECISION", "no") if mixed_precision == "no" else mixed_precision
+                )
             self.initialized = True
 
     def __repr__(self):
-        use_fp16 = self.deepspeed_plugin.fp16 if self.distributed_type == DistributedType.DEEPSPEED else self.use_fp16
+        mixed_precision = self.mixed_precision
+        if self.distributed_type == DistributedType.DEEPSPEED:
+            if self.deepspeed_plugin.fp16:
+                mixed_precision = "fp16"
+            if self.deepspeed_plugin.bflaot16:
+                mixed_precision = "bf16"
+
         repr = (
             f"Distributed environment: {self.distributed_type}{('  Backend: ' + self.backend) if self.backend else ''}\n"
             f"Num processes: {self.num_processes}\n"
             f"Process index: {self.process_index}\n"
             f"Local process index: {self.local_process_index}\n"
             f"Device: {self.device}\n"
-            f"Use FP16 precision: {use_fp16}\n"
+            f"Mixed precision type: {mixed_precision}\n"
         )
         if self.distributed_type == DistributedType.DEEPSPEED:
             repr += f"ds_config: {self.deepspeed_plugin.ds_config}\n"

--- a/src/accelerate/test_utils/test_script.py
+++ b/src/accelerate/test_utils/test_script.py
@@ -245,7 +245,49 @@ def training_check():
     accelerator.print("Training yielded the same results on one CPU or distributes setup with batch split.")
 
     # Mostly a test that FP16 doesn't crash as the operation inside the model is not converted to FP16
+    accelerator = Accelerator(mixed_precision="fp16")
+    train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
+    model = RegressionModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    train_dl, model, optimizer = accelerator.prepare(train_dl, model, optimizer)
+    set_seed(42)
+    generator.manual_seed(42)
+    for _ in range(3):
+        for batch in train_dl:
+            model.zero_grad()
+            output = model(batch["x"])
+            loss = torch.nn.functional.mse_loss(output, batch["y"])
+            accelerator.backward(loss)
+            optimizer.step()
+
+    model = accelerator.unwrap_model(model).cpu()
+    assert torch.allclose(old_model.a, model.a), "Did not obtain the same model on CPU or distributed training."
+    assert torch.allclose(old_model.b, model.b), "Did not obtain the same model on CPU or distributed training."
+
+    # TEST that previous fp16 flag still works
     accelerator = Accelerator(fp16=True)
+    train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
+    model = RegressionModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+    train_dl, model, optimizer = accelerator.prepare(train_dl, model, optimizer)
+    set_seed(42)
+    generator.manual_seed(42)
+    for _ in range(3):
+        for batch in train_dl:
+            model.zero_grad()
+            output = model(batch["x"])
+            loss = torch.nn.functional.mse_loss(output, batch["y"])
+            accelerator.backward(loss)
+            optimizer.step()
+
+    model = accelerator.unwrap_model(model).cpu()
+    assert torch.allclose(old_model.a, model.a), "Did not obtain the same model on CPU or distributed training."
+    assert torch.allclose(old_model.b, model.b), "Did not obtain the same model on CPU or distributed training."
+
+    # Mostly a test that BF16 doesn't crash as the operation inside the model is not converted to BF16
+    accelerator = Accelerator(mixed_precision="bf16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)

--- a/src/accelerate/test_utils/test_script.py
+++ b/src/accelerate/test_utils/test_script.py
@@ -245,6 +245,7 @@ def training_check():
     accelerator.print("Training yielded the same results on one CPU or distributes setup with batch split.")
 
     # Mostly a test that FP16 doesn't crash as the operation inside the model is not converted to FP16
+    print("FP16 training check.")
     accelerator = Accelerator(mixed_precision="fp16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -266,6 +267,7 @@ def training_check():
     assert torch.allclose(old_model.b, model.b), "Did not obtain the same model on CPU or distributed training."
 
     # TEST that previous fp16 flag still works
+    print("Legacy FP16 training check.")
     accelerator = Accelerator(fp16=True)
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -287,6 +289,7 @@ def training_check():
     assert torch.allclose(old_model.b, model.b), "Did not obtain the same model on CPU or distributed training."
 
     # Mostly a test that BF16 doesn't crash as the operation inside the model is not converted to BF16
+    print("BF16 training check.")
     accelerator = Accelerator(mixed_precision="bf16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()

--- a/src/accelerate/test_utils/training.py
+++ b/src/accelerate/test_utils/training.py
@@ -36,6 +36,10 @@ class RegressionModel(torch.nn.Module):
         super().__init__()
         self.a = torch.nn.Parameter(torch.tensor(a).float())
         self.b = torch.nn.Parameter(torch.tensor(b).float())
+        self.first_batch = True
 
     def forward(self, x=None):
+        if self.first_batch:
+            print(f"Model dtype: {self.a.dtype}, {self.b.dtype}. Input dtype: {x.dtype}")
+            self.first_batch = False
         return x * self.a + self.b

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -240,23 +240,23 @@ def initialize_tensors(data_structure):
 
 def convert_to_fp32(tensor):
     """
-    Recursively converts the elements nested list/tuple/dictionary of tensors in FP16 precision to FP32.
+    Recursively converts the elements nested list/tuple/dictionary of tensors in FP16/BF16 precision to FP32.
 
     Args:
         tensor (nested list/tuple/dictionary of :obj:`torch.Tensor`):
-            The data to convert from FP16 to FP32.
+            The data to convert from FP16/BF16 to FP32.
 
     Returns:
-        The same data structure as :obj:`tensor` with all tensors that were in FP16 precision converted to FP32.
+        The same data structure as :obj:`tensor` with all tensors that were in FP16/BF16 precision converted to FP32.
     """
 
     def _convert_to_fp32(tensor):
         return tensor.float()
 
-    def _is_fp16_tensor(tensor):
-        return hasattr(tensor, "dtype") and tensor.dtype == torch.float16
+    def _is_fp16_bf16_tensor(tensor):
+        return hasattr(tensor, "dtype") and (tensor.dtype == torch.float16 or tensor.dtype == torch.bfloat16)
 
-    return recursively_apply(_convert_to_fp32, tensor, test_type=_is_fp16_tensor)
+    return recursively_apply(_convert_to_fp32, tensor, test_type=_is_fp16_bf16_tensor)
 
 
 def convert_outputs_to_fp32(model_forward):


### PR DESCRIPTION
Implement bfloat16 support (#243). I added a new flag named "mixed precision" that can be "no" for FP32 training. "fp16" for FP16 training and "bf16" for bfloat16 training. This version of the code is compatible with previous scripts/config files using accelerate, the fp16 flag has the same behavior as before (Should the users be advice to use the new flag when they use the fp16 flag with a deprecation warning?)

I tested the code using a T5-large model. FP16 mixed precision results NaN loss, thanks to bfloat16 training using mixed precision is possible. 

![image](https://user-images.githubusercontent.com/18737249/152558952-d784bdb8-024d-45b4-bf07-083fde9e1f3b.png)



