### PR TITLE
Better checks for if a TPU device exists

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -33,6 +33,7 @@ except ImportError:
 
 try:
     import torch_xla.core.xla_model as xm  # noqa: F401
+
     try:
         # Will raise a RuntimeError if no XLA configuration is found
         _ = xm.xla_device()

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -33,8 +33,12 @@ except ImportError:
 
 try:
     import torch_xla.core.xla_model as xm  # noqa: F401
-
-    _tpu_available = True
+    try:
+        # Will raise a RuntimeError if no XLA configuration is found
+        _ = xm.xla_device()
+        _tpu_available = True
+    except RuntimeError:
+        _tpu_available = False
 except ImportError:
     _tpu_available = False
 


### PR DESCRIPTION
This PR fixes a situation where `torch_xla` is installed but a TPU device isn't present. 

This originally would cause the import to pass, even though a TPU device isn't found. Instead we combine this with a quick `xm.xla_device()`, that raises a `RuntimeError` if not on a TPU.

I've tested this on a CPU and TPU version of Colab. 

cc @sgugger 