### PR TITLE
Raise a clear warning if a user tries to modify the AcceleratorState

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -205,7 +205,7 @@ class AcceleratorState:
             template = Template(
                 "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `$flag` to `Accelerate()`."
             )
-            if cpu and not self.device == "cpu":
-                raise ValueError(template.substitute(flag="cpu=True"))
+            if cpu and self.device.type != "cpu":
+                raise ValueError(template.substitute(flag=self.device))
             if mixed_precision is not None and mixed_precision != self.mixed_precision:
                 raise ValueError(template.substitute(flag=f"mixed_precision='{mixed_precision}'"))

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -198,9 +198,10 @@ class AcceleratorState:
     def use_fp16(self):
         return self.mixed_precision != "no"
 
-    def _reset(self):
-        "Resets `_shared_state`, used internally"
-        self._shared_state = {}
+    @classmethod
+    def _reset_state(cls):
+        "Resets `_shared_state`, is used internally and should not be called"
+        cls._shared_state = {}
 
     def _check_initialized(self, mixed_precision=None, cpu=None):
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -198,10 +198,10 @@ class AcceleratorState:
     def use_fp16(self):
         return self.mixed_precision != "no"
 
-    @classmethod
-    def _reset_state(cls):
+    @staticmethod
+    def _reset_state():
         "Resets `_shared_state`, is used internally and should not be called"
-        cls._shared_state = {}
+        AcceleratorState._shared_state = {}
 
     def _check_initialized(self, mixed_precision=None, cpu=None):
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -198,6 +198,10 @@ class AcceleratorState:
     def use_fp16(self):
         return self.mixed_precision != "no"
 
+    def _reset(self):
+        "Resets `_shared_state`, used internally"
+        self._shared_state = {}
+
     def _check_initialized(self, mixed_precision=None, cpu=None):
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"
         if getattr(self, "initialized", False):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -14,7 +14,6 @@
 
 import os
 from distutils.util import strtobool
-from string import Template
 
 import torch
 
@@ -202,10 +201,8 @@ class AcceleratorState:
     def _check_initialized(self, mixed_precision=None, cpu=None):
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"
         if getattr(self, "initialized", False):
-            template = Template(
-                "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `$flag` to `Accelerate()`."
-            )
+            err = "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `{flag}` to `Accelerate()`."
             if cpu and self.device.type != "cpu":
-                raise ValueError(template.substitute(flag=self.device))
+                raise ValueError(err.format(flag="cpu=True"))
             if mixed_precision is not None and mixed_precision != self.mixed_precision:
-                raise ValueError(template.substitute(flag=f"mixed_precision='{mixed_precision}'"))
+                raise ValueError(err.format(flag=f"mixed_precision='{mixed_precision}'"))

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -75,6 +75,11 @@ class AcceleratorState:
         self.__dict__ = self._shared_state
         if parse_flag_from_env("USE_CPU"):
             cpu = True
+        if getattr(self, "initialized", False) and cpu and not self.device == "cpu":
+            raise ValueError(
+                "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `cpu=True` to `Accelerate()`."
+            )
+
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
         if not getattr(self, "initialized", False):
             self.backend = None

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -247,7 +247,7 @@ def training_check():
 
     # Mostly a test that FP16 doesn't crash as the operation inside the model is not converted to FP16
     print("FP16 training check.")
-    AcceleratorState()._reset()
+    AcceleratorState._reset_state()
     accelerator = Accelerator(mixed_precision="fp16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -270,7 +270,7 @@ def training_check():
 
     # TEST that previous fp16 flag still works
     print("Legacy FP16 training check.")
-    AcceleratorState()._reset()
+    AcceleratorState._reset_state()
     accelerator = Accelerator(fp16=True)
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -293,7 +293,7 @@ def training_check():
 
     # Mostly a test that BF16 doesn't crash as the operation inside the model is not converted to BF16
     print("BF16 training check.")
-    AcceleratorState()._reset()
+    AcceleratorState._reset_state()
     accelerator = Accelerator(mixed_precision="bf16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -247,7 +247,7 @@ def training_check():
 
     # Mostly a test that FP16 doesn't crash as the operation inside the model is not converted to FP16
     print("FP16 training check.")
-    AcceleratorState._reset()
+    AcceleratorState()._reset()
     accelerator = Accelerator(mixed_precision="fp16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -270,7 +270,7 @@ def training_check():
 
     # TEST that previous fp16 flag still works
     print("Legacy FP16 training check.")
-    AcceleratorState._reset()
+    AcceleratorState()._reset()
     accelerator = Accelerator(fp16=True)
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -293,7 +293,7 @@ def training_check():
 
     # Mostly a test that BF16 doesn't crash as the operation inside the model is not converted to BF16
     print("BF16 training check.")
-    AcceleratorState._reset()
+    AcceleratorState()._reset()
     accelerator = Accelerator(mixed_precision="bf16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -247,6 +247,7 @@ def training_check():
 
     # Mostly a test that FP16 doesn't crash as the operation inside the model is not converted to FP16
     print("FP16 training check.")
+    AcceleratorState._shared_state = {}
     accelerator = Accelerator(mixed_precision="fp16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -269,6 +270,7 @@ def training_check():
 
     # TEST that previous fp16 flag still works
     print("Legacy FP16 training check.")
+    AcceleratorState._shared_state = {}
     accelerator = Accelerator(fp16=True)
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -291,6 +293,7 @@ def training_check():
 
     # Mostly a test that BF16 doesn't crash as the operation inside the model is not converted to BF16
     print("BF16 training check.")
+    AcceleratorState._shared_state = {}
     accelerator = Accelerator(mixed_precision="bf16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -247,7 +247,7 @@ def training_check():
 
     # Mostly a test that FP16 doesn't crash as the operation inside the model is not converted to FP16
     print("FP16 training check.")
-    AcceleratorState._shared_state = {}
+    AcceleratorState._reset()
     accelerator = Accelerator(mixed_precision="fp16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -270,7 +270,7 @@ def training_check():
 
     # TEST that previous fp16 flag still works
     print("Legacy FP16 training check.")
-    AcceleratorState._shared_state = {}
+    AcceleratorState._reset()
     accelerator = Accelerator(fp16=True)
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
@@ -293,7 +293,7 @@ def training_check():
 
     # Mostly a test that BF16 doesn't crash as the operation inside the model is not converted to BF16
     print("BF16 training check.")
-    AcceleratorState._shared_state = {}
+    AcceleratorState._reset()
     accelerator = Accelerator(mixed_precision="bf16")
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()


### PR DESCRIPTION
# Raise warnings if attempting a modification of the `AcceleratorState`

## What does this add?

This PR adds a guard if the user tries to pass a different `mixed_precision` or `cpu` flag to `Accelerator()` after the `AcceleratorState` has been initialized once.

## Who is it for?

Users of Accelerate

## Why is it needed?

Currently if a modification is attempted to be made, it gets ignored leaving the user confused as to why they passed in a new mixed precision type, or told the Accelerator to run on the CPU, when in actually it has not due to the AcceleratorState being built once. 

## What parts of the API does this impact?

### User-facing:
Nothing

### Internal structure:

A new `_check_initialized` function has been included in the `AcceleratorState` that fills a clear string template of what they tried to do, why they cannot do it, and how to achieve their desired behavior.