### PR TITLE
Load model and optimizet states on CPU to void OOMs

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -107,14 +107,14 @@ def load_accelerator_state(input_dir, models, optimizers, process_index, scaler=
     for i, model in enumerate(models):
         weights_name = f"{MODEL_NAME}.bin" if i == 0 else f"{MODEL_NAME}_{i}.bin"
         input_model_file = os.path.join(input_dir, weights_name)
-        models[i].load_state_dict(torch.load(input_model_file))
+        models[i].load_state_dict(torch.load(input_model_file, map_location="cpu"))
     logger.info("All model weights loaded successfully")
 
     # Optimizer states
     for i, opt in enumerate(optimizers):
         optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
         input_optimizer_file = os.path.join(input_dir, optimizer_name)
-        optimizers[i].load_state_dict(torch.load(input_optimizer_file))
+        optimizers[i].load_state_dict(torch.load(input_optimizer_file, map_location="cpu"))
     logger.info("All optimizer states loaded successfully")
 
     # GradScaler state


### PR DESCRIPTION
This PR makes sure we load the model and optimizer state dicts (in the `load_state` method) on the CPU. Otherwise, those might be tensors that are on GPU 0 (since `save_state` only saves on process 0), which may result in an OOM: at some point we may have the optimizer state properly loaded on GPU 0 (by process 0) but also loaded a second time in GPU 0 by process 1 during `load_state_dict`, so twice that size on poor GPU 0.