### PR TITLE
Introduce nightly runners

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,7 +1,7 @@
 name: Build Docker images (scheduled)
 
 on:
-  repository_dispatch:
+  workflow_dispatch:
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,7 +1,7 @@
 name: Build Docker images (scheduled)
 
 on:
-  workflow_dispatch:
+  repository_dispatch:
   schedule:
     - cron: "0 1 * * *"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,65 @@
+name: Self-hosted runner (scheduled)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  run_all_tests_single_gpu:
+    runs-on: [self-hosted, docker-gpu, multi-gpu]
+    env:
+      CUDA_VISIBLE_DEVICES: "0"
+      ALL_SLOW: "yes"
+    container:
+      image: huggingface/accelerate-gpu:latest
+      options: --gpus all --shm-size "16gb"
+    defaults:
+      run:
+        working-directory: accelerate/
+        shell: bash
+    steps:
+      - name: Update clone & pip install
+        run: |
+          source activate accelerate
+          git config --global --add safe.directory '*'
+          git fetch && git checkout ${{ github.sha }}
+          pip install -e . --no-deps
+          pip install tensorflow -U
+      - name: Run test on GPUs
+        run: |
+          source activate accelerate
+          make test_cuda
+      - name: Run examples on GPUs
+        run: |
+          source activate accelerate
+          make test_examples
+
+  run_all_tests_multi_gpu:
+    runs-on: [self-hosted, docker-gpu, multi-gpu]
+    env:
+      ALL_SLOW: "yes"
+    container:
+      image: huggingface/accelerate-gpu:latest
+      options: --gpus all --shm-size "16gb"
+    defaults:
+      run:
+        working-directory: accelerate/
+        shell: bash
+    steps:
+      - name: Update clone
+        run: |
+          source activate accelerate
+          git config --global --add safe.directory '*'
+          git fetch && git checkout ${{ github.sha }}
+          pip install -e . --no-deps
+          pip install tensorflow -U
+      - name: Run test on GPUs
+        run: |
+          source activate accelerate
+          make test_cuda
+
+      - name: Run examples on GPUs
+        run: |
+          source activate accelerate
+          make test_examples

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,11 @@ jobs:
           source activate accelerate
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
+          pip install tensorflow -U 
           pip install -e . --no-deps
+
+# Note: tensorflow upgrade is needed until dropped py 3.6 support
+
       - name: Run test on GPUs
         run: |
           source activate accelerate
@@ -51,7 +55,11 @@ jobs:
           source activate accelerate
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
+          pip install tensorflow -U
           pip install -e . --no-deps
+
+        # Note: tensorflow upgrade is needed until dropped py 3.6 support
+
       - name: Run test on GPUs
         run: |
           source activate accelerate

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,6 @@ jobs:
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
           pip install -e . --no-deps
-          pip install tensorflow -U
       - name: Run test on GPUs
         run: |
           source activate accelerate
@@ -53,7 +52,6 @@ jobs:
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
           pip install -e . --no-deps
-          pip install tensorflow -U
       - name: Run test on GPUs
         run: |
           source activate accelerate

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     env:
       ALL_SLOW: "yes"
+      CUDA_VISIBLE_DEVICES: "0,1"
     container:
       image: huggingface/accelerate-gpu:latest
       options: --gpus all --shm-size "16gb"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install Python dependencies
       run: pip install setuptools==59.5.0; pip install -e .[test,test_trackers]
     - name: Run Tests
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install Python dependencies
       run: pip install setuptools==59.5.0; pip install -e .[test] tensorboard
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       with:
         python-version: 3.7
     - name: Install Python dependencies
-      run: pip install setuptools==59.5.0; pip install -e .[test,test_trackers]
+      run: pip install -e .[test,test_trackers]
     - name: Run Tests
       run: make test_cpu
       
@@ -25,6 +25,6 @@ jobs:
       with:
         python-version: 3.7
     - name: Install Python dependencies
