### PR TITLE
Better check for deepspeed availability

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -57,8 +57,9 @@ def is_deepspeed_available():
     # AND checking it has an author field in the metadata that is HuggingFace.
     if package_exists:
         try:
-            _ = importlib_metadata.version("deepspeed")
             _deepspeed_metadata = importlib_metadata.metadata("deepspeed")
+            if _deepspeed_metadata.get("version", None) is None:
+                return False
             if _deepspeed_metadata.get("author", "") != "DeepSpeed Team":
                 return False
             return True

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -57,11 +57,7 @@ def is_deepspeed_available():
     # AND checking it has an author field in the metadata that is HuggingFace.
     if package_exists:
         try:
-            _deepspeed_metadata = importlib_metadata.metadata("deepspeed")
-            if _deepspeed_metadata.get("version", None) is None:
-                return False
-            if _deepspeed_metadata.get("author", "") != "DeepSpeed Team":
-                return False
+            _ = importlib_metadata.metadata("deepspeed")
             return True
         except importlib_metadata.PackageNotFoundError:
             return False

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import importlib
+import sys
+
+
+# The package importlib_metadata is in a different place, depending on the Python version.
+if sys.version_info < (3, 8):
+    import importlib_metadata
+else:
+    import importlib.metadata as importlib_metadata
 
 
 try:
@@ -45,7 +52,18 @@ def is_tpu_available():
 
 
 def is_deepspeed_available():
-    return importlib.util.find_spec("deepspeed") is not None
+    package_exists = importlib.util.find_spec("deepspeed") is not None
+    # Check we're not importing a "deepspeed" directory somewhere but the actual library by trying to grab the version
+    # AND checking it has an author field in the metadata that is HuggingFace.
+    if package_exists:
+        try:
+            _ = importlib_metadata.version("deepspeed")
+            _deepspeed_metadata = importlib_metadata.metadata("deepspeed")
+            if _deepspeed_metadata.get("author", "") != "DeepSpeed Team":
+                return False
+            return True
+        except importlib_metadata.PackageNotFoundError:
+            return False
 
 
 def is_tensorflow_available():


### PR DESCRIPTION
We are having issues in the tests of Transformers where there is a folder called `deepspeed` containing test files for DeepSpeed.
That folder gets interpreted as the "DeepSpeed" package by Accelerate, which then tries to import things.

This PR fixes that by making the test for `deepspeed` more robust (like we have for Datasets in Transformers).