### PR TITLE
Add guards for batch size finder

### DIFF
--- a/src/accelerate/memory_utils.py
+++ b/src/accelerate/memory_utils.py
@@ -80,7 +80,6 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                     gc.collect()
                     torch.cuda.empty_cache()
                     batch_size //= 2
-                else:
-                    raise
-
+                    if batch_size == 0:
+                        raise RuntimeError("No executable batch size found, reached zero.")
     return decorator

--- a/src/accelerate/memory_utils.py
+++ b/src/accelerate/memory_utils.py
@@ -82,4 +82,5 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                     batch_size //= 2
                     if batch_size == 0:
                         raise RuntimeError("No executable batch size found, reached zero.")
+
     return decorator

--- a/src/accelerate/memory_utils.py
+++ b/src/accelerate/memory_utils.py
@@ -73,6 +73,8 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                 f"Remove this as the decorator already does so: `{function.__name__}({arg_str})`"
             )
         while True:
+            if batch_size == 0:
+                raise RuntimeError("No executable batch size found, reached zero.")
             try:
                 return function(batch_size, *args, **kwargs)
             except Exception as e:
@@ -80,7 +82,5 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                     gc.collect()
                     torch.cuda.empty_cache()
                     batch_size //= 2
-                    if batch_size == 0:
-                        raise RuntimeError("No executable batch size found, reached zero.")
 
     return decorator

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -59,6 +59,17 @@ class MemoryTest(unittest.TestCase):
             mock_training_loop_function()
             self.assertIn("No executable batch size found, reached zero.", cm.exception.args[0])
 
+    def test_approach_zero(self):
+        @find_executable_batch_size(starting_batch_size=16)
+        def mock_training_loop_function(batch_size):
+            if batch_size > 0:
+                raise_fake_out_of_memory()
+            pass
+
+        with self.assertRaises(RuntimeError) as cm:
+            mock_training_loop_function()
+            self.assertIn("No executable batch size found, reached zero.", cm.exception.args[0])
+
     def test_verbose_guard(self):
         @find_executable_batch_size(starting_batch_size=128)
         def mock_training_loop_function(batch_size, arg1, arg2):

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -50,7 +50,7 @@ class MemoryTest(unittest.TestCase):
         self.assertListEqual(batch_sizes, [128, 64, 32, 16, 8])
         self.assertListEqual([bs, arg1], [8, "hello"])
 
-    def test_zero(self):
+    def test_start_zero(self):
         @find_executable_batch_size(starting_batch_size=0)
         def mock_training_loop_function(batch_size):
             pass

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -50,6 +50,15 @@ class MemoryTest(unittest.TestCase):
         self.assertListEqual(batch_sizes, [128, 64, 32, 16, 8])
         self.assertListEqual([bs, arg1], [8, "hello"])
 
+    def test_zero(self):
+        @find_executable_batch_size(starting_batch_size=0)
+        def mock_training_loop_function(batch_size):
+            pass
+
+        with self.assertRaises(RuntimeError) as cm:
+            mock_training_loop_function()
+            self.assertIn("No executable batch size found, reached zero.", cm.exception.args[0])
+
     def test_verbose_guard(self):
         @find_executable_batch_size(starting_batch_size=128)
         def mock_training_loop_function(batch_size, arg1, arg2):


### PR DESCRIPTION
Makes sure that if zero is reached when finding the batch size, we raise an error stating no batch size will fit