### PR TITLE
Fix OneCycle step length when in multiprocess

### DIFF
--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -61,7 +61,9 @@ class AcceleratedScheduler:
             # num_processes steps per training step
             num_processes = AcceleratorState().num_processes
             for _ in range(num_processes):
-                self.scheduler.step(*args, **kwargs)
+                # Special case when using OneCycle and `drop_last` was not used
+                if getattr(self.scheduler, "total_steps", 0) < self.scheduler.last_epoch:
+                    self.scheduler.step(*args, **kwargs)
 
     # Passthroughs
     def get_last_lr(self):


### PR DESCRIPTION
# Fix improper number of times OneCycle scheduler is called

## What does this add?

This PR fixes an issue where `torch.optim.lr_scheduler.OneCycle.step` expects to be called a particular number of times, and will raise an issue when called more than this. The typical scenario of when this happens is when the user did not specify `drop_last=True` in their `DataLoaders`. For now this is specific to `OneCycle`, but the API will ideally be consistent if another scheduler is added to Pytorch that uses this same method of tracking maximum steps. 

Note: All other schedulers work, it's just OneCycle that does not

## Why is it needed?

The cv_examples currently all break in multiproc settings, due to the incorrect number of times `.step()` is being called

## What parts of the API does this impact?

### User-facing:

Nothing

### Internal structure:

Adds the following check if not `self.split_batches`:
```diff
for _ in range(num_processes):
   + if getattr(self.scheduler, "total_steps", 0) < self.scheduler.last_epoch:
        self.scheduler.step(*args, **kwargs)
```