### PR TITLE
Handle deprication errors in launch

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -134,7 +134,7 @@ def launch_command_parser(subparsers=None):
         help="Skip prepending the training script with 'python' - just execute it directly. Useful when the script is not a Python script.",
     )
     parser.add_argument(
-        "--main_process_port",
+        "--num_cpu_threads_per_process",
         type=int,
         default=1,
         help="The number of CPU threads per process. Can be tuned for optimal performance.",
@@ -273,7 +273,7 @@ def multi_gpu_launcher(args):
         current_env["FSDP_OFFLOAD_PARAMS"] = str(args.offload_params).lower()
         current_env["FSDP_MIN_NUM_PARAMS"] = str(args.min_num_params)
         current_env["FSDP_SHARDING_STRATEGY"] = str(args.sharding_strategy)
-    current_env["OMP_NUM_THREADS"] = args.num_threads
+    current_env["OMP_NUM_THREADS"] = args.num_cpu_threads_per_process
     process = subprocess.Popen(cmd, env=current_env)
     process.wait()
     if process.returncode != 0:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -33,6 +33,8 @@ from accelerate.utils import (
     PrepareForLaunch,
     is_sagemaker_available,
 )
+from accelerate.utils.versions import _torch_version
+from packaging import version
 
 
 def launch_command_parser(subparsers=None):
@@ -211,7 +213,13 @@ def simple_launcher(args):
 
 
 def multi_gpu_launcher(args):
-    cmd = [sys.executable, "-m", "torch.distributed.launch", "--use_env"]
+    if _torch_version >= version.parse("1.10.0"):
+        launch_cmd = ["torchrun"]
+    elif _torch_version >= version.parse("1.9.0"):
+        launch_cmd = ["torch.distributed.run"]
+    else:
+        launch_cmd = ["torch.distributed.launch", "--use_env"]
+    cmd = [sys.executable, "-m"] + launch_cmd
     if args.num_machines > 1:
         cmd.extend(
             [

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -273,7 +273,7 @@ def multi_gpu_launcher(args):
         current_env["FSDP_OFFLOAD_PARAMS"] = str(args.offload_params).lower()
         current_env["FSDP_MIN_NUM_PARAMS"] = str(args.min_num_params)
         current_env["FSDP_SHARDING_STRATEGY"] = str(args.sharding_strategy)
-    current_env["OMP_NUM_THREADS"] = args.num_cpu_threads_per_process
+    current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
     process = subprocess.Popen(cmd, env=current_env)
     process.wait()
     if process.returncode != 0:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -134,6 +134,12 @@ def launch_command_parser(subparsers=None):
         help="Skip prepending the training script with 'python' - just execute it directly. Useful when the script is not a Python script.",
     )
     parser.add_argument(
+        "--main_process_port",
+        type=int,
+        default=1,
+        help="The number of CPU threads per process. Can be tuned for optimal performance.",
+    )
+    parser.add_argument(
         "--aws_access_key_id",
         type=str,
         default=None,
@@ -267,6 +273,7 @@ def multi_gpu_launcher(args):
         current_env["FSDP_OFFLOAD_PARAMS"] = str(args.offload_params).lower()
         current_env["FSDP_MIN_NUM_PARAMS"] = str(args.min_num_params)
         current_env["FSDP_SHARDING_STRATEGY"] = str(args.sharding_strategy)
+    current_env["OMP_NUM_THREADS"] = args.num_threads
     process = subprocess.Popen(cmd, env=current_env)
     process.wait()
     if process.returncode != 0:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -216,9 +216,9 @@ def multi_gpu_launcher(args):
     if _torch_version >= version.parse("1.10.0"):
         launch_cmd = ["torchrun"]
     elif _torch_version >= version.parse("1.9.0"):
-        launch_cmd = ["torch.distributed.run"]
+        launch_cmd = [sys.executable, "-m", "torch.distributed.run"]
     else:
-        launch_cmd = ["torch.distributed.launch", "--use_env"]
+        launch_cmd = [sys.executable, "-m", "torch.distributed.launch", "--use_env"]
     cmd = [sys.executable, "-m"] + launch_cmd
     if args.num_machines > 1:
         cmd.extend(

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -33,7 +33,7 @@ from accelerate.utils import (
     PrepareForLaunch,
     is_sagemaker_available,
 )
-from accelerate.utils.versions import _torch_version
+from accelerate.utils.versions import torch_version
 from packaging import version
 
 
@@ -219,9 +219,9 @@ def simple_launcher(args):
 
 
 def multi_gpu_launcher(args):
-    if _torch_version >= version.parse("1.10.0"):
+    if torch_version >= version.parse("1.10.0"):
         cmd = ["torchrun"]
-    elif _torch_version >= version.parse("1.9.0"):
+    elif torch_version >= version.parse("1.9.0"):
         cmd = [sys.executable, "-m", "torch.distributed.run"]
     else:
         cmd = [sys.executable, "-m", "torch.distributed.launch", "--use_env"]

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -220,12 +220,11 @@ def simple_launcher(args):
 
 def multi_gpu_launcher(args):
     if _torch_version >= version.parse("1.10.0"):
-        launch_cmd = ["torchrun"]
+        cmd = ["torchrun"]
     elif _torch_version >= version.parse("1.9.0"):
-        launch_cmd = [sys.executable, "-m", "torch.distributed.run"]
+        cmd = [sys.executable, "-m", "torch.distributed.run"]
     else:
-        launch_cmd = [sys.executable, "-m", "torch.distributed.launch", "--use_env"]
-    cmd = [sys.executable, "-m"] + launch_cmd
+        cmd = [sys.executable, "-m", "torch.distributed.launch", "--use_env"]
     if args.num_machines > 1:
         cmd.extend(
             [

--- a/src/accelerate/utils/versions.py
+++ b/src/accelerate/utils/versions.py
@@ -1,0 +1,25 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+from packaging.version import parse
+
+
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
+
+_torch_version = parse(importlib_metadata.version("torch"))

--- a/src/accelerate/utils/versions.py
+++ b/src/accelerate/utils/versions.py
@@ -22,4 +22,4 @@ if sys.version_info < (3, 8):
 else:
     import importlib.metadata as importlib_metadata
 
-_torch_version = parse(importlib_metadata.version("torch"))
+torch_version = parse(importlib_metadata.version("torch"))


### PR DESCRIPTION
- Checks for the right launcher based on the torch version
- Adds `num_cpu_threads_per_process` and sets it to env to get rid of torchrun warning. Default is torchrun default