### PR TITLE
Speedup main CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,34 +1,44 @@
 name: Run Tests
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
+
+env:
+  HF_HOME: ~/hf_cache
 
 jobs:
-  test:
+  run-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test-kind: [
+          test,
+          test_example_differences,
+          test_checkpoint_step,
+          test_checkpoint_epoch,
+          test_rest
+        ]
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up python 3.7
+      id: setup_python
+      uses: actions/setup-python@v3
       with:
         python-version: 3.7
-    - name: Install Python dependencies
-      run: |
-        pip install --upgrade pip
-        pip install -e .[test,test_trackers]
-    - name: Run Tests
-      run: make test
-      
-  test_examples:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.7
-      uses: actions/setup-python@v2
+    
+    - name: Activate python cache
+      id: python_cache
+      uses: actions/cache@v3
       with:
-        python-version: 3.7
-    - name: Install Python dependencies
+        path: |
+          ${{ env.pythonLocation }}
+          ${{ env.HF_HOME }}
+        key: ${{ env.pythonLocation }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
+    
+    - name: Install the library
       run: |
         pip install --upgrade pip
-        pip install -e .[test,tensorboard]
+        pip install -e .[test,test_trackers,tensorboard]
+    
     - name: Run Tests
-      run: make test_examples
+      run: |
+        make ${{ matrxi.test-kind }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up python 3.7
-      id: setup_python
       uses: actions/setup-python@v3
       with:
         python-version: 3.7
     
     - name: Activate python cache
-      id: python_cache
       uses: actions/cache@v3
       with:
         path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 
 env:
   HF_HOME: ~/hf_cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
     
     - name: Run Tests
       run: |
-        make ${{ matrxi.test-kind }}
+        make ${{ matrix.test-kind }}

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,16 @@ test:
 
 test_examples:
 	python -m pytest -s -v ./tests/test_examples.py
+
+# Broken down example tests for the CI runners
+test_example_differences:
+	python -m pytest -s -v ./tests/test_examples.py::ExampleDifferenceTests
+
+test_checkpoint_epoch:
+	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "by_epoch"
+
+test_checkpoint_step:
+	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "by_step"
+
+test_rest:
+	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "not by_step and not by_epoch"


### PR DESCRIPTION
# Speed up main GitHub CI

## What does this add?

This PR speeds up the time for the github CI tests to pass by ~2.5x through a few basic optimizations:

### Adjustments to the Makefile
Four new test conditionals were added to the `Makefile` based on groupings of how each example test needs to be ran, and how their topics relate to each other:  
- `test_example_differences`: The quick method that checks if the .py files are missing any parts in the examples/ dir
- `test_checkpoint_step`: tests relating to checkpoint by step and load checkpoint by step
- `test_checkpoint_epoch`: tests relating to checkpoint by epoch and loading checkpoint by epoch
- `test_rest`: Everything that did not fall under the previous three

### Use setup-python@v3 and cache@v3
By using these two specific actions, we can speed up the time it takes to setup the python environment, cache the pip installation, and also cache the model downloads. 

### Total Speedup
* Main tests: 2m42s -> 1m16s (~2x speedup)
* Example tests: 9m5s -> ~(3m47s, 4m20s) (~2.1-2.4x speedup)
(This also counts as the overall time taken)

Without the cache, it's ~8.5 minutes on that first commit/run. 