### PR TITLE
Introduce multiprocess logger

### DIFF
--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import logging
 import os
 
 import torch
@@ -28,9 +27,6 @@ from transformers import (
     get_linear_schedule_with_warmup,
     set_seed,
 )
-
-
-logger = logging.getLogger(__name__)
 
 
 ########################################################################

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -26,6 +26,7 @@ from packaging import version
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import prepare_data_loader
 from .kwargs_handlers import DistributedDataParallelKwargs, GradScalerKwargs, InitProcessGroupKwargs, KwargsHandler
+from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
 from .state import AcceleratorState, DistributedType, is_deepspeed_available
@@ -52,10 +53,7 @@ if is_deepspeed_available():
 
     from .deepspeed_utils import DeepSpeedEngineWrapper, DeepSpeedOptimizerWrapper
 
-import logging
-
-
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Accelerator:

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -28,11 +28,10 @@ from .utils import MODEL_NAME, OPTIMIZER_NAME, RNG_STATE_NAME, SCALER_NAME, SCHE
 if is_tpu_available():
     import torch_xla.core.xla_model as xm
 
-import logging
+from .logging import get_logger
 
 
-logger = logging.getLogger(__name__)
-
+logger = get_logger(__name__)
 
 def save_accelerator_state(
     output_dir: str,

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -33,6 +33,7 @@ from .logging import get_logger
 
 logger = get_logger(__name__)
 
+
 def save_accelerator_state(
     output_dir: str,
     model_states: List[dict],

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -32,7 +32,10 @@ class MultiProcessAdapter(logging.LoggerAdapter):
 
     def log(self, level, msg, *args, **kwargs):
         """
-        Delegates logger call after checking if we should log
+        Delegates logger call after checking if we should log.
+
+        Accepts a new kwarg of `main_process_only`, which will dictate whether it will be logged across all processes
+        or only the main executed one. Default is `True` if not passed
         """
         main_process_only = kwargs.pop("main_process_only", True)
         if self.isEnabledFor(level) and self._should_log(main_process_only):

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -31,7 +31,8 @@ class MultiProcessAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         main_process_only = kwargs.pop("main_process_only", True)
         if self._should_log(main_process_only):
-            return super().process(msg, kwargs)
+            kwargs["extra"] = self.extra
+            return msg, kwargs
 
 def get_logger(name:str):
     """

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -31,8 +31,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
         main_process_only = kwargs.pop("main_process_only", True)
         if self._should_log(main_process_only):
-            kwargs["extra"] = self.extra
-            return msg, kwargs
+            return super().process(msg, kwargs)
 
 def get_logger(name:str):
     """
@@ -52,4 +51,4 @@ def get_logger(name:str):
             The name for the logger, such as `__file__`
     """
     logger = logging.getLogger(name)
-    return MultiProcessAdapter(logger)
+    return MultiProcessAdapter(logger, {})

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -1,0 +1,54 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from .state import AcceleratorState
+
+class MultiProcessAdapter(logging.LoggerAdapter):
+    """
+    An adapter to assist with logging in multiprocess.
+
+    `log` takes in an additional `main_process_only` argument, which 
+    dictates whether it should be called on all processes or only the 
+    main executed one. By default it will.
+    """
+    @staticmethod
+    def _should_log(main_process_only):
+        "Check if log should be performed"
+        return not main_process_only or (main_process_only and AcceleratorState().local_process_index == 0)
+
+    def process(self, msg, kwargs):
+        main_process_only = kwargs.pop("main_process_only", True)
+        if self._should_log(main_process_only):
+            return super().process(msg, kwargs)
+
+def get_logger(name:str):
+    """
+    Returns a `logging.Logger` for `name` that can handle multiprocessing.
+
+    If a log should be called on all processes, pass `main_process_only=False`
+
+    E.g.
+    ```python
+    logger.info("My log", main_process_only=False)
+    logger.debug("My log", main_process_only=False)
+    ... 
+    ```
+
+    Args:
+        name (`str`):
+            The name for the logger, such as `__file__`
+    """
+    logger = logging.getLogger(name)
+    return MultiProcessAdapter(logger)

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -13,26 +13,18 @@
 # limitations under the License.
 
 import logging
-from sys import exc_info
+
 from .state import AcceleratorState
-
-old_factory = logging.getLogRecordFactory()
-
-def multiprocess_record_factory(context_id):
-    def record_factory(*args, **kwargs):
-        record = old_factory(*args, **kwargs)
-
-        record.main_process_only = not main_process_only or (main_process_only and AcceleratorState().local_process_index == 0)
 
 
 class MultiProcessAdapter(logging.LoggerAdapter):
     """
     An adapter to assist with logging in multiprocess.
 
-    `log` takes in an additional `main_process_only` kwarg, which 
-    dictates whether it should be called on all processes or only the 
-    main executed one. Default is `main_process_only=True`.
+    `log` takes in an additional `main_process_only` kwarg, which dictates whether it should be called on all processes
+    or only the main executed one. Default is `main_process_only=True`.
     """
+
     @staticmethod
     def _should_log(main_process_only):
         "Check if log should be performed"
@@ -47,7 +39,8 @@ class MultiProcessAdapter(logging.LoggerAdapter):
             msg, kwargs = self.process(msg, kwargs)
             self.logger.log(level, msg, *args, **kwargs)
 
-def get_logger(name:str):
+
+def get_logger(name: str):
     """
     Returns a `logging.Logger` for `name` that can handle multiprocessing.
 
@@ -57,7 +50,6 @@ def get_logger(name:str):
     ```python
     logger.info("My log", main_process_only=False)
     logger.debug("My log", main_process_only=False)
-    ... 
     ```
 
     Args:

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -32,6 +32,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         main_process_only = kwargs.pop("main_process_only", True)
         if self._should_log(main_process_only):
             return super().process(msg, kwargs)
+        return
 
 def get_logger(name:str):
     """

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -15,11 +15,11 @@
 # Expectation:
 # Provide a project dir name, then each type of logger gets stored in project/{`logging_dir`}
 
-import logging
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import List, Optional, Union
 
+from .logging import get_logger
 from .utils import LoggerType, is_comet_ml_available, is_tensorboard_available, is_wandb_available
 
 
@@ -41,7 +41,7 @@ if is_comet_ml_available():
     _available_trackers.append(LoggerType.COMETML)
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def get_available_trackers():

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -73,7 +73,6 @@ class DummyModel(nn.Module):
     def forward(self, x):
         return x * self.a + self.b
 
-
 class CheckpointTest(unittest.TestCase):
     def test_can_resume_training(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -73,6 +73,7 @@ class DummyModel(nn.Module):
     def forward(self, x):
         return x * self.a + self.b
 
+
 class CheckpointTest(unittest.TestCase):
     def test_can_resume_training(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
# Introduce Multi-Process aware Logger

## What does this add?

Adds a new `LoggerAdapter` and a `get_logger` helper to help aid with printing logs repeatedly when in multiprocess

## Why is it needed?

Users were reporting that the logs can confuse them with the actions actually occuring (such as logging multiple times a model was saved even though it only happened once).

Rather than an onslaught of if statements, this PR takes the simpler approach of creating an Adapter that will do the check for us. 

By default it will only log to the main processor, but if all processes should log just pass `main_process_only=False` (see examples below) 

## What parts of the API does this impact?

### User-facing:

Loggers in Accelerate now accept a `main_process_only` kwarg

## Basic Usage Example(s):

```python
from accelerate.logging import get_logger
logger = get_logger("my_logger")

# If we only want it called in the main process
logger.info("My message!")
# or
logger.info("My message!", main_process_only=True)

# If it should be called across all processes
logger.info("My message!", main_process_only=False)
```