### PR TITLE
Refactor Utility Documentation

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -19,10 +19,10 @@
     title: Notebook Launcher
   - local: kwargs
     title: Kwargs Handlers
-  - local: internal
-    title: Internals
   - local: checkpoint
     title: Checkpointing
+  - local: internal
+    title: Internals
   - local: tracking
     title: Experiment Tracking
   - local: fsdp
@@ -31,4 +31,6 @@
     title: Memory Utilities
   - local: deepspeed
     title: DeepSpeed
+  - local: utilities
+    title: General Utilities
   title: API Reference

--- a/docs/source/internal.mdx
+++ b/docs/source/internal.mdx
@@ -44,34 +44,6 @@ The main work on your PyTorch `DataLoader` is done by the following function:
 
 [[autodoc]] state.AcceleratorState
 
-### DistributedType
-
-[[autodoc]] state.DistributedType
-
 ## Tracking
 
 [[autodoc]] tracking.GeneralTracker
-
-## Utilities
-
-[[autodoc]] utils.extract_model_from_parallel
-
-[[autodoc]] utils.is_bf16_available
-
-[[autodoc]] utils.is_torch_version
-
-[[autodoc]] utils.is_tpu_available
-
-[[autodoc]] utils.gather
-
-[[autodoc]] utils.send_to_device
-
-[[autodoc]] utils.set_seed
-
-[[autodoc]] utils.synchronize_rng_state
-
-[[autodoc]] utils.synchronize_rng_states
-
-[[autodoc]] utils.wait_for_everyone
-
-[[autodoc]] utils.write_basic_config

--- a/docs/source/utilities.mdx
+++ b/docs/source/utilities.mdx
@@ -10,7 +10,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Helpful Utility Functions
+# Helpful Utilities
 
 ## Data Classes
 

--- a/docs/source/utilities.mdx
+++ b/docs/source/utilities.mdx
@@ -12,7 +12,11 @@ specific language governing permissions and limitations under the License.
 
 # Helpful Utilities
 
+Below are a variety of utility functions that Accelerate provides, broken down by use-case. 
+
 ## Data Classes
+
+These are basic dataclasses used throughout Accelerate and can be passed in as parameters.
 
 [[autodoc]] utils.DistributedType
 
@@ -38,6 +42,8 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 ## Environment Checks
 
+These functionalities check the state of the current working environment including information about the operating system itself, what it can support, and if particular dependencies are installed. 
+
 [[autodoc]] utils.get_max_memory
 
 [[autodoc]] utils.is_bf16_available
@@ -50,7 +56,11 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 [[autodoc]] utils.write_basic_config
 
+When setting up Accelerate for the first time, rather than running `accelerate config` [~utils.write_basic_config] can be used as alternative for quick configuration.
+
 ## Modeling
+
+These utilities relate to interacting with PyTorch models
 
 [[autodoc]] utils.extract_model_from_parallel
 
@@ -61,6 +71,8 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 ## Parallel
 
+These include general utilities that should be used when working in parallel.
+
 [[autodoc]] utils.extract_model_from_parallel
 
 [[autodoc]] utils.save
@@ -69,6 +81,8 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 
 ## Random
+
+These utilities relate to setting and synchronizing of all the random states.
 
 [[autodoc]] utils.set_seed
 

--- a/docs/source/utilities.mdx
+++ b/docs/source/utilities.mdx
@@ -38,6 +38,8 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 ## Environment Checks
 
+[[autodoc]] utils.get_max_memory
+
 [[autodoc]] utils.is_bf16_available
 
 [[autodoc]] utils.is_torch_version
@@ -52,9 +54,7 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 [[autodoc]] utils.extract_model_from_parallel
 
-[[autodoc]] utils.compute_module_sizes
-
-[[autodoc]] utils.get_max_memory
+[[autodoc]] utils.get_max_layer_size
 
 [[autodoc]] utils.offload_state_dict
 

--- a/docs/source/utilities.mdx
+++ b/docs/source/utilities.mdx
@@ -10,9 +10,9 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-## Helpful Utility Functions
+# Helpful Utility Functions
 
-### Data Classes
+## Data Classes
 
 [[autodoc]] utils.DistributedType
 
