### PR TITLE
Revamp TPU internals to be more efficient

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -712,17 +712,13 @@ class Accelerator:
         return tuple(result)
 
     def prepare_data_loader(self, data_loader):
-        if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
-            device_placement = False
-        else:
-            device_placement = self.device_placement
         return prepare_data_loader(
             data_loader,
             self.device,
             num_processes=self.num_processes,
             process_index=self.process_index,
             split_batches=self.split_batches,
-            put_on_device=device_placement,
+            put_on_device=self.device_placement if self.distributedType != DistributedType.TPU else False,
             rng_types=self.rng_types.copy(),
             dispatch_batches=self.dispatch_batches,
         )

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -21,9 +21,10 @@ import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from typing import List, Optional, Union
-from accelerate.accelerate.src.accelerate.utils.imports import is_tpu_available
 
 import torch
+
+from accelerate.accelerate.src.accelerate.utils.imports import is_tpu_available
 
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import prepare_data_loader

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -713,16 +713,16 @@ class Accelerator:
 
     def prepare_data_loader(self, data_loader):
         if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
-            device = None
+            device_placement = False
         else:
-            device = self.device
+            device_placement = self.device_placement
         return prepare_data_loader(
             data_loader,
-            device,
+            self.device,
             num_processes=self.num_processes,
             process_index=self.process_index,
             split_batches=self.split_batches,
-            put_on_device=self.device_placement,
+            put_on_device=device_placement,
             rng_types=self.rng_types.copy(),
             dispatch_batches=self.dispatch_batches,
         )

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -24,8 +24,6 @@ from typing import List, Optional, Union
 
 import torch
 
-from accelerate.accelerate.src.accelerate.utils.imports import is_tpu_available
-
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import prepare_data_loader
 from .logging import get_logger
