### PR TITLE
Introduce post-merge runners

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -40,8 +40,6 @@ jobs:
 
   run_all_tests_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
-    env:
-      ALL_SLOW: "yes"
     container:
       image: huggingface/accelerate-gpu:latest
       options: --gpus all --shm-size "16gb"

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -25,7 +25,7 @@ jobs:
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
           pip install tensorflow -U 
-          pip install -e . --no-deps
+          pip install -e . -U
 
 # Note: tensorflow upgrade is needed until dropped py 3.6 support
 
@@ -54,7 +54,7 @@ jobs:
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
           pip install tensorflow -U
-          pip install -e . --no-deps
+          pip install -e . -U
 
         # Note: tensorflow upgrade is needed until dropped py 3.6 support
 

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,16 +1,16 @@
-name: Self-hosted runner (scheduled)
+name: Self-hosted runner (push to "main")
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 2 * * *"
+  push:
+    branches:
+      - "main"
 
 jobs:
   run_all_tests_single_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     env:
       CUDA_VISIBLE_DEVICES: "0"
-      ALL_SLOW: "yes"
     container:
       image: huggingface/accelerate-gpu:latest
       options: --gpus all --shm-size "16gb"
@@ -42,7 +42,6 @@ jobs:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     env:
       ALL_SLOW: "yes"
-      CUDA_VISIBLE_DEVICES: "0,1"
     container:
       image: huggingface/accelerate-gpu:latest
       options: --gpus all --shm-size "16gb"


### PR DESCRIPTION
# Introduce post-merge commit CUDA workflow

## What does this add?

This PR adds a similar workflow to the nightly tests, that will run tests for Accelerate post a commit to main. The main difference is we do not run the slow tests so that if multiple PR's are accepted in rapid succession (or pushes to main in general), the queue is not hanging for ages to let everyone through. But, it is rapid enough to where if a push to main did break something in CUDA, we are made aware of it. 
