### PR TITLE
Refactor tests to use accelerate launch

### DIFF
--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -104,7 +104,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
 
 # For testing only
-if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+if os.environ.get("TESTING_MOCKED_DATALOADERS", None) == "1":
     from accelerate.test_utils.training import mocked_dataloaders
 
     get_dataloaders = mocked_dataloaders  # noqa: F811

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -55,7 +55,6 @@ from transformers import (
 MAX_GPU_BATCH_SIZE = 16
 EVAL_BATCH_SIZE = 32
 
-
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
     Creates a set of `DataLoader`s for the `glue` dataset,
@@ -101,6 +100,10 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     )
 
     return train_dataloader, eval_dataloader
+
+if os.environ["IN_TEST_ENV"] == '1':
+    from ...tests.test_examples import mocked_dataloaders
+    get_dataloaders = mocked_dataloaders
 
 
 def training_function(config, args):

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -102,7 +102,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     return train_dataloader, eval_dataloader
 
 if os.environ["IN_TEST_ENV"] == '1':
-    from ...tests.test_examples import mocked_dataloaders
+    from accelerate.test_utils.training import mocked_dataloaders
     get_dataloaders = mocked_dataloaders
 
 

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -101,7 +101,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
     return train_dataloader, eval_dataloader
 
-if os.environ["IN_TEST_ENV"] == '1':
+if os.environ.get("IN_TEST_ENV", None) == '1':
     from accelerate.test_utils.training import mocked_dataloaders
     get_dataloaders = mocked_dataloaders
 

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -55,6 +55,7 @@ from transformers import (
 MAX_GPU_BATCH_SIZE = 16
 EVAL_BATCH_SIZE = 32
 
+
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
     Creates a set of `DataLoader`s for the `glue` dataset,
@@ -101,9 +102,12 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
     return train_dataloader, eval_dataloader
 
-if os.environ.get("IN_TEST_ENV", None) == '1':
+
+# For testing only
+if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
     from accelerate.test_utils.training import mocked_dataloaders
-    get_dataloaders = mocked_dataloaders
+
+    get_dataloaders = mocked_dataloaders  # noqa: F811
 
 
 def training_function(config, args):

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -75,7 +75,7 @@ class TorchTracemalloc:
 
 
 # For testing only
-if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+if os.environ.get("TESTING_MOCKED_DATALOADERS", None) == "1":
     from accelerate.test_utils.training import mocked_dataloaders
 
     get_dataloaders = mocked_dataloaders  # noqa: F811

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -74,6 +74,13 @@ class TorchTracemalloc:
         # print(f"delta used/peak {self.used:4d}/{self.peaked:4d}")
 
 
+# For testing only
+if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+    from accelerate.test_utils.training import mocked_dataloaders
+
+    get_dataloaders = mocked_dataloaders  # noqa: F811
+
+
 def training_function(config, args):
     # Initialize accelerator
     if args.with_tracking:

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -105,7 +105,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
 
 # For testing only
-if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+if os.environ.get("TESTING_MOCKED_DATALOADERS", None) == "1":
     from accelerate.test_utils.training import mocked_dataloaders
 
     get_dataloaders = mocked_dataloaders  # noqa: F811

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import os
 
 import torch
 from torch.utils.data import DataLoader
@@ -101,6 +102,13 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     )
 
     return train_dataloader, eval_dataloader
+
+
+# For testing only
+if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+    from accelerate.test_utils.training import mocked_dataloaders
+
+    get_dataloaders = mocked_dataloaders  # noqa: F811
 
 
 def training_function(config, args):

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import os
 
 import torch
 from torch.utils.data import DataLoader
@@ -102,6 +103,13 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     )
 
     return train_dataloader, eval_dataloader
+
+
+# For testing only
+if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+    from accelerate.test_utils.training import mocked_dataloaders
+
+    get_dataloaders = mocked_dataloaders  # noqa: F811
 
 
 def training_function(config, args):

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -106,7 +106,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
 
 # For testing only
-if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+if os.environ.get("TESTING_MOCKED_DATALOADERS", None) == "1":
     from accelerate.test_utils.training import mocked_dataloaders
 
     get_dataloaders = mocked_dataloaders  # noqa: F811

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -104,7 +104,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
 
 # For testing only
-if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+if os.environ.get("TESTING_MOCKED_DATALOADERS", None) == "1":
     from accelerate.test_utils.training import mocked_dataloaders
 
     get_dataloaders = mocked_dataloaders  # noqa: F811

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -103,6 +103,13 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     return train_dataloader, eval_dataloader
 
 
+# For testing only
+if os.environ.get("USE_MOCKED_DATALOADERS", None) == "1":
+    from accelerate.test_utils.training import mocked_dataloaders
+
+    get_dataloaders = mocked_dataloaders  # noqa: F811
+
+
 def training_function(config, args):
     # Initialize Accelerator
 

