### PR TITLE
Offload and modules with unused submodules

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -88,7 +88,7 @@ def cpu_offload(
     execution_device: Optional[torch.device] = None,
     offload_buffers: bool = False,
     state_dict: Optional[Dict[str, torch.Tensor]] = None,
-    load_all_weights_classes: Optional[List[str]] = None,
+    preload_module_classes: Optional[List[str]] = None,
 ):
     """
     Activates full CPU offload for a model. As a result, all parameters of the model will be offloaded and only one
@@ -105,7 +105,7 @@ def cpu_offload(
             Whether or not to offload the buffers with the model parameters.
         state_dict (`Dict[str, torch.Tensor]`, *optional*):
             The state dict of the model that will be kept on CPU.
-        load_all_weights_classes (`List[str]`, *optional*):
+        preload_module_classes (`List[str]`, *optional*):
             A list of classes whose instances should load all their weights (even in the submodules) at the beginning
             of the forward. This should only be used for classes that have submodules which are registered but not
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
@@ -121,7 +121,7 @@ def cpu_offload(
         offload=True,
         offload_buffers=offload_buffers,
         weights_map=state_dict,
-        load_all_weights_classes=load_all_weights_classes,
+        preload_module_classes=preload_module_classes,
     )
     add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     return model
@@ -132,7 +132,7 @@ def disk_offload(
     offload_dir: Union[str, os.PathLike],
     execution_device: Optional[torch.device] = None,
     offload_buffers: bool = False,
-    load_all_weights_classes: Optional[List[str]] = None,
+    preload_module_classes: Optional[List[str]] = None,
 ):
     """
     Activates full disk offload for a model. As a result, all parameters of the model will be offloaded as
