### PR TITLE
Add launch flags --module and --no_python (#256)

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -204,9 +204,9 @@ def multi_gpu_launcher(args):
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")
-    if args.module:
+    elif args.module:
         cmd.append("--module")
-    if args.no_python:
+    elif args.no_python:
         cmd.append("--no_python")
     cmd.append(args.training_script)
     cmd.extend(args.training_script_args)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -251,9 +251,9 @@ def deepspeed_launcher(args):
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")
-    if args.module:
+    elif args.module:
         cmd.append("--module")
-    if args.no_python:
+    elif args.no_python:
         cmd.append("--no_python")
     cmd.append(args.training_script)
     cmd.extend(args.training_script_args)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -356,7 +356,9 @@ def sagemaker_launcher(sagemaker_config: SageMakerConfig, args):
             "Please install sagemaker to be able to launch training on Amazon SageMaker with `pip install accelerate[sagemaker]`"
         )
     if args.module or args.no_python:
-        raise ValueError("SageMaker requires a python training script file and cannot be used with --module or --no_python")
+        raise ValueError(
+            "SageMaker requires a python training script file and cannot be used with --module or --no_python"
+        )
 
     from sagemaker.huggingface import HuggingFace
 


### PR DESCRIPTION
A few notes:

- I have tested the various configurations of `simple_launcher()` locally, but not the others.
- I did not add any pytest tests.
- There is a bit of repetition in the spots that check for when both flags are set together. This could be done in the sanity check section before a specific launcher is called, or it could be omitted entirely since the error would hopefully be obvious, but I thought the best solution was to just do it where the flags are used.
- I ran `black` but it changed a lot of unrelated code, so I undid that.
- It's kind of a niche feature so I didn't bother adding anything to the .rst docs.

I'm happy to take feedback on these notes or any other comments.