### PR TITLE
fix deepspeed model saving

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -881,7 +881,7 @@ class Accelerator:
                 is_zero_3 = self.state.deepspeed_plugin.zero_stage == 3
 
         if is_zero_3:
-            state_dict = model._zero3_consolidated_fp16_state_dict()
+            state_dict = model._zero3_consolidated_16bit_state_dict()
         else:
             model = self.unwrap_model(model)
             state_dict = model.state_dict()


### PR DESCRIPTION
### What does this PR do?
Fixes #369
1. Fixes the deepspeed model saving in Zero Stage-3. This saves the model in 16-bit precision by first gathering all the parameters across processes onto main process  to get complete state dict.  A point to note  - this is expensive in time and memory.