### PR TITLE
Don't use dispatch_batches when torch is < 1.8.0

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -166,6 +166,10 @@ class Accelerator:
         self.device_placement = device_placement
         self.split_batches = split_batches
         self.dispatch_batches = dispatch_batches
+        if dispatch_batches is True and version.parse(torch.__version__) < version.parse("1.8.0"):
+            raise ImportError(
+                "Using `DataLoaderDispatcher` requires PyTorch 1.8.0 minimum. You have {torch.__version__}."
+            )
 
         # Mixed precision attributes
         self.scaler = None


### PR DESCRIPTION
`torch.distributed` does not have `broadcast_object_list` until v1.8.0 and above, so we can't use the `DispatchDataLoader` for versions smaller than this. This PR adapts the defaults and raises proper ImportError.

This was reported on the [forums](https://discuss.huggingface.co/t/why-my-accelerate-just-doesnt-work/15409)