### PR TITLE
Enable slow tests during nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,12 +5,14 @@ on:
   schedule:
     - cron: "0 2 * * *"
 
+env:
+  RUN_SLOW: "yes"
+
 jobs:
   run_all_tests_single_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     env:
       CUDA_VISIBLE_DEVICES: "0"
-      ALL_SLOW: "yes"
     container:
       image: huggingface/accelerate-gpu:latest
       options: --gpus all --shm-size "16gb"
@@ -38,7 +40,6 @@ jobs:
   run_all_tests_multi_gpu:
     runs-on: [self-hosted, docker-gpu, multi-gpu]
     env:
-      ALL_SLOW: "yes"
       CUDA_VISIBLE_DEVICES: "0,1"
     container:
       image: huggingface/accelerate-gpu:latest


### PR DESCRIPTION
# What does this PR do?

This PR enables the slow tests to be ran as part of the nightly builds. These seem to have gotten fixed during https://github.com/huggingface/accelerate/pull/420 as shown in https://github.com/huggingface/accelerate/runs/6697809890?check_suite_focus=true

(Failure in that runner is unrelated to the slow tests, and the multi-gpu one ran before the new docker image was out).

Finally stabilized our full CI test suite outside TPUs ❤️ 