--- a/src/accelerate/test_utils/training.py
+++ b/src/accelerate/test_utils/training.py
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from accelerate.utils.dataclasses import DistributedType
-from transformers import AutoTokenizer
-from datasets import load_dataset
-from torch.utils.data import DataLoader
 import numpy as np
 import torch
+from torch.utils.data import DataLoader
+
+from accelerate.utils.dataclasses import DistributedType
+from datasets import load_dataset
+from transformers import AutoTokenizer
 
 
 class RegressionDataset:
@@ -47,6 +48,7 @@ class RegressionModel(torch.nn.Module):
             print(f"Model dtype: {self.a.dtype}, {self.b.dtype}. Input dtype: {x.dtype}")
             self.first_batch = False
         return x * self.a + self.b
+
 
 def mocked_dataloaders(accelerator, batch_size: int = 16):
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -151,7 +151,6 @@ class FeatureExamplesTests(TempDirTestCase):
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "epoch_1")))
 
-    @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_checkpointing_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
@@ -161,7 +160,6 @@ class FeatureExamplesTests(TempDirTestCase):
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
-    @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_epoch(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
@@ -176,7 +174,6 @@ class FeatureExamplesTests(TempDirTestCase):
                 mocked_print.assert_any_call("epoch 1:", dummy_results)
             mocked_print.assert_any_call("epoch 2:", dummy_results)
 
-    @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
@@ -201,12 +198,10 @@ class FeatureExamplesTests(TempDirTestCase):
             call = mocked_print.mock_calls[-1]
             self.assertGreaterEqual(call.args[1]["accuracy"], 0.75)
 
-    @mock.patch("multi_process_metrics.get_dataloaders", mocked_dataloaders)
     def test_multi_process_metrics(self):
         testargs = ["examples/by_feature/multi_process_metrics.py"]
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
 
-    @mock.patch("tracking.get_dataloaders", mocked_dataloaders)
     def test_tracking(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             testargs = f"""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -157,7 +157,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --checkpointing_steps 2
         --output_dir {self.tmpdir}
         """.split()
-        _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
+        _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env={"IN_TEST_ENV":"1"})
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
     def test_load_states_by_epoch(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -180,31 +180,28 @@ class FeatureExamplesTests(TempDirTestCase):
         --checkpointing_steps epoch
         --output_dir {self.tmpdir}
         """.split()
-        print(self._launch_args + testargs)
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "epoch_1")))
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_checkpointing_by_steps(self):
         testargs = f"""
-        checkpointing.py
+        examples/by_feature/checkpointing.py
         --checkpointing_steps 2
         --output_dir {self.tmpdir}
         """.split()
-        with mock.patch.object(sys, "argv", testargs):
-            checkpointing.main()
-            self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
+        _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_epoch(self):
         testargs = f"""
-        checkpointing.py
+        examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
         dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
-            with mock.patch.object(sys, "argv", testargs):
-                checkpointing.main()
+            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
             with self.assertRaises(AssertionError):
                 mocked_print.assert_any_call("epoch 0:", dummy_results)
             with self.assertRaises(AssertionError):
@@ -214,13 +211,12 @@ class FeatureExamplesTests(TempDirTestCase):
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_load_states_by_steps(self):
         testargs = f"""
-        checkpointing.py
+        examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
         dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
         with mock.patch("accelerate.Accelerator.print") as mocked_print:
-            with mock.patch.object(sys, "argv", testargs):
-                checkpointing.main()
+            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
             with self.assertRaises(AssertionError):
                 mocked_print.assert_any_call("epoch 0:", dummy_results)
             mocked_print.assert_any_call("epoch 1:", dummy_results)
@@ -229,29 +225,26 @@ class FeatureExamplesTests(TempDirTestCase):
     @slow
     def test_cross_validation(self):
         testargs = """
-        cross_validation.py
+        examples/by_feature/cross_validation.py
         --num_folds 2
         """.split()
-        with mock.patch.object(sys, "argv", testargs):
-            with mock.patch("accelerate.Accelerator.print") as mocked_print:
-                cross_validation.main()
-                call = mocked_print.mock_calls[-1]
-                self.assertGreaterEqual(call.args[1]["accuracy"], 0.75)
+        with mock.patch("accelerate.Accelerator.print") as mocked_print:
+            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
+            call = mocked_print.mock_calls[-1]
+            self.assertGreaterEqual(call.args[1]["accuracy"], 0.75)
 
     @mock.patch("multi_process_metrics.get_dataloaders", mocked_dataloaders)
     def test_multi_process_metrics(self):
-        testargs = ["multi_process_metrics.py"]
-        with mock.patch.object(sys, "argv", testargs):
-            multi_process_metrics.main()
+        testargs = ["examples/by_feature/multi_process_metrics.py"]
+        _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
 
     @mock.patch("tracking.get_dataloaders", mocked_dataloaders)
     def test_tracking(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             testargs = f"""
-            tracking.py
+            examples/by_feature/tracking.py
             --with_tracking
             --logging_dir {tmpdir}
             """.split()
-            with mock.patch.object(sys, "argv", testargs):
-                tracking.main()
-                self.assertTrue(os.path.exists(os.path.join(tmpdir, "tracking")))
+            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
+            self.assertTrue(os.path.exists(os.path.join(tmpdir, "tracking")))

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -151,7 +151,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, check=True).decode("utf-8")
+        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True)
         self.assertNotIn("epoch 0:", output)
         self.assertNotIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -161,7 +161,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, check=True).decode("utf-8")
+        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True)
         self.assertNotIn("epoch 0:", output)
         self.assertIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from msilib.schema import Feature
 import os
 import shutil
 import subprocess
@@ -161,7 +162,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.setUp()
+        super(FeatureExamplesTests, cls).setUpClass()
         cls._tmpdir = tempfile.mkdtemp()
         cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
 
@@ -170,7 +171,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls().tearDown()
+        super(FeatureExamplesTests, cls).tearDownClass()
         shutil.rmtree(cls._tmpdir)
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -173,6 +173,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --checkpointing_steps epoch
         --output_dir {self.tmpdir}
         """.split()
+        print(self._launch_args + testargs)
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "epoch_1")))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -118,7 +118,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(FeatureExamplesTests, cls).setUpClass()
+        super().setUpClass()
         cls._tmpdir = tempfile.mkdtemp()
         cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
 
