### PR TITLE
improve train loss metric logged in examples

### DIFF
--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -301,7 +301,7 @@ def training_function(config, args):
                     {
                         "accuracy": eval_metric["accuracy"],
                         "f1": eval_metric["f1"],
-                        "train_loss": total_loss.item(),
+                        "train_loss": total_loss.item() / len(train_dataloader),
                     },
                     step=epoch,
                 )

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -222,7 +222,7 @@ def training_function(config, args):
                 {
                     "accuracy": eval_metric["accuracy"],
                     "f1": eval_metric["f1"],
-                    "train_loss": total_loss.item(),
+                    "train_loss": total_loss.item() / len(train_dataloader),
                     "epoch": epoch,
                 },
                 step=epoch,

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -258,7 +258,12 @@ def training_function(config, args):
         accelerator.print(f"epoch {epoch}: {100 * eval_metric:.2f}")
         if args.with_tracking:
             accelerator.log(
-                {"accuracy": 100 * eval_metric, "total_loss": total_loss, "epoch": epoch}, step=overall_step
+                {
+                    "accuracy": 100 * eval_metric,
+                    "train_loss": total_loss.item() / len(train_dataloader),
+                    "epoch": epoch,
+                },
+                step=overall_step,
             )
         if checkpointing_steps == "epoch":
             output_dir = f"epoch_{epoch}"

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -246,7 +246,7 @@ def training_function(config, args):
                 {
                     "accuracy": eval_metric["accuracy"],
                     "f1": eval_metric["f1"],
-                    "train_loss": total_loss.item(),
+                    "train_loss": total_loss.item() / len(train_dataloader),
                     "epoch": epoch,
                 },
                 step=epoch,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -100,13 +100,13 @@ class ExampleDifferenceTests(unittest.TestCase):
         cv_path = os.path.abspath(os.path.join("examples", "cv_example.py"))
         special_strings = [
             " " * 16 + "{\n\n",
-            " " * 18 + '"accuracy": eval_metric["accuracy"],\n\n',
-            " " * 18 + '"f1": eval_metric["f1"],\n\n',
-            " " * 18 + '"train_loss": total_loss.item(),\n\n',
-            " " * 18 + '"epoch": epoch,\n\n',
+            " " * 20 + '"accuracy": eval_metric["accuracy"],\n\n',
+            " " * 20 + '"f1": eval_metric["f1"],\n\n',
+            " " * 20 + '"train_loss": total_loss.item() / len(train_dataloader),\n\n',
+            " " * 20 + '"epoch": epoch,\n\n',
             " " * 16 + "},\n\n",
             " " * 16 + "step=epoch,\n",
-            " " * 8,
+            " " * 12,
         ]
         self.one_complete_example("complete_cv_example.py", True, cv_path, special_strings)
         self.one_complete_example("complete_cv_example.py", False, cv_path, special_strings)


### PR DESCRIPTION
### What does this PR do?

1. Train loss being logged wasn't normalized and as such wasn't intuitive to understand. This also made it difficult to compare train loss between different tools such as comparing train loss from Trainer with that of Accelerate. This PR normalizes the train_loss per epoch to make is more intuitive and comparable.