### PR TITLE
Build Docker Images nightly

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -2,7 +2,6 @@ name: Build Docker images (scheduled)
 
 on:
   workflow_dispatch:
-  pull_request:
   schedule:
     - cron: "0 1 * * *"
 
@@ -10,41 +9,41 @@ jobs:
   latest-cuda:
     name: "Latest Accelerate GPU [dev]"
     runs-on: ubuntu-latest
-    # steps:
-    #   - name: Set up Docker Buildx
-    #     uses: docker/setup-buildx-action@v1
-    #   - name: Check out code
-    #     uses: actions/checkout@v2
-    #   - name: Login to DockerHub
-    #     uses: docker/login-action@v1
-    #     with:
-    #       username: ${{ secrets.DOCKERHUB_UESRNAME }}
-    #       password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_UESRNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-    #   - name: Build and Push GPU
-    #     uses: docker/build-push-action@v2
-    #     with:
-    #       context: ./docker/accelerate-gpu
-    #       push: true
-    #       tags: huggingface/accelerate-latest-gpu
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-gpu
+          push: true
+          tags: huggingface/accelerate-latest-gpu
 
   latest-cpu:
     name: "Latest Accelerate CPU [dev]"
     runs-on: ubuntu-latest
-    # steps:
-    #   - name: Set up Docker Buildx
-    #     uses: docker/setup-buildx-action@v1
-    #   - name: Check out code
-    #     uses: actions/checkout@v2
-    #   - name: Login to DockerHub
-    #     uses: docker/login-action@v1
-    #     with:
-    #       username: ${{ secrets.DOCKERHUB_UESRNAME }}
-    #       password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_UESRNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-    #   - name: Build and Push CPU
-    #     uses: docker/build-push-action@v2
-    #     with:
-    #       context: ./docker/accelerate-cpu
-    #       push: true
-    #       tags: huggingface/accelerate-latest-cpu
+      - name: Build and Push CPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-cpu
+          push: true
+          tags: huggingface/accelerate-latest-cpu

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_UESRNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push CPU

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,0 +1,49 @@
+name: Build Docker images (scheduled)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
+
+jobs:
+  latest-cuda:
+    name: "Latest Accelerate GPU [dev]"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_UESRNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-gpu
+          push: true
+          tags: huggingface/accelerate-latest-gpu
+
+  latest-cpu:
+    name: "Latest Accelerate CPU [dev]"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_UESRNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push CPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-cpu
+          push: true
+          tags: huggingface/accelerate-latest-cpu

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,7 +1,7 @@
 name: Build Docker images (scheduled)
 
 on:
-  repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           context: ./docker/accelerate-gpu
           push: true
-          tags: huggingface/accelerate-latest-gpu
+          tags: huggingface/accelerate-gpu
 
   latest-cpu:
     name: "Latest Accelerate CPU [dev]"
@@ -46,4 +46,4 @@ jobs:
         with:
           context: ./docker/accelerate-cpu
           push: true
-          tags: huggingface/accelerate-latest-cpu
+          tags: huggingface/accelerate-cpu

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -5,28 +5,11 @@ on:
   schedule:
     - cron: "0 1 * * *"
 
+concurrency:
+  group: docker-image-builds
+  cancel-in-progress: false
+
 jobs:
-  latest-cuda:
-    name: "Latest Accelerate GPU [dev]"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-      - name: Build and Push GPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-gpu
-          push: true
-          tags: huggingface/accelerate-gpu
-
   latest-cpu:
     name: "Latest Accelerate CPU [dev]"
     runs-on: ubuntu-latest
@@ -47,3 +30,24 @@ jobs:
           context: ./docker/accelerate-cpu
           push: true
           tags: huggingface/accelerate-cpu
+
+  latest-cuda:
+    name: "Latest Accelerate GPU [dev]"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-gpu
+          push: true
+          tags: huggingface/accelerate-gpu

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -2,6 +2,7 @@ name: Build Docker images (scheduled)
 
 on:
   workflow_dispatch:
+  pull_request:
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_UESRNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push GPU

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,7 +1,7 @@
 name: Build Docker images (scheduled)
 
 on:
-  workflow_dispatch:
+  repository_dispatch:
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -10,41 +10,41 @@ jobs:
   latest-cuda:
     name: "Latest Accelerate GPU [dev]"
     runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_UESRNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    # steps:
+    #   - name: Set up Docker Buildx
+    #     uses: docker/setup-buildx-action@v1
+    #   - name: Check out code
+    #     uses: actions/checkout@v2
+    #   - name: Login to DockerHub
+    #     uses: docker/login-action@v1
+    #     with:
+    #       username: ${{ secrets.DOCKERHUB_UESRNAME }}
+    #       password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and Push GPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-gpu
-          push: true
-          tags: huggingface/accelerate-latest-gpu
+    #   - name: Build and Push GPU
+    #     uses: docker/build-push-action@v2
+    #     with:
+    #       context: ./docker/accelerate-gpu
+    #       push: true
+    #       tags: huggingface/accelerate-latest-gpu
 
   latest-cpu:
     name: "Latest Accelerate CPU [dev]"
     runs-on: ubuntu-latest
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_UESRNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    # steps:
+    #   - name: Set up Docker Buildx
+    #     uses: docker/setup-buildx-action@v1
+    #   - name: Check out code
+    #     uses: actions/checkout@v2
+    #   - name: Login to DockerHub
+    #     uses: docker/login-action@v1
+    #     with:
+    #       username: ${{ secrets.DOCKERHUB_UESRNAME }}
+    #       password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      - name: Build and Push CPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-cpu
-          push: true
-          tags: huggingface/accelerate-latest-cpu
+    #   - name: Build and Push CPU
+    #     uses: docker/build-push-action@v2
+    #     with:
+    #       context: ./docker/accelerate-cpu
+    #       push: true
+    #       tags: huggingface/accelerate-latest-cpu

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -28,6 +28,8 @@ RUN python3 -m pip install --no-cache-dir \
 # Stage 2
 FROM python:3.6-slim AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
