### PR TITLE
Fix default config dicts

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -139,6 +139,14 @@ class ClusterConfig(BaseConfig):
     # args for fsdp
     fsdp_config: dict = None
 
+    def __post_init__(self):
+        if self.deepspeed_config is None:
+            self.deepspeed_config = {}
+        if self.fsdp_config is None:
+            self.fsdp_config = {}
+        return super().__post_init__()
+
+
 
 @dataclass
 class SageMakerConfig(BaseConfig):

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -147,7 +147,6 @@ class ClusterConfig(BaseConfig):
         return super().__post_init__()
 
 
-
 @dataclass
 class SageMakerConfig(BaseConfig):
     ec2_instance_type: str


### PR DESCRIPTION
If an existing config does not have anything on FSDP (as will be the case for most users since the future just went out) there is currently an error in the launcher that the config has a `None` `fsdp_config`. This PR takes care of this by making sure all dicts attributes of the config are initialized in the post_init.

cc @pacman100 for information.