-      run: pip install setuptools==59.5.0; pip install -e .[test] tensorboard
+      run: pip install -e .[test] tensorboard
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install Python dependencies
-      run: pip install -e .[test,test_trackers]
+      run: pip install setuptools==59.5.0; pip install -e .[test,test_trackers]
     - name: Run Tests
       run: make test_cpu
       
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.7
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.7
+        python-version: 3.6
     - name: Install Python dependencies
-      run: pip install -e .[test] tensorboard
+      run: pip install setuptools==59.5.0; pip install -e .[test] tensorboard
     - name: Run Tests
       run: make test_examples

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -1,7 +1,7 @@
 # Builds CPU-only Docker image of PyTorch
 # Uses multi-staged approach to reduce size
 # Stage 1
-FROM python:3.6-slim as compile-image
+FROM python:3.7-slim as compile-image
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -25,7 +25,7 @@ RUN python3 -m pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu
     
 # Stage 2
-FROM python:3.6-slim AS build-image
+FROM python:3.7-slim AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
 # Install apt libs
 RUN apt-get update && \

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -21,8 +21,8 @@ WORKDIR /workspace
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
-    torch --extra-index-url https://download.pytorch.org/whl/cpu \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers]
+    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers] \
+    --extra-index-url https://download.pytorch.org/whl/cpu
     
 # Stage 2
 FROM python:3.6-slim AS build-image

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -22,7 +22,7 @@ RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
     torch --extra-index-url https://download.pytorch.org/whl/cpu \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev]
+    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers]
     
 # Stage 2
 FROM python:3.6-slim AS build-image

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /workspace
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
-    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[dev,test_trackers] \
+    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[test,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cpu
     
 # Stage 2

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -27,8 +27,11 @@ RUN python3 -m pip install --no-cache-dir \
 # Stage 2
 FROM python:3.6-slim AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
-RUN useradd -ms /bin/bash user
-USER user
+# Install apt libs
+RUN apt-get update && \
+    apt-get install -y curl git wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists*
 
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -1,7 +1,7 @@
 # Builds CPU-only Docker image of PyTorch
 # Uses multi-staged approach to reduce size
 # Stage 1
-FROM python:3.7-slim as compile-image
+FROM python:3.6-slim as compile-image
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -21,17 +21,14 @@ WORKDIR /workspace
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
-    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[test,test_trackers] \
+    git+https://github.com/huggingface/accelerate#egg=accelerate[test,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cpu
     
 # Stage 2
-FROM python:3.7-slim AS build-image
+FROM python:3.6-slim AS build-image
 COPY --from=compile-image /opt/venv /opt/venv
-# Install apt libs
-RUN apt-get update && \
-    apt-get install -y curl git wget && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists*
+RUN useradd -ms /bin/bash user
+USER user
 
 # Make sure we use the virtualenv
 ENV PATH="/opt/venv/bin:$PATH"

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -21,8 +21,8 @@ WORKDIR /workspace
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers] \
-    --extra-index-url https://download.pytorch.org/whl/cpu
+    torch --extra-index-url https://download.pytorch.org/whl/cpu \
+    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers]
     
 # Stage 2
 FROM python:3.6-slim AS build-image

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /workspace
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers] \
+    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[dev,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cpu
     
 # Stage 2

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -30,9 +30,13 @@ FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda
 ENV PATH /opt/conda/bin:$PATH
 
-RUN echo "source activate accelerate" >> /.bashrc
+# Install apt libs
+RUN apt-get update && \
+    apt-get install -y curl git wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists*
 
-RUN useradd -ms /bin/bash user
-USER user
+RUN echo "source activate accelerate" >> ~/.profile
+
 # Activate the virtualenv
 CMD ["/bin/bash"]

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -23,7 +23,7 @@ SHELL ["/bin/bash", "-c"]
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
     torch --extra-index-url https://download.pytorch.org/whl/cu113 \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev]
+    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers]
 
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -22,8 +22,8 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    torch --extra-index-url https://download.pytorch.org/whl/cu113 \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers]
+    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers] \
+    --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -4,7 +4,7 @@
 # Use base conda image to reduce time
 FROM continuumio/miniconda3:latest AS compile-image
 # Specify py version