@@ -20,7 +20,7 @@ specific language governing permissions and limitations under the License.
 
 [[autodoc]] utils.PrecisionType
 
-### Data Manipulation and Operations
+## Data Manipulation and Operations
 
 These include data operations that mimic the same `torch` ops but can be used on distributed processes.
 
@@ -36,7 +36,7 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 [[autodoc]] utils.send_to_device
 
-### Environment Checks
+## Environment Checks
 
 [[autodoc]] utils.is_bf16_available
 
@@ -44,11 +44,11 @@ These include data operations that mimic the same `torch` ops but can be used on
 
 [[autodoc]] utils.is_tpu_available
 
-### Environment Configuration
+## Environment Configuration
 
 [[autodoc]] utils.write_basic_config
 
-### Modeling
+## Modeling
 
 [[autodoc]] utils.extract_model_from_parallel
 
@@ -59,7 +59,7 @@ These include data operations that mimic the same `torch` ops but can be used on
 [[autodoc]] utils.offload_state_dict
 
 
-### Parallel
+## Parallel
 
 [[autodoc]] utils.extract_model_from_parallel
 
@@ -68,7 +68,7 @@ These include data operations that mimic the same `torch` ops but can be used on
 [[autodoc]] utils.wait_for_everyone
 
 
-### Random
+## Random
 
 [[autodoc]] utils.set_seed
 

--- a/docs/source/utilities.mdx
+++ b/docs/source/utilities.mdx
@@ -1,0 +1,77 @@
+<!--Copyright 2021 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+## Helpful Utility Functions
+
+### Data Classes
+
+[[autodoc]] utils.DistributedType
+
+[[autodoc]] utils.LoggerType
+
+[[autodoc]] utils.PrecisionType
+
+### Data Manipulation and Operations
+
+These include data operations that mimic the same `torch` ops but can be used on distributed processes.
+
+[[autodoc]] utils.broadcast
+
+[[autodoc]] utils.concatenate
+
+[[autodoc]] utils.gather
+
+[[autodoc]] utils.pad_across_processes
+
+[[autodoc]] utils.reduce
+
+[[autodoc]] utils.send_to_device
+
+### Environment Checks
+
+[[autodoc]] utils.is_bf16_available
+
+[[autodoc]] utils.is_torch_version
+
+[[autodoc]] utils.is_tpu_available
+
+### Environment Configuration
+
+[[autodoc]] utils.write_basic_config
+
+### Modeling
+
+[[autodoc]] utils.extract_model_from_parallel
+
+[[autodoc]] utils.compute_module_sizes
+
+[[autodoc]] utils.get_max_memory
+
+[[autodoc]] utils.offload_state_dict
+
+
+### Parallel
+
+[[autodoc]] utils.extract_model_from_parallel
+
+[[autodoc]] utils.save
+
+[[autodoc]] utils.wait_for_everyone
+
+
+### Random
+
+[[autodoc]] utils.set_seed
+
+[[autodoc]] utils.synchronize_rng_state
+
+[[autodoc]] utils.synchronize_rng_states

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -179,6 +179,16 @@ class BaseEnum(enum.Enum, metaclass=EnumWithContains):
 
 
 class LoggerType(BaseEnum):
+    """Represents a type of supported experiment tracker
+
+    Values:
+
+        - **ALL** -- all available trackers in the environment that are supported
+        - **TENSORBOARD** -- TensorBoard as an experiment tracker
+        - **WANDB** -- wandb as an experiment tracker
+        - **COMETML** -- comet_ml as an experiment tracker
+    """
+
     ALL = "all"
     TENSORBOARD = "tensorboard"
     WANDB = "wandb"
@@ -186,6 +196,15 @@ class LoggerType(BaseEnum):
 
 
 class PrecisionType(BaseEnum):
+    """Represents a type of precision used on floating point values
+
+    Values:
+
+        - **NO** -- using full precision (FP32)
+        - **FP16** -- using half precision
+        - **BF16** -- using brain floating point precision
+    """
+
     NO = "no"
     FP16 = "fp16"
     BF16 = "bf16"


### PR DESCRIPTION
This PR refactors the docs with a "General Utilities" landing page, that includes more of what exists in `accelerate.utils`. This was made with the belief of improving and exposing more in the docs that a user (and potentially power user) may want to find and/or see what is available to be used. 