@@ -127,7 +127,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(FeatureExamplesTests, cls).tearDownClass()
+        super().tearDownClass()
         shutil.rmtree(cls._tmpdir)
 
     def test_checkpointing_by_epoch(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -153,7 +153,9 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
+        output = subprocess.run(
+            self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertNotIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -163,7 +165,9 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
+        output = subprocess.run(
+            self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        ).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -175,7 +179,9 @@ class FeatureExamplesTests(TempDirTestCase):
         --num_folds 2
         """.split()
         with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
-            output = subprocess.run(self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
+            output = subprocess.run(
+                self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            ).stdout
             results = ast.literal_eval(re.findall("({.+})", output)[-1])
             self.assertGreaterEqual(results["accuracy"], 0.75)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -112,7 +112,7 @@ class ExampleDifferenceTests(unittest.TestCase):
         self.one_complete_example("complete_cv_example.py", False, cv_path, special_strings)
 
 
-@mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "1"})
+@mock.patch.dict(os.environ, {"TESTING_MOCKED_DATALOADERS": "1"})
 class FeatureExamplesTests(TempDirTestCase):
     clear_on_setup = False
 
@@ -178,7 +178,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/cross_validation.py
         --num_folds 2
         """.split()
-        with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
+        with mock.patch.dict(os.environ, {"TESTING_MOCKED_DATALOADERS": "0"}):
             output = subprocess.run(
                 self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             ).stdout

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -152,13 +152,10 @@ class FeatureExamplesTests(TempDirTestCase):
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
         dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
-        with mock.patch("accelerate.Accelerator.print") as mocked_print:
-            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
-            with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 0:", dummy_results)
-            with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 1:", dummy_results)
-            mocked_print.assert_any_call("epoch 2:", dummy_results)
+        output = subprocess.check_output(self._launch_args + testargs, stdout=subprocess.PIPE)
+        self.assertNotIn(f"epoch 0: {dummy_results}", output)
+        self.assertNotIn(f"epoch 1: {dummy_results}", output)
+        self.assertIn(f"epoch 2: {dummy_results}", output)
 
     def test_load_states_by_steps(self):
         testargs = f"""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -176,7 +176,7 @@ class FeatureExamplesTests(TempDirTestCase):
         """.split()
         with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
             output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
-            results = ast.literal_eval(re.search('({.+})', output).group(-1))
+            results = ast.literal_eval(re.findall('({.+})', output)[-1])
             self.assertGreaterEqual(results["accuracy"], 0.75)
 
     def test_multi_process_metrics(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -157,7 +157,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --checkpointing_steps 2
         --output_dir {self.tmpdir}
         """.split()
-        with mock.patch.dict(os.environ, {"IN_TEST_ENV":1}, clear=True):
+        with mock.patch.dict(os.environ, {"IN_TEST_ENV":"1"}, clear=True):
             _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -176,7 +176,7 @@ class FeatureExamplesTests(TempDirTestCase):
         """.split()
         with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
             output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
-            results = ast.literal_eval(re.findall('({.+})', output)[-1])
+            results = ast.literal_eval(re.findall("({.+})", output)[-1])
             self.assertGreaterEqual(results["accuracy"], 0.75)
 
     def test_multi_process_metrics(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -160,11 +161,15 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass()
-        cls.configPath = os.path.join(cls.tmpdir, "default_config.yml")
+        cls._tmpdir = tempfile.mkdtemp()
+        cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
 
         write_basic_config(save_location=cls.configPath)
         cls._launch_args = ["accelerate", "launch", "--config_file", cls.configPath]
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls._tmpdir)
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_checkpointing_by_epoch(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -161,7 +161,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(cls).setUp()
+        cls.setUp()
         cls._tmpdir = tempfile.mkdtemp()
         cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
 
@@ -170,7 +170,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super(cls).tearDown()
+        cls().tearDown()
         shutil.rmtree(cls._tmpdir)
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -151,7 +151,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True)
+        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertNotIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -161,7 +161,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True)
+        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -161,6 +161,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def setUpClass(cls):
+        super().setUp()
         cls._tmpdir = tempfile.mkdtemp()
         cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
 
@@ -169,6 +170,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        super().tearDown()
         shutil.rmtree(cls._tmpdir)
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -173,14 +173,13 @@ class FeatureExamplesTests(TempDirTestCase):
         super(FeatureExamplesTests, cls).tearDownClass()
         shutil.rmtree(cls._tmpdir)
 
-    @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
+    #@mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_checkpointing_by_epoch(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
         --checkpointing_steps epoch
         --output_dir {self.tmpdir}
         """.split()
-        print(self._launch_args + testargs)
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "epoch_1")))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -161,7 +161,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUp()
+        super(cls).setUp()
         cls._tmpdir = tempfile.mkdtemp()
         cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
 
@@ -170,7 +170,7 @@ class FeatureExamplesTests(TempDirTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        super().tearDown()
+        super(cls).tearDown()
         shutil.rmtree(cls._tmpdir)
 
     @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -153,7 +153,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, capture_output=True).stdout
+        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertNotIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -163,7 +163,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, capture_output=True).stdout
+        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -175,7 +175,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --num_folds 2
         """.split()
         with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
-            output = subprocess.run(self._launch_args + testargs, universal_newlines=True, capture_output=True).stdout
+            output = subprocess.run(self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).stdout
             results = ast.literal_eval(re.findall("({.+})", output)[-1])
             self.assertGreaterEqual(results["accuracy"], 0.75)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -173,13 +173,14 @@ class FeatureExamplesTests(TempDirTestCase):
         super(FeatureExamplesTests, cls).tearDownClass()
         shutil.rmtree(cls._tmpdir)
 
-    #@mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
+    @mock.patch("checkpointing.get_dataloaders", mocked_dataloaders)
     def test_checkpointing_by_epoch(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
         --checkpointing_steps epoch
         --output_dir {self.tmpdir}
         """.split()
+        print(self._launch_args + testargs)
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "epoch_1")))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -157,7 +157,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --checkpointing_steps 2
         --output_dir {self.tmpdir}
         """.split()
-        with mock.patch.dict(os.environ, {"IN_TEST_ENV":"1"}, clear=True):
+        with mock.patch.dict(os.environ, {"IN_TEST_ENV":"1"}):
             _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -152,7 +152,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
         dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
-        output = subprocess.check_output(self._launch_args + testargs)
+        output = subprocess.check_output(self._launch_args + testargs).decode("utf-8")
         self.assertNotIn(f"epoch 0: {dummy_results}", output)
         self.assertNotIn(f"epoch 1: {dummy_results}", output)
         self.assertIn(f"epoch 2: {dummy_results}", output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -173,10 +175,9 @@ class FeatureExamplesTests(TempDirTestCase):
         --num_folds 2
         """.split()
         with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
-            with mock.patch("accelerate.Accelerator.print") as mocked_print:
-                _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
-                call = mocked_print.mock_calls[-1]
-                self.assertGreaterEqual(call.args[1]["accuracy"], 0.75)
+            output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
+            results = ast.literal_eval(re.search('({.+})', output).group(-1))
+            self.assertGreaterEqual(results["accuracy"], 0.75)
 
     def test_multi_process_metrics(self):
         testargs = ["examples/by_feature/multi_process_metrics.py"]

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -152,7 +152,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
         dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
-        output = subprocess.check_output(self._launch_args + testargs, stdout=subprocess.PIPE)
+        output = subprocess.check_output(self._launch_args + testargs)
         self.assertNotIn(f"epoch 0: {dummy_results}", output)
         self.assertNotIn(f"epoch 1: {dummy_results}", output)
         self.assertIn(f"epoch 2: {dummy_results}", output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -157,7 +157,8 @@ class FeatureExamplesTests(TempDirTestCase):
         --checkpointing_steps 2
         --output_dir {self.tmpdir}
         """.split()
-        _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env={"IN_TEST_ENV":"1"})
+        with mock.patch.dict(os.environ, {"IN_TEST_ENV":1}, clear=True):
+            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
         self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
     def test_load_states_by_epoch(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -151,27 +151,20 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
-        dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
-        with mock.patch("accelerate.Accelerator.print") as mocked_print:
-            output = subprocess.run(self._launch_args + testargs, check=True)
-            with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 0:", dummy_results)
-            with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 1:", dummy_results)
-            mocked_print.assert_any_call("epoch 2:", dummy_results)
+        output = subprocess.run(self._launch_args + testargs, check=True).decode("utf-8")
+        self.assertNotIn("epoch 0:", output)
+        self.assertNotIn("epoch 1:", output)
+        self.assertIn("epoch 2:", output)
 
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
-        dummy_results = {"accuracy": mock.ANY, "f1": mock.ANY}
-        with mock.patch("accelerate.Accelerator.print") as mocked_print:
-            _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE)
-            with self.assertRaises(AssertionError):
-                mocked_print.assert_any_call("epoch 0:", dummy_results)
-            mocked_print.assert_any_call("epoch 1:", dummy_results)
-            mocked_print.assert_any_call("epoch 2:", dummy_results)
+        output = subprocess.run(self._launch_args + testargs, check=True).decode("utf-8")
+        self.assertNotIn("epoch 0:", output)
+        self.assertIn("epoch 1:", output)
+        self.assertIn("epoch 2:", output)
 
     @slow
     def test_cross_validation(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from msilib.schema import Feature
 import os
 import shutil
 import subprocess

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -153,7 +153,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_1")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
+        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, capture_output=True).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertNotIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -163,7 +163,7 @@ class FeatureExamplesTests(TempDirTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
-        output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
+        output = subprocess.run(self._launch_args + testargs, universal_newlines=True, capture_output=True).stdout
         self.assertNotIn("epoch 0:", output)
         self.assertIn("epoch 1:", output)
         self.assertIn("epoch 2:", output)
@@ -175,7 +175,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --num_folds 2
         """.split()
         with mock.patch.dict(os.environ, {"USE_MOCKED_DATALOADERS": "0"}):
-            output = subprocess.run(self._launch_args + testargs, text=True, capture_output=True).stdout
+            output = subprocess.run(self._launch_args + testargs, universal_newlines=True, capture_output=True).stdout
             results = ast.literal_eval(re.findall("({.+})", output)[-1])
             self.assertGreaterEqual(results["accuracy"], 0.75)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -33,6 +33,12 @@ from transformers import AutoTokenizer
 SRC_DIRS = [os.path.abspath(os.path.join("examples", "by_feature"))]
 sys.path.extend(SRC_DIRS)
 
+if SRC_DIRS is not None:
+    import checkpointing
+    import cross_validation
+    import multi_process_metrics
+    import tracking
+
 # DataLoaders built from `test_samples/MRPC` for quick testing
 # Should mock `{script_name}.get_dataloaders` via:
 # @mock.patch("{script_name}.get_dataloaders", mocked_dataloaders)


### PR DESCRIPTION
# Refactor tests to use accelerate launch

## What does this add?

This PR refactors all the example tests to use `accelerate launch` to be ran, adjusting any testing logic that needs to be done to compensate for this. Mostly changing the accelerate.print mocks to use string matching instead based on stdout from `subprocess.run`

## Why is it needed?

In order to have our tests be ran on more than one GPU, the tests needed to be refactored to allow for the `accelerate launch` command to be used via subprocess rather than calling it in python directly. 

## What parts of the API does this impact?

### User-facing:

All of the example scripts now contain a small snippet denoting that a particular import is only used for testing, and should be ignored

### Internal structure:

`mocked_dataloaders` was migrated to the test utils. 