### PR TITLE
Fix secrets in Docker workflow

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -3,7 +3,7 @@ name: Check for dependency modification
 on:
   push:
     branches:
-      - fix-secrets
+      - main
   workflow_dispatch:
 
 env:

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -3,7 +3,7 @@ name: Check for dependency modification
 on:
   push:
     branches:
-      - main
+      - fix-secrets
   workflow_dispatch:
 
 env:
@@ -37,3 +37,4 @@ jobs:
     needs: check-for-setup
     if: (github.event_name == 'push') && (needs.check-for-setup.outputs.changed == '1')
     uses: ./.github/workflows/build-docker-images.yml
+    secrets: inherit

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup
 from setuptools import find_packages
-# A comment
+
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
 extras["docs"] = []

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@
 
 from setuptools import setup
 from setuptools import find_packages
-
+# A comment
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
 extras["docs"] = []


### PR DESCRIPTION
Noticed that when merged, the Docker images couldn't be made (failed here: https://github.com/huggingface/accelerate/actions/runs/2449927979).

This PR makes the runner inherit the repository secrets safely (documented [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) in step 3)

Shown success is here: https://github.com/huggingface/accelerate/actions/runs/2450268127

( @ydshieh mostly so you're aware of such a behavior, I didn't know about it 😄 )