### PR TITLE
Add a utility for writing a barebones config file

### DIFF
--- a/docs/source/internal.mdx
+++ b/docs/source/internal.mdx
@@ -67,3 +67,5 @@ The main work on your PyTorch `DataLoader` is done by the following function:
 [[autodoc]] utils.synchronize_rng_states
 
 [[autodoc]] utils.wait_for_everyone
+
+[[autodoc]] utils.write_basic_config

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -33,8 +33,8 @@ from ..utils import gather, is_comet_ml_available, is_tensorflow_available, is_t
 
 def write_basic_config(mixed_precision="no"):
     """
-    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs.
-    Will also set CPU if it is a CPU-only machine.
+    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
+    set CPU if it is a CPU-only machine.
 
     Args:
         mixed_precision (`str`, *optional*, defaults to "no"):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -25,48 +25,8 @@ from unittest import mock
 
 import torch
 
-from ..commands.config.cluster import ClusterConfig
-from ..commands.config.config_args import default_json_config_file
 from ..state import AcceleratorState
 from ..utils import gather, is_comet_ml_available, is_tensorflow_available, is_tpu_available, is_wandb_available
-
-
-def write_basic_config(mixed_precision="no"):
-    """
-    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
-    set CPU if it is a CPU-only machine.
-
-    Args:
-        mixed_precision (`str`, *optional*, defaults to "no"):
-            Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
-    """
-    path = Path(default_json_config_file)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        print(
-            "User configuration already setup, will not override existing configuration. Run `accelerate config` manually."
-        )
-        return
-    mixed_precision = mixed_precision.lower()
-    if mixed_precision not in ["no", "fp16", "bf16"]:
-        raise ValueError(f"`mixed_precision` should be one of 'no', 'fp16', or 'bf16'. Received {mixed_precision}")
-    config = {"compute_environment": "LOCAL_MACHINE", "mixed_precision": mixed_precision}
-    if torch.cuda.is_available():
-        num_gpus = torch.cuda.device_count()
-        config["num_processes"] = num_gpus
-        config["use_cpu"] = False
-        if num_gpus > 1:
-            config["distributed_type"] = "MULTI_GPU"
-        else:
-            config["distributed_type"] = "NO"
-    else:
-        num_gpus = 0
-        config["use_cpu"] = True
-        config["num_processes"] = 1
-        config["distributed_type"] = "NO"
-    if not path.exists():
-        config = ClusterConfig(**config)
-        config.to_json_file(path)
 
 
 def parse_flag_from_env(key, default=False):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -25,8 +25,48 @@ from unittest import mock
 
 import torch
 
+from ..commands.config.cluster import ClusterConfig
+from ..commands.config.config_args import default_json_config_file
 from ..state import AcceleratorState
 from ..utils import gather, is_comet_ml_available, is_tensorflow_available, is_tpu_available, is_wandb_available
+
+
+def write_basic_config(mixed_precision="no"):
+    """
+    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs.
+    Will also set CPU if it is a CPU-only machine.
+
+    Args:
+        mixed_precision (`str`, *optional*, defaults to "no"):
+            Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
+    """
+    path = Path(default_json_config_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        print(
+            "User configuration already setup, will not override existing configuration. Run `accelerate config` manually."
+        )
+        return
+    mixed_precision = mixed_precision.lower()
+    if mixed_precision not in ["no", "fp16", "bf16"]:
+        raise ValueError(f"`mixed_precision` should be one of 'no', 'fp16', or 'bf16'. Received {mixed_precision}")
+    config = {"compute_environment": "LOCAL_MACHINE", "mixed_precision": mixed_precision}
+    if torch.cuda.is_available():
+        num_gpus = torch.cuda.device_count()
+        config["num_processes"] = num_gpus
+        config["use_cpu"] = False
+        if num_gpus > 1:
+            config["distributed_type"] = "MULTI_GPU"
+        else:
+            config["distributed_type"] = "NO"
+    else:
+        num_gpus = 0
+        config["use_cpu"] = True
+        config["num_processes"] = 1
+        config["distributed_type"] = "NO"
+    if not path.exists():
+        config = ClusterConfig(**config)
+        config.to_json_file(path)
 
 
 def parse_flag_from_env(key, default=False):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -72,5 +72,12 @@ if is_deepspeed_available():
 
 from .launch import PrepareForLaunch
 from .memory import find_executable_batch_size
-from .other import extract_model_from_parallel, get_pretty_name, patch_environment, save, wait_for_everyone
+from .other import (
+    extract_model_from_parallel,
+    get_pretty_name,
+    patch_environment,
+    save,
+    wait_for_everyone,
+    write_basic_config,
+)
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -124,8 +124,8 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
         save_location (`str`, *optional*, defaults to `default_json_config_file`):
             Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
-            location is inside the huggingface cache folder as default_config.yaml, can be overriden by setting the
-            `HF_HOME` environmental variable.
+            location is inside the huggingface cache folder (`~/.cache/huggingface`) but can be overriden by setting the
+            `HF_HOME` environmental variable, followed by `accelerate/default_config.yaml`.
     """
     path = Path(save_location)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -124,7 +124,7 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
         save_location (`str`, *optional*, defaults to `default_json_config_file`):
             Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
