### PR TITLE
Fixup all checkpointing examples

### DIFF
--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -224,7 +224,6 @@ def training_function(config, args):
             if isinstance(checkpointing_steps, int):
                 output_dir = f"step_{overall_step}"
                 if overall_step % checkpointing_steps == 0:
-                    accelerator.print(f"Saving step_{overall_step}")
                     if args.output_dir is not None:
                         output_dir = os.path.join(args.output_dir, output_dir)
                     accelerator.save_state(output_dir)

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -166,6 +166,8 @@ def training_function(config, args):
     # New Code #
     # We need to keep track of how many total steps we have iterated over
     overall_step = 0
+    # We also need to keep track of the stating epoch so files are named properly
+    starting_epoch = 0
 
     # We need to load the checkpoint back in before training here with `load_state`
     # The total number of epochs is adjusted based on where the state is being loaded from,
@@ -184,23 +186,23 @@ def training_function(config, args):
         training_difference = os.path.splitext(path)[0]
 
         if "epoch" in training_difference:
-            num_epochs -= int(training_difference.replace("epoch_", ""))
+            starting_epoch = int(training_difference.replace("epoch_", "")) + 1
             resume_step = None
         else:
             resume_step = int(training_difference.replace("step_", ""))
-            num_epochs -= resume_step // len(train_dataloader)
-            # If resuming by step, we also need to know exactly how far into the DataLoader we went
-            resume_step = (num_epochs * len(train_dataloader)) - resume_step
+            starting_epoch = resume_step // len(train_dataloader)
+            resume_step -= starting_epoch * len(train_dataloader)
 
     # Now we train the model
-    for epoch in range(num_epochs):
+    for epoch in range(starting_epoch, num_epochs):
         model.train()
         for step, batch in enumerate(train_dataloader):
             # New Code #
             # We need to skip steps until we reach the resumed step during the first epoch
-            if args.resume_from_checkpoint and epoch == 0:
+            if args.resume_from_checkpoint and epoch == starting_epoch:
                 if resume_step is not None and step < resume_step:
-                    pass
+                    overall_step += 1
+                    continue
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
             outputs = model(**batch)
@@ -222,6 +224,7 @@ def training_function(config, args):
             if isinstance(checkpointing_steps, int):
                 output_dir = f"step_{overall_step}"
                 if overall_step % checkpointing_steps == 0:
+                    accelerator.print(f"Saving step_{overall_step}")
                     if args.output_dir is not None:
                         output_dir = os.path.join(args.output_dir, output_dir)
                     accelerator.save_state(output_dir)
@@ -246,7 +249,7 @@ def training_function(config, args):
 
         # New Code #
         # We save the model, optimizer, lr_scheduler, and seed states by calling `save_state`
-        # These are saved to folders named `step_{overall_step}`
+        # These are saved to folders named `epoch_{epoch}`
         # Will contain files: "pytorch_model.bin", "optimizer.bin", "scheduler.bin", and "random_states.pkl"
         # If mixed precision was used, will also save a "scalar.bin" file
         if checkpointing_steps == "epoch":

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -201,7 +201,7 @@ def training_function(config, args):
             resume_step -= starting_epoch * len(train_dataloader)
 
     # Now we train the model
-    for epoch in range(num_epochs):
+    for epoch in range(starting_epoch, num_epochs):
         model.train()
         if args.with_tracking:
             total_loss = 0

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -173,6 +173,10 @@ def training_function(config, args):
     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
         model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
     )
+    # We need to keep track of how many total steps we have iterated over
+    overall_step = 0
+    # We also need to keep track of the stating epoch so files are named properly
+    starting_epoch = 0
 
     # Potentially load in the weights and states from a previous save
     if args.resume_from_checkpoint:
@@ -189,15 +193,13 @@ def training_function(config, args):
         training_difference = os.path.splitext(path)[0]
 
         if "epoch" in training_difference:
-            num_epochs -= int(training_difference.replace("epoch_", ""))
+            starting_epoch = int(training_difference.replace("epoch_", "")) + 1
             resume_step = None
         else:
             resume_step = int(training_difference.replace("step_", ""))
-            num_epochs -= resume_step // len(train_dataloader)
-            # If resuming by step, we also need to know exactly how far into the DataLoader we went
-            resume_step = (num_epochs * len(train_dataloader)) - resume_step
+            starting_epoch = resume_step // len(train_dataloader)
+            resume_step -= starting_epoch * len(train_dataloader)
 
-    overall_step = 0
     # Now we train the model
     for epoch in range(num_epochs):
         model.train()
@@ -205,9 +207,10 @@ def training_function(config, args):
             total_loss = 0
         for step, batch in enumerate(train_dataloader):
             # We need to skip steps until we reach the resumed step
-            if args.resume_from_checkpoint and epoch == 0:
+            if args.resume_from_checkpoint and epoch == starting_epoch:
                 if resume_step is not None and step < resume_step:
