### PR TITLE
Link CI slow runners to the commit

### DIFF
--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - actions
   workflow_dispatch:
 
 env:

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - actions
   workflow_dispatch:
 
 env:
@@ -38,3 +39,7 @@ jobs:
     if: (github.event_name == 'push') && (needs.check-for-setup.outputs.changed == '1')
     uses: ./.github/workflows/build-docker-images.yml
     secrets: inherit
+
+  run-tests:
+    needs: build-docker-containers
+    uses: ./.github/workflows/on-merge.yml

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -1,4 +1,4 @@
-name: Check for dependency modification
+name: Trigger docker images and run slow tests
 
 on:
   push:

--- a/.github/workflows/check_dependencies.yml
+++ b/.github/workflows/check_dependencies.yml
@@ -42,4 +42,5 @@ jobs:
 
   run-tests:
     needs: build-docker-containers
+    if: always()
     uses: ./.github/workflows/on-merge.yml

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,6 +1,7 @@
 name: Self-hosted runner tests (push to "main")
 
 on:
+  workflow_call:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -1,10 +1,6 @@
-name: Self-hosted runner (push to "main")
+name: Self-hosted runner tests (push to "main")
 
 on:
-  workflow_run:
-    workflows: ["Check for dependency modification"]
-    branches: ["main"]
-    types: [completed]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Currently slow runner tests don't show up on the commit to main as they're triggered separately, making it hard to realize when they fail. This PR makes the on-merge ci (aka the slow runner) reusable and has `check_dependencies` trigger it at the very end. This lets the commit SHA/message be linked and it will show up in the merge history with a checkmark or x if there was a failure. 

Some git specifics:

If you combine an `if: always()` with a `needs: {workflow}`, it will wait until `{workflow}` finishes running and then will always run. 