### PR TITLE
Add packaging to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         ]
     },
     python_requires=">=3.6.0",
-    install_requires=["numpy>=1.17", "pyyaml", "torch>=1.4.0", "packaging>=20.0"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "pyyaml", "torch>=1.4.0"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         ]
     },
     python_requires=">=3.6.0",
-    install_requires=["torch>=1.4.0", "pyyaml", "numpy>=1.17"],
+    install_requires=["numpy>=1.17", "pyyaml", "torch>=1.4.0", "packaging>=20.0"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
# Add packaging to the project requirements

## What does this add?

This PR adds `packaging>=20.0` to the project requirements, which is the same pin as in [transformers](https://github.com/huggingface/transformers/blob/main/setup.py#L132)

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/393

## Why is it needed?

Current installations from source fail due to the `packaging` package needing to be installed in both accelerator.py and versions.py in huggingface/accelerate