@@ -52,6 +50,7 @@ from .utils import (
     is_deepspeed_available,
     is_torch_version,
     is_transformers_available,
+    is_tpu_available,
     pad_across_processes,
     reduce,
     save,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -993,6 +993,8 @@ class Accelerator:
             if isinstance(obj, torch.nn.Module):
                 obj = extract_model_from_parallel(obj)
                 named_parameters.update({n: p for n, p in obj.named_parameters()})
+            elif self.distributed_type == DistributedType.TPU and isinstance(obj, xmp.MpModelWrapper):
+                named_parameters.update({n: p for n, p in obj._model.named_parameters()})
         return named_parameters
 
     def _get_devices(self, *args):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -551,6 +551,7 @@ class Accelerator:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
             model.forward = convert_outputs_to_fp32(model.forward)
         if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
+            model = model.to(self.device)
             model = xmp.MpModelWrapper(model).to(self.device)
         return model
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -71,6 +71,7 @@ if is_deepspeed_available():
 
 if is_tpu_available():
     import torch_xla.distributed.xla_multiprocessing as xmp
+    import torch_xla.core.xla_model as xm
 
 logger = get_logger(__name__)
 
@@ -383,7 +384,9 @@ class Accelerator:
         """
         Use in replacement of `print()` to only print once per server.
         """
-        if self.is_local_main_process:
+        if self.distributed_type == DistributedType.TPU:
+            xm.master_print(*args, **kwargs)
+        elif self.is_local_main_process:
             print(*args, **kwargs)
 
     def _prepare_one(self, obj, first_pass=False):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -550,7 +550,7 @@ class Accelerator:
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
             model.forward = convert_outputs_to_fp32(model.forward)
-        if self.distributed_type == DistributedType.TPU and self.state.use_fork:
+        if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         return model
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -542,8 +542,6 @@ class Accelerator:
         elif self.distributed_type == DistributedType.MULTI_CPU:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
             model = torch.nn.parallel.DistributedDataParallel(model, **kwargs)
-        elif self.distributed_type == DistributedType.TPU:
-            model = xmp.MpModelWrapper(model).to(self.device)
         if self.native_amp:
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -542,7 +542,7 @@ class Accelerator:
         elif self.distributed_type == DistributedType.MULTI_CPU:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
             model = torch.nn.parallel.DistributedDataParallel(model, **kwargs)
-        if self.native_amp:
+        if self.native_amp and self.distributed_type != DistributedType.TPU:
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
             elif self.mixed_precision == "bf16":
@@ -551,7 +551,6 @@ class Accelerator:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
             model.forward = convert_outputs_to_fp32(model.forward)
         if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
-            model = model.to(self.device)
             model = xmp.MpModelWrapper(model).to(self.device)
         return model
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -712,7 +712,7 @@ class Accelerator:
     def prepare_data_loader(self, data_loader):
         return prepare_data_loader(
             data_loader,
-            self.device,
+            self.device if self.distributed_type != DistributedType.TPU else None,
             num_processes=self.num_processes,
             process_index=self.process_index,
             split_batches=self.split_batches,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -542,7 +542,7 @@ class Accelerator:
         elif self.distributed_type == DistributedType.MULTI_CPU:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
             model = torch.nn.parallel.DistributedDataParallel(model, **kwargs)
-        if self.native_amp and self.distributed_type != DistributedType.TPU:
+        if self.native_amp:
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
             elif self.mixed_precision == "bf16":
@@ -550,8 +550,8 @@ class Accelerator:
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
             model.forward = convert_outputs_to_fp32(model.forward)
-        if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
-            model = xmp.MpModelWrapper(model).to(self.device)
+        # if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
+        #     model = xmp.MpModelWrapper(model).to(self.device)
         return model
 
     def _prepare_deepspeed(self, *args):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -550,8 +550,8 @@ class Accelerator:
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
             model.forward = convert_outputs_to_fp32(model.forward)
-        # if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
-        #     model = xmp.MpModelWrapper(model).to(self.device)
+        if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
+            model = xmp.MpModelWrapper(model).to(self.device)
         return model
 
     def _prepare_deepspeed(self, *args):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -550,7 +550,7 @@ class Accelerator:
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
             model.forward = convert_outputs_to_fp32(model.forward)
-        if self.distributed_type == DistributedType.TPU and self.num_processes > 1:
+        if self.distributed_type == DistributedType.TPU and self.state.use_fork:
             model = xmp.MpModelWrapper(model).to(self.device)
         return model
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -543,7 +543,7 @@ class Accelerator:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
             model = torch.nn.parallel.DistributedDataParallel(model, **kwargs)
         elif self.distributed_type == DistributedType.TPU:
-            model = xmp.MpModelWrapper(model)
+            model = xmp.MpModelWrapper(model).to(self.device)
         if self.native_amp:
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
@@ -993,8 +993,6 @@ class Accelerator:
             if isinstance(obj, torch.nn.Module):
                 obj = extract_model_from_parallel(obj)
                 named_parameters.update({n: p for n, p in obj.named_parameters()})
-            elif self.distributed_type == DistributedType.TPU and isinstance(obj, xmp.MpModelWrapper):
-                named_parameters.update({n: p for n, p in obj._model.named_parameters()})
         return named_parameters
 
     def _get_devices(self, *args):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -718,7 +718,7 @@ class Accelerator:
             num_processes=self.num_processes,
             process_index=self.process_index,
             split_batches=self.split_batches,
-            put_on_device=self.device_placement if self.distributedType != DistributedType.TPU else False,
+            put_on_device=self.device_placement if self.distributed_type != DistributedType.TPU else False,
             rng_types=self.rng_types.copy(),
             dispatch_batches=self.dispatch_batches,
         )

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -70,8 +70,8 @@ if is_deepspeed_available():
     )
 
 if is_tpu_available():
-    import torch_xla.distributed.xla_multiprocessing as xmp
     import torch_xla.core.xla_model as xm
+    import torch_xla.distributed.xla_multiprocessing as xmp
 
 logger = get_logger(__name__)
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -305,7 +305,7 @@ if is_tpu_available():
     class TPUShardedDataLoader(xpl.MpDeviceLoader):
         def __iter__(self):
             for batch in super().__iter__():
