### PR TITLE
Fix DataLoader sharding for deepspeed in accelerate

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -440,7 +440,10 @@ class Accelerator:
             batch_size_per_device * deepspeed_plugin.gradient_accumulation_steps * self.num_processes
         )
 
-        result = [self._prepare_one(obj, first_pass=True) if isinstance(obj, torch.utils.data.DataLoader) else obj for obj in args]
+        result = [
+            self._prepare_one(obj, first_pass=True) if isinstance(obj, torch.utils.data.DataLoader) else obj
+            for obj in args
+        ]
 
         model = None
         optimizer = None

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -440,7 +440,7 @@ class Accelerator:
             batch_size_per_device * deepspeed_plugin.gradient_accumulation_steps * self.num_processes
         )
 
-        result = [self._prepare_one(obj) if isinstance(obj, torch.utils.data.DataLoader) else obj for obj in args]
+        result = [self._prepare_one(obj, first_pass=True) if isinstance(obj, torch.utils.data.DataLoader) else obj for obj in args]
 
         model = None
         optimizer = None


### PR DESCRIPTION
# Summary
I noticed that my training using the deepspeed integration in accelerate had some strange behavior, the number of iterations per epoch didn't go down as I increased number of GPUs. Also loss wasn't converging as expected.

After a bunch of debugging, I found that `_prepare_deepspeed(...)` doesn't appear to call `_prepare_one(...)` properly. It calls without setting `first_pass=True`, which means that `prepare_one(...)` skips wrapping the DataLoaders... defeating the whole point

# How I tested

I added logging to my training flow to print out `len(data_loader)` after `accelerator.prepare(...)` is called. 

I validated that with this fix, the length is divided by the number of processes, as expected.