### PR TITLE
Make accelerated model with AMP possible to pickle

### DIFF
--- a/src/accelerate/test_utils/test_script.py
+++ b/src/accelerate/test_utils/test_script.py
@@ -270,11 +270,6 @@ def training_check():
     assert torch.allclose(old_model.a, model.a), "Did not obtain the same model on CPU or distributed training."
     assert torch.allclose(old_model.b, model.b), "Did not obtain the same model on CPU or distributed training."
 
-    try:
-        _ = pickle.dumps(model)
-    except AttributeError:
-        assert False, "Could not pickle model"
-
     # TEST that previous fp16 flag still works
     print("Legacy FP16 training check.")
     accelerator = Accelerator(fp16=True)

--- a/src/accelerate/test_utils/test_script.py
+++ b/src/accelerate/test_utils/test_script.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
-
 import torch
 from torch.utils.data import DataLoader
 

--- a/src/accelerate/test_utils/test_script.py
+++ b/src/accelerate/test_utils/test_script.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pickle
+
 import torch
 from torch.utils.data import DataLoader
 
@@ -267,6 +269,11 @@ def training_check():
     model = accelerator.unwrap_model(model).cpu()
     assert torch.allclose(old_model.a, model.a), "Did not obtain the same model on CPU or distributed training."
     assert torch.allclose(old_model.b, model.b), "Did not obtain the same model on CPU or distributed training."
+
+    try:
+        _ = pickle.dumps(model)
+    except AttributeError:
+        assert False, "Could not pickle model"
 
     # TEST that previous fp16 flag still works
     print("Legacy FP16 training check.")

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -288,6 +288,7 @@ class ConvertOutputsToFp32:
     Returns:
         The same function as :obj:`model_forward` but with converted outputs.
     """
+
     def __init__(self, model_forward):
         self.model_forward = model_forward
         update_wrapper(self, model_forward)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,12 +13,14 @@
 # limitations under the License.
 
 import os
+import pickle
 import unittest
 from collections import UserDict, namedtuple
 
 import torch
 
-from accelerate.utils import patch_environment, send_to_device
+from accelerate.test_utils.training import RegressionModel
+from accelerate.utils import convert_outputs_to_fp32, patch_environment, send_to_device
 
 
 TestNamedTuple = namedtuple("TestNamedTuple", "a b c")
@@ -71,3 +73,8 @@ class UtilsTester(unittest.TestCase):
 
         self.assertNotIn("AA", os.environ)
         self.assertNotIn("BB", os.environ)
+
+    def test_convert_to_32_lets_model_pickle(self):
+        model = RegressionModel()
+        model.forward = convert_outputs_to_fp32(model.forward)
+        _ = pickle.dumps(model)


### PR DESCRIPTION
Solves issue #273

## Description

As discussed in the issue, the solution is to use a class instead of a
closure to achieve the same result.

## Implementation

I created an alias `convert_outputs_to_fp32` = `ConvertOutputsToFp32` so
that importing `convert_outputs_to_fp32` can still be imported.

Alternatively, I could remove the alias and change import to use
`ConvertOutputsToFp32` directly, but this may break backwards
compatibility. Or I could name the class `convert_outputs_to_fp32` because
it acts like a function.

Regarding the testing, I added a check to `test_script.py` for the model
trained with `mixed_precision='fp16'`. Locally, this test could not trigger
the error in the issue because the forward method is never replaced. I
believe this is because `AcceleratorState` detects that my machine can't
perform fp16 training. I hope that in CI, this would be detected.