### PR TITLE
Add in checkpointing capability

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -564,7 +564,7 @@ class Accelerator:
 
     def save_state(self, output_dir: str):
         """
-        Saves the current states of the model, optimizer, scaler, and RNG generators to `folder_name`.
+        Saves the current states of the model, optimizer, scaler, and RNG generators.
 
         Args:
             output_dir (:obj:`str` or :obj:`os.PathLike`):
@@ -579,7 +579,7 @@ class Accelerator:
 
     def load_state(self, input_dir: str):
         """
-        Loads the current states of the model, optimizer, scaler, and RNG generators from `folder_name`.
+        Loads the current states of the model, optimizer, scaler, and RNG generators.
 
         Args:
             input_dir (:obj:`str` or :obj:`os.PathLike`):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -583,7 +583,7 @@ class Accelerator:
         for i, model in enumerate(self._models):
             state = self.get_state_dict(model)
             weights_name = "pytorch_model"
-            if i == 0:
+            if i != 0:
                 weights_name += f"_{i}"
             weights_name += ".bin"
             output_model_file = os.path.join(output_dir, weights_name)
@@ -593,20 +593,20 @@ class Accelerator:
         for i, opt in enumerate(self._optimizers):
             state = opt.state_dict()
             optimizer_name = "optimizer"
-            if i == 0:
+            if i != 0:
                 optimizer_name += f"_{i}"
             optimizer_name += ".pt"
             output_optimizer_file = os.path.join(output_dir, optimizer_name)
-            torch.save(state, output_optimizer_file)
+            accelerator.save(state, output_optimizer_file)
             logger.info(f"Optimizer state saved in {output_optimizer_file}")
         # GradScalar state
         if self.scaler is not None:
             state = self.scaler.state_dict()
-            scalar_name = "scaler.bin"
-            output_scalar_file = os.path.join(output_dir, scalar_name)
-            torch.save(state, output_scalar_file)
-            logger.info(f"GradScalar state saved in {output_scalar_file}")
-        # Random states
+            scaler_name = "scaler.pt"
+            output_scaler_file = os.path.join(output_dir, scaler_name)
+            torch.save(state, output_scaler_file)
+            logger.info(f"Gradient scaler state saved in {output_scaler_file}")
+        # Random number generator states
         states = {}
         states_name = "random_states.pkl"
         states["random_state"] = random.getstate()
@@ -637,7 +637,7 @@ class Accelerator:
         # Model states
         for i, model in enumerate(self._models):
             weights_name = "pytorch_model"
-            if i == 0:
+            if i != 0:
                 weights_name += f"_{i}"
             weights_name += ".bin"
             input_model_file = os.path.join(input_dir, weights_name)
@@ -646,7 +646,7 @@ class Accelerator:
         # Optimizer states
         for i, opt in enumerate(self._optimizers):
             optimizer_name = "optimizer"
-            if i == 0:
+            if i != 0:
                 optimizer_name += f"_{i}"
             optimizer_name += ".pt"
             input_optimizer_file = os.path.join(input_dir, optimizer_name)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -15,10 +15,7 @@
 import gc
 import os
 import random
-<<<<<<< HEAD
 import warnings
-=======
->>>>>>> 820d74f086b7ebbdeb991f19227929f72b99aab3
 from contextlib import contextmanager
 from typing import List, Optional, Union
 
@@ -603,15 +600,9 @@ class Accelerator:
             torch.save(state, output_optimizer_file)
             logger.info(f"Optimizer state saved in {output_optimizer_file}")
         # GradScalar state
-<<<<<<< HEAD
         if self.scaler is not None:
             state = self.scaler.state_dict()
             scalar_name = "scaler.bin"
-=======
-        if self.scalar is not None:
-            state = self.scalar.state_dict()
-            scalar_name = "scalar.bin"
->>>>>>> 820d74f086b7ebbdeb991f19227929f72b99aab3
             output_scalar_file = os.path.join(output_dir, scalar_name)
             torch.save(state, output_scalar_file)
             logger.info(f"GradScalar state saved in {output_scalar_file}")

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -645,7 +645,6 @@ class Accelerator:
         logger.info("All model weights loaded successfully")
         # Optimizer states
         for i, opt in enumerate(self._optimizers):
-            # state = opt.state_dict()
             optimizer_name = "optimizer"
             if i == 0:
                 optimizer_name += f"_{i}"

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -14,8 +14,8 @@
 
 import gc
 import os