@@ -148,7 +148,7 @@ def disk_offload(
             model's first parameter device.
         offload_buffers (`bool`, *optional*, defaults to `False`):
             Whether or not to offload the buffers with the model parameters.
-        load_all_weights_classes (`List[str]`, *optional*):
+        preload_module_classes (`List[str]`, *optional*):
             A list of classes whose instances should load all their weights (even in the submodules) at the beginning
             of the forward. This should only be used for classes that have submodules which are registered but not
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
@@ -165,7 +165,7 @@ def disk_offload(
         offload=True,
         offload_buffers=offload_buffers,
         weights_map=weights_map,
-        load_all_weights_classes=load_all_weights_classes,
+        preload_module_classes=preload_module_classes,
     )
     add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     return model
@@ -178,7 +178,7 @@ def dispatch_model(
     state_dict: Optional[Dict[str, torch.Tensor]] = None,
     offload_dir: Union[str, os.PathLike] = None,
     offload_buffers: bool = False,
-    load_all_weights_classes: Optional[List[str]] = None,
+    preload_module_classes: Optional[List[str]] = None,
 ):
     """
     Dispatches a model according to a given device map. Layers of the model might be spread across GPUs, offloaded on
@@ -199,7 +199,7 @@ def dispatch_model(
             The folder in which to offload the model weights (or where the model weights are already offloaded).
         offload_buffers (`bool`, *optional*, defaults to `False`):
             Whether or not to offload the buffers with the model parameters.
-        load_all_weights_classes (`List[str]`, *optional*):
+        preload_module_classes (`List[str]`, *optional*):
             A list of classes whose instances should load all their weights (even in the submodules) at the beginning
             of the forward. This should only be used for classes that have submodules which are registered but not
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
@@ -243,7 +243,7 @@ def dispatch_model(
         offload=offload,
         offload_buffers=offload_buffers,
         weights_map=weights_map,
-        load_all_weights_classes=load_all_weights_classes,
+        preload_module_classes=preload_module_classes,
     )
     model.hf_device_map = device_map
     return model
@@ -259,7 +259,7 @@ def load_checkpoint_and_dispatch(
     offload_buffers: bool = False,
     dtype: Optional[Union[str, torch.dtype]] = None,
     offload_state_dict: bool = False,
-    load_all_weights_classes: Optional[List[str]] = None,
+    preload_module_classes: Optional[List[str]] = None,
 ):
     """
     Loads a (potentially sharded) checkpoint inside a model, potentially sending weights to a given device as they are
@@ -293,7 +293,7 @@ def load_checkpoint_and_dispatch(
         offload_state_dict (`bool`, *optional*, defaults to `False`):
             If `True`, will temporarily offload the CPU state dict on the hard drive to avoig getting out of CPU RAM if
             the weight of the CPU state dict + the biggest shard does not fit.
-        load_all_weights_classes (`List[str]`, *optional*):
+        preload_module_classes (`List[str]`, *optional*):
             A list of classes whose instances should load all their weights (even in the submodules) at the beginning
             of the forward. This should only be used for classes that have submodules which are registered but not
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
@@ -318,5 +318,5 @@ def load_checkpoint_and_dispatch(
         device_map=device_map,
         offload_dir=offload_folder,
         offload_buffers=offload_buffers,
-        load_all_weights_classes=load_all_weights_classes,
+        preload_module_classes=preload_module_classes,
     )

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import functools
-from typing import Dict, Mapping, Optional, Union
+from typing import Dict, List, Mapping, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -220,17 +220,23 @@ class AlignDevicesHook(ModelHook):
             for name, _ in named_module_tensors(module, recurse=self.place_submodules):
                 set_module_tensor_to_device(module, name, self.execution_device)
         elif self.offload:
-            self.original_devices = {name: param.device for name, param in named_module_tensors(module)}
+            self.original_devices = {
+                name: param.device for name, param in named_module_tensors(module, recurse=self.place_submodules)
+            }
             if self.weights_map is None:
                 self.weights_map = {
                     name: param.to("cpu")
-                    for name, param in named_module_tensors(module, include_buffers=self.offload_buffers)
+                    for name, param in named_module_tensors(
+                        module, include_buffers=self.offload_buffers, recurse=self.place_submodules
+                    )
                 }
 
-            for name, _ in named_module_tensors(module, include_buffers=self.offload_buffers):
+            for name, _ in named_module_tensors(
+                module, include_buffers=self.offload_buffers, recurse=self.place_submodules
+            ):
                 set_module_tensor_to_device(module, name, "meta")
             if not self.offload_buffers and self.execution_device is not None:
-                for name, _ in module.named_buffers(recurse=False):
+                for name, _ in module.named_buffers(recurse=self.place_submodules):
                     set_module_tensor_to_device(module, name, self.execution_device)
         return module
 
@@ -238,14 +244,18 @@ class AlignDevicesHook(ModelHook):
         if self.io_same_device:
             self.input_device = find_device([args, kwargs])
         if self.offload:
-            for name, _ in named_module_tensors(module, include_buffers=self.offload_buffers):
+            for name, _ in named_module_tensors(
+                module, include_buffers=self.offload_buffers, recurse=self.place_submodules
+            ):
                 set_module_tensor_to_device(module, name, self.execution_device, value=self.weights_map[name])
 
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 
     def post_forward(self, module, output):
         if self.offload:
-            for name, _ in named_module_tensors(module, include_buffers=self.offload_buffers):
+            for name, _ in named_module_tensors(
+                module, include_buffers=self.offload_buffers, recurse=self.place_submodules
+            ):
                 set_module_tensor_to_device(module, name, "meta")
 
         if self.io_same_device and self.input_device is not None:
@@ -260,7 +270,11 @@ class AlignDevicesHook(ModelHook):
                     set_module_tensor_to_device(module, name, device, value=self.weights_map.get(name, None))
 
 
-def attach_execution_device_hook(module: torch.nn.Module, execution_device: Union[int, str, torch.device]):
+def attach_execution_device_hook(
+    module: torch.nn.Module,
+    execution_device: Union[int, str, torch.device],
+    load_all_weights_classes: Optional[List[str]] = None,
+):
     """
     Recursively attaches `AlignDevicesHook` to all submodules of a given model to make sure they have the right
     execution device
@@ -270,9 +284,18 @@ def attach_execution_device_hook(module: torch.nn.Module, execution_device: Unio
             The module where we want to attach the hooks.
         execution_device (`int`, `str` or `torch.device`):
             The device on which inputs and model weights should be placed before the forward pass.
+        load_all_weights_classes (`List[str]`, *optional*):
+            A list of classes whose instances should load all their weights (even in the submodules) at the beginning
+            of the forward. This should only be used for classes that have submodules which are registered but not
+            called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
+            `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
     """
     if not hasattr(module, "_hf_hook") and len(module.state_dict()) > 0:
         add_hook_to_module(module, AlignDevicesHook(execution_device))
+
+    # Break the recursion if we get to a load all weights module.
+    if load_all_weights_classes is not None and module.__class__.__name__ in load_all_weights_classes:
+        return
 
     for child in module.children():
         attach_execution_device_hook(child, execution_device)
@@ -285,6 +308,7 @@ def attach_align_device_hook(
     weights_map: Optional[Mapping] = None,
     offload_buffers: bool = False,
     module_name: str = "",
+    load_all_weights_classes: Optional[List[str]] = None,
 ):
     """
     Recursively attaches `AlignDevicesHook` to all submodules of a given model that have direct parameters and/or
@@ -303,10 +327,19 @@ def attach_align_device_hook(
             Whether or not to include the associated module's buffers when offloading.
         module_name (`str`, *optional*, defaults to `""`):
             The name of the module.
+        load_all_weights_classes (`List[str]`, *optional*):
+            A list of classes whose instances should load all their weights (even in the submodules) at the beginning
+            of the forward. This should only be used for classes that have submodules which are registered but not
+            called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
+            `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
     """
     # Attach the hook on this module if it has any direct tensor.
     directs = named_module_tensors(module)
-    if len(list(directs)) > 0:
+    full_offload = (
+        offload and load_all_weights_classes is not None and module.__class__.__name__ in load_all_weights_classes
+    )
+
+    if len(list(directs)) > 0 or full_offload:
         if weights_map is not None:
             prefix = f"{module_name}." if len(module_name) > 0 else ""
             prefixed_weights_map = PrefixedDataset(weights_map, prefix)
@@ -317,8 +350,13 @@ def attach_align_device_hook(
             offload=offload,
             weights_map=prefixed_weights_map,
             offload_buffers=offload_buffers,
+            place_submodules=full_offload,
         )
         add_hook_to_module(module, hook)
+
+    # We stop the recursion in case we hit the full offload.
+    if full_offload:
+        return
 
     # Recurse on all children of the module.
     for child_name, child in module.named_children():
@@ -330,6 +368,7 @@ def attach_align_device_hook(
             weights_map=weights_map,
             offload_buffers=offload_buffers,
             module_name=child_name,
+            load_all_weights_classes=load_all_weights_classes,
         )
 
 
@@ -352,6 +391,7 @@ def attach_align_device_hook_on_blocks(
     weights_map: Mapping = None,
     offload_buffers: bool = False,
     module_name: str = "",
+    load_all_weights_classes: Optional[List[str]] = None,
 ):
     """
     Attaches `AlignDevicesHook` to all blocks of a given model as needed.
@@ -371,6 +411,11 @@ def attach_align_device_hook_on_blocks(
             Whether or not to include the associated module's buffers when offloading.
         module_name (`str`, *optional*, defaults to `""`):
             The name of the module.
+        load_all_weights_classes (`List[str]`, *optional*):
+            A list of classes whose instances should load all their weights (even in the submodules) at the beginning
+            of the forward. This should only be used for classes that have submodules which are registered but not
+            called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
+            `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
     """
     # If one device and one offload, we've got one hook.
     if not isinstance(execution_device, Mapping) and not isinstance(offload, dict):
@@ -410,11 +455,14 @@ def attach_align_device_hook_on_blocks(
             weights_map=weights_map,
             offload_buffers=offload_buffers,
             module_name=module_name,
+            load_all_weights_classes=load_all_weights_classes,
         )
         if not hasattr(module, "_hf_hook"):
             hook = AlignDevicesHook(execution_device=execution_device[module_name], io_same_device=(module_name == ""))
             add_hook_to_module(module, hook)
-        attach_execution_device_hook(module, execution_device[module_name])
+        attach_execution_device_hook(
+            module, execution_device[module_name], load_all_weights_classes=load_all_weights_classes
+        )
     elif module_name == "":
         hook = AlignDevicesHook(io_same_device=True)
         add_hook_to_module(module, hook)
@@ -428,4 +476,5 @@ def attach_align_device_hook_on_blocks(
             weights_map=weights_map,
             offload_buffers=offload_buffers,
             module_name=child_name,
+            load_all_weights_classes=load_all_weights_classes,
         )

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -434,7 +434,7 @@ def attach_align_device_hook_on_blocks(
         return
 
     if not isinstance(execution_device, Mapping):
-        execution_device = {key: offload for key in offload.keys()}
+        execution_device = {key: execution_device for key in offload.keys()}
     if not isinstance(offload, Mapping):
         offload = {key: offload for key in execution_device.keys()}
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -293,7 +293,7 @@ def attach_execution_device_hook(
     if not hasattr(module, "_hf_hook") and len(module.state_dict()) > 0:
         add_hook_to_module(module, AlignDevicesHook(execution_device))
 
-    # Break the recursion if we get to a load all weights module.
+    # Break the recursion if we get to a preload module.
     if preload_module_classes is not None and module.__class__.__name__ in preload_module_classes:
         return
 

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -56,7 +56,7 @@ class BiggerModelForTest(nn.Module):
         return self.linear4(self.linear3(self.batchnorm(self.linear2(self.linear1(x)))))
 
 
-# To test load_all_weights_classes
+# To test preload_module_classes
 class ModuleWithUnusedSubModules(nn.Module):
     def __init__(self, input_dim, output_dim):
         super().__init__()
@@ -137,7 +137,7 @@ class BigModelingTester(unittest.TestCase):
 
         device = torch.device(0 if torch.cuda.is_available() else "cpu")
 
-        cpu_offload(model, execution_device=device, load_all_weights_classes=["ModuleWithUnusedSubModules"])
+        cpu_offload(model, execution_device=device, preload_module_classes=["ModuleWithUnusedSubModules"])
         output = model(x)
         self.assertTrue(
             torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
@@ -150,7 +150,7 @@ class BigModelingTester(unittest.TestCase):
             model,
             execution_device=device,
             offload_buffers=True,
-            load_all_weights_classes=["ModuleWithUnusedSubModules"],
+            preload_module_classes=["ModuleWithUnusedSubModules"],
         )
         output = model(x)
         self.assertTrue(
@@ -204,7 +204,7 @@ class BigModelingTester(unittest.TestCase):
 
         with TemporaryDirectory() as tmp_dir:
             disk_offload(
-                model, tmp_dir, execution_device=device, load_all_weights_classes=["ModuleWithUnusedSubModules"]
+                model, tmp_dir, execution_device=device, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
             self.assertTrue(
@@ -220,7 +220,7 @@ class BigModelingTester(unittest.TestCase):
                 tmp_dir,
                 execution_device=device,
                 offload_buffers=True,
-                load_all_weights_classes=["ModuleWithUnusedSubModules"],
+                preload_module_classes=["ModuleWithUnusedSubModules"],
             )
             output = model(x)
             self.assertTrue(
@@ -329,7 +329,7 @@ class BigModelingTester(unittest.TestCase):
 
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(
-                model, device_map, offload_dir=tmp_dir, load_all_weights_classes=["ModuleWithUnusedSubModules"]
+                model, device_map, offload_dir=tmp_dir, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
@@ -344,7 +344,7 @@ class BigModelingTester(unittest.TestCase):
 
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(
-                model, device_map, offload_dir=tmp_dir, load_all_weights_classes=["ModuleWithUnusedSubModules"]
+                model, device_map, offload_dir=tmp_dir, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
@@ -409,7 +409,7 @@ class BigModelingTester(unittest.TestCase):
 
             new_model = ModelWithUnusedSubModulesForTest()
             new_model = load_checkpoint_and_dispatch(
-                new_model, checkpoint, device_map=device_map, load_all_weights_classes=["ModuleWithUnusedSubModules"]
+                new_model, checkpoint, device_map=device_map, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
@@ -435,7 +435,7 @@ class BigModelingTester(unittest.TestCase):
 
             new_model = ModelWithUnusedSubModulesForTest()
             new_model = load_checkpoint_and_dispatch(
-                new_model, checkpoint, device_map=device_map, load_all_weights_classes=["ModuleWithUnusedSubModules"]
+                new_model, checkpoint, device_map=device_map, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.


### PR DESCRIPTION
This PR deals with models with unused submodules combined with offload (on CPU and disk). By unused submodules, we mean a something like the `ModuleWithUnusedSubModules` introduced in the test file in this PR: a module that defines a submodule, but does not call it during its forward, just does some operations using its weights.

Currently, the offload will fail for such modules because the weights are fetched in a pre-forward hook and the forward method is never called. This PR fixes that by introducing a new argument named `load_all_weights_classes` (if you have any better suggestion, please let me know as I'm not super happy with this name) which contains the name of such submodules used (like `no_split_module_classes` contains the names of the modules that shouldn't be split across devices).