+RUN useradd -ms /bin/bash user
+USER user
 
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -16,9 +16,6 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv ${VIRTUAL_ENV}
 # Make sure we use the virtualenv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-
-RUN useradd -ms /bin/bash user
-USER user
 WORKDIR /workspace
 # Install specific CPU torch wheel to save on space
 RUN python3 -m pip install --upgrade --no-cache-dir pip
@@ -30,7 +27,6 @@ RUN python3 -m pip install --no-cache-dir \
 # Stage 2
 FROM python:3.6-slim AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
-COPY --from=compile-image /home/user /home/user
 RUN useradd -ms /bin/bash user
 USER user
 

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -17,6 +17,8 @@ RUN python3 -m venv ${VIRTUAL_ENV}
 # Make sure we use the virtualenv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 
+RUN useradd -ms /bin/bash user
+USER user
 WORKDIR /workspace
 # Install specific CPU torch wheel to save on space
 RUN python3 -m pip install --upgrade --no-cache-dir pip
@@ -28,6 +30,7 @@ RUN python3 -m pip install --no-cache-dir \
 # Stage 2
 FROM python:3.6-slim AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
+COPY --from=compile-image /home/user /home/user
 RUN useradd -ms /bin/bash user
 USER user
 

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -16,13 +16,13 @@ RUN conda create --name accelerate python=${PYTHON_VERSION} ipython jupyter pip
 # We don't install pytorch here yet since CUDA isn't available
 # instead we use the direct torch wheel
 ENV PATH /opt/conda/envs/accelerate/bin:$PATH
-ENV PATH /home/user/.local/bin$:PATH
 # Activate our bash shell
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
 # Activate usergroup
 RUN useradd -ms /bin/bash user
 USER user
+ENV PATH /home/user/.local/bin$:PATH
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -28,7 +28,6 @@ RUN source activate accelerate && \
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
-COPY --from=compile-image /home/user /home/user
 ENV PATH /opt/conda/bin:$PATH
 
 RUN echo "source activate accelerate" >> /.bashrc

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -19,10 +19,6 @@ ENV PATH /opt/conda/envs/accelerate/bin:$PATH
 # Activate our bash shell
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
-# Activate usergroup
-RUN useradd -ms /bin/bash user
-USER user
-ENV PATH /home/user/.local/bin$:PATH
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -29,6 +29,8 @@ RUN source activate accelerate && \
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
 ENV PATH /opt/conda/bin:$PATH
+RUN useradd -ms /bin/bash user
+USER user
 
 RUN echo "source activate accelerate" >> /.bashrc
 # Activate the virtualenv

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -19,6 +19,9 @@ ENV PATH /opt/conda/envs/accelerate/bin:$PATH
 # Activate our bash shell
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
+# Activate usergroup
+RUN useradd -ms /bin/bash user
+USER user
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -16,6 +16,7 @@ RUN conda create --name accelerate python=${PYTHON_VERSION} ipython jupyter pip
 # We don't install pytorch here yet since CUDA isn't available
 # instead we use the direct torch wheel
 ENV PATH /opt/conda/envs/accelerate/bin:$PATH
+ENV PATH /home/user/.local/bin$:PATH
 # Activate our bash shell
 RUN chsh -s /bin/bash
 SHELL ["/bin/bash", "-c"]
@@ -31,6 +32,7 @@ RUN source activate accelerate && \
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
+COPY --from=compile-image /home/user /home/user
 ENV PATH /opt/conda/bin:$PATH
 
 RUN echo "source activate accelerate" >> /.bashrc

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -29,9 +29,10 @@ RUN source activate accelerate && \
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
 ENV PATH /opt/conda/bin:$PATH
-RUN useradd -ms /bin/bash user
-USER user
 
 RUN echo "source activate accelerate" >> /.bashrc
+
+RUN useradd -ms /bin/bash user
+USER user
 # Activate the virtualenv
 CMD ["/bin/bash"]


### PR DESCRIPTION
# Build Docker Images Nightly
## What does this add?

This PR adds a workflow to publish two docker containers nightly: 

- [huggingface/accelerate-cpu](https://hub.docker.com/r/huggingface/accelerate-cpu)
- [huggingface/accelerate-gpu](https://hub.docker.com/r/huggingface/accelerate-gpu)

These will eventually be up-streamed and used in our nightly tests for testing multigpu, gpu, etc. 

I also modified the Dockerfile slightly to add a different end-user when launching the docker container for security reasons.