-import warnings
 import random
+import warnings
 from contextlib import contextmanager
 from typing import List, Optional, Union
 
@@ -600,9 +600,9 @@ class Accelerator:
             torch.save(state, output_optimizer_file)
             logger.info(f"Optimizer state saved in {output_optimizer_file}")
         # GradScalar state
-        if self.scalar is not None:
-            state = self.scalar.state_dict()
-            scalar_name = "scalar.bin"
+        if self.scaler is not None:
+            state = self.scaler.state_dict()
+            scalar_name = "scaler.bin"
             output_scalar_file = os.path.join(output_dir, scalar_name)
             torch.save(state, output_scalar_file)
             logger.info(f"GradScalar state saved in {output_scalar_file}")
@@ -650,13 +650,13 @@ class Accelerator:
                 optimizer_name += f"_{i}"
             optimizer_name += ".pt"
             input_optimizer_file = os.path.join(input_dir, optimizer_name)
-            self._optimizers.load_state_dict(torch.load(input_optimizer_file))
+            self._optimizers[i].load_state_dict(torch.load(input_optimizer_file))
         logger.info("All optimizer states loaded successfully")
         # GradScalar state
-        if self.scalar is not None:
-            scalar_name = "scalar.bin"
-            input_scalar_file = os.path.join(input_dir, scalar_name)
-            self.scalar.load_state_dict(torch.load(input_scalar_file))
+        if self.scaler is not None:
+            scaler_name = "scaler.bin"
+            input_scaler_file = os.path.join(input_dir, scaler_name)
+            self.scaler.load_state_dict(torch.load(input_scaler_file))
             logger.info("GradScalar state loaded successfully")
         # Random states
         states = torch.load(os.path.join(input_dir, "random_states.pkl"))

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -62,7 +62,7 @@ def save_accelerator_state(
         state = opt.state_dict()
         optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
         output_optimizer_file = os.path.join(output_dir, optimizer_name)
-        torch.save(state, output_optimizer_file)
+        save(state, output_optimizer_file)
         logger.info(f"Optimizer state saved in {output_optimizer_file}")
     # GradScaler state
     if scaler is not None:

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -1,0 +1,79 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import random
+
+import numpy as np
+import torch
+
+from .state import is_tpu_available
+from .utils import MODEL_NAME, OPTIMIZER_NAME, RNG_STATE_NAME, SCALAR_NAME, save
+
+
+if is_tpu_available():
+    import torch_xla.core.xla_model as xm
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def save_accelerator_state(model_states, optimizers, process_index, scalar=None, output_dir="."):
+    """
+    Saves the current states of the `models`, `optimizers`, scalar, and RNG generators to `output_dir`.
+
+    Args:
+        model_states (:obj:`list`):
+            A list of model state dicts received from `Accelerator().get_state_dict`
+        output_dir (:obj:`str` or :obj:`os.PathLike`):
+            The name of the folder to save all relevant weights and states.
+    """
+    # Model states
+    for i, state in enumerate(model_states):
+        weights_name = f"{MODEL_NAME}.bin" if i == 0 else f"{MODEL_NAME}_{i}.bin"
+        output_model_file = os.path.join(output_dir, weights_name)
+        save(state, output_model_file)
+        logger.info(f"Model weights saved in {output_model_file}")
+    # Optimizer states
+    for i, opt in enumerate(optimizers):
+        state = opt.state_dict()
+        optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
+        output_optimizer_file = os.path.join(output_dir, optimizer_name)
+        torch.save(state, output_optimizer_file)
+        logger.info(f"Optimizer state saved in {output_optimizer_file}")
+    # GradScalar state
+    if scaler is not None:
+        state = scaler.state_dict()
+        output_scaler_file = os.path.join(output_dir, SCALAR_NAME)
+        torch.save(state, output_scaler_file)
+        logger.info(f"Gradient scaler state saved in {output_scaler_file}")
+    # Random number generator states
+    states = {}
+    states_name = f"{RNG_STATE_NAME}_{process_index}.pkl"
+    states["random_state"] = random.getstate()
+    states["numpy_random_seed"] = np.random.get_state()
+    states["torch_manual_seed"] = torch.get_rng_state()
+    states["torch_cuda_manual_seed"] = torch.cuda.get_rng_state()
+    # ^^ safe to call this function even if cuda is not available
+    if is_tpu_available():
+        states["xm_seed"] = torch.tensor(xm.get_rng_state())
+    output_states_file = os.path.join(output_dir, states_name)
+    torch.save(states, output_states_file)
+    logger.info(f"Random states saved in {output_states_file}")
+    return output_dir
+
+
+# def load_accelerator_state(models, optimizers, scalar, input_dir)

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -93,13 +93,13 @@ def load_accelerator_state(input_dir, models, optimizers, process_index, scaler=
     Args:
         input_dir (:obj:`str` or :obj:`os.PathLike`):
             The name of the folder to load all relevant weights and states.
-        model_stmodelsates (:obj:`list`):
+        model_stmodelsates (:obj:`List[torch.nn.Module]`):
             A list of model instances
-        optimizers (:obj:`list`):
+        optimizers (:obj:`List[torch.optim.Optimizer]`):
             A list of optimizer instances
         process_index (:obj:`int`):
             The current process index in the Accelerator state
-        scaler (:obj:`GradScaler`), Optional:
+        scaler (:obj:`torch.cuda.amp.GradScaler`, `optional`):
             An optional `GradScaler` instance to load
     """
     # Model states

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -76,8 +76,8 @@ def save_accelerator_state(
     states["random_state"] = random.getstate()
     states["numpy_random_seed"] = np.random.get_state()
     states["torch_manual_seed"] = torch.get_rng_state()
-    states["torch_cuda_manual_seed"] = torch.cuda.get_rng_state()
-    # ^^ safe to call this function even if cuda is not available
+    if torch.cuda.is_available():
+        states["torch_cuda_manual_seed"] = torch.cuda.get_rng_state()
     if is_tpu_available():
         states["xm_seed"] = torch.tensor(xm.get_rng_state())
     output_states_file = os.path.join(output_dir, states_name)
@@ -127,8 +127,8 @@ def load_accelerator_state(input_dir, models, optimizers, process_index, scaler=
     random.setstate(states["random_state"])
     np.random.set_state(states["numpy_random_seed"])
     torch.set_rng_state(states["torch_manual_seed"])
-    torch.cuda.set_rng_state(states["torch_cuda_manual_seed"])
-    # ^^ safe to call this function even if cuda is not available
+    if torch.cuda.is_available():
+        torch.cuda.set_rng_state(states["torch_cuda_manual_seed"])
     if is_tpu_available():
         xm.set_rng_state(states["xm_seed"])
     logger.info("All random states loaded successfully")

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -76,9 +76,8 @@ def save_accelerator_state(
     states["random_state"] = random.getstate()
     states["numpy_random_seed"] = np.random.get_state()
     states["torch_manual_seed"] = torch.get_rng_state()
-    if torch.cuda.is_available():
-        logger.info("Saving cuda state")
-        states["torch_cuda_manual_seed"] = torch.cuda.get_rng_state()
+    states["torch_cuda_manual_seed"] = torch.cuda.get_rng_state_all()
+    # ^^ safe to call this function even if cuda is not available
     if is_tpu_available():
         states["xm_seed"] = torch.tensor(xm.get_rng_state())
     output_states_file = os.path.join(output_dir, states_name)
@@ -128,9 +127,8 @@ def load_accelerator_state(input_dir, models, optimizers, process_index, scaler=
     random.setstate(states["random_state"])
     np.random.set_state(states["numpy_random_seed"])
     torch.set_rng_state(states["torch_manual_seed"])
-    if torch.cuda.is_available():
-        logger.info("Loading cuda state")
-        torch.cuda.set_rng_state(states["torch_cuda_manual_seed"])
+    torch.cuda.set_rng_state_all(states["torch_cuda_manual_seed"])
+    # ^^ safe to call this function even if cuda is not available
     if is_tpu_available():
         xm.set_rng_state(states["xm_seed"])
     logger.info("All random states loaded successfully")

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -1,4 +1,4 @@
-# Copyright 2021 The HuggingFace Team. All rights reserved.
+# Copyright 2022 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -37,19 +37,19 @@ def save_accelerator_state(
     output_dir: str, model_states: List[dict], optimizers: list, process_index: int, scaler: GradScaler = None
 ):
     """
-    Saves the current states of the `models`, `optimizers`, scaler, and RNG generators to `output_dir`.
+    Saves the current states of the models, optimizers, scaler, and RNG generators to a given directory.
 
     Args:
         output_dir (:obj:`str` or :obj:`os.PathLike`):
             The name of the folder to save all relevant weights and states.
-        model_states (:obj:`list`):
+        model_states (:obj:`List[torch.nn.Module]`):
             A list of model states
-        optimizers (:obj:`list`):
+        optimizers (:obj:`List[torch.optim.Optimizer]`):
             A list of optimizer instances
         process_index (:obj:`int`):
             The current process index in the Accelerator state
-        scaler (:obj:`GradScaler`), Optional:
-            An optional `GradScaler` instance to save
+        scaler (:obj:`torch.cuda.amp.GradScaler`, `optional`):
+            An optional gradient scaler instance to save
     """
     # Model states
     for i, state in enumerate(model_states):
@@ -88,7 +88,7 @@ def save_accelerator_state(
 
 def load_accelerator_state(input_dir, models, optimizers, process_index, scaler=None):
     """
-    Loads states of the `models`, `optimizers`, scaler, and RNG generators from `input_dir`.
+    Loads states of the models, optimizers, scaler, and RNG generators from a given directory.
 
     Args:
         input_dir (:obj:`str` or :obj:`os.PathLike`):

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -77,6 +77,7 @@ def save_accelerator_state(
     states["numpy_random_seed"] = np.random.get_state()
     states["torch_manual_seed"] = torch.get_rng_state()
     if torch.cuda.is_available():
+        logger.info("Saving cuda state")
         states["torch_cuda_manual_seed"] = torch.cuda.get_rng_state()
     if is_tpu_available():
         states["xm_seed"] = torch.tensor(xm.get_rng_state())
@@ -128,6 +129,7 @@ def load_accelerator_state(input_dir, models, optimizers, process_index, scaler=
     np.random.set_state(states["numpy_random_seed"])
     torch.set_rng_state(states["torch_manual_seed"])
     if torch.cuda.is_available():
+        logger.info("Loading cuda state")
         torch.cuda.set_rng_state(states["torch_cuda_manual_seed"])
     if is_tpu_available():
         xm.set_rng_state(states["xm_seed"])

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -45,7 +45,7 @@ if is_deepspeed_available():
 
 SCALAR_NAME = "scalar.pt"
 MODEL_NAME = "pytorch_model.bin"
-RNG_STATE_NAME = "rng_state.pth"
+RNG_STATE_NAME = "random_states"
 OPTIMIZER_NAME = "optimizer.pt"
 
 

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -43,10 +43,10 @@ def is_sagemaker_available():
 if is_deepspeed_available():
     from deepspeed import DeepSpeedEngine
 
-SCALAR_NAME = "scalar.pt"
-MODEL_NAME = "pytorch_model.bin"
+SCALER_NAME = "scaler.pt"
+MODEL_NAME = "pytorch_model"
 RNG_STATE_NAME = "random_states"
-OPTIMIZER_NAME = "optimizer.pt"
+OPTIMIZER_NAME = "optimizer"
 
 
 class RNGType(Enum):

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -43,6 +43,11 @@ def is_sagemaker_available():
 if is_deepspeed_available():
     from deepspeed import DeepSpeedEngine
 
+SCALAR_NAME = "scalar.pt"
+MODEL_NAME = "pytorch_model.bin"
+RNG_STATE_NAME = "rng_state.pth"
+OPTIMIZER_NAME = "optimizer.pt"
+
 
 class RNGType(Enum):
     TORCH = "torch"

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -78,12 +78,15 @@ def test_can_resume_training(args):
                 accelerator.backward(loss)
                 optimizer.step()
                 optimizer.zero_grad()
-        (a1, b1) = model.a.item(), model.b.item()
+
+        model_unwrapped = accelerator.unwrap_model(model)
+        (a1, b1) = model_unwrapped.a.item(), model_unwrapped.b.item()
         opt_state1 = optimizer.state_dict()
 
         # Train partially
         accelerator.load_state(initial)
-        (a2, b2) = model.a.item(), model.b.item()
+        model_unwrapped = accelerator.unwrap_model(model)
+        (a2, b2) = model_unwrapped.a.item(), model_unwrapped.b.item()
         opt_state2 = optimizer.state_dict()
         assert a == a2
         assert b == b2
@@ -115,7 +118,8 @@ def test_can_resume_training(args):
                 accelerator.backward(loss)
                 optimizer.step()
                 optimizer.zero_grad()
-        (a3, b3) = model.a.item(), model.b.item()
+        model_unwrapped = accelerator.unwrap_model(model)
+        (a3, b3) = model_unwrapped.a.item(), model_unwrapped.b.item()
         opt_state3 = optimizer.state_dict()
         assert a1 == a3
         assert b1 == b3

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import os
 import random
 import tempfile
@@ -77,7 +76,7 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision, device_placement=True)
+            accelerator = Accelerator()
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -122,23 +121,3 @@ class CheckpointTest(unittest.TestCase):
             self.assertEqual(b1, b3)
             self.assertEqual(opt_state1, opt_state3)
             self.assertEqual(ground_truth_rands, test_rands)
-
-
-def main():
-    parser = argparse.ArgumentParser(description="Simple example of training script.")
-    parser.add_argument(
-        "--mixed_precision",
-        type=str,
-        default="no",
-        choices=["no", "fp16", "bf16"],
-        help="Whether to use mixed precision. Choose"
-        "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
-        "and an Nvidia Ampere GPU.",
-    )
-    parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
-    args = parser.parse_args()
-    CheckpointTest().test_can_resume_training(args)
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -94,7 +94,9 @@ class CheckpointTest(unittest.TestCase):
 
             # Train partially
             ground_truth_rands = train(3, model, train_dataloader, optimizer, accelerator)
-            rand_a = [random.getstate(), np.random.get_state(), torch.get_rng_state(), torch.cuda.get_rng_state()]
+            rand_a = [random.getstate(), np.random.get_state(), torch.get_rng_state()]
+            if torch.cuda.is_available:
+                rand_a += [torch.cuda.get_rng_state()]
             model_unwrapped = accelerator.unwrap_model(model)
             (a1, b1) = model_unwrapped.a.item(), model_unwrapped.b.item()
             opt_state1 = optimizer.state_dict()
@@ -121,7 +123,9 @@ class CheckpointTest(unittest.TestCase):
             # Load everything back in and make sure all states work
             accelerator.load_state(checkpoint)
             test_rands += train(1, model, train_dataloader, optimizer, accelerator)
-            rand_b = [random.getstate(), np.random.get_state(), torch.get_rng_state(), torch.cuda.get_rng_state()]
+            rand_b = [random.getstate(), np.random.get_state(), torch.get_rng_state()]
+            if torch.cuda.is_available:
+                rand_b += [torch.cuda.get_rng_state()]
             model_unwrapped = accelerator.unwrap_model(model)
             (a3, b3) = model_unwrapped.a.item(), model_unwrapped.b.item()
             opt_state3 = optimizer.state_dict()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -69,7 +69,7 @@ class DummyModel(nn.Module):
 
 
 class CheckpointTest(unittest.TestCase):
-    def test_can_resume_training(self, args):
+    def test_can_resume_training(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             set_seed(42)
             model = DummyModel()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -95,7 +95,7 @@ class CheckpointTest(unittest.TestCase):
             # Train partially
             ground_truth_rands = train(3, model, train_dataloader, optimizer, accelerator)
             rand_a = [random.getstate(), np.random.get_state(), torch.get_rng_state()]
-            if torch.cuda.is_available:
+            if torch.cuda.is_available():
                 rand_a += [torch.cuda.get_rng_state()]
             model_unwrapped = accelerator.unwrap_model(model)
             (a1, b1) = model_unwrapped.a.item(), model_unwrapped.b.item()
@@ -124,7 +124,7 @@ class CheckpointTest(unittest.TestCase):
             accelerator.load_state(checkpoint)
             test_rands += train(1, model, train_dataloader, optimizer, accelerator)
             rand_b = [random.getstate(), np.random.get_state(), torch.get_rng_state()]
-            if torch.cuda.is_available:
+            if torch.cuda.is_available():
                 rand_b += [torch.cuda.get_rng_state()]
             model_unwrapped = accelerator.unwrap_model(model)
             (a3, b3) = model_unwrapped.a.item(), model_unwrapped.b.item()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -14,6 +14,7 @@
 
 import argparse
 import os
+import random
 import tempfile
 
 import torch

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -1,0 +1,135 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import random
+import unittest
+import tempfile
+import argparse
+
+from accelerate import Accelerator
+
+from torch.utils.data import DataLoader, TensorDataset
+from torch import nn
+import torch
+
+from accelerate.utils import set_seed
+
+
+def dummy_dataloaders(a=2, b=3, batch_size=16, n_train_batches:int=10, n_valid_batches:int=2):
+    "Generates a tuple of dummy DataLoaders to test with"
+    def get_dataset(n_batches):
+        x = torch.randn(batch_size*n_batches, 1)
+        return TensorDataset(x, a*x + b + 0.1*torch.randn(batch_size*n_batches, 1))
+    train_dataset = get_dataset(n_train_batches)
+    valid_dataset = get_dataset(n_valid_batches)
+    train_dataloader = DataLoader(train_dataset, shuffle=True, batch_size=batch_size, num_workers=4)
+    valid_dataloader = DataLoader(valid_dataset, shuffle=False, batch_size=batch_size, num_workers=4)
+    return (train_dataloader, valid_dataloader)
+
+class DummyModel(nn.Module):
+    "Simple model to do y=mx+b"
+    def __init__(self):
+        super().__init__()
+        self.a = nn.Parameter(torch.randn(1))
+        self.b = nn.Parameter(torch.randn(1))
+    def forward(self, x):
+        return x * self.a + self.b
+
+def test_can_resume_training(args):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        set_seed(42)
+        model = DummyModel()
+        optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
+        train_dataloader, valid_dataloader = dummy_dataloaders()
+        # Train baseline
+        accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu, mixed_precision=args.mixed_precision, device_placement=True)
+        model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
+            model, optimizer, train_dataloader, valid_dataloader
+        )
+        for epoch in range(3):
+            # Train quickly
+            model.train()
+            for step, batch in enumerate(train_dataloader):
+                outputs = model(inputs)
+                loss = torch.nn.functional.mse_loss(outputs, batch)
+                accelerator.backward(loss)
+                optimizer.step()
+                optimizer.zero_grad()
+        (a,b) = model.a.item(), model.b.item()
+        opt_state = optimizer.state_dict()
+
+        # Train partially
+        set_seed(42)
+        accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu, mixed_precision=args.mixed_precision, device_placement=True)
+        model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
+            model, optimizer, train_dataloader, valid_dataloader
+        )
+        for epoch in range(2):
+            # Train quickly
+            model.train()
+            for step, batch in enumerate(train_dataloader):
+                outputs = model(inputs)
+                loss = torch.nn.functional.mse_loss(outputs, batch)
+                accelerator.backward(loss)
+                optimizer.step()
+                optimizer.zero_grad()
+        # Save everything
+        checkpoint = os.path.join(tmpdir, "checkpoint")
+        accelerator.save_state(checkpoint)
+
+        # Reinitalize model, optimizer, and DataLoaders
+        model = DummyModel()
+        optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
+        train_dataloader, valid_dataloader = dummy_dataloaders()
+        accelerator = Accelerator(fp16=args.fp16, cpu=args.cpu, mixed_precision=args.mixed_precision, device_placement=True)
+        model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
+            model, optimizer, train_dataloader, valid_dataloader
+        )
+
+        # Load everything back in and make sure all states work
+        accelerator.load_state(checkpoint)
+        for epoch in range(1):
+            # Train quickly
+            model.train()
+            for step, batch in enumerate(train_dataloader):
+                outputs = model(inputs)
+                loss = torch.nn.functional.mse_loss(outputs, batch)
+                accelerator.backward(loss)
+                optimizer.step()
+                optimizer.zero_grad()
+        (a1,b1) = model.a.item(), model.b.item()
+        opt_state1 = optimizer.state_dict()
+
+        assert a==a1
+        assert b==b1
+        assert opt_state==opt_state1
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple example of training script.")
+    parser.add_argument("--fp16", action="store_true", help="If passed, will use FP16 training.")
+    parser.add_argument(
+        "--mixed_precision",
+        type=str,
+        default="no",
+        choices=["no", "fp16", "bf16"],
+        help="Whether to use mixed precision. Choose"
+        "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
+        "and an Nvidia Ampere GPU.",
+    )
+    parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
+    args = parser.parse_args()
+    test_can_resume_training(args)
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -94,6 +94,14 @@ class CheckpointTest(unittest.TestCase):
             opt_state1 = optimizer.state_dict()
 
             # Train partially
