### PR TITLE
Refactor Tracker logic and write guards for logging_dir

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -29,20 +29,17 @@ from .kwargs_handlers import DistributedDataParallelKwargs, GradScalerKwargs, In
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
 from .state import AcceleratorState, DistributedType, is_deepspeed_available
-from .tracking import CometMLTracker, GeneralTracker, TensorBoardTracker, WandBTracker, get_available_trackers
+from .tracking import GeneralTracker, get_available_trackers
 from .utils import (
+    LOGGER_TYPE_TO_CLASS,
     DeepSpeedPlugin,
     LoggerType,
-    LOGGER_TYPE_TO_CLASS,
     PrecisionType,
     RNGType,
     convert_outputs_to_fp32,
     extract_model_from_parallel,
     gather,
     get_pretty_name,
-    is_comet_ml_available,
-    is_tensorboard_available,
-    is_wandb_available,
     pad_across_processes,
     save,
     wait_for_everyone,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -29,9 +29,8 @@ from .kwargs_handlers import DistributedDataParallelKwargs, GradScalerKwargs, In
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
 from .state import AcceleratorState, DistributedType, is_deepspeed_available
-from .tracking import GeneralTracker, get_available_trackers
+from .tracking import LOGGER_TYPE_TO_CLASS, GeneralTracker, get_available_trackers
 from .utils import (
-    LOGGER_TYPE_TO_CLASS,
     DeepSpeedPlugin,
     LoggerType,
     PrecisionType,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -154,11 +154,18 @@ class Accelerator:
                         log_type = LoggerType(log_type)
                         if log_type not in loggers:
                             if log_type in get_available_trackers():
+                                tracker_init = LOGGER_TYPE_TO_CLASS[str(log_type)]
+                                if getattr(tracker_init, "requires_logging_directory"):
+                                    if logging_dir is None:
+                                        raise ValueError(
+                                            f"Logging with `{str(log_type)}` requires a `logging_dir` to be passed in."
+                                        )
                                 loggers.append(log_type)
                             else:
                                 logger.info(
                                     f"Tried adding logger {log_type}, but package is unavailable in the system."
                                 )
+
         self.log_with = loggers
         self.logging_dir = logging_dir
 
@@ -650,12 +657,8 @@ class Accelerator:
             else:
                 tracker_init = LOGGER_TYPE_TO_CLASS[str(tracker)]
                 if getattr(tracker_init, "requires_logging_directory"):
-                    if self.logging_dir is None:
-                        raise ValueError(
-                            f"Logging with `{str(tracker)}` requires a `logging_dir` to be passed into `Accelerator.__init__`. Please reinstantiate Accelerator with one, or assign a value to `self.logging_dir`"
-                        )
-                    else:
-                        self.trackers.append(tracker_init(project_name, self.logging_dir))
+                    # We can skip this check since it was done in `__init__`
+                    self.trackers.append(tracker_init(project_name, self.logging_dir))
                 else:
                     self.trackers.append(tracker_init(project_name))
         if config is not None:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -129,7 +129,7 @@ class Accelerator:
         deepspeed_plugin: DeepSpeedPlugin = None,
         rng_types: Optional[List[Union[str, RNGType]]] = None,
         log_with: Optional[List[Union[str, LoggerType, GeneralTracker]]] = None,
-        logging_dir: Optional[Union[str, os.PathLike]] = "",
+        logging_dir: Optional[Union[str, os.PathLike]] = None,
         dispatch_batches: Optional[bool] = None,
         step_scheduler_with_optimizer: bool = True,
         kwargs_handlers: Optional[List[KwargsHandler]] = None,

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -18,7 +18,7 @@
 import logging
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from .utils import LoggerType, is_comet_ml_available, is_tensorboard_available, is_wandb_available
 
@@ -266,3 +266,57 @@ class CometMLTracker(GeneralTracker):
 
 
 LOGGER_TYPE_TO_CLASS = {"tensorboard": TensorBoardTracker, "wandb": WandBTracker, "comet_ml": CometMLTracker}
+
+
+def filter_trackers(
+    log_with: List[Union[str, LoggerType, GeneralTracker]], logging_dir: Union[str, os.PathLike] = None
+):
+    """
+    Takes in a list of potential tracker types and checks that:
+        - The tracker wanted is available in that environment
+        - Filters out repeats of tracker types
+        - If `all` is in `log_with`, will return all trackers in the environment
+        - If a tracker requires a `logging_dir`, ensures that `logging_dir` is not `None`
+
+    Args:
+        log_with (list of `str`, [`~utils.LoggerType`] or [`~tracking.GeneralTracker`], *optional*):
+            A list of loggers to be setup for experiment tracking. Should be one or several of:
+
+            - `"all"`
+            - `"tensorboard"`
+            - `"wandb"`
+            - `"comet_ml"`
+            If `"all`" is selected, will pick up all available trackers in the environment and intialize them. Can also
+            accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
+        logging_dir (`str`, `os.PathLike`, *optional*):
+            A path to a directory for storing logs of locally-compatible loggers.
+    """
+    if log_with is not None:
+        if not isinstance(log_with, (list, tuple)):
+            log_with = [log_with]
+            logger.debug(f"{log_with}")
+        if "all" in log_with or LoggerType.ALL in log_with:
+            loggers = [o for o in log_with if issubclass(type(o), GeneralTracker)] + get_available_trackers()
+        else:
+            for log_type in log_with:
+                if log_type not in LoggerType and not issubclass(type(log_type), GeneralTracker):
+                    raise ValueError(f"Unsupported logging capability: {log_type}. Choose between {LoggerType.list()}")
+                if issubclass(type(log_type), GeneralTracker):
+                    loggers.append(log_type)
+                else:
+                    log_type = LoggerType(log_type)
+                    if log_type not in loggers:
+                        if log_type in get_available_trackers():
+                            tracker_init = LOGGER_TYPE_TO_CLASS[str(log_type)]
+                            if getattr(tracker_init, "requires_logging_directory"):
+                                if logging_dir is None:
+                                    raise ValueError(
+                                        f"Logging with `{str(log_type)}` requires a `logging_dir` to be passed in."
+                                    )
+                            loggers.append(log_type)
+                        else:
+                            logger.info(f"Tried adding logger {log_type}, but package is unavailable in the system.")
+    else:
+        loggers = []
+
+    return loggers

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -17,7 +17,7 @@
 
 import logging
 import os
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import Optional, Union
 
 from .utils import LoggerType, is_comet_ml_available, is_tensorboard_available, is_wandb_available
@@ -53,6 +53,17 @@ class GeneralTracker(object, metaclass=ABCMeta):
     """
     A base Tracker class to be used for all logging integration implementations.
     """
+
+    @abstractproperty
+    def requires_logging_directory(self):
+        """
+        Whether the logger requires a directory to store their logs. Should either return
+        `True` or `False`.
+        The default behavior is `False`
+        """
+        return False
+
+
 
     @abstractmethod
     def store_init_configuration(self, values: dict):
@@ -99,8 +110,9 @@ class TensorBoardTracker(GeneralTracker):
         logging_dir (`str`, `os.PathLike`):
             Location for TensorBoard logs to be stored.
     """
+    requires_logging_directory = True
 
-    def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ""):
+    def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]]):
         self.run_name = run_name
         self.logging_dir = os.path.join(logging_dir, run_name)
         self.writer = tensorboard.SummaryWriter(self.logging_dir)
@@ -156,6 +168,7 @@ class WandBTracker(GeneralTracker):
         run_name (`str`):
             The name of the experiment run.
     """
+    requires_logging_directory = False
 
     def __init__(self, run_name: str):
         self.run_name = run_name
@@ -208,6 +221,7 @@ class CometMLTracker(GeneralTracker):
         run_name (`str`):
             The name of the experiment run.
     """
+    requires_logging_directory = False
 
     def __init__(self, run_name: str):
         self.run_name = run_name

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -291,6 +291,7 @@ def filter_trackers(
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.
     """
+    loggers = []
     if log_with is not None:
         if not isinstance(log_with, (list, tuple)):
             log_with = [log_with]
@@ -316,7 +317,5 @@ def filter_trackers(
                             loggers.append(log_type)
                         else:
                             logger.info(f"Tried adding logger {log_type}, but package is unavailable in the system.")
-    else:
-        loggers = []
 
     return loggers

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -57,13 +57,10 @@ class GeneralTracker(object, metaclass=ABCMeta):
     @abstractproperty
     def requires_logging_directory(self):
         """
-        Whether the logger requires a directory to store their logs. Should either return
-        `True` or `False`.
-        The default behavior is `False`
+        Whether the logger requires a directory to store their logs. Should either return `True` or `False`. The
+        default behavior is `False`
         """
         return False
-
-
 
     @abstractmethod
     def store_init_configuration(self, values: dict):
@@ -110,6 +107,7 @@ class TensorBoardTracker(GeneralTracker):
         logging_dir (`str`, `os.PathLike`):
             Location for TensorBoard logs to be stored.
     """
+
     requires_logging_directory = True
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]]):
@@ -168,6 +166,7 @@ class WandBTracker(GeneralTracker):
         run_name (`str`):
             The name of the experiment run.
     """
+
     requires_logging_directory = False
 
     def __init__(self, run_name: str):
@@ -221,6 +220,7 @@ class CometMLTracker(GeneralTracker):
         run_name (`str`):
             The name of the experiment run.
     """
+
     requires_logging_directory = False
 
     def __init__(self, run_name: str):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -60,7 +60,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         Whether the logger requires a directory to store their logs. Should either return `True` or `False`. The
         default behavior is `False`
         """
-        return False
+        pass
 
     @abstractmethod
     def store_init_configuration(self, values: dict):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -57,8 +57,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
     @abstractproperty
     def requires_logging_directory(self):
         """
-        Whether the logger requires a directory to store their logs. Should either return `True` or `False`. The
-        default behavior is `False`
+        Whether the logger requires a directory to store their logs. Should either return `True` or `False`.
         """
         pass
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -264,3 +264,6 @@ class CometMLTracker(GeneralTracker):
         """
         self.writer.end()
         logger.info("CometML run closed")
+
+
+LOGGER_TYPE_TO_CLASS = {"tensorboard": TensorBoardTracker, "wandb": WandBTracker, "comet_ml": CometMLTracker}

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -98,11 +98,8 @@ class LoggerType(BaseEnum):
     WANDB = "wandb"
     COMETML = "comet_ml"
 
-LOGGER_TYPE_TO_CLASS = {
-    "tensorboard":TensorBoardTracker,
-    "wandb":WandBTracker,
-    "comet_ml":CometMLTracker
-}
+
+LOGGER_TYPE_TO_CLASS = {"tensorboard": TensorBoardTracker, "wandb": WandBTracker, "comet_ml": CometMLTracker}
 
 
 class PrecisionType(BaseEnum):

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -28,7 +28,6 @@ import torch
 from packaging import version
 
 from .state import AcceleratorState, DistributedType, is_deepspeed_available, is_tpu_available
-from .tracking import CometMLTracker, TensorBoardTracker, WandBTracker
 
 
 if is_tpu_available():
@@ -97,9 +96,6 @@ class LoggerType(BaseEnum):
     TENSORBOARD = "tensorboard"
     WANDB = "wandb"
     COMETML = "comet_ml"
-
-
-LOGGER_TYPE_TO_CLASS = {"tensorboard": TensorBoardTracker, "wandb": WandBTracker, "comet_ml": CometMLTracker}
 
 
 class PrecisionType(BaseEnum):

--- a/src/accelerate/utils.py
+++ b/src/accelerate/utils.py
@@ -28,6 +28,7 @@ import torch
 from packaging import version
 
 from .state import AcceleratorState, DistributedType, is_deepspeed_available, is_tpu_available
+from .tracking import CometMLTracker, TensorBoardTracker, WandBTracker
 
 
 if is_tpu_available():
@@ -96,6 +97,12 @@ class LoggerType(BaseEnum):
     TENSORBOARD = "tensorboard"
     WANDB = "wandb"
     COMETML = "comet_ml"
+
+LOGGER_TYPE_TO_CLASS = {
+    "tensorboard":TensorBoardTracker,
+    "wandb":WandBTracker,
+    "comet_ml":CometMLTracker
+}
 
 
 class PrecisionType(BaseEnum):

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -243,6 +243,8 @@ class MyCustomTracker(GeneralTracker):
         "some_string",
     ]
 
+    requires_logging_directory = False
+
     def __init__(self, dir: str):
         self.f = open(f"{dir}/log.csv", "w+")
         self.writer = csv.DictWriter(self.f, fieldnames=self._col_names)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -103,6 +103,12 @@ class TensorBoardTrackingTest(unittest.TestCase):
         self.assertEqual(iteration, values["iteration"])
         self.assertEqual(my_text, values["my_text"])
 
+    def test_logging_dir(self):
+        with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `logging_dir`"):
+            _ = Accelerator(log_with="tensorboard")
+        with tempfile.TemporaryDirectory() as dirpath:
+            _ = Accelerator(log_with="tensorboard", logging_dir=dirpath)
+
 
 @mock.patch.dict(os.environ, {"WANDB_MODE": "offline"})
 class WandBTrackingTest(TempDirTestCase, MockingTestCase):


### PR DESCRIPTION
# Refactor `logging_dir` logic and make better guards for trackers that need one

## What does this add?

This PR refactors much of the logic when it comes to how Trackers are initialized and checked inside of `Accelerate`

## Who is it for?

- Users of Accelerate who want to use W&B, TensorBoard, etc and want clear errors as to what went wrong

## Why is it needed?

I noticed that users were finding it confusing as to why a `logging_dir` must always be passed in when using `"all"`, and this was because of `TensorBoard` requiring a logging directory.

On top of this, the current logic to check if a tracker can be added is a heap of spaghetti code that isn't maintainable. 

## What parts of the API does this impact?

### User-facing:

When users forget to pass in a `logging_dir` to `Accelerate.__init__` and a particular tracker needs them, an error is now raised stating:
```
Logging with `TensorBoardTracker` requires a `logging_dir` to be passed in.
```

### Internal structure:

Each `GeneralTracker` implementation now requires that the `requires_logging_directory` be set, as this is a foundational method for checking whether `logging_dir` should be passed. As a result this is an abstract property, not a default (as the user should know explicitly).

There also now exists a `LOGGER_TYPE_TO_CLASS` dictionary to severely reduce the boilerplate code needed in `Accelerator.init_trackers` when it comes to checking if a logging_dir argument is needed