### PR TITLE
Pass along execution info to the exit of autocast

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -14,6 +14,7 @@
 
 import gc
 import os
+import sys
 import warnings
 from contextlib import contextmanager
 from typing import List, Optional, Union
@@ -705,7 +706,7 @@ class Accelerator:
 
             autocast_context.__enter__()
             yield
-            autocast_context.__exit__()
+            autocast_context.__exit__(*sys.exc_info())
         else:
             yield
 


### PR DESCRIPTION
This PR passes along the execution info expected by the `__exit__` of any context manager.
We were previously able to get around that because PyTorch had written the signature of thier autocast `__exit__` as `*args`, but they updated it to the normal `exc_type, exc_value, exc_tb` in v1.11.

Fixes #281