+            set_seed(42)
+            model = DummyModel()
+            optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
+            train_dataloader, valid_dataloader = dummy_dataloaders()
+            accelerator = Accelerator()
+            model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
+                model, optimizer, train_dataloader, valid_dataloader
+            )
             accelerator.load_state(initial)
             (a2, b2) = model.a.item(), model.b.item()
             opt_state2 = optimizer.state_dict()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -79,7 +79,7 @@ def test_can_resume_training(args):
                 accelerator.backward(loss)
                 optimizer.step()
                 optimizer.zero_grad()
-
+            random.random()  # For each random num
         model_unwrapped = accelerator.unwrap_model(model)
         (a1, b1) = model_unwrapped.a.item(), model_unwrapped.b.item()
         opt_state1 = optimizer.state_dict()
@@ -92,6 +92,10 @@ def test_can_resume_training(args):
         assert a == a2
         assert b == b2
         assert opt_state == opt_state2
+        # Reset seeed
+        set_seed(42)
+        # Rebuild the dataloaders again here
+        # Ensure all numbers align
 
         for epoch in range(2):
             # Train quickly

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -89,7 +89,7 @@ class CheckpointTest(unittest.TestCase):
             accelerator.save_state(initial)
             (a, b) = model.a.item(), model.b.item()
             opt_state = optimizer.state_dict()
