### PR TITLE
Improve num_processes question in CLI

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -133,7 +133,7 @@ def get_cluster_input():
         main_training_function = "main"
 
     num_processes = _ask_field(
-        "How many devices should be used for (potentially) distributed training? [1:]",
+        "How many devices should be used for (potentially) distributed training? [1]:",
         lambda x: int(x),
         default=1,
         error_message="Please enter an integer.",

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -133,7 +133,7 @@ def get_cluster_input():
         main_training_function = "main"
 
     num_processes = _ask_field(
-        "How many processes in total will you use? [1]: ",
+        "How many devices should be used for (potentially) distributed training? [1:]",
         lambda x: int(x),
         default=1,
         error_message="Please enter an integer.",


### PR DESCRIPTION
# Improve the phrasing of asking the number of processes to be used during training

## What does this add?

This slightly tweaks the question asking how many devices the user will be using when running `accelerate config`

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/338

## Why is it needed?

Stating the number of processes is very general, and I as well found it a bit confusing until I learned that just means number of GPUs, CPUs, etc that will be the **main training device**. As a result, PR proposes changing it from:

```
How many processes in total will you use? [1]
```
To:
```
How many devices should be used for (potentially) distributed training? [1:]
```