### PR TITLE
fix tracking

### DIFF
--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -294,7 +294,7 @@ def training_function(config, args):
                     {
                         "accuracy": eval_metric["accuracy"],
                         "f1": eval_metric["f1"],
-                        "train_loss": total_loss.item() if type(total_loss) == torch.Tensor else total_loss,
+                        "train_loss": total_loss.item(),
                     },
                     step=epoch,
                 )

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -103,11 +103,12 @@ def training_function(config, args):
 
     # We need to initialize the trackers we use, and also store our configuration
     if args.with_tracking:
-        run = os.path.split(__file__)[-1].split(".")[0]
-        if args.logging_dir:
-            run = os.path.join(args.logging_dir, run)
-            accelerator.print(run)
-        accelerator.init_trackers(run, config)
+        if accelerator.is_main_process:
+            run = os.path.split(__file__)[-1].split(".")[0]
+            if args.logging_dir:
+                run = os.path.join(args.logging_dir, run)
+                accelerator.print(run)
+            accelerator.init_trackers(run, config)
 
     tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
     datasets = load_dataset("glue", "mrpc")
@@ -293,7 +294,7 @@ def training_function(config, args):
                     {
                         "accuracy": eval_metric["accuracy"],
                         "f1": eval_metric["f1"],
-                        "train_loss": total_loss,
+                        "train_loss": total_loss.item() if type(total_loss) == torch.Tensor else total_loss,
                     },
                     step=epoch,
                 )

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -161,10 +161,11 @@ def training_function(config, args):
     # New Code #
     # We need to initalize the trackers we use. Overall configurations can also be stored
     if args.with_tracking:
-        run = os.path.split(__file__)[-1].split(".")[0]
-        if args.logging_dir:
-            run = os.path.join(args.logging_dir, run)
-        accelerator.init_trackers(run, config)
+        if accelerator.is_main_process:
+            run = os.path.split(__file__)[-1].split(".")[0]
+            if args.logging_dir:
+                run = os.path.join(args.logging_dir, run)
+            accelerator.init_trackers(run, config)
 
     # Now we train the model
     for epoch in range(num_epochs):
@@ -208,15 +209,16 @@ def training_function(config, args):
 
         # New Code #
         # To actually log, we call `Accelerator.log`
-        # The values passed can be of `str`, `int`, or `float`
+        # The values passed can be of `str`, `int`, `float` or `dict` of `str` to `float`/`int`
         if args.with_tracking:
             accelerator.log(
                 {
                     "accuracy": eval_metric["accuracy"],
                     "f1": eval_metric["f1"],
-                    "train_loss": total_loss,
+                    "train_loss": total_loss.item() if type(total_loss) == torch.Tensor else total_loss,
                     "epoch": epoch,
-                }
+                },
+                step=epoch,
             )
 
     # New Code #

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -215,7 +215,7 @@ def training_function(config, args):
                 {
                     "accuracy": eval_metric["accuracy"],
                     "f1": eval_metric["f1"],
-                    "train_loss": total_loss.item() if type(total_loss) == torch.Tensor else total_loss,
+                    "train_loss": total_loss.item(),
                     "epoch": epoch,
                 },
                 step=epoch,

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -104,10 +104,11 @@ def training_function(config, args):
 
     # We need to initialize the trackers we use, and also store our configuration
     if args.with_tracking:
-        run = os.path.split(__file__)[-1].split(".")[0]
-        if args.logging_dir:
-            run = os.path.join(args.logging_dir, run)
-        accelerator.init_trackers(run, config)
+        if accelerator.is_main_process:
+            run = os.path.split(__file__)[-1].split(".")[0]
+            if args.logging_dir:
+                run = os.path.join(args.logging_dir, run)
+            accelerator.init_trackers(run, config)
 
     # Grab all the image filenames
     file_names = [os.path.join(args.data_dir, fname) for fname in os.listdir(args.data_dir) if fname.endswith(".jpg")]

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -246,7 +246,7 @@ def training_function(config, args):
                 {
                     "accuracy": eval_metric["accuracy"],
                     "f1": eval_metric["f1"],
-                    "train_loss": total_loss.item() if type(total_loss) == torch.Tensor else total_loss,
+                    "train_loss": total_loss.item(),
                     "epoch": epoch,
                 },
                 step=epoch,

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -81,10 +81,11 @@ def training_function(config, args):
 
     # We need to initialize the trackers we use, and also store our configuration
     if args.with_tracking:
-        run = os.path.split(__file__)[-1].split(".")[0]
-        if args.logging_dir:
-            run = os.path.join(args.logging_dir, run)
-        accelerator.init_trackers(run, config)
+        if accelerator.is_main_process:
+            run = os.path.split(__file__)[-1].split(".")[0]
+            if args.logging_dir:
+                run = os.path.join(args.logging_dir, run)
+            accelerator.init_trackers(run, config)
 
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
     datasets = load_dataset("glue", "mrpc")
@@ -245,9 +246,10 @@ def training_function(config, args):
                 {
                     "accuracy": eval_metric["accuracy"],
                     "f1": eval_metric["f1"],
-                    "train_loss": total_loss,
+                    "train_loss": total_loss.item() if type(total_loss) == torch.Tensor else total_loss,
                     "epoch": epoch,
-                }
+                },
+                step=epoch,
             )
 
         if checkpointing_steps == "epoch":

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -263,7 +263,7 @@ class CometMLTracker(GeneralTracker):
             if isinstance(v, (int, float)):
                 self.writer.log_metric(k, v, step=step)
             elif isinstance(v, str):
