### PR TITLE
Fix debug_launcher issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,8 @@ style:
 	python utils/style_doc.py src/accelerate docs/source --max_len 119
 	
 # Run tests for the library
-test_cpu:
+test:
 	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py
-
-test_cuda:
-	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py --ignore=./tests/test_scheduler.py --ignore=./tests/test_cpu.py
-	python -m pytest -s -v ./tests/test_cpu.py ./tests/test_scheduler.py
 
 test_examples:
 	python -m pytest -s -v ./tests/test_examples.py

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -2,5 +2,13 @@
 # There's no way to ignore "F401 '...' imported but unused" warnings in this
 # module, but to preserve other warnings. So, don't check this module at all.
 
-from .testing import are_the_same_tensors, execute_subprocess_async, require_cuda, require_multi_gpu, require_tpu, slow
+from .testing import (
+    are_the_same_tensors,
+    execute_subprocess_async,
+    require_cpu,
+    require_cuda,
+    require_multi_gpu,
+    require_tpu,
+    slow,
+)
 from .training import RegressionDataset, RegressionModel

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -56,6 +56,13 @@ def slow(test_case):
     return unittest.skipUnless(_run_slow_tests, "test is slow")(test_case)
 
 
+def require_cpu(test_case):
+    """
+    Decorator marking a test that must be only ran on the CPU. These tests are skipped when a GPU is available.
+    """
+    return unittest.skipUnless(not torch.cuda.is_available(), "test requires only a CPU")(test_case)
+
+
 def require_cuda(test_case):
     """
     Decorator marking a test that requires CUDA. These tests are skipped when there are no GPU available.

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -15,9 +15,10 @@
 import unittest
 
 from accelerate import debug_launcher
-from accelerate.test_utils import test_script
+from accelerate.test_utils import require_cpu, test_script
 
 
+@require_cpu
 class MultiCPUTester(unittest.TestCase):
     def test_cpu(self):
         debug_launcher(test_script.main)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -18,6 +18,7 @@ from functools import partial
 import torch
 
 from accelerate import Accelerator, debug_launcher
+from accelerate.test_utils import require_cpu
 
 
 def scheduler_test(num_processes=2, step_scheduler_with_optimizer=True, split_batches=False):
@@ -46,6 +47,7 @@ def scheduler_test(num_processes=2, step_scheduler_with_optimizer=True, split_ba
     ), f"Wrong lr found at second step, expected {expected_lr}, got {scheduler.get_last_lr()[0]}"
 
 
+@require_cpu
 class SchedulerTester(unittest.TestCase):
     def test_scheduler_steps_with_optimizer_single_process(self):
         debug_launcher(partial(scheduler_test, num_processes=1), num_processes=1)


### PR DESCRIPTION
# Fix Debug Launcher + CUDA breakage with tests

## What does this add?

This PR introduces fixes for tests that run `debug_launcher`. They must be performed only on the CPU, as otherwise at some point if any previous tests were ran on the GPU, CUDA has been initialized for this instance of python and as a result torch will complain and break saying that a multiprocessing error has occured.

## Who is it for?

closes https://github.com/huggingface/accelerate/issues/402

## Why is it needed?

Currently running all of the tests will crash the CUDA process, due to it trying to reinitialize CUDA. From there we had the Makefile split into 2 separate calls to pytest, but given that this breakage (and since they really only run on the CPU), these tests are now under a `require_cpu` tag that will only run if CUDA is not available. 

> Note: If these tests are run *first*, it will not break. But for keeping it simple for the user we are going with this methodology

## What parts of the API does this impact?

### User-facing:

Nothing

### Internal structure:

If any test should be ran on the GPU, decorate it with:

```python
from accelerate.test_utils import require_cpu

@require_cpu
def some_test_for_cpu_only(self):
...
```