-                    pass
+                    overall_step += 1
+                    continue
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch = {k: v.to(accelerator.device) for k, v in batch.items()}
             inputs = (batch["image"] - mean) / std

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -69,6 +69,8 @@ class TempDirTestCase(unittest.TestCase):
     The temporary directory location will be stored in `self.tmpdir`
     """
 
+    clear_on_setup = True
+
     @classmethod
     def setUpClass(cls):
         "Creates a `tempfile.TemporaryDirectory` and stores it in `cls.tmpdir`"
@@ -82,11 +84,12 @@ class TempDirTestCase(unittest.TestCase):
 
     def setUp(self):
         "Destroy all contents in `self.tmpdir`, but not `self.tmpdir`"
-        for path in Path(self.tmpdir).glob("**/*"):
-            if path.is_file():
-                path.unlink()
-            elif path.is_dir():
-                shutil.rmtree(path)
+        if self.clear_on_setup:
+            for path in Path(self.tmpdir).glob("**/*"):
+                if path.is_file():
+                    path.unlink()
+                elif path.is_dir():
+                    shutil.rmtree(path)
 
 
 class MockingTestCase(unittest.TestCase):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -192,10 +192,11 @@ class FeatureExamplesTests(TempDirTestCase):
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
             with mock.patch.object(sys, "argv", testargs):
                 checkpointing.main()
-            for call in mocked_print.mock_calls:
-                self.assertNotIn("epoch 0:", call.args)
-                self.assertNotIn("epoch 1:", call.args)
-            self.assertIn("epoch 2:", mocked_print.mock_calls[-1].args[0])
+            with self.assertRaises(AssertionError):
+                mocked_print.assert_any_call("epoch 0:", {"accuracy": 0.5, "f1": 0.0})
+            with self.assertRaises(AssertionError):
+                mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
+            mocked_print.assert_any_call("epoch 2:", {"accuracy": 0.5, "f1": 0.0})
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_steps(self):
@@ -206,10 +207,10 @@ class FeatureExamplesTests(TempDirTestCase):
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
             with mock.patch.object(sys, "argv", testargs):
                 checkpointing.main()
-            for call in mocked_print.mock_calls:
-                self.assertNotIn("epoch 0:", call.args)
-            self.assertIn("epoch 1:", mocked_print.mock_calls[-2].args[0])
-            self.assertIn("epoch 2:", mocked_print.mock_calls[-1].args[0])
+            with self.assertRaises(AssertionError):
+                mocked_print.assert_any_call("epoch 0:", {"accuracy": 0.5, "f1": 0.0})
+            mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
+            mocked_print.assert_any_call("epoch 2:", {"accuracy": 0.5, "f1": 0.0})
 
     @slow
     def test_cross_validation(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -181,7 +181,7 @@ class FeatureExamplesTests(TempDirTestCase):
         """.split()
         with mock.patch.object(sys, "argv", testargs):
             checkpointing.main()
-            self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
+            self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_8")))
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_epoch(self):
@@ -202,14 +202,15 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
+        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_8")}
         """.split()
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
             with mock.patch.object(sys, "argv", testargs):
                 checkpointing.main()
             with self.assertRaises(AssertionError):
                 mocked_print.assert_any_call("epoch 0:", {"accuracy": 0.5, "f1": 0.0})
-            mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
+            with self.assertRaises(AssertionError):
+                mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
             mocked_print.assert_any_call("epoch 2:", {"accuracy": 0.5, "f1": 0.0})
 
     @slow

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -189,14 +189,15 @@ class FeatureExamplesTests(TempDirTestCase):
         checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
+        dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
             with mock.patch.object(sys, "argv", testargs):
                 checkpointing.main()
             with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 0:", {"accuracy": 0.5, "f1": 0.0})
+                mocked_print.assert_any_call("epoch 0:", dummy_results)
             with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
-            mocked_print.assert_any_call("epoch 2:", {"accuracy": 0.5, "f1": 0.0})
+                mocked_print.assert_any_call("epoch 1:", dummy_results)
+            mocked_print.assert_any_call("epoch 2:", dummy_results)
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_steps(self):
@@ -204,13 +205,14 @@ class FeatureExamplesTests(TempDirTestCase):
         checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
+        dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
             with mock.patch.object(sys, "argv", testargs):
                 checkpointing.main()
             with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 0:", {"accuracy": 0.5, "f1": 0.0})
-            mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
-            mocked_print.assert_any_call("epoch 2:", {"accuracy": 0.5, "f1": 0.0})
+                mocked_print.assert_any_call("epoch 0:", dummy_results)
+            mocked_print.assert_any_call("epoch 1:", dummy_results)
+            mocked_print.assert_any_call("epoch 2:", dummy_results)
 
     @slow
     def test_cross_validation(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -181,7 +181,7 @@ class FeatureExamplesTests(TempDirTestCase):
         """.split()
         with mock.patch.object(sys, "argv", testargs):
             checkpointing.main()
-            self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_8")))
+            self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_epoch(self):
@@ -202,15 +202,14 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_8")}
+        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
             with mock.patch.object(sys, "argv", testargs):
                 checkpointing.main()
             with self.assertRaises(AssertionError):
                 mocked_print.assert_any_call("epoch 0:", {"accuracy": 0.5, "f1": 0.0})
-            with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
+            mocked_print.assert_any_call("epoch 1:", {"accuracy": 0.5, "f1": 0.0})
             mocked_print.assert_any_call("epoch 2:", {"accuracy": 0.5, "f1": 0.0})
 
     @slow

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -184,7 +184,7 @@ class FeatureExamplesTests(TempDirTestCase):
             self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
-    def test_load_states(self):
+    def test_load_states_by_epoch(self):
         testargs = f"""
         checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
@@ -197,6 +197,8 @@ class FeatureExamplesTests(TempDirTestCase):
                 self.assertNotIn("epoch 1:", call.args)
             self.assertIn("epoch 2:", mocked_print.mock_calls[-1].args[0])
 
+    @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
+    def test_load_states_by_steps(self):
         testargs = f"""
         checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}


### PR DESCRIPTION
# Fix logic in *all* checkpointing examples

## What does this add?

This PR fixes a number of bugs currently present in the save/load examples

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/322

## Why is it needed?

As I was exploring solving 322 and writing tests, I was noticing that some behaviors weren't *quite* behaving how I would have expected them to. 

It also didn't make logical sense to me that if we resume at epoch 1, the numbering starts at epoch 0 again (and thus, our checkpoint saves do as well!). So, that behavior had to change slightly.