### PR TITLE
Add psutil as depenedency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
 extras["docs"] = []
 extras["test"] = [
-    "psutil",
     "pytest",
     "pytest-xdist",
     "pytest-subtests",
@@ -60,7 +59,7 @@ setup(
         ]
     },
     python_requires=">=3.7.0",
-    install_requires=["numpy>=1.17", "packaging>=20.0", "pyyaml", "torch>=1.4.0"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.4.0"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR adds `psutil` as a dependency as it's required by the big model inference files.

Fixes #444 