### PR TITLE
Leave default as None in `mixed_precision` for launch command

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -56,7 +56,6 @@ def launch_command_parser(subparsers=None):
     )
     parser.add_argument(
         "--mixed_precision",
-        default="no",
         type=str,
         choices=["no", "fp16", "bf16"],
         help="Whether or not to use mixed precision training. "


### PR DESCRIPTION
The default in `mixed_precision` for the launch command should be `None`, otherwise the config value is not used. Thanks @nbroad1881 for reporting the bug!