-            train(3, model, train_dataloader, optimizer, accelerator)
+            ground_truth_rands = train(3, model, train_dataloader, optimizer, accelerator)
             (a1, b1) = model.a.item(), model.b.item()
             opt_state1 = optimizer.state_dict()
 
@@ -101,16 +101,17 @@ class CheckpointTest(unittest.TestCase):
             self.assertEqual(b, b2)
             self.assertEqual(opt_state, opt_state2)
 
-            train(2, model, train_dataloader, optimizer, accelerator)
+            test_rands = train(2, model, train_dataloader, optimizer, accelerator)
             # Save everything
             checkpoint = os.path.join(tmpdir, "checkpoint")
             accelerator.save_state(checkpoint)
 
             # Load everything back in and make sure all states work
             accelerator.load_state(checkpoint)
-            train(1, model, train_dataloader, optimizer, accelerator)
+            test_rands += train(1, model, train_dataloader, optimizer, accelerator)
             (a3, b3) = model.a.item(), model.b.item()
             opt_state3 = optimizer.state_dict()
             self.assertEqual(a1, a3)
             self.assertEqual(b1, b3)
             self.assertEqual(opt_state1, opt_state3)
+            self.assertEqual(ground_truth_rands, test_rands)

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -88,7 +88,7 @@ class CheckpointTest(unittest.TestCase):
             (a, b) = model_unwrapped.a.item(), model_unwrapped.b.item()
             opt_state = optimizer.state_dict()
 