-                self.writer.log_others(v)
+                self.writer.log_other(k, v)
             elif isinstance(v, dict):
                 self.writer.log_metrics(v, step=step)
         logger.info("Successfully logged to CometML")

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -263,7 +263,7 @@ class CometMLTracker(GeneralTracker):
             if isinstance(v, (int, float)):
                 self.writer.log_metric(k, v, step=step)
             elif isinstance(v, str):
-                self.writer.log_others(k, v, step=step)
+                self.writer.log_others(v)
             elif isinstance(v, dict):
                 self.writer.log_metrics(v, step=step)
         logger.info("Successfully logged to CometML")

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -137,8 +137,8 @@ class TensorBoardTracker(GeneralTracker):
 
         Args:
             values (Dictionary `str` to `str`, `float`, `int` or `dict` of `str` to `float`/`int`):
-                Values to be logged as key-value pairs. The values need to have type `str`, `float`, `int`
-                or `dict` of `str` to `float`/`int`.
+                Values to be logged as key-value pairs. The values need to have type `str`, `float`, `int` or `dict` of
+                `str` to `float`/`int`.
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
         """
@@ -197,8 +197,8 @@ class WandBTracker(GeneralTracker):
 
         Args:
             values (Dictionary `str` to `str`, `float`, `int` or `dict` of `str` to `float`/`int`):
-                Values to be logged as key-value pairs. The values need to have type `str`, `float`, `int`
-                or `dict` of `str` to `float`/`int`.
+                Values to be logged as key-value pairs. The values need to have type `str`, `float`, `int` or `dict` of
+                `str` to `float`/`int`.
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
         """
@@ -252,8 +252,8 @@ class CometMLTracker(GeneralTracker):
 
         Args:
             values (Dictionary `str` to `str`, `float`, `int` or `dict` of `str` to `float`/`int`):
-                Values to be logged as key-value pairs. The values need to have type `str`, `float`, `int`
-                or `dict` of `str` to `float`/`int`.
+                Values to be logged as key-value pairs. The values need to have type `str`, `float`, `int` or `dict` of
+                `str` to `float`/`int`.
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
         """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -149,9 +149,10 @@ class ExampleDifferenceTests(unittest.TestCase):
             " " * 16 + "{\n\n",
             " " * 18 + '"accuracy": eval_metric["accuracy"],\n\n',
             " " * 18 + '"f1": eval_metric["f1"],\n\n',
-            " " * 18 + '"train_loss": total_loss,\n\n',
+            " " * 18 + '"train_loss": total_loss.item(),\n\n',
             " " * 18 + '"epoch": epoch,\n\n',
             " " * 16 + "}\n",
+            " " * 16 + "step=epoch,\n",
             " " * 8,
         ]
         self.one_complete_example("complete_cv_example.py", True, cv_path, special_strings)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -151,7 +151,7 @@ class ExampleDifferenceTests(unittest.TestCase):
             " " * 18 + '"f1": eval_metric["f1"],\n\n',
             " " * 18 + '"train_loss": total_loss.item(),\n\n',
             " " * 18 + '"epoch": epoch,\n\n',
-            " " * 16 + "}\n",
+            " " * 16 + "},\n\n",
             " " * 16 + "step=epoch,\n",
             " " * 8,
         ]

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -203,6 +203,9 @@ class CometMLTest(unittest.TestCase):
             if "log_other" in j.keys():
                 if j["log_other"]["key"] == key:
                     return j["log_other"]["val"]
+            if "metric" in j.keys():
+                if j["metric"]["metricName"] == key:
+                    return j["metric"]["metricValue"]
 
     def test_init_trackers(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
### What does this PR do?

1. When dictionary of metrics is provided to the accelerate tracker, tensorboard wasn't able to log it. Example with dict of metrics is in this transformers script [run_glue_no_trainer.py](https://github.com/huggingface/transformers/blob/9f16a1cc13029c37fd3b7713d0edb743a8a86e39/examples/pytorch/text-classification/run_glue_no_trainer.py#L541). Fixed support for dictionary of int/float metrics 
2. Fixing examples so that run is created only for the main process else wandb will create num_processes runs with no data.
3. comet-ml logging wasn't helpful as everything was being logged in others `log_others`. No plots were being created. Fixing it to be able to get plots for metrics using `log_metric` and `log_metrics`.

Post these changes, below are the plots for the [run_glue_no_trainer.py](https://github.com/huggingface/transformers/blob/main/examples/pytorch/text-classification/run_glue_no_trainer.py) script on MRPC task using all trackers.
<img width="1495" alt="Screenshot 2022-05-12 at 8 11 16 PM" src="https://user-images.githubusercontent.com/13534540/168102355-8b1eae0b-3856-4dba-af6c-b63ae25abf80.png">
<img width="1497" alt="Screenshot 2022-05-12 at 8 10 51 PM" src="https://user-images.githubusercontent.com/13534540/168102370-30d36c47-9863-46f4-a9d8-094598c75677.png">
<img width="1015" alt="Screenshot 2022-05-12 at 8 10 17 PM" src="https://user-images.githubusercontent.com/13534540/168102371-7a9d8998-af14-403d-9bf3-95bc83459f5d.png">

 