### PR TITLE
Fix minor typo in `notebook_launcher` error message

### DIFF
--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -80,7 +80,7 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False, mix
     else:
         if num_processes is None:
             raise ValueError(
-                "You have to specify the number of GPUs you would like to use, add `num_process=...` to your call."
+                "You have to specify the number of GPUs you would like to use, add `num_processes=...` to your call."
             )
 
         if num_processes > 1:


### PR DESCRIPTION
Fixing a minor typo, `num_process=...`  -->  `num_processes=...` in the error message when `num_processes` is `None` for `notebook_launcher`.