### PR TITLE
Switch to evaluate for metrics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
-        pip install git+https://github.com/huggingface/evaluate.git
         pip install -e .[test,test_trackers]
     - name: Run Tests
       run: make test
@@ -30,7 +29,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
-        pip install git+https://github.com/huggingface/evaluate.git
         pip install -e .[test] tensorboard
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install setuptools==59.5.0
+        pip install git+https://github.com/huggingface/evaluate.git
         pip install -e .[test,test_trackers]
     - name: Run Tests
       run: make test
@@ -31,6 +32,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install setuptools==59.5.0
+        pip install git+https://github.com/huggingface/evaluate.git
         pip install -e .[test] tensorboard
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
-        pip install -e .[test] tensorboard
+        pip install -e .[test] protobuf<=3.20.1 tensorboard
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
-        pip install -e .[test] protobuf<=3.20.1 tensorboard
+        pip install -e .[test,tensorboard]
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,10 @@ jobs:
       with:
         python-version: 3.6
     - name: Install Python dependencies
-      run: pip install --upgrade pip
-      run: pip install setuptools==59.5.0; pip install -e .[test,test_trackers]
+      run: |
+        pip install --upgrade pip
+        pip install setuptools==59.5.0
+        pip install -e .[test,test_trackers]
     - name: Run Tests
       run: make test
       
@@ -26,7 +28,9 @@ jobs:
       with:
         python-version: 3.6
     - name: Install Python dependencies
-      run: pip install --upgrade pip
-      run: pip install setuptools==59.5.0; pip install -e .[test] tensorboard
+      run: |
+        pip install --upgrade pip
+        pip install setuptools==59.5.0
+        pip install -e .[test] tensorboard
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       with:
         python-version: 3.6
     - name: Install Python dependencies
+      run: pip install --upgrade pip
       run: pip install setuptools==59.5.0; pip install -e .[test,test_trackers]
     - name: Run Tests
       run: make test
@@ -25,6 +26,7 @@ jobs:
       with:
         python-version: 3.6
     - name: Install Python dependencies
+      run: pip install --upgrade pip
       run: pip install setuptools==59.5.0; pip install -e .[test] tensorboard
     - name: Run Tests
       run: make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
-        pip install setuptools==59.5.0
         pip install git+https://github.com/huggingface/evaluate.git
         pip install -e .[test,test_trackers]
     - name: Run Tests
@@ -31,7 +30,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install --upgrade pip
-        pip install setuptools==59.5.0
         pip install git+https://github.com/huggingface/evaluate.git
         pip install -e .[test] tensorboard
     - name: Run Tests

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,7 +23,7 @@ The [nlp_example.py](./nlp_example.py) script is a simple example to train a Ber
 Prior to running it you should install 🤗 Dataset and 🤗 Transformers:
 
 ```bash
-pip install datasets transformers
+pip install datasets evaluate transformers
 ```
 
 The same script can be run in any of the following configurations:

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -18,8 +18,9 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AdamW,
     AutoModelForSequenceClassification,
@@ -137,7 +138,7 @@ def training_function(config, args):
     set_seed(seed)
 
     train_dataloader, eval_dataloader = get_dataloaders(accelerator, batch_size)
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     # If the batch size is too big we use gradient accumulation
     gradient_accumulation_steps = 1

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -19,8 +19,9 @@ import numpy as np
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import DatasetDict, load_dataset, load_metric
+from datasets import DatasetDict, load_dataset
 
 # New Code #
 # We'll be using StratifiedKFold for this example
@@ -144,7 +145,7 @@ def training_function(config, args):
     seed = int(config["seed"])
     batch_size = int(config["batch_size"])
 
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     # If the batch size is too big we use gradient accumulation
     gradient_accumulation_steps = 1

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -19,8 +19,9 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, get_linear_schedule_with_warmup, set_seed
 
 
@@ -119,7 +120,7 @@ def training_function(config, args):
 
     tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
     datasets = load_dataset("glue", "mrpc")
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -17,11 +17,11 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
-from accelerate import Accelerator, DistributedType
-
 # New Code #
+import evaluate
+from accelerate import Accelerator, DistributedType
 from accelerate.utils import find_executable_batch_size
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AdamW,
     AutoModelForSequenceClassification,
@@ -121,7 +121,7 @@ def training_function(config, args):
     seed = int(config["seed"])
     batch_size = int(config["batch_size"])
 
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     # If the batch size is too big we use gradient accumulation
     gradient_accumulation_steps = 1

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -18,8 +18,9 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AdamW,
     AutoModelForSequenceClassification,
@@ -122,7 +123,7 @@ def training_function(config, args):
     seed = int(config["seed"])
     batch_size = int(config["batch_size"])
 
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     # If the batch size is too big we use gradient accumulation
     gradient_accumulation_steps = 1

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -18,8 +18,9 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AdamW,
     AutoModelForSequenceClassification,
@@ -132,7 +133,7 @@ def training_function(config, args):
     set_seed(seed)
 
     train_dataloader, eval_dataloader = get_dataloaders(accelerator, batch_size)
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     # If the batch size is too big we use gradient accumulation
     gradient_accumulation_steps = 1

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -18,8 +18,9 @@ import os
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AdamW,
     AutoModelForSequenceClassification,
@@ -89,7 +90,7 @@ def training_function(config, args):
 
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
     datasets = load_dataset("glue", "mrpc")
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -17,8 +17,9 @@ import argparse
 import torch
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator, DistributedType
-from datasets import load_dataset, load_metric
+from datasets import load_dataset
 from transformers import (
     AdamW,
     AutoModelForSequenceClassification,
@@ -106,7 +107,7 @@ def training_function(config, args):
     seed = int(config["seed"])
     batch_size = int(config["batch_size"])
 
-    metric = load_metric("glue", "mrpc")
+    metric = evaluate.load("glue", "mrpc")
 
     # If the batch size is too big we use gradient accumulation
     gradient_accumulation_steps = 1

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ extras["test"] = [
     "pytest-xdist",
     "pytest-subtests",
     "datasets",
+    "evaluate",
     "transformers",
     "scipy",
     "sklearn"

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ extras["test"] = [
     "scipy",
     "sklearn"
 ]
-extras["test_trackers"] = ["wandb", "comet-ml", "tensorflow>=2.6.2", "tensorboard"]
+extras["test_trackers"] = ["wandb", "comet-ml", "protobuf<=3.20.1", "tensorflow>=2.6.2", "tensorboard"]
 extras["dev"] = extras["quality"] + extras["test"]
 
 extras["sagemaker"] = [

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ extras["test"] = [
     "scipy",
     "sklearn"
 ]
-extras["test_trackers"] = ["wandb", "comet-ml", "protobuf<=3.20.1", "tensorflow>=2.6.2", "tensorboard"]
+extras["tensorboard"] = ["protobuf<=3.20.1", "tensorflow>=2.6.2", "tensorboard"]
+extras["test_trackers"] = extras["tensorboard"] + ["wandb", "comet-ml"]
 extras["dev"] = extras["quality"] + extras["test"]
 
 extras["sagemaker"] = [


### PR DESCRIPTION
This PR switches all example scripts to use `evaluate` instead of `datasets` for the metric computation. cc @lvwerra 