### PR TITLE
Use --no_local_rank for DeepSpeed launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ mpirun -np 2 python examples/nlp_example.py
 
 ## Launching training using DeepSpeed
 
-🤗 Accelerate supports training on single/multiple GPUs using DeepSpeed. to use it, you don't need to change anything in your training code; you can set everything using just `accelerate config`. However, if you desire to tweak your DeepSpeed related args from your python script, we provide you the `DeepSpeedPlugin`.
+🤗 Accelerate supports training on single/multiple GPUs using DeepSpeed. To use it, you don't need to change anything in your training code; you can set everything using just `accelerate config`. However, if you desire to tweak your DeepSpeed related args from your python script, we provide you the `DeepSpeedPlugin`.
 
 ```python
 from accelerator import Accelerator, DeepSpeedPlugin

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -398,10 +398,6 @@ DeepSpeed support is experimental, so the underlying API will evolve in the near
 breaking changes. In particular, 🤗 Accelerate does not support DeepSpeed config you have written yourself yet, this
 will be added in a next version.
 
-One main caveat for the DeepSpeed integration is that the DeepSpeed launcher always passes a `local_rank` variable to
-the training script, so your training script should accept it (whether you launch training with the DeepSpeed launcher
-or `accelerate launch`).
-
 <Tip warning={true}>
 
 The [`notebook_launcher`] does not support the DeepSpeed integration yet.

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -233,7 +233,7 @@ def multi_gpu_launcher(args):
 
 
 def deepspeed_launcher(args):
-    cmd = ["deepspeed"]
+    cmd = ["deepspeed", "--no_local_rank"]
     if args.num_machines > 1:
         cmd.extend(
             [


### PR DESCRIPTION
This way a user doesn't have to add a `local_rank` argument in their script.