### PR TITLE
Fix Accelerate CLI CPU option + small fix for W&B tests

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -54,9 +54,10 @@ def get_cluster_input():
 
     if distributed_type == DistributedType.NO:
         use_cpu = _ask_field(
-            "Do you want to run your training on CPU only (even if a GPU is available)? [no]:",
-            lambda x: bool(x),
+            "Do you want to run your training on CPU only (even if a GPU is available)? [yes/NO]:",
+            _convert_yes_no_to_bool,
             default=False,
+            error_message="Please enter yes or no.",
         )
     elif distributed_type == DistributedType.MULTI_CPU:
         use_cpu = True

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -160,9 +160,9 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         # Check HPS through careful parsing and cleaning
         cleaned_log = re.sub(r"[\x00-\x1f]+", " ", content.decode("utf8", "ignore"))
         self.assertTrue("0.1" in self.get_value_from_log("total_loss", cleaned_log))
-        self.assertEqual("1" in self.get_value_from_log("iteration", cleaned_log))
-        self.assertEqual("some_value" in self.get_value_from_log("my_text", cleaned_log))
-        self.assertEqual("0" in self.get_value_from_log("_step", cleaned_log))
+        self.assertTrue("1" in self.get_value_from_log("iteration", cleaned_log))
+        self.assertTrue("some_value" in self.get_value_from_log("my_text", cleaned_log))
+        self.assertTrue("0" in self.get_value_from_log("_step", cleaned_log))
 
 
 # Comet has a special `OfflineExperiment` we need to use for testing

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -159,10 +159,10 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
                 break
         # Check HPS through careful parsing and cleaning
         cleaned_log = re.sub(r"[\x00-\x1f]+", " ", content.decode("utf8", "ignore"))
-        self.assertEqual(self.get_value_from_log("total_loss", cleaned_log), "0.1")
-        self.assertEqual(self.get_value_from_log("iteration", cleaned_log), "1")
-        self.assertEqual(self.get_value_from_log("my_text", cleaned_log), "some_value")
-        self.assertEqual(self.get_value_from_log("_step", cleaned_log), "0")
+        self.assertTrue("0.1" in self.get_value_from_log("total_loss", cleaned_log))
+        self.assertEqual("1" in self.get_value_from_log("iteration", cleaned_log))
+        self.assertEqual("some_value" in self.get_value_from_log("my_text", cleaned_log))
+        self.assertEqual("0" in self.get_value_from_log("_step", cleaned_log))
 
 
 # Comet has a special `OfflineExperiment` we need to use for testing


### PR DESCRIPTION
# Fix Accelerate CLI CPU option + Small W&B testfix

## What does this add?

- Change CPU param to use `convert_yes_no_to_bool` in the CLI Config
- Changes the logic for W&B `.log` tests to be `assertTrue` and "str" in `output`

## Why is this needed?

- Fixes an undocumented issue where the Accelerate Config CPU param expected a boolean argument, but it was phrased in a way where it seemed like yes/no could be passed in [forums post](https://discuss.huggingface.co/t/accelerate-on-1-gpu/16617)
- Noticed that the CI seemed to be slightly unstable with the W&B log parsing (unsurprising), so rather than a `self.assertEqual` I opted for a `self.assertTrue` and runs an `in` check, since we only care that the value itself is in the log, with potentially a little bit of noise