### PR TITLE
Fix fdsp config in cluster

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -99,6 +99,7 @@ def get_cluster_input():
                 default=1,
             )
 
+    fsdp_config = None
     if distributed_type in [DistributedType.MULTI_GPU]:
         use_fsdp = _ask_field(
             "Do you want to use FullyShardedDataParallel? [yes/NO]: ",


### PR DESCRIPTION
`fsdp_config` doesn't have a default `None` value and will raise an issue if you aren't using `DistributedType.MULTI_GPU`

```python
Traceback (most recent call last):
  File "/opt/conda/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.8/site-packages/accelerate/commands/accelerate_cli.py", line 43, in main
    args.func(args)
  File "/opt/conda/lib/python3.8/site-packages/accelerate/commands/config/__init__.py", line 64, in config_command
    config = get_user_input()
  File "/opt/conda/lib/python3.8/site-packages/accelerate/commands/config/__init__.py", line 37, in get_user_input
    config = get_cluster_input()
  File "/opt/conda/lib/python3.8/site-packages/accelerate/commands/config/cluster.py", line 165, in get_cluster_input
    fsdp_config=fsdp_config,
UnboundLocalError: local variable 'fsdp_config' referenced before assignment
```