### PR TITLE
Create new TestCase classes and clean up W&B tests

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -30,7 +30,7 @@ from ..utils import gather, is_tensorflow_available
 
 class TempDirTestCase(unittest.TestCase):
     """
-    A TestCase class that keeps a single tmpdir open for the duration of the class, wipes its data at the start of a
+    A TestCase class that keeps a single `tempfile.TemporaryDirectory` open for the duration of the class, wipes its data at the start of a
     test, and then destroyes it at the end of the TestCase.
 
     Useful for when a class or API requires a single constant folder throughout it's use, such as Weights and Biases
@@ -40,7 +40,7 @@ class TempDirTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        "Creates a tmpdir and stores it in `cls.tmpdir`"
+        "Creates a `tempfile.TemporaryDirectory` and stores it in `cls.tmpdir`"
         cls.tmpdir = tempfile.mkdtemp()
 
     @classmethod
@@ -67,12 +67,19 @@ class MockingTestCase(unittest.TestCase):
     setting an environment variable with that information.
 
     The `add_mocks` function should be ran at the end of a `TestCase`'s `setUp` function, after a call to
-    `super().setUp()`
+    `super().setUp()` such as:
+    ```python
+    def setUp(self):
+        super().setUp()
+        mocks = mock.patch.dict(os.environ, {"SOME_ENV_VAR", "SOME_VALUE"})
+        self.add_mocks(mocks)
+    ```
     """
 
     def add_mocks(self, mocks: Union[mock.Mock, List[mock.Mock]]):
         """
-        Add custom mocks for tests that should persist. Should be run in setUp.
+        Add custom mocks for tests that should be repeated on each test. 
+        Should be called during `MockingTestCase.setUp`, after `super().setUp()`.
 
         Args:
             mocks (`mock.Mock` or list of `mock.Mock`):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -60,8 +60,8 @@ class TempDirTestCase(unittest.TestCase):
 
 class MockingTestCase(unittest.TestCase):
     """
-    A TestCase class designed to dynamically add various mockers that should be used in every test, mimicking the behavior
-    of a class-wide mock when defining one normally will not do.
+    A TestCase class designed to dynamically add various mockers that should be used in every test, mimicking the
+    behavior of a class-wide mock when defining one normally will not do.
 
     Useful when a mock requires specific information available only initialized after `TestCase.setUpClass`, such as
     setting an environment variable with that information.

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -30,8 +30,8 @@ from ..utils import gather, is_tensorflow_available
 
 class TempDirTestCase(unittest.TestCase):
     """
-    A TestCase class that keeps a single `tempfile.TemporaryDirectory` open for the duration of the class, wipes its data at the start of a
-    test, and then destroyes it at the end of the TestCase.
+    A TestCase class that keeps a single `tempfile.TemporaryDirectory` open for the duration of the class, wipes its
+    data at the start of a test, and then destroyes it at the end of the TestCase.
 
     Useful for when a class or API requires a single constant folder throughout it's use, such as Weights and Biases
 
@@ -78,8 +78,8 @@ class MockingTestCase(unittest.TestCase):
 
     def add_mocks(self, mocks: Union[mock.Mock, List[mock.Mock]]):
         """
-        Add custom mocks for tests that should be repeated on each test. 
-        Should be called during `MockingTestCase.setUp`, after `super().setUp()`.
+        Add custom mocks for tests that should be repeated on each test. Should be called during
+        `MockingTestCase.setUp`, after `super().setUp()`.
 
         Args:
             mocks (`mock.Mock` or list of `mock.Mock`):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -60,7 +60,7 @@ class TempDirTestCase(unittest.TestCase):
 
 class MockingTestCase(unittest.TestCase):
     """
-    A TestCase class designed to dynamically add various mockers that should be used in every test, mimicing a behavior
+    A TestCase class designed to dynamically add various mockers that should be used in every test, mimicking the behavior
     of a class-wide mock when defining one normally will not do.
 
     Useful when a mock requires specific information available only initialized after `TestCase.setUpClass`, such as

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -64,7 +64,7 @@ class MockingTestCase(unittest.TestCase):
     of a class-wide mock when defining one normally will not do.
 
     Useful when a mock requires specific information available only initialized after `TestCase.setUpClass`, such as
-    the creation of a `tmpdir`.
+    setting an environment variable with that information.
 
     The `add_mocks` function should be ran at the end of a `TestCase`'s `setUp` function, after a call to
     `super().setUp()`

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -124,7 +124,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         accelerator.init_trackers(project_name, config)
         accelerator.end_training()
         # The latest offline log is stored at wandb/latest-run/*.wandb
-        for child in Path(f"{os.environ['WANDB_DIR']}/wandb/latest-run").glob("*"):
+        for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
             logger.info(child)
             if child.is_file() and child.suffix == ".wandb":
                 with open(child, "rb") as f:
@@ -146,7 +146,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         accelerator.log(values, step=0)
         accelerator.end_training()
         # The latest offline log is stored at wandb/latest-run/*.wandb
-        for child in Path(f"{os.environ['WANDB_DIR']}/wandb/latest-run").glob("*"):
+        for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
             if child.is_file() and child.suffix == ".wandb":
                 with open(child, "rb") as f:
                     content = f.read()


### PR DESCRIPTION
Cleans up the tests in trackers to better utilize mocking, tmpdir's, and make wandb like us.

(It didn't like if we removed the original logging dir, but doesn't complain when we just wipe everything inside it and keep writing to it!)