### PR TITLE
Create alias for Accelerator.free_memory

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -725,6 +725,13 @@ class Accelerator:
         gc.collect()
         torch.cuda.empty_cache()
 
+    def clear(self):
+        """
+        Alias for `Accelerate.free_memory`, releases all references to the internal objects stored and call the garbage
+        collector. You should call this method between two trainings with different models/optimizers.
+        """
+        self.free_memory()
+
     def _get_named_parameters(self, *args):
         named_parameters = {}
         for obj in args:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -727,8 +727,8 @@ class Accelerator:
 
     def clear(self):
         """
-        Alias for [`Accelerate.free_memory`], releases all references to the internal objects stored and call the garbage
-        collector. You should call this method between two trainings with different models/optimizers.
+        Alias for [`Accelerate.free_memory`], releases all references to the internal objects stored and call the
+        garbage collector. You should call this method between two trainings with different models/optimizers.
         """
         self.free_memory()
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -727,7 +727,7 @@ class Accelerator:
 
     def clear(self):
         """
-        Alias for `Accelerate.free_memory`, releases all references to the internal objects stored and call the garbage
+        Alias for [`Accelerate.free_memory`], releases all references to the internal objects stored and call the garbage
         collector. You should call this method between two trainings with different models/optimizers.
         """
         self.free_memory()


### PR DESCRIPTION
# Create alias for `Accelerator.free_memory`

## What does this add?

This PR introduces `Accelerator.clear`, an alias for `Accelerator.free_memory`. The reasoning for this addition is a user may be wanting to destroy all of the stored items in Accelerate, and they may instinctively search for a "clear" function.

They may dig for a bit until they see that `free_memory` is what they should call, so this pr helps to aid that workflow style and expectation.

(This PR is 100% opinionated ;) ) 