### PR TITLE
Move datasets and transformers to under func

### DIFF
--- a/src/accelerate/test_utils/training.py
+++ b/src/accelerate/test_utils/training.py
@@ -17,8 +17,6 @@ import torch
 from torch.utils.data import DataLoader
 
 from accelerate.utils.dataclasses import DistributedType
-from datasets import load_dataset
-from transformers import AutoTokenizer
 
 
 class RegressionDataset:
@@ -51,6 +49,9 @@ class RegressionModel(torch.nn.Module):
 
 
 def mocked_dataloaders(accelerator, batch_size: int = 16):
+    from datasets import load_dataset
+    from transformers import AutoTokenizer
+
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
     data_files = {"train": "tests/test_samples/MRPC/train.csv", "validation": "tests/test_samples/MRPC/dev.csv"}
     datasets = load_dataset("csv", data_files=data_files)


### PR DESCRIPTION
# Refactor test-specific imports for `mocked_dataloaders` under the function

## What does this add?

This PR changes when imports are called for importing datasets and transformers. 

## Who is it for?

closes https://github.com/huggingface/accelerate/issues/403

## Why is it needed?

Due to how imports are checked in python, currently the released Accelerate version on pypi technically requires datasets and transformers to be required. This PR remedy's this. I'd recommend a patch release afterwards. (So this wouldn't increase our minimum python from 3.6 *yet*)