-            location is inside the huggingface cache folder as default_config.yaml, can be overriden by setting the 
+            location is inside the huggingface cache folder as default_config.yaml, can be overriden by setting the
             `HF_HOME` environmental variable.
     """
     path = Path(save_location)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -124,8 +124,8 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
         save_location (`str`, *optional*, defaults to `default_json_config_file`):
             Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
-            location is inside the huggingface cache folder (`~/.cache/huggingface`) but can be overriden by setting the
-            `HF_HOME` environmental variable, followed by `accelerate/default_config.yaml`.
+            location is inside the huggingface cache folder (`~/.cache/huggingface`) but can be overriden by setting
+            the `HF_HOME` environmental variable, followed by `accelerate/default_config.yaml`.
     """
     path = Path(save_location)
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -114,7 +114,7 @@ def get_pretty_name(obj):
     return str(obj)
 
 
-def write_basic_config(mixed_precision="no"):
+def write_basic_config(mixed_precision="no", save_location: str = default_json_config_file):
     """
     Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
     set CPU if it is a CPU-only machine.
@@ -122,12 +122,16 @@ def write_basic_config(mixed_precision="no"):
     Args:
         mixed_precision (`str`, *optional*, defaults to "no"):
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
+        save_location (`str`, *optional*):
+            Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`.
     """
-    path = Path(default_json_config_file)
+    if save_location is None:
+        save_location = default_json_config_file
+    path = Path(save_location)
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():
         print(
-            "User configuration already setup, will not override existing configuration. Run `accelerate config` manually."
+            f"Configuration already exists at {save_location}, will not override. Run `accelerate config` manually or pass a different `save_location`."
         )
         return
     mixed_precision = mixed_precision.lower()

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -14,9 +14,12 @@
 
 import os
 from contextlib import contextmanager
+from pathlib import Path
 
 import torch
 
+from ..commands.config.cluster import ClusterConfig
+from ..commands.config.config_args import default_json_config_file
 from ..state import AcceleratorState
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
@@ -109,3 +112,41 @@ def get_pretty_name(obj):
     if hasattr(obj, "__name__"):
         return obj.__name__
     return str(obj)
+
+
+def write_basic_config(mixed_precision="no"):
+    """
+    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
+    set CPU if it is a CPU-only machine.
+
+    Args:
+        mixed_precision (`str`, *optional*, defaults to "no"):
+            Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
+    """
+    path = Path(default_json_config_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        print(
+            "User configuration already setup, will not override existing configuration. Run `accelerate config` manually."
+        )
+        return
+    mixed_precision = mixed_precision.lower()
+    if mixed_precision not in ["no", "fp16", "bf16"]:
+        raise ValueError(f"`mixed_precision` should be one of 'no', 'fp16', or 'bf16'. Received {mixed_precision}")
+    config = {"compute_environment": "LOCAL_MACHINE", "mixed_precision": mixed_precision}
+    if torch.cuda.is_available():
+        num_gpus = torch.cuda.device_count()
+        config["num_processes"] = num_gpus
+        config["use_cpu"] = False
+        if num_gpus > 1:
+            config["distributed_type"] = "MULTI_GPU"
+        else:
+            config["distributed_type"] = "NO"
+    else:
+        num_gpus = 0
+        config["use_cpu"] = True
+        config["num_processes"] = 1
+        config["distributed_type"] = "NO"
+    if not path.exists():
+        config = ClusterConfig(**config)
+        config.to_json_file(path)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -122,11 +122,9 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
     Args:
         mixed_precision (`str`, *optional*, defaults to "no"):
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
-        save_location (`str`, *optional*):
+        save_location (`str`, *optional*, defaults to "~/.cache/huggingface/accelerate/default_config.yaml"):
             Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`.
     """
-    if save_location is None:
-        save_location = default_json_config_file
     path = Path(save_location)
     path.parent.mkdir(parents=True, exist_ok=True)
     if path.exists():

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -122,8 +122,10 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
     Args:
         mixed_precision (`str`, *optional*, defaults to "no"):
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
-        save_location (`str`, *optional*, defaults to "~/.cache/huggingface/accelerate/default_config.yaml"):
-            Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`.
+        save_location (`str`, *optional*, defaults to `default_json_config_file`):
+            Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
+            location is inside the huggingface cache folder as default_config.yaml, can be overriden by setting the 
+            `HF_HOME` environmental variable.
     """
     path = Path(save_location)
     path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Introduce barebones config file generator

## What does this add?

This PR adds a `write_basic_config` file that will write a barebones config file automatically setting the GPU's to be the maximum GPUs available (or CPU), and takes in one param for mixed precision

## Who is it for?

Folks who want to avoid running `accelerate config` and for tests that need to be ran with `accelerate launch`.

## Why is it needed?

Along with a request in the fastai integration https://github.com/fastai/fastai/pull/3646, I was working on fixing up the tests we currently run and was noticing some frustration when trying to setup and configure them to be launched on multi gpu. 

## What parts of the API does this impact?

### User-facing:

Adds a `write_basic_config` config to `test_utils/testing.py`, that should be used in tests but users can optionally use it to setup a basic configuration if wanted. It **will not** override an already setup configuration.

## Basic Usage Example(s):

```python
from accelerate.test_utils import write_basic_config
write_basic_config("fp16")
```

## When would I use it, and when wouldn't I?

You'd use it when you don't want to run `accelerate config` and don't care about TPU setup or a fine-grained configuration setup for multi-gpu