### PR TITLE
Fix subtle bug in BF16

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -253,7 +253,7 @@ class Accelerator:
             kwargs = self.scaler_handler.to_kwargs() if self.scaler_handler is not None else {}
             self.scaler = torch.cuda.amp.GradScaler(**kwargs)
         elif self.state.mixed_precision == "bf16":
-            self.native_amp = is_bf16_available(True)
+            self.native_amp = is_bf16_available()
             if mixed_precision == "bf16" and not self.native_amp:
                 raise ValueError(err.format(mode="bf16", requirement="PyTorch >= 1.10 and a supported device."))
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -253,8 +253,8 @@ class Accelerator:
             kwargs = self.scaler_handler.to_kwargs() if self.scaler_handler is not None else {}
             self.scaler = torch.cuda.amp.GradScaler(**kwargs)
         elif self.state.mixed_precision == "bf16":
-            self.native_amp = is_bf16_available()
-            if mixed_precision == "bf16" and not self.native_amp:
+            self.native_amp = is_bf16_available(True)
+            if mixed_precision == "bf16" and not self.native_amp and not is_tpu_available():
                 raise ValueError(err.format(mode="bf16", requirement="PyTorch >= 1.10 and a supported device."))
 
             # Only on the GPU do we care about scaling the gradients

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -80,7 +80,9 @@ class AcceleratorState:
         if not getattr(self, "initialized", False):
             self.backend = None
             self.deepspeed_plugin = None
-            mixed_precision = mixed_precision.lower() if mixed_precision else None
+            mixed_precision = (
+                parse_choice_from_env("MIXED_PRECISION", "no") if mixed_precision is None else mixed_precision.lower()
+            )
             if not _from_accelerator:
                 raise ValueError(
                     "Please make sure to properly initialize your accelerator via `accelerator = Accelerator()` "


### PR DESCRIPTION
This PR fixes two subtle bugs I noticed post my previous PR:
- We currently can no longer get the mixed precision from the environment variable (oops)
- If on a TPU and you select bf16 an error will be raised in the bf16 flag, this has the flag get ignored if a tpu is available in the check as all of the bf16 logic for TPU's lives in `state`