-                yield send_to_device(batch, self.device)
+                yield send_to_device(batch, self._device)
 
 
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -489,8 +489,6 @@ def prepare_data_loader(
         raise ValueError("Using `dispatch_batches=True` requires `put_on_device=True`.")
     # Grab defaults from AcceleratorState
     state = AcceleratorState()
-    if state.distributed_type == DistributedType.TPU:
-        put_on_device = False
     if num_processes is None:
         num_processes = state.num_processes
     if process_index is None:
@@ -567,7 +565,7 @@ def prepare_data_loader(
     else:
         dataloader = DataLoaderShard(
             new_dataset,
-            device=device if put_on_device else None,
+            device=device if put_on_device or state.distributed_type != DistributedType.TPU else None,
             batch_sampler=new_batch_sampler,
             rng_types=rng_types,
             generator=generator,

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -35,7 +35,6 @@ from .utils import (
 
 
 if is_tpu_available():
-    import torch_xla.core.xla_model as xm
     import torch_xla.distributed.parallel_loader as xpl
 
 
@@ -490,6 +489,8 @@ def prepare_data_loader(
         raise ValueError("Using `dispatch_batches=True` requires `put_on_device=True`.")
     # Grab defaults from AcceleratorState
     state = AcceleratorState()
+    if state.distributed_type == DistributedType.TPU:
+        put_on_device = False
     if num_processes is None:
         num_processes = state.num_processes
     if process_index is None:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -565,7 +565,7 @@ def prepare_data_loader(
     else:
         dataloader = DataLoaderShard(
             new_dataset,
-            device=device if put_on_device or state.distributed_type != DistributedType.TPU else None,
+            device=device if put_on_device else None,
             batch_sampler=new_batch_sampler,
             rng_types=rng_types,
             generator=generator,

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -301,8 +301,8 @@ class DataLoaderShard(DataLoader):
             synchronize_rng_states(self.rng_types, self.generator)
         state = AcceleratorState()
         for batch in super().__iter__():
-            if state.distributed_type == DistributedType.TPU:
-                xm.mark_step()
+            # if state.distributed_type == DistributedType.TPU:
+            #     xm.mark_step()
             yield batch if self.device is None else send_to_device(batch, self.device)
 
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -301,7 +301,7 @@ class DataLoaderShard(DataLoader):
             synchronize_rng_states(self.rng_types, self.generator)
         state = AcceleratorState()
         for batch in super().__iter__():
-            if state.distributed_type == DistributedType.TPU and state.num_processes > 1:
+            if state.distributed_type == DistributedType.TPU and state.num_processes < 2:
                 xm.mark_step()
             yield batch if self.device is None else send_to_device(batch, self.device)
 
@@ -410,7 +410,7 @@ class DataLoaderDispatcher(DataLoader):
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
 
-            if state.distributed_type == DistributedType.TPU and state.num_processes > 1:
+            if state.distributed_type == DistributedType.TPU and state.num_processes < 2:
                 xm.mark_step()
             yield slice_tensors(batch, data_slice)
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -299,10 +299,7 @@ class DataLoaderShard(DataLoader):
     def __iter__(self):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.generator)
-        state = AcceleratorState()
         for batch in super().__iter__():
-            if state.distributed_type == DistributedType.TPU and state.num_processes < 2:
-                xm.mark_step()
             yield batch if self.device is None else send_to_device(batch, self.device)
 
 
@@ -409,9 +406,6 @@ class DataLoaderDispatcher(DataLoader):
                 batch_size += 1
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
-
-            if state.distributed_type == DistributedType.TPU and state.num_processes < 2:
-                xm.mark_step()
             yield slice_tensors(batch, data_slice)
 
     def __len__(self):
@@ -579,6 +573,6 @@ def prepare_data_loader(
             **kwargs,
         )
 
-    if state.distributed_type == DistributedType.TPU and state.num_processes > 1:
+    if state.distributed_type == DistributedType.TPU:
         return xpl.MpDeviceLoader(dataloader, device)
     return dataloader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -301,6 +301,7 @@ class DataLoaderShard(DataLoader):
         for batch in super().__iter__():
             yield batch if self.device is None else send_to_device(batch, self.device)
 
+
 class DataLoaderDispatcher(DataLoader):
     """
     Subclass of a PyTorch `DataLoader` that will iterate and preprocess on process 0 only, then dispatch on each

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -301,17 +301,6 @@ class DataLoaderShard(DataLoader):
         for batch in super().__iter__():
             yield batch if self.device is None else send_to_device(batch, self.device)
 
-if is_tpu_available():
-    class TPUShardedDataLoader(xpl.MpDeviceLoader):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self._state = AcceleratorState()
-        def __iter__(self):
-            for batch in super().__iter__():
-                yield send_to_device(batch, self._state.device)
-
-
-
 class DataLoaderDispatcher(DataLoader):
     """
     Subclass of a PyTorch `DataLoader` that will iterate and preprocess on process 0 only, then dispatch on each
@@ -583,5 +572,5 @@ def prepare_data_loader(
         )
 
     if state.distributed_type == DistributedType.TPU:
-        return TPUShardedDataLoader(dataloader, device)
+        return xpl.MpDeviceLoader(dataloader, device)
     return dataloader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -303,9 +303,12 @@ class DataLoaderShard(DataLoader):
 
 if is_tpu_available():
     class TPUShardedDataLoader(xpl.MpDeviceLoader):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._state = AcceleratorState()
         def __iter__(self):
             for batch in super().__iter__():
-                yield send_to_device(batch, self._device)
+                yield send_to_device(batch, self._state.device)
 
 
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -579,6 +579,6 @@ def prepare_data_loader(
             **kwargs,
         )
 
-    if state.distributed_type == DistributedType.TPU:
+    if state.distributed_type == DistributedType.TPU and state.num_processes > 1:
         return xpl.MpDeviceLoader(dataloader, device)
     return dataloader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -564,7 +564,7 @@ def prepare_data_loader(
     else:
         dataloader = DataLoaderShard(
             new_dataset,
-            device=device if put_on_device or state.distributed_type != DistributedType.TPU else None,
+            device=device if put_on_device and state.distributed_type != DistributedType.TPU else None,
             batch_sampler=new_batch_sampler,
             rng_types=rng_types,
             generator=generator,

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -75,6 +75,7 @@ class AcceleratorState:
         self.__dict__ = self._shared_state
         if parse_flag_from_env("USE_CPU"):
             cpu = True
+        self.use_fork = parse_flag_from_env("USE_LAUNCHER", 0)
         if not getattr(self, "initialized", False):
             self.backend = None
             self.deepspeed_plugin = None

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -75,7 +75,7 @@ class AcceleratorState:
         self.__dict__ = self._shared_state
         if parse_flag_from_env("USE_CPU"):
             cpu = True
-        self.use_fork = parse_flag_from_env("USE_LAUNCHER", 0)
+        self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
         if not getattr(self, "initialized", False):
             self.backend = None
             self.deepspeed_plugin = None

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -90,7 +90,9 @@ class AcceleratorState:
                 self.process_index = xm.get_ordinal()
                 self.local_process_index = xm.get_local_ordinal()
                 self.device = xm.xla_device()
-                self.mixed_precision = "no"
+                self.mixed_precision = (
+                    parse_choice_from_env("MIXED_PRECISION", "no") if mixed_precision is None else mixed_precision
+                )
             elif os.environ.get("USE_DEEPSPEED", "false") == "true" and not cpu:
                 assert (
                     is_deepspeed_available()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -338,10 +338,5 @@ def main():
     training_check()
 
 
-def _mp_fn(index):
-    # For xla_spawn (TPUs)
-    main()
-
-
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -337,6 +337,9 @@ def main():
         print("\n**Training integration test**")
     training_check()
 
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
 
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -337,9 +337,11 @@ def main():
         print("\n**Training integration test**")
     training_check()
 
+
 def _mp_fn(index):
     # For xla_spawn (TPUs)
     main()
+
 
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -337,5 +337,10 @@ def main():
     training_check()
 
 
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -326,7 +326,8 @@ def main():
     if state.local_process_index == 0:
         print("\n**DataLoader integration test**")
     dl_preparation_check()
-    central_dl_preparation_check()
+    if state.distributed_type != DistributedType.TPU:
+        central_dl_preparation_check()
 
     # Trainings are not exactly the same in DeepSpeed and CPU mode
     if state.distributed_type == DistributedType.DEEPSPEED:

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -125,9 +125,11 @@ def main():
             print("**Distributed `no_sync` gradient accumulation**")
         test_distributed_sync(accelerator)
 
+
 def _mp_fn(index):
     # For xla_spawn (TPUs)
     main()
+
 
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -125,6 +125,9 @@ def main():
             print("**Distributed `no_sync` gradient accumulation**")
         test_distributed_sync(accelerator)
 
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
 
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -126,10 +126,5 @@ def main():
         test_distributed_sync(accelerator)
 
 
-def _mp_fn(index):
-    # For xla_spawn (TPUs)
-    main()
-
-
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -126,5 +126,10 @@ def main():
         test_distributed_sync(accelerator)
 
 
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
 if __name__ == "__main__":
     main()

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -68,4 +68,5 @@ class PrepareForLaunch:
             os.environ["LOCAL_RANK"] = str(index)
             os.environ["RANK"] = str(index)
 
+        os.environ["USE_LAUNCHER"] = str(1)
         self.launcher(*args)

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -68,5 +68,5 @@ class PrepareForLaunch:
             os.environ["LOCAL_RANK"] = str(index)
             os.environ["RANK"] = str(index)
 
-        os.environ["USE_LAUNCHER"] = str(1)
+        os.environ["FORK_LAUNCHED"] = str(1)
         self.launcher(*args)

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -25,8 +25,8 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from .imports import is_tpu_available
 from .offload import offload_weight, save_offload_index
+
 
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -28,9 +28,6 @@ import torch.nn as nn
 from .imports import is_tpu_available
 from .offload import offload_weight, save_offload_index
 
-if is_tpu_available():
-    import torch_xla.distributed.xla_multiprocessing as xmp
-
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
 
 
@@ -615,17 +612,3 @@ def load_checkpoint_in_model(
     if offload_state_dict:
         load_offloaded_weights(model, state_dict_index, state_dict_folder)
         shutil.rmtree(state_dict_folder)
-
-def WrapTPUModel(model:nn.Module) -> nn.Module:
-    """Wraps a model in `xmp.MpModelWrapper` for efficient
-    memory usage on the TPU. If not on a TPU this does nothing.
-    
-    Should be called before `xla.spawn` is used.
-
-    Args:
-        model (`nn.Module`):
-            A PyTorch model
-    """
-    if is_tpu_available():
-        return xmp.MpModelWrapper(model)
-    return model

--- a/tests/test_tpu.py
+++ b/tests/test_tpu.py
@@ -24,7 +24,7 @@ from accelerate.test_utils import execute_subprocess_async, require_tpu
 class MultiTPUTester(unittest.TestCase):
     def setUp(self):
         mod_file = inspect.getfile(accelerate.test_utils)
-        self.test_file_path = os.path.sep.join(mod_file.split(os.path.sep)[:-1] + ["test_script.py"])
+        self.test_file_path = os.path.sep.join(mod_file.split(os.path.sep)[:-1] + ["scripts", "test_script.py"])
         self.test_dir = os.path.sep.join(inspect.getfile(self.__class__).split(os.path.sep)[:-1])
 
     @require_tpu

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -78,11 +78,7 @@ def main():
 
     # Patch sys.argv
     sys.argv = [args.training_script] + args.training_script_args + ["--tpu_num_cores", str(args.num_cores)]
-    xmp.spawn(mod.__main__, args=(), nprocs=args.num_cores)
-
-def _mp_fn(index):
-    # For xla_spawn (TPUs)
-    main()
+    xmp.spawn(mod._mp_fn, args=(), nprocs=args.num_cores)
 
 if __name__ == "__main__":
     main()

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -78,7 +78,7 @@ def main():
 
     # Patch sys.argv
     sys.argv = [args.training_script] + args.training_script_args + ["--tpu_num_cores", str(args.num_cores)]
-    xmp.spawn(mod.main, args=(), nprocs=args.num_cores)
+    xmp.spawn(mod._mp_fn, args=(), nprocs=args.num_cores)
 
 
 if __name__ == "__main__":

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -80,5 +80,6 @@ def main():
     sys.argv = [args.training_script] + args.training_script_args + ["--tpu_num_cores", str(args.num_cores)]
     xmp.spawn(mod._mp_fn, args=(), nprocs=args.num_cores)
 
+
 if __name__ == "__main__":
     main()

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -78,7 +78,7 @@ def main():
 
     # Patch sys.argv
     sys.argv = [args.training_script] + args.training_script_args + ["--tpu_num_cores", str(args.num_cores)]
-    xmp.spawn(mod._mp_fn, args=(), nprocs=args.num_cores)
+    xmp.spawn(mod.main, args=(), nprocs=args.num_cores)
 
 
 if __name__ == "__main__":

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -78,7 +78,6 @@ def main():
 
     # Patch sys.argv
     sys.argv = [args.training_script] + args.training_script_args + ["--tpu_num_cores", str(args.num_cores)]
-
     xmp.spawn(mod._mp_fn, args=(), nprocs=args.num_cores)
 
 

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -78,8 +78,11 @@ def main():
 
     # Patch sys.argv
     sys.argv = [args.training_script] + args.training_script_args + ["--tpu_num_cores", str(args.num_cores)]
-    xmp.spawn(mod._mp_fn, args=(), nprocs=args.num_cores)
+    xmp.spawn(mod.__main__, args=(), nprocs=args.num_cores)
 
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
# Revamp TPU internals

## What does this add?

- Make `prepare_model` use [`MpModelWrapper`](https://pytorch.org/xla/master/index.html#torch_xla.distributed.xla_multiprocessing.MpModelWrapper) to distribute the model across all devices efficiently when used
- Changes `prepare_dataloader` to create an [`MpDeviceLoader`](https://github.com/pytorch/xla/blob/master/torch_xla/distributed/parallel_loader.py#L171) allowing for the dataloaders to be more efficient. 
- Changes `DataLoaderShard` to no longer do `xm.mark_step`, `MpDeviceLoader` will handle this for us. Instead if on TPU we set the device as `None` in `prepare_dataloader` letting `MpDeviceLoader` take over with the `device` when needed. 
- Allow for FP16 and BF16 precision types on the TPU via AcceleratorState since they are now supported

## Who is it for?

- Users of TPUs

## Why is it needed?

We currently have a number of "bad practices" in TPU handling due to improvements in the xla API. Here are some benchmarks I ran on a high-memory colab TPU instance with the nlp example script:

**Baseline**:
- Post warmup: 56 seconds

**W/ MpModelWrapper and MpDeviceLoader**:
- Post warmup: 48 seconds

**W/ previous and `default_tensor_type` change**:
- Post warmup: 34 to 36 seconds

Roughly a 40% boost to speed once this is all done. I also saw some speed increases on the initial launch as well anecdotally, but I did not time them.

I also saw a 2x speedup when using the new DataLoader class vs the old one

## About `default_tensor_type`:
Though we do set the device to `bf16` which helps with automatically converting the tensors to the right types, if we add `torch.set_default_tensor_type('torch.FloatTensor')` there is a considerable speedup when it comes to training TPUs. 

I'm a bit unsure as to where it would be best to put this, as either something hidden when we initialize the Accelerator or as a util that should get called when you are training on TPUs, open to ideas

## Anticipated maintenance burden? (What will happen in say, 3 months if something changes)

This is pretty stable and considered as "good practices" when running on TPUs w/ XLA, so it's unlikely these will change. However after this PR a subsequent PR will be opened to change the `nlp_example` and `cv_example` notebook, as another best practice is to declare the model outside of `xm.spawn`. This includes the internals to make the model as memory efficient as we can, so that will be the last stage needed. 
