### PR TITLE
Add docbuilder to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 extras = {}
-extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3"]
+extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3", "hf-doc-builder >= 0.3.0"]
 extras["docs"] = []
 extras["test"] = [
     "pytest",


### PR DESCRIPTION
Adds docbuilder to the setup.py similar to transformers. 

I could put it also in the `docs` subsection as well, but as we're mimicking it twice I'd rather we wait until doc-specific dependencies are needed, then it may be a good idea to have a `deps_list` util similar to that of `transformers`. For now though I think that's unnecessary. 