### PR TITLE
Expose some is_*_available utils in docs

### DIFF
--- a/docs/source/internal.mdx
+++ b/docs/source/internal.mdx
@@ -56,6 +56,12 @@ The main work on your PyTorch `DataLoader` is done by the following function:
 
 [[autodoc]] utils.extract_model_from_parallel
 
+[[autodoc]] utils.is_bf16_available
+
+[[autodoc]] utils.is_torch_version
+
+[[autodoc]] utils.is_tpu_available
+
 [[autodoc]] utils.gather
 
 [[autodoc]] utils.send_to_device

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -57,6 +57,7 @@ def is_apex_available():
 
 
 def is_tpu_available():
+    "Checks if `torch_xla` is installed and if a TPU is in the environment"
     return _tpu_available
 
 


### PR DESCRIPTION
This PR adds the following to the documentation:

- `is_bf16_available`
- `is_torch_version`
- `is_tpu_available`

My motivation for this is while they're mildly small utility functions, they have more usecases than just being used internally. Especially the `is_bf16_available`, as pytorch's own check isn't shown in their general documentation so many people did not even know it existed!

I'm 50/50 on if we want to show `is_torch_version`, but bare minimum `is_tpu_available` and `is_bf16_available` are a must IMO as they have different underlying checks than just "is this package installed"