-            gt_rands = train(3, model, train_dataloader, optimizer, accelerator)
+            ground_truth_rands = train(3, model, train_dataloader, optimizer, accelerator)
 
             model_unwrapped = accelerator.unwrap_model(model)
             (a1, b1) = model_unwrapped.a.item(), model_unwrapped.b.item()
@@ -121,7 +121,7 @@ class CheckpointTest(unittest.TestCase):
             self.assertEqual(a1, a3)
             self.assertEqual(b1, b3)
             self.assertEqual(opt_state1, opt_state3)
-            self.assertEqual(gt_rands, test_rands)
+            self.assertEqual(ground_truth_rands, test_rands)
 
 
 def main():

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -66,7 +66,8 @@ def test_can_resume_training(args):
         # Save initial
         initial = os.path.join(tmpdir, "initial")
         accelerator.save_state(initial)
-        (a, b) = model.a.item(), model.b.item()
+        model_unwrapped = accelerator.unwrap_model(model)
+        (a, b) = model_unwrapped.a.item(), model_unwrapped.b.item()
         opt_state = optimizer.state_dict()
         for epoch in range(3):
             # Train quickly


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/171

This PR adds in two functions, `Accelerator.save_state` and `Accelerator.load_state`, which will go through and checkpoint the current state of everything accelerator touches.

I've included a testing script, but this needs to be properly turned into a test, as currently it is just a script with a bunch of asserts. I have tested successfully on:

- Single GPU
- Single CPU
- Multi-GPU