-ENV PYTHON_VERSION=3.7
+ENV PYTHON_VERSION=3.6
 # Install apt libs
 RUN apt-get update && \
     apt-get install -y curl git wget && \

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers] \
+    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[dev,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Stage 2

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[dev,test_trackers] \
+    git+https://github.com/huggingface/accelerate@nightly-runner#egg=accelerate[test,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Stage 2

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -4,7 +4,7 @@
 # Use base conda image to reduce time
 FROM continuumio/miniconda3:latest AS compile-image
 # Specify py version
-ENV PYTHON_VERSION=3.6 
+ENV PYTHON_VERSION=3.7
 # Install apt libs
 RUN apt-get update && \
     apt-get install -y curl git wget && \

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -22,8 +22,8 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers] \
-    --extra-index-url https://download.pytorch.org/whl/cu113
+    torch --extra-index-url https://download.pytorch.org/whl/cu113 \
+    git+https://github.com/huggingface/accelerate#egg=accelerate[dev,test_trackers]
 
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
 extras["docs"] = []
 extras["test"] = [
+    "psutil", 
     "pytest",
     "pytest-xdist",
     "pytest-subtests",
@@ -27,7 +28,7 @@ extras["test"] = [
     "scipy",
     "sklearn"
 ]
-extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow"]
+extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow>=2.6.2", "tensorboard"]
 extras["dev"] = extras["quality"] + extras["test"]
 
 extras["sagemaker"] = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras["test"] = [
     "scipy",
     "sklearn"
 ]
-extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow>=2.8.0", "tensorboard"]
+extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow>=2.6.2", "tensorboard"]
 extras["dev"] = extras["quality"] + extras["test"]
 
 extras["sagemaker"] = [

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras["test"] = [
     "scipy",
     "sklearn"
 ]
-extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow>=2.6.2", "tensorboard"]
+extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow>=2.8.0", "tensorboard"]
 extras["dev"] = extras["quality"] + extras["test"]
 
 extras["sagemaker"] = [

--- a/src/accelerate/test_utils/training.py
+++ b/src/accelerate/test_utils/training.py
@@ -17,8 +17,6 @@ import torch
 from torch.utils.data import DataLoader
 
 from accelerate.utils.dataclasses import DistributedType
-from datasets import load_dataset
-from transformers import AutoTokenizer
 
 
 class RegressionDataset:
@@ -51,6 +49,9 @@ class RegressionModel(torch.nn.Module):
 
 
 def mocked_dataloaders(accelerator, batch_size: int = 16):
+    from datasets import load_dataset
+    from transformers import AutoTokenizer
+
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
     data_files = {"train": "tests/test_samples/MRPC/train.csv", "validation": "tests/test_samples/MRPC/dev.csv"}
     datasets = load_dataset("csv", data_files=data_files)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -147,7 +147,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
-        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_6")))
 
     def test_load_states_by_epoch(self):
         testargs = f"""
@@ -164,7 +164,7 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
+        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_6")}
         """.split()
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,7 +17,6 @@ import os
 import re
 import shutil
 import subprocess
-import torch
 import tempfile
 import unittest
 from unittest import mock
@@ -25,6 +24,7 @@ from unittest import mock
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import TempDirTestCase, slow
 from accelerate.utils import write_basic_config
+from accelerate.state import AcceleratorState
 
 
 # DataLoaders built from `test_samples/MRPC` for quick testing
@@ -169,10 +169,11 @@ class FeatureExamplesTests(TempDirTestCase):
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).stdout
-        if torch.cuda.is_available():
-            num_processes = torch.cuda.device_count()
-        else:
-            num_processes = 1
+        num_processes = AcceleratorState().num_processes
+        # if torch.cuda.is_available():
+        #     num_processes = torch.cuda.device_count()
+        # else:
+        #     num_processes = 1
         if num_processes > 1:
             self.assertNotIn("epoch 0:", output)
             self.assertNotIn("epoch 1:", output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,10 +21,11 @@ import tempfile
 import unittest
 from unittest import mock
 
+import torch
+
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import TempDirTestCase, slow
 from accelerate.utils import write_basic_config
-from accelerate.state import AcceleratorState
 
 
 # DataLoaders built from `test_samples/MRPC` for quick testing

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -147,7 +147,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
-        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_5")))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
 
     def test_load_states_by_epoch(self):
         testargs = f"""
@@ -164,7 +164,7 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_5")}
+        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
         """.split()
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -21,6 +21,7 @@ import tempfile
 import unittest
 from unittest import mock
 
+from accelerate import Accelerator
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import TempDirTestCase, slow
 from accelerate.utils import write_basic_config
@@ -142,11 +143,11 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_checkpointing_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --checkpointing_steps 2
+        --checkpointing_steps 1
         --output_dir {self.tmpdir}
         """.split()
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
-        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_4")))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_5")))
 
     def test_load_states_by_epoch(self):
         testargs = f"""
@@ -163,14 +164,20 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_4")}
+        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_5")}
         """.split()
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).stdout
-        self.assertNotIn("epoch 0:", output)
-        self.assertIn("epoch 1:", output)
-        self.assertIn("epoch 2:", output)
+        num_processes = Accelerator().num_processes
+        if num_processes > 1:
+            self.assertNotIn("epoch 0:", output)
+            self.assertNotIn("epoch 1:", output)
+            self.assertIn("epoch 2:", output)
+        else:
+            self.assertNotIn("epoch 0:", output)
+            self.assertIn("epoch 1:", output)
+            self.assertIn("epoch 2:", output)
 
     @slow
     def test_cross_validation(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -147,7 +147,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         _ = subprocess.run(self._launch_args + testargs, stdout=subprocess.PIPE, env=os.environ)
-        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_6")))
+        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_5")))
 
     def test_load_states_by_epoch(self):
         testargs = f"""
@@ -164,7 +164,7 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_6")}
+        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_5")}
         """.split()
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -169,11 +169,10 @@ class FeatureExamplesTests(TempDirTestCase):
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).stdout
-        num_processes = AcceleratorState().num_processes
-        # if torch.cuda.is_available():
-        #     num_processes = torch.cuda.device_count()
-        # else:
-        #     num_processes = 1
+        if torch.cuda.is_available():
+            num_processes = torch.cuda.device_count()
+        else:
+            num_processes = 1
         if num_processes > 1:
             self.assertNotIn("epoch 0:", output)
             self.assertNotIn("epoch 1:", output)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,11 +17,11 @@ import os
 import re
 import shutil
 import subprocess
+import torch
 import tempfile
 import unittest
 from unittest import mock
 
-from accelerate import Accelerator
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import TempDirTestCase, slow
 from accelerate.utils import write_basic_config
@@ -169,7 +169,10 @@ class FeatureExamplesTests(TempDirTestCase):
         output = subprocess.run(
             self._launch_args + testargs, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         ).stdout
-        num_processes = Accelerator().num_processes
+        if torch.cuda.is_available():
+            num_processes = torch.cuda.device_count()
+        else:
+            num_processes = 1
         if num_processes > 1:
             self.assertNotIn("epoch 0:", output)
             self.assertNotIn("epoch 1:", output)


### PR DESCRIPTION
# Introduce nightly runners

## Important

**Should be merged after**:
* #407 
* #408 
* #409 

## What does this add?

This PR adds nightly runners that will test on a GPU and multi-GPU, and runs all slow tests. In total it should take somewhere between 5-10 minutes to run (depending on whether a cache of a Docker image needed to be downloaded beforehand)

## Why is it needed?

We currently have no runners for testing CUDA and multi-GPU tests, or slow tests on the CI. As a result there were **many** undiscovered errors and bugs that needed to be solved. This PR ensures that we can trust the quality of our code and know when we have issues on platforms other than on the CPU.

Currently they are running nightly, a different workflow will handle when pushes to main occur that I will work on later next week.