### PR TITLE
Patchfix infinite loop in bs finder

### DIFF
--- a/src/accelerate/memory_utils.py
+++ b/src/accelerate/memory_utils.py
@@ -82,5 +82,7 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                     gc.collect()
                     torch.cuda.empty_cache()
                     batch_size //= 2
+                else:
+                    raise
 
     return decorator

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -80,3 +80,12 @@ class MemoryTest(unittest.TestCase):
             mock_training_loop_function(128, "hello", "world")
             self.assertIn("Batch size was passed into `f`", cm.exception.args[0])
             self.assertIn("`f(arg1='hello', arg2='world')", cm.exception.args[0])
+
+    def test_any_other_error(self):
+        @find_executable_batch_size(starting_batch_size=16)
+        def mock_training_loop_function(batch_size):
+            raise ValueError("Oops, we had an error!")
+
+        with self.assertRaises(ValueError) as cm:
+            mock_training_loop_function()
+            self.assertIn("Oops, we had an error!", cm.exception.args[0])


### PR DESCRIPTION
Raising any error if it doesn't relate to CUDA OOM was removed in https://github.com/huggingface/accelerate/pull/334, this adds it back. 

Otherwise this would result in an infinite loop constantly reducing a bs of 0