### PR TITLE
Fix training in DeepSpeed

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -285,9 +285,9 @@ class Accelerator:
     def mixed_precision(self):
         if self.distributed_type == DistributedType.DEEPSPEED:
             config = self.state.deepspeed_plugin.deepspeed_config
-            if "fp16" in config and config["fp16"]["enabled"]:
+            if "fp16" in config and config["fp16"].get("enabled", False):
                 mixed_precision = "fp16"
-            elif "bf16" in config and config["bf16"]["enabled"]:
+            elif "bf16" in config and config["bf16"].get("enabled", False):
                 mixed_precision = "bf16"
             else:
                 mixed_precision = "no"

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -285,9 +285,9 @@ class Accelerator:
     def mixed_precision(self):
         if self.distributed_type == DistributedType.DEEPSPEED:
             config = self.state.deepspeed_plugin.deepspeed_config
-            if "fp16" in config and config["fp16"].get("enabled", False):
+            if config.get("fp16", {}).get("enabled", False):
                 mixed_precision = "fp16"
-            elif "bf16" in config and config["bf16"].get("enabled", False):
+            elif config.get("bf16", {}).get("enabled", False):
                 mixed_precision = "bf16"
             else:
                 mixed_precision = "no"

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -284,9 +284,10 @@ class Accelerator:
     @property
     def mixed_precision(self):
         if self.distributed_type == DistributedType.DEEPSPEED:
-            if self.state.deepspeed_plugin.deepspeed_config["fp16"]["enabled"]:
+            config = self.state.deepspeed_plugin.deepspeed_config
+            if "fp16" in config and config["fp16"]["enabled"]:
                 mixed_precision = "fp16"
-            elif self.state.deepspeed_plugin.deepspeed_config["bf16"]["enabled"]:
+            elif "bf16" in config and config["bf16"]["enabled"]:
                 mixed_precision = "bf16"
             else:
                 mixed_precision = "no"


### PR DESCRIPTION
When mixed precision is set to no or bf16 with DeepSpeed, everything fails in Accelerate becasue the deepspeed config as no "fp16" key. This PR fixes that.

Fixes #302 