### PR TITLE
Fix documentation not rendering on main

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -13,5 +13,6 @@ jobs:
     with:
       commit_sha: ${{ github.sha }}
       package: accelerate
+      additional_args: yes
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from setuptools import find_packages
 
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3", "hf-doc-builder >= 0.3.0"]
+extras["docs"] = []
 extras["test"] = [
     "pytest",
     "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ from setuptools import find_packages
 
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3", "hf-doc-builder >= 0.3.0"]
-extras["docs"] = ["deepspeed"] + extras["quality"]
 extras["test"] = [
     "pytest",
     "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from setuptools import find_packages
 
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3", "hf-doc-builder >= 0.3.0"]
-extras["docs"] = []
+extras["docs"] = ["deepspeed"] + extras["quality"]
 extras["test"] = [
     "pytest",
     "pytest-xdist",
@@ -30,7 +30,6 @@ extras["test"] = [
     "parameterized",
     "deepspeed",
 ]
-
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard"]
 extras["dev"] = extras["quality"] + extras["test"]
 


### PR DESCRIPTION
This PR should solve some of why the docs on main don't render. The reason is we need deepspeed installed in our system to render the docs, otherwise we get a "cannot find ... in accelerate" for deepspeed utils such as this failed run:

https://github.com/huggingface/doc-builder/runs/6988543241?check_suite_focus=true

What's scary is this was a very hidden bug that didn't show on our runs to main. I *think* this solves the problem, but not sure how to 100% test it on deployed docs
