### PR TITLE
Introduce automatic gradient accumulation wrapper + fix a few test issues

### DIFF
--- a/docs/source/accelerator.mdx
+++ b/docs/source/accelerator.mdx
@@ -46,13 +46,13 @@ actually be performed, and auto-scale the loss:
 accelerator = Accelerator(gradient_accumulation_steps=2)
 
 for (input, label) in enumerate(training_dataloader):
-  with accelerator.accumulate(model):
-    predictions = model(input)
-    loss = loss_function(predictions, labels)
-    accelerator.backward(loss)
-    optimizer.step()
-    scheduler.step()
-    optimizer.zero_grad()
+    with accelerator.accumulate(model):
+        predictions = model(input)
+        loss = loss_function(predictions, labels)
+        accelerator.backward(loss)
+        optimizer.step()
+        scheduler.step()
+        optimizer.zero_grad()
 ```
 
 **Note**: Using this with `dispatch_batches=True` is currently not supported.

--- a/docs/source/accelerator.mdx
+++ b/docs/source/accelerator.mdx
@@ -38,4 +38,23 @@ should search for and replace by the corresponding methods of your `accelerator`
 - Use [`~Accelerator.clip_grad_norm_`] instead of `torch.nn.utils.clip_grad_norm_` and
   [`~Accelerator.clip_grad_value_`] instead of `torch.nn.utils.clip_grad_value_`.
 
+To perform gradient accumulation use [`~Accelerator.accumulate`] and specify a `gradient_accumulation_steps`. 
+This will also automatically ensure the gradients are synced or unsynced when on multi-node, check if the step should
+actually be performed, and auto-scale the loss:
+
+```python
+accelerator = Accelerator(gradient_accumulation_steps=2)
+
+for (input, label) in enumerate(training_dataloader):
+  with accelerator.accumulate(model):
+    predictions = model(input)
+    loss = loss_function(predictions, labels)
+    accelerator.backward(loss)
+    optimizer.step()
+    scheduler.step()
+    optimizer.zero_grad()
+```
+
+**Note**: Using this with `dispatch_batches=True` is currently not supported.
+
 [[autodoc]] Accelerator

--- a/docs/source/accelerator.mdx
+++ b/docs/source/accelerator.mdx
@@ -39,7 +39,7 @@ should search for and replace by the corresponding methods of your `accelerator`
   [`~Accelerator.clip_grad_value_`] instead of `torch.nn.utils.clip_grad_value_`.
 
 To perform gradient accumulation use [`~Accelerator.accumulate`] and specify a `gradient_accumulation_steps`. 
-This will also automatically ensure the gradients are synced or unsynced when on multi-node, check if the step should
+This will also automatically ensure the gradients are synced or unsynced when on multi-device training, check if the step should
 actually be performed, and auto-scale the loss:
 
 ```python
@@ -55,6 +55,10 @@ for (input, label) in enumerate(training_dataloader):
         optimizer.zero_grad()
 ```
 
-**Note**: Using this with `dispatch_batches=True` is currently not supported.
+<Tip warning={true}>
+
+Using this with `dispatch_batches=True`  (which is the default for iterable datasets) is currently not supported.
+
+</Tip>
 
 [[autodoc]] Accelerator

--- a/docs/source/internal.mdx
+++ b/docs/source/internal.mdx
@@ -12,6 +12,10 @@ specific language governing permissions and limitations under the License.
 
 # Internals
 
+## Gradient Accumulation states
+
+[[autodoc]] state.GradientState
+
 ## Optimizer
 
 [[autodoc]] optimizer.AcceleratedOptimizer

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -102,19 +102,21 @@ if os.environ.get("TESTING_MOCKED_DATALOADERS", None) == "1":
 
 
 def training_function(config, args):
+    # New Code #
+    gradient_accumulation_steps = int(args.gradient_accumulation_steps)
     # Initialize accelerator
-    accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision)
+    accelerator = Accelerator(
+        cpu=args.cpu, mixed_precision=args.mixed_precision, gradient_accumulation_steps=gradient_accumulation_steps
+    )
+    if accelerator.distributed_type == DistributedType.TPU and gradient_accumulation_steps > 1:
+        raise NotImplementedError(
+            "Gradient accumulation on TPUs is currently not supported. Pass `gradient_accumulation_steps=1`"
+        )
     # Sample hyper-parameters for learning rate, batch size, seed and a few other HPs
     lr = config["lr"]
     num_epochs = int(config["num_epochs"])
     seed = int(config["seed"])
     batch_size = int(config["batch_size"])
-    # New Code #
-    gradient_accumulation_steps = int(args.gradient_accumulation_steps)
-    if accelerator.distributed_type == DistributedType.TPU and gradient_accumulation_steps > 1:
-        raise NotImplementedError(
-            "Gradient accumulation on TPUs is currently not supported. Pass `gradient_accumulation_steps=1`"
-        )
 
     metric = evaluate.load("glue", "mrpc")
 
@@ -152,19 +154,14 @@ def training_function(config, args):
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
             # New code #
-            # We use the new `no_sync` context manager to prevent gradient averaging
-            # until we want to at the proper step if we happen to be in a distributed setup
-            # otherwise it does nothing
+            # We use the new `accumulate` context manager to perform gradient accumulation
             # We also currently do not support TPUs nor advise it as bugs were found on the XLA side when running our tests.
             with accelerator.accumulate(model):
                 output = model(**batch)
                 loss = output.loss
-                # Check if in ctx mgr & see if I have access to that
                 accelerator.backward(loss)
-                # Interensic check accelerator.n_steps
                 optimizer.step()
-                # Can call lr_scheduler.step() when optimizer.step() is done
-                # lr_scheduler.step()
+                lr_scheduler.step()
                 optimizer.zero_grad()
 
         model.eval()

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -235,12 +235,17 @@ class Accelerator:
             **kwargs,
         )
 
-        if gradient_accumulation_steps > 1 and self.state.distributed_type == DistributedType.TPU:
-            raise NotImplementedError(
-                "Gradient accumulation on TPU is not supported. Pass in `gradient_accumulation_steps=1`"
-            )
-        self.gradient_accumulation_steps = gradient_accumulation_steps
+        if gradient_accumulation_steps > 1:
+            if self.state.distributed_type == DistributedType.TPU:
+                raise NotImplementedError(
+                    "Gradient accumulation on TPU is not supported. Pass in `gradient_accumulation_steps=1`"
+                )
+            if dispatch_batches:
+                raise NotImplementedError(
+                    "Gradient accumulation with dispatched dataloaders is not supported. Pass in `gradient_accumulation_steps=1` or `dispatch_batches=False`"
+                )
 
+        self.gradient_accumulation_steps = gradient_accumulation_steps
         self.device_placement = device_placement
         self.split_batches = split_batches
         self.dispatch_batches = dispatch_batches

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -382,7 +382,7 @@ class Accelerator:
 
     @property
     def _do_sync(self) -> bool:
-        "Checks if self.step % self.gradient_accumulation_steps == 0 or if we're on the last batch"
+        "Checks if gradients should be synchronized and the optimizers + schedulers should be stepped"
         if self.state.end_of_dataloader:
             self.step = 0
             return True

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -92,8 +92,8 @@ class Accelerator:
             default to the value in the environment variable `MIXED_PRECISION`, which will use the default value in the
             accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp16'
             requires pytorch 1.6 or higher. 'bf16' requires pytorch 1.10 or higher.
-        gradient_accumulation_steps (`int`, *optional*):
-            The number of steps that should pass before gradients are accumulated. Should be combined with
+        gradient_accumulation_steps (`int`, *optional*, default to 1):
+            The number of steps that should pass before gradients are accumulated. A number > 1 should be combined with
             `Accelerator.accumulate`.
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore GPU available if set to `True` and force

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -94,7 +94,8 @@ class Accelerator:
             requires pytorch 1.6 or higher. 'bf16' requires pytorch 1.10 or higher.
         gradient_accumulation_steps (`int`, *optional*):
             The number of steps that should pass before gradients are accumulated. Should be combined with
-            `Accelerator.accumulate`
+            `Accelerator.accumulate`. If `step_scheduler_with_optimizer` is `True`, will assume that the scheduler
+            has been made with gradient accumulation in mind.
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore GPU available if set to `True` and force
             the execution on one process only.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -383,11 +383,8 @@ class Accelerator:
     @property
     def _do_sync(self) -> bool:
         "Checks if gradients should be synchronized and the optimizers + schedulers should be stepped"
-        if self.state.end_of_dataloader:
-            self.step = 0
-            return True
         self.step += 1
-        if (self.gradient_accumulation_steps == 1) or ((self.step % self.gradient_accumulation_steps) == 0):
+        if (self.step % self.gradient_accumulation_steps) == 0 or self.state.end_of_dataloader:
             return True
         return False
 
@@ -412,6 +409,9 @@ class Accelerator:
 
         with context(model):
             yield
+
+        if self.state.end_of_dataloader:
+            self.step = 0
 
     def print(self, *args, **kwargs):
         """

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -94,8 +94,7 @@ class Accelerator:
             requires pytorch 1.6 or higher. 'bf16' requires pytorch 1.10 or higher.
         gradient_accumulation_steps (`int`, *optional*):
             The number of steps that should pass before gradients are accumulated. Should be combined with
-            `Accelerator.accumulate`. If `step_scheduler_with_optimizer` is `True`, will assume that the scheduler
-            has been made with gradient accumulation in mind.
+            `Accelerator.accumulate`.
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore GPU available if set to `True` and force
             the execution on one process only.

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -304,7 +304,10 @@ class DataLoaderShard(DataLoader):
         self.gradient_state._set_end_of_dataloader(False)
         dataloader_iter = super().__iter__()
         # We iterate one batch ahead to check when we are at the end
-        current_batch = next(dataloader_iter)
+        try:
+            current_batch = next(dataloader_iter)
+        except StopIteration:
+            raise StopIteration("Tried iterating over an empty dataloader")
         while True:
             try:
                 # But we still move it to the device so it is done before `StopIteration` is reached

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -386,25 +386,44 @@ class DataLoaderDispatcher(DataLoader):
 
     def __iter__(self):
         state = AcceleratorState()
-        main_iterator = None
         if state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
             main_iterator = super().__iter__()
-            self.gradient_state._set_end_of_dataloader(False)
         stop_iteration = False
         first_batch = None
-        batch, batch_info = self._draw_batch(main_iterator, stop_iteration)
-
+        self.gradient_state._set_end_of_dataloader(False)
         while not stop_iteration:
-            # On process 0 we gather the batch to dispatch
+            # On process 0, we gather the batch to dispatch.
+            if state.process_index == 0:
+                try:
+                    if self.split_batches:
+                        # One batch of the main iterator is dispatched and split.
+                        batch = next(main_iterator)
+                    else:
+                        # num_processes batches of the main iterator are concatenated then dispatched and split.
+                        # We add the batches one by one so we have the remainder available when drop_last=False.
+                        batches = []
+                        for _ in range(state.num_processes):
+                            batches.append(next(main_iterator))
+                        batch = concatenate(batches, dim=0)
+                    # In both cases, we need to get the structure of the batch that we will broadcast on other
+                    # processes to initialize the tensors with the right shape.
+                    # data_structure, stop_iteration
+                    batch_info = [get_data_structure(batch), False]
+                except StopIteration:
+                    batch_info = [None, True]
+            else:
+                batch_info = [None, stop_iteration]
+
             # This is inplace, so after this instruction, every process has the same `batch_info` as process 0.
             broadcast_object_list(batch_info)
             stop_iteration = batch_info[1]
             if stop_iteration:
+                self.gradient_state._set_end_of_dataloader(True)
                 # If drop_last is False and split_batches is False, we may have a remainder to take care of.
                 if not self.split_batches and not self.drop_last:
-                    if state.process_index == 0 and len(batch) > 0:
-                        batch = concatenate(batch_info, dim=0)
+                    if state.process_index == 0 and len(batches) > 0:
+                        batch = concatenate(batches, dim=0)
                         batch_info = [get_data_structure(batch), False]
                     else:
                         batch_info = [None, True]
@@ -434,9 +453,7 @@ class DataLoaderDispatcher(DataLoader):
                 batch_size += 1
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
-            next_batch, next_batch_info = self._draw_batch(main_iterator, stop_iteration)
             yield slice_tensors(batch, data_slice)
-            batch, batch_info = next_batch, next_batch_info
 
     def __len__(self):
         state = AcceleratorState()

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-from tracemalloc import stop
 from typing import List, Optional, Union
 
 import torch
@@ -325,18 +324,16 @@ class DataLoaderShard(DataLoader):
 
 class DataLoaderDispatcher(DataLoader):
     """
+    Args:
     Subclass of a PyTorch `DataLoader` that will iterate and preprocess on process 0 only, then dispatch on each
     process their part of the batch.
-    Args:
         split_batches (`bool`, *optional*, defaults to `False`):
             Whether the resulting `DataLoader` should split the batches of the original data loader across devices or
             yield full batches (in which case it will yield batches starting at the `process_index`-th and advancing of
-            `num_processes` batches at each iteration).
-            Another way to see this is that the observed batch size will be the same as the initial `dataloader` if
-            this option is set to `True`, the batch size of the initial `dataloader` multiplied by `num_processes`
-            otherwise.
-            Setting this option to `True` requires that the batch size of the `dataloader` is a round multiple of
-            `batch_size`.
+            `num_processes` batches at each iteration). Another way to see this is that the observed batch size will be
+            the same as the initial `dataloader` if this option is set to `True`, the batch size of the initial
+            `dataloader` multiplied by `num_processes` otherwise. Setting this option to `True` requires that the batch
+            size of the `dataloader` is a round multiple of `batch_size`.
     """
 
     def __init__(self, dataset, split_batches: bool = False, **kwargs):
@@ -364,32 +361,31 @@ class DataLoaderDispatcher(DataLoader):
         if state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
             main_iterator = super().__iter__()
-
         stop_iteration = False
         first_batch = None
-        # On process 0, we gather the batch to dispatch.
-        if state.process_index == 0:
-            try:
-                if self.split_batches:
-                    # One batch of the main iterator is dispatched and split.
-                    batch = next(main_iterator)
-                else:
-                    # num_processes batches of the main iterator are concatenated then dispatched and split.
-                    # We add the batches one by one so we have the remainder available when drop_last=False.
-                    batches = []
-                    for _ in range(state.num_processes):
-                        batches.append(next(main_iterator))
-                    batch = concatenate(batches, dim=0)
-                # In both cases, we need to get the structure of the batch that we will broadcast on other
-                # processes to initialize the tensors with the right shape.
-                # data_structure, stop_iteration
-                batch_info = [get_data_structure(batch), False]
-            except StopIteration:
-                batch_info = [None, True]
-        else:
-            batch_info = [None, stop_iteration]
-        
         while not stop_iteration:
+            # On process 0, we gather the batch to dispatch.
+            if state.process_index == 0:
+                try:
+                    if self.split_batches:
+                        # One batch of the main iterator is dispatched and split.
+                        batch = next(main_iterator)
+                    else:
+                        # num_processes batches of the main iterator are concatenated then dispatched and split.
+                        # We add the batches one by one so we have the remainder available when drop_last=False.
+                        batches = []
+                        for _ in range(state.num_processes):
+                            batches.append(next(main_iterator))
+                        batch = concatenate(batches, dim=0)
+                    # In both cases, we need to get the structure of the batch that we will broadcast on other
+                    # processes to initialize the tensors with the right shape.
+                    # data_structure, stop_iteration
+                    batch_info = [get_data_structure(batch), False]
+                except StopIteration:
+                    batch_info = [None, True]
+            else:
+                batch_info = [None, stop_iteration]
+
             # This is inplace, so after this instruction, every process has the same `batch_info` as process 0.
             broadcast_object_list(batch_info)
             stop_iteration = batch_info[1]
@@ -427,31 +423,7 @@ class DataLoaderDispatcher(DataLoader):
                 batch_size += 1
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
-            # On process 0, we gather the batch to dispatch.
-            if state.process_index == 0:
-                try:
-                    if self.split_batches:
-                        # One batch of the main iterator is dispatched and split.
-                        next_batch = next(main_iterator)
-                    else:
-                        # num_processes batches of the main iterator are concatenated then dispatched and split.
-                        # We add the batches one by one so we have the remainder available when drop_last=False.
-                        batches = []
-                        for _ in range(state.num_processes):
-                            batches.append(next(main_iterator))
-                        next_batch = concatenate(batches, dim=0)
-                    # In both cases, we need to get the structure of the batch that we will broadcast on other
-                    # processes to initialize the tensors with the right shape.
-                    # data_structure, stop_iteration
-                    next_batch_info = [get_data_structure(next_batch), False]
-                except StopIteration:
-                    next_batch_info = [None, True]
-            else:
-                next_batch_info = [None, stop_iteration]
-            if next_batch_info[1]:
-                self.gradient_state._set_end_of_dataloader(True)
             yield slice_tensors(batch, data_slice)
-            batch, batch_info = next_batch, next_batch_info
 
     def __len__(self):
         whole_length = super().__len__()
@@ -459,6 +431,7 @@ class DataLoaderDispatcher(DataLoader):
             return whole_length // self.state.num_processes
         else:
             return math.ceil(whole_length / self.state.num_processes)
+
 
 def prepare_data_loader(
     dataloader: DataLoader,

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -307,7 +307,7 @@ class DataLoaderShard(DataLoader):
         try:
             current_batch = next(dataloader_iter)
         except StopIteration:
-            raise StopIteration("Tried iterating over an empty dataloader")
+            yield current_batch
         while True:
             try:
                 # But we still move it to the device so it is done before `StopIteration` is reached
@@ -357,77 +357,81 @@ class DataLoaderDispatcher(DataLoader):
             )
         if shuffle:
             torch.utils.data.graph_settings.apply_shuffle_settings(dataset, shuffle=shuffle)
+        self.gradient_state = GradientState()
+        self.state = AcceleratorState()
+
+    def _next_batch(self, iterator):
+        if self.state.process_index == 0:
+            try:
+                if self.split_batches:
+                    # One batch of the main iterator is dispatched and split.
+                    batch = next(iterator)
+                else:
+                    # num_processes batches of the main iterator are concatenated then dispatched and split.
+                    # We add the batches one by one so we have the remainder available when drop_last=False.
+                    batches = []
+                    for _ in range(self.state.num_processes):
+                        batches.append(next(iterator))
+                    batch = concatenate(batches, dim=0)
+                # In both cases, we need to get the structure of the batch that we will broadcast on other
+                # processes to initialize the tensors with the right shape.
+                # data_structure, stop_iteration
+                batch_info = [get_data_structure(batch), False]
+            except StopIteration:
+                batch_info = [None, True]
+            return batches, batch_info
 
     def __iter__(self):
         state = AcceleratorState()
         if state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
             main_iterator = super().__iter__()
+            self.gradient_state._set_end_of_dataloader(False)
+            current_batch, current_batch_info = self._next_batch(main_iterator)
         stop_iteration = False
         first_batch = None
-        GradientState()._set_end_of_dataloader(False)
-        while not stop_iteration:
-            # On process 0, we gather the batch to dispatch.
-            if state.process_index == 0:
-                try:
-                    if self.split_batches:
-                        # One batch of the main iterator is dispatched and split.
-                        batch = next(main_iterator)
-                    else:
-                        # num_processes batches of the main iterator are concatenated then dispatched and split.
-                        # We add the batches one by one so we have the remainder available when drop_last=False.
-                        batches = []
-                        for _ in range(state.num_processes):
-                            batches.append(next(main_iterator))
-                        batch = concatenate(batches, dim=0)
-                    # In both cases, we need to get the structure of the batch that we will broadcast on other
-                    # processes to initialize the tensors with the right shape.
-                    # data_structure, stop_iteration
-                    batch_info = [get_data_structure(batch), False]
-                except StopIteration:
-                    batch_info = [None, True]
-            else:
-                batch_info = [None, stop_iteration]
 
+        while not stop_iteration:
             # This is inplace, so after this instruction, every process has the same `batch_info` as process 0.
-            broadcast_object_list(batch_info)
-            stop_iteration = batch_info[1]
+            broadcast_object_list(current_batch_info)
+            stop_iteration = current_batch_info[1]
             if stop_iteration:
                 # If drop_last is False and split_batches is False, we may have a remainder to take care of.
                 if not self.split_batches and not self.drop_last:
-                    if state.process_index == 0 and len(batches) > 0:
-                        batch = concatenate(batches, dim=0)
-                        batch_info = [get_data_structure(batch), False]
+                    if state.process_index == 0 and len(current_batch) > 0:
+                        current_batch = concatenate(current_batch, dim=0)
+                        current_batch_info = [get_data_structure(current_batch), False]
                     else:
-                        batch_info = [None, True]
-                    broadcast_object_list(batch_info)
-                    if batch_info[1]:
+                        current_batch_info = [None, True]
+                    broadcast_object_list(current_batch_info)
+                    if current_batch_info[1]:
                         continue
                 else:
                     continue
 
             if state.process_index != 0:
                 # Initialize tensors on other processes than process 0.
-                batch = initialize_tensors(batch_info[0])
-            batch = send_to_device(batch, state.device)
+                current_batch = initialize_tensors(current_batch_info[0])
+            current_batch = send_to_device(current_batch, state.device)
             # Broadcast the batch before splitting it.
-            batch = broadcast(batch, from_process=0)
+            current_batch = broadcast(current_batch, from_process=0)
 
             if not self.drop_last and first_batch is None:
                 # We keep at least num processes elements of the first batch to be able to complete the last batch
-                first_batch = slice_tensors(batch, slice(0, state.num_processes))
+                first_batch = slice_tensors(current_batch, slice(0, state.num_processes))
 
-            observed_batch_size = find_batch_size(batch)
+            observed_batch_size = find_batch_size(current_batch)
             batch_size = observed_batch_size // state.num_processes
 
             if not self.drop_last and stop_iteration and observed_batch_size % state.num_processes != 0:
                 # If the last batch is not complete, let's add the first batch to it.
-                batch = concatenate([batch, first_batch], dim=0)
+                current_batch = concatenate([current_batch, first_batch], dim=0)
                 batch_size += 1
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
-            yield slice_tensors(batch, data_slice)
-        GradientState()._set_end_of_dataloader(True)
+            next_batch, next_batch_info = self._next_batch(main_iterator)
+            yield slice_tensors(current_batch, data_slice)
+            current_batch, current_batch_info = next_batch, next_batch_info
 
     def __len__(self):
         state = AcceleratorState()

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -361,6 +361,7 @@ class DataLoaderDispatcher(DataLoader):
         self.state = AcceleratorState()
 
     def _draw_batch(self, iterator, stop_iteration):
+        batch = None
         if self.state.process_index == 0:
             try:
                 if self.split_batches:
@@ -380,7 +381,6 @@ class DataLoaderDispatcher(DataLoader):
             except StopIteration:
                 batch_info = [None, True]
         else:
-            batch = []
             batch_info = [None, stop_iteration]
         return batch, batch_info
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -379,7 +379,7 @@ class DataLoaderDispatcher(DataLoader):
                 batch_info = [get_data_structure(batch), False]
             except StopIteration:
                 batch_info = [None, True]
-            return batches, batch_info
+            return batch, batch_info
 
     def __iter__(self):
         state = AcceleratorState()

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+from tracemalloc import stop
 from typing import List, Optional, Union
 
 import torch
@@ -382,39 +383,19 @@ class DataLoaderDispatcher(DataLoader):
                 batch_info = [None, True]
         else:
             batch_info = [None, stop_iteration]
-        return batch, batch_info
+            batches = []
+        return batch, batches, batch_info
 
     def __iter__(self):
         state = AcceleratorState()
+        stop_iteration, main_iterator = False, None
         if state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
             main_iterator = super().__iter__()
-        stop_iteration = False
         first_batch = None
         self.gradient_state._set_end_of_dataloader(False)
+        batch, batches, batch_info = self._draw_batch(main_iterator, stop_iteration)
         while not stop_iteration:
-            # On process 0, we gather the batch to dispatch.
-            if state.process_index == 0:
-                try:
-                    if self.split_batches:
-                        # One batch of the main iterator is dispatched and split.
-                        batch = next(main_iterator)
-                    else:
-                        # num_processes batches of the main iterator are concatenated then dispatched and split.
-                        # We add the batches one by one so we have the remainder available when drop_last=False.
-                        batches = []
-                        for _ in range(state.num_processes):
-                            batches.append(next(main_iterator))
-                        batch = concatenate(batches, dim=0)
-                    # In both cases, we need to get the structure of the batch that we will broadcast on other
-                    # processes to initialize the tensors with the right shape.
-                    # data_structure, stop_iteration
-                    batch_info = [get_data_structure(batch), False]
-                except StopIteration:
-                    batch_info = [None, True]
-            else:
-                batch_info = [None, stop_iteration]
-
             # This is inplace, so after this instruction, every process has the same `batch_info` as process 0.
             broadcast_object_list(batch_info)
             stop_iteration = batch_info[1]
@@ -452,9 +433,10 @@ class DataLoaderDispatcher(DataLoader):
                 batch_size += 1
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
-            if stop_iteration:
-                self.gradient_state._set_end_of_dataloader(True)
+            next_batch, next_batches, next_batch_info = self._draw_batch(main_iterator, stop_iteration)
+            self.gradient_state._set_end_of_dataloader(next_batch_info[1])
             yield slice_tensors(batch, data_slice)
+            batch, batches, batch_info = next_batch, next_batches, next_batch_info
 
     def __len__(self):
         state = AcceleratorState()

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -298,7 +298,8 @@ class DataLoaderShard(DataLoader):
     def __iter__(self):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.generator)
-        for batch in super().__iter__():
+        for i, batch in enumerate(super().__iter__()):
+            AcceleratorState._set_state("end_of_dataloader", i == len(self) - 1)
             yield batch if self.device is None else send_to_device(batch, self.device)
 
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -398,6 +398,7 @@ class DataLoaderDispatcher(DataLoader):
                 return stop_iteration, batch, batch_info
             else:
                 return stop_iteration, [], batch_info
+        return stop_iteration, [], batch_info
 
     def __iter__(self):
         main_iterator = None

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -365,13 +365,13 @@ class DataLoaderDispatcher(DataLoader):
             try:
                 if self.split_batches:
                     # One batch of the main iterator is dispatched and split.
-                    batch = next(main_iterator)
+                    batch = next(iterator)
                 else:
                     # num_processes batches of the main iterator are concatenated then dispatched and split.
                     # We add the batches one by one so we have the remainder available when drop_last=False.
                     batches = []
                     for _ in range(self.state.num_processes):
-                        batches.append(next(main_iterator))
+                        batches.append(next(iterator))
                     batch = concatenate(batches, dim=0)
                 # In both cases, we need to get the structure of the batch that we will broadcast on other
                 # processes to initialize the tensors with the right shape.

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -419,7 +419,6 @@ class DataLoaderDispatcher(DataLoader):
             broadcast_object_list(batch_info)
             stop_iteration = batch_info[1]
             if stop_iteration:
-                self.gradient_state._set_end_of_dataloader(True)
                 # If drop_last is False and split_batches is False, we may have a remainder to take care of.
                 if not self.split_batches and not self.drop_last:
                     if state.process_index == 0 and len(batches) > 0:
@@ -453,6 +452,8 @@ class DataLoaderDispatcher(DataLoader):
                 batch_size += 1
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
+            if stop_iteration:
+                self.gradient_state._set_end_of_dataloader(True)
             yield slice_tensors(batch, data_slice)
 
     def __len__(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -391,6 +391,7 @@ class DataLoaderDispatcher(DataLoader):
             self.gradient_state._set_end_of_dataloader(False)
         stop_iteration = False
         first_batch = None
+        main_iterator = None
         batch, batch_info = self._draw_batch(main_iterator, stop_iteration)
 
         while not stop_iteration:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -303,7 +303,7 @@ class DataLoaderShard(DataLoader):
             synchronize_rng_states(self.rng_types, self.generator)
         self.gradient_state._set_end_of_dataloader(False)
         _current_batch = 0
-        _dataloader_length = len(self) - 1 if hasattr("__len__", self) else False
+        _dataloader_length = len(self) - 1 if hasattr(self, "__len__") else False
         for batch in super().__iter__():
             if _dataloader_length:
                 self.gradient_state._set_end_of_dataloader(_current_batch == _dataloader_length)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -387,7 +387,7 @@ class DataLoaderDispatcher(DataLoader):
             # We only iterate through the DataLoader on process 0.
             main_iterator = super().__iter__()
             self.gradient_state._set_end_of_dataloader(False)
-            current_batch, current_batch_info = self._next_batch(main_iterator)
+        current_batch, current_batch_info = self._next_batch(main_iterator)
         stop_iteration = False
         first_batch = None
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -309,13 +309,11 @@ class DataLoaderShard(DataLoader):
             try:
                 # But we still move it to the device so it is done before `StopIteration` is reached
                 if self.device is not None:
-                    send_to_device(current_batch, self.device)
+                    current_batch = send_to_device(current_batch, self.device)
                 next_batch = next(dataloader_iter)
                 yield current_batch
                 current_batch = next_batch
             except StopIteration:
-                if self.device is not None:
-                    send_to_device(current_batch, self.device)
                 self.gradient_state._set_end_of_dataloader(True)
                 yield current_batch
                 break

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -346,6 +346,7 @@ class DataLoaderDispatcher(DataLoader):
             main_iterator = super().__iter__()
         stop_iteration = False
         first_batch = None
+        current_idx = 0
         while not stop_iteration:
             # On process 0, we gather the batch to dispatch.
             if state.process_index == 0:
@@ -407,6 +408,8 @@ class DataLoaderDispatcher(DataLoader):
 
             data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
             yield slice_tensors(batch, data_slice)
+            current_idx += 1
+            AcceleratorState._set_state("end_of_dataloader", current_idx == len(self) - 1)
 
     def __len__(self):
         state = AcceleratorState()

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -314,6 +314,8 @@ class DataLoaderShard(DataLoader):
                 yield current_batch
                 current_batch = next_batch
             except StopIteration:
+                if self.device is not None:
+                    send_to_device(current_batch, self.device)
                 self.gradient_state._set_end_of_dataloader(True)
                 yield current_batch
                 break

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -385,13 +385,13 @@ class DataLoaderDispatcher(DataLoader):
 
     def __iter__(self):
         state = AcceleratorState()
+        main_iterator = None
         if state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
             main_iterator = super().__iter__()
             self.gradient_state._set_end_of_dataloader(False)
         stop_iteration = False
         first_batch = None
-        main_iterator = None
         batch, batch_info = self._draw_batch(main_iterator, stop_iteration)
 
         while not stop_iteration:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -380,6 +380,7 @@ class DataLoaderDispatcher(DataLoader):
             except StopIteration:
                 batch_info = [None, True]
         else:
+            batch = []
             batch_info = [None, stop_iteration]
         return batch, batch_info
 
@@ -415,7 +416,7 @@ class DataLoaderDispatcher(DataLoader):
 
             if state.process_index != 0:
                 # Initialize tensors on other processes than process 0.
-                batch_info = initialize_tensors(batch_info[0])
+                batch = initialize_tensors(batch_info[0])
             batch = send_to_device(batch, state.device)
             # Broadcast the batch before splitting it.
             batch = broadcast(batch, from_process=0)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -448,7 +448,7 @@ class DataLoaderDispatcher(DataLoader):
                     next_batch_info = [None, True]
             else:
                 next_batch_info = [None, stop_iteration]
-            if next_batch[1]:
+            if next_batch_info[1]:
                 self.gradient_state._set_end_of_dataloader(True)
             yield slice_tensors(batch, data_slice)
             batch, batch_info = next_batch, next_batch_info

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -359,19 +359,26 @@ class DataLoaderDispatcher(DataLoader):
         self.gradient_state = GradientState()
         self.state = AcceleratorState()
 
-    def _draw_batch(self, iterator, stop_iteration):
+    def __iter__(self):
+        state = AcceleratorState()
+        if state.process_index == 0:
+            # We only iterate through the DataLoader on process 0.
+            main_iterator = super().__iter__()
+
+        stop_iteration = False
+        first_batch = None
         # On process 0, we gather the batch to dispatch.
-        if self.state.process_index == 0:
+        if state.process_index == 0:
             try:
                 if self.split_batches:
                     # One batch of the main iterator is dispatched and split.
-                    batch = next(iterator)
+                    batch = next(main_iterator)
                 else:
                     # num_processes batches of the main iterator are concatenated then dispatched and split.
                     # We add the batches one by one so we have the remainder available when drop_last=False.
                     batches = []
-                    for _ in range(self.state.num_processes):
-                        batches.append(next(iterator))
+                    for _ in range(state.num_processes):
+                        batches.append(next(main_iterator))
                     batch = concatenate(batches, dim=0)
                 # In both cases, we need to get the structure of the batch that we will broadcast on other
                 # processes to initialize the tensors with the right shape.
@@ -381,60 +388,69 @@ class DataLoaderDispatcher(DataLoader):
                 batch_info = [None, True]
         else:
             batch_info = [None, stop_iteration]
-
-        # This is inplace, so after this instruction, every process has the same `batch_info` as process 0.
-        broadcast_object_list(batch_info)
-        stop_iteration = batch_info[1]
-        if stop_iteration:
-            # If drop_last is False and split_batches is False, we may have a remainder to take care of.
-            if not self.split_batches and not self.drop_last:
-                if self.state.process_index == 0 and len(batches) > 0:
-                    batch = concatenate(batches, dim=0)
-                    batch_info = [get_data_structure(batch), False]
-                else:
-                    batch_info = [None, True]
-                broadcast_object_list(batch_info)
-                self.gradient_state._set_end_of_dataloader(batch_info[1])
-                return stop_iteration, batch, batch_info
-            else:
-                return stop_iteration, [], batch_info
-        return stop_iteration, [], batch_info
-
-    def __iter__(self):
-        main_iterator = None
-        if self.state.process_index == 0:
-            # We only iterate through the DataLoader on process 0.
-            main_iterator = super().__iter__()
-        stop_iteration, batch, batch_info = self._draw_batch(main_iterator, False)
-        first_batch = None
-        next_stop_iteration = False
-        self.gradient_state._set_end_of_dataloader(False)
+        
         while not stop_iteration:
-            stop_iteration = next_stop_iteration
-            if self.state.process_index != 0:
+            # This is inplace, so after this instruction, every process has the same `batch_info` as process 0.
+            broadcast_object_list(batch_info)
+            stop_iteration = batch_info[1]
+            if stop_iteration:
+                # If drop_last is False and split_batches is False, we may have a remainder to take care of.
+                if not self.split_batches and not self.drop_last:
+                    if state.process_index == 0 and len(batches) > 0:
+                        batch = concatenate(batches, dim=0)
+                        batch_info = [get_data_structure(batch), False]
+                    else:
+                        batch_info = [None, True]
+                    broadcast_object_list(batch_info)
+                    if batch_info[1]:
+                        continue
+                else:
+                    continue
+
+            if state.process_index != 0:
                 # Initialize tensors on other processes than process 0.
                 batch = initialize_tensors(batch_info[0])
-            batch = send_to_device(batch, self.state.device)
+            batch = send_to_device(batch, state.device)
             # Broadcast the batch before splitting it.
             batch = broadcast(batch, from_process=0)
 
             if not self.drop_last and first_batch is None:
                 # We keep at least num processes elements of the first batch to be able to complete the last batch
-                first_batch = slice_tensors(batch, slice(0, self.state.num_processes))
+                first_batch = slice_tensors(batch, slice(0, state.num_processes))
 
             observed_batch_size = find_batch_size(batch)
-            batch_size = observed_batch_size // self.state.num_processes
+            batch_size = observed_batch_size // state.num_processes
 
-            if not self.drop_last and stop_iteration and observed_batch_size % self.state.num_processes != 0:
+            if not self.drop_last and stop_iteration and observed_batch_size % state.num_processes != 0:
                 # If the last batch is not complete, let's add the first batch to it.
                 batch = concatenate([batch, first_batch], dim=0)
                 batch_size += 1
 
-            data_slice = slice(self.state.process_index * batch_size, (self.state.process_index + 1) * batch_size)
-            next_stop_iteration, next_batch, next_batch_info = self._draw_batch(main_iterator, False)
-            yield slice_tensors(batch, data_slice)
-            if next_stop_iteration:
+            data_slice = slice(state.process_index * batch_size, (state.process_index + 1) * batch_size)
+            # On process 0, we gather the batch to dispatch.
+            if state.process_index == 0:
+                try:
+                    if self.split_batches:
+                        # One batch of the main iterator is dispatched and split.
+                        next_batch = next(main_iterator)
+                    else:
+                        # num_processes batches of the main iterator are concatenated then dispatched and split.
+                        # We add the batches one by one so we have the remainder available when drop_last=False.
+                        batches = []
+                        for _ in range(state.num_processes):
+                            batches.append(next(main_iterator))
+                        next_batch = concatenate(batches, dim=0)
+                    # In both cases, we need to get the structure of the batch that we will broadcast on other
+                    # processes to initialize the tensors with the right shape.
+                    # data_structure, stop_iteration
+                    next_batch_info = [get_data_structure(next_batch), False]
+                except StopIteration:
+                    next_batch_info = [None, True]
+            else:
+                next_batch_info = [None, stop_iteration]
+            if next_batch[1]:
                 self.gradient_state._set_end_of_dataloader(True)
+            yield slice_tensors(batch, data_slice)
             batch, batch_info = next_batch, next_batch_info
 
     def __len__(self):

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -155,3 +155,4 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         """Whether or not the optimizer step was skipped."""
         if self._is_overflow:
             return True
+        return not self.gradient_state.sync_gradients

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -155,4 +155,3 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         """Whether or not the optimizer step was skipped."""
         if self._is_overflow:
             return True
-        return not self.gradient_state.sync_gradients

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -153,4 +153,6 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
     @property
     def step_was_skipped(self):
         """Whether or not the optimizer step was skipped."""
-        return self._is_overflow
+        if self._is_overflow:
+            return True
+        return not self.gradient_state.sync_gradients

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -101,37 +101,39 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         return self.optimizer.state_dict()
 
     def zero_grad(self, set_to_none=None):
-        if is_torch_version("<", "1.7.0"):
-            if set_to_none is not None:
-                raise ValueError(
-                    "`set_to_none` for Optimizer.zero_grad` was introduced in PyTorch 1.7.0 and can't be used for "
-                    f"earlier versions (found version {torch.__version__})."
-                )
-            self.optimizer.zero_grad()
-        else:
-            accept_arg = "set_to_none" in inspect.signature(self.optimizer.zero_grad).parameters
-            if accept_arg:
-                if set_to_none is None:
-                    set_to_none = False
-                self.optimizer.zero_grad(set_to_none=set_to_none)
-            else:
+        if self.accelerator_state.sync_gradients:
+            if is_torch_version("<", "1.7.0"):
                 if set_to_none is not None:
-                    raise ValueError("`set_to_none` for Optimizer.zero_grad` is not supported by this optimizer.")
+                    raise ValueError(
+                        "`set_to_none` for Optimizer.zero_grad` was introduced in PyTorch 1.7.0 and can't be used for "
+                        f"earlier versions (found version {torch.__version__})."
+                    )
                 self.optimizer.zero_grad()
+            else:
+                accept_arg = "set_to_none" in inspect.signature(self.optimizer.zero_grad).parameters
+                if accept_arg:
+                    if set_to_none is None:
+                        set_to_none = False
+                    self.optimizer.zero_grad(set_to_none=set_to_none)
+                else:
+                    if set_to_none is not None:
+                        raise ValueError("`set_to_none` for Optimizer.zero_grad` is not supported by this optimizer.")
+                    self.optimizer.zero_grad()
 
     def step(self, closure=None):
-        if self.accelerator_state.distributed_type == DistributedType.TPU:
-            optimizer_args = {"closure": closure} if closure is not None else {}
-            xm.optimizer_step(self.optimizer, optimizer_args=optimizer_args)
-        elif self.scaler is not None:
-            scale_before = self.scaler.get_scale()
-            self.scaler.step(self.optimizer, closure)
-            self.scaler.update()
-            scale_after = self.scaler.get_scale()
-            # If we reduced the loss scale, it means the optimizer step was skipped because of gradient overflow.
-            self._is_overflow = scale_after < scale_before
-        else:
-            self.optimizer.step(closure)
+        if self.accelerator_state.sync_gradients:
+            if self.accelerator_state.distributed_type == DistributedType.TPU:
+                optimizer_args = {"closure": closure} if closure is not None else {}
+                xm.optimizer_step(self.optimizer, optimizer_args=optimizer_args)
+            elif self.scaler is not None:
+                scale_before = self.scaler.get_scale()
+                self.scaler.step(self.optimizer, closure)
+                self.scaler.update()
+                scale_after = self.scaler.get_scale()
+                # If we reduced the loss scale, it means the optimizer step was skipped because of gradient overflow.
+                self._is_overflow = scale_after < scale_before
+            else:
+                self.optimizer.step(closure)
 
     def _switch_parameters(self, parameters_map):
         for param_group in self.optimizer.param_groups:

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -152,4 +152,6 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
     @property
     def step_was_skipped(self):
         """Whether or not the optimizer step was skipped."""
-        return self._is_overflow
+        if self._is_overflow:
+            return True
+        return not self.accelerator_state.sync_gradients

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -153,6 +153,4 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
     @property
     def step_was_skipped(self):
         """Whether or not the optimizer step was skipped."""
-        if self._is_overflow:
-            return True
-        return not self.gradient_state.sync_gradients
+        return self._is_overflow

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .state import AcceleratorState
+from .state import AcceleratorState, GradientState
 
 
 class AcceleratedScheduler:
@@ -40,6 +40,7 @@ class AcceleratedScheduler:
         self.scheduler = scheduler
         self.optimizers = optimizers if isinstance(optimizers, (list, tuple)) else [optimizers]
         self.split_batches = split_batches
+        self.gradient_state = GradientState()
         self.step_with_optimizer = step_with_optimizer
 
     def step(self, *args, **kwargs):

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# We ignore warnings about stepping the scheduler since we step it ourselves during gradient accumulation
+
+import warnings
+
 from .state import AcceleratorState, GradientState
+
+
+warnings.filterwarnings("ignore", category=UserWarning, module="torch.optim.lr_scheduler")
 
 
 class AcceleratedScheduler:
@@ -44,7 +51,7 @@ class AcceleratedScheduler:
         self.step_with_optimizer = step_with_optimizer
 
     def step(self, *args, **kwargs):
-        if not self.step_with_optimizer:
+        if not self.step_with_optimizer or not self.gradient_state.sync_gradients:
             # No link between scheduler and optimizer -> just step
             self.scheduler.step(*args, **kwargs)
             return

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -40,10 +40,11 @@ class AcceleratedScheduler:
         self.scheduler = scheduler
         self.optimizers = optimizers if isinstance(optimizers, (list, tuple)) else [optimizers]
         self.split_batches = split_batches
+        self.accelerator_state = AcceleratorState()
         self.step_with_optimizer = step_with_optimizer
 
     def step(self, *args, **kwargs):
-        if not self.step_with_optimizer:
+        if not self.step_with_optimizer and self.accelerator_state.sync_gradients:
             # No link between scheduler and optimizer -> just step
             self.scheduler.step(*args, **kwargs)
             return
@@ -52,18 +53,18 @@ class AcceleratedScheduler:
         for opt in self.optimizers:
             if opt.step_was_skipped:
                 return
-
-        if self.split_batches:
-            # Split batches -> the training dataloader batch size is not changed so one step per training step
-            self.scheduler.step(*args, **kwargs)
-        else:
-            # Otherwise the training dataloader batch size was multiplied by `num_processes`, so we need to do
-            # num_processes steps per training step
-            num_processes = AcceleratorState().num_processes
-            for _ in range(num_processes):
-                # Special case when using OneCycle and `drop_last` was not used
-                if getattr(self.scheduler, "total_steps", 0) <= self.scheduler.last_epoch:
-                    self.scheduler.step(*args, **kwargs)
+        if self.accelerator_state.sync_gradients:
+            if self.split_batches:
+                # Split batches -> the training dataloader batch size is not changed so one step per training step
+                self.scheduler.step(*args, **kwargs)
+            else:
+                # Otherwise the training dataloader batch size was multiplied by `num_processes`, so we need to do
+                # num_processes steps per training step
+                num_processes = AcceleratorState().num_processes
+                for _ in range(num_processes):
+                    # Special case when using OneCycle and `drop_last` was not used
+                    if getattr(self.scheduler, "total_steps", 0) <= self.scheduler.last_epoch:
+                        self.scheduler.step(*args, **kwargs)
 
     # Passthroughs
     def get_last_lr(self):

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -51,7 +51,7 @@ class AcceleratedScheduler:
         self.step_with_optimizer = step_with_optimizer
 
     def step(self, *args, **kwargs):
-        if not self.step_with_optimizer or not self.gradient_state.sync_gradients:
+        if not self.step_with_optimizer:
             # No link between scheduler and optimizer -> just step
             self.scheduler.step(*args, **kwargs)
             return

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -233,12 +233,11 @@ class GradientState:
             self.end_of_dataloader = False
         self.initialized = True
 
-    @staticmethod
-    def _set_state(key, val):
-        "Sets `key` to `val` in GradientState"
-        if GradientState._shared_state != {} and key not in GradientState._shared_state.keys():
-            raise KeyError(f"{key} is not a valid key of `GradientState`, {GradientState._shared_state.keys()}")
-        GradientState._shared_state[key] = val
-
     def __repr__(self):
         return f"Sync Gradients: {self.sync_gradients}\n" f"At end of current dataloader: {self.end_of_dataloader}\n"
+
+    def _set_sync_gradients(self, sync_gradients):
+        self.sync_gradients = sync_gradients
+
+    def _set_end_of_dataloader(self, end_of_dataloader):
+        self.end_of_dataloader = end_of_dataloader

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -52,6 +52,7 @@ class AcceleratorState:
     Attributes:
 
         - **device** (`torch.device`) -- The device to use.
+        - **sync_gradients** (`bool`) -- Whether to sync the gradients or not
         - **distributed_type** (`~accelerate.state.DistributedType`) -- The type of distributed environment currently
           in use.
         - **num_processes** (`int`) -- The number of processes currently launched in parallel.
@@ -75,6 +76,7 @@ class AcceleratorState:
         self.__dict__ = self._shared_state
         if parse_flag_from_env("USE_CPU"):
             cpu = True
+        self.sync_gradients = True
         self._check_initialized(mixed_precision, cpu)
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
         if not getattr(self, "initialized", False):
@@ -200,6 +202,11 @@ class AcceleratorState:
     def _reset_state():
         "Resets `_shared_state`, is used internally and should not be called"
         AcceleratorState._shared_state = {}
+
+    @staticmethod
+    def _set_state(key, val):
+        "Sets `key` to `val` in AcceleratorState"
+        AcceleratorState._shared_state[key] = val
 
     def _check_initialized(self, mixed_precision=None, cpu=None):
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -237,7 +237,9 @@ class GradientState:
         return f"Sync Gradients: {self.sync_gradients}\n" f"At end of current dataloader: {self.end_of_dataloader}\n"
 
     def _set_sync_gradients(self, sync_gradients):
+        "Private function that sets whether gradients should be synchronized. Users should not have to call this."
         self.sync_gradients = sync_gradients
 
     def _set_end_of_dataloader(self, end_of_dataloader):
+        "Private function that sets whether the end of the current dataloader has been reached. Users should not have to call this."
         self.end_of_dataloader = end_of_dataloader

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -143,7 +143,7 @@ def test_distributed_sync(accelerator):
 def test_gradient_accumulation():
     accelerator = Accelerator(gradient_accumulation_steps=2)
     # Test that context manager behaves properly
-    model, ddp_model, ddp_input, ddp_target = get_training_setup(accelerator, True)
+    model, ddp_model, ddp_input, ddp_target = get_training_setup(accelerator)
     for iteration in range(4):
         # Gather the distributed inputs and targs for the base model
         input, target = accelerator.gather((ddp_input, ddp_target))

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -202,7 +202,6 @@ def test_gradient_accumulation_with_opt_and_scheduler():
                 assert (
                     torch.allclose(param.grad, ddp_param.grad) is True
                 ), f"Gradients not in sync when they should be at iteration {iteration}:\nModel grad ({param.grad}) != DDP grad ({ddp_param.grad})"
-            
 
         assert (
             ddp_opt.optimizer._step_count == opt._step_count

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -214,11 +214,11 @@ def main():
     state = accelerator.state
     if state.distributed_type == DistributedType.NO:
         if state.local_process_index == 0:
-            print("**Test NOOP `no_sync` gradient accumulation**")
+            print("**Test NOOP `no_sync` context manager**")
         test_noop_sync(accelerator)
     if state.distributed_type in (DistributedType.MULTI_GPU, DistributedType.MULTI_CPU):
         if state.local_process_index == 0:
-            print("**Test Distributed `no_sync` gradient accumulation**")
+            print("**Test Distributed `no_sync` context manager**")
         test_distributed_sync(accelerator)
         if state.local_process_index == 0:
             print("**Test `accumulate` gradient accumulation**")

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -221,9 +221,9 @@ def main():
     accelerator = Accelerator(gradient_accumulation_steps=2)
     if state.distributed_type == DistributedType.MULTI_GPU:
         print("**Test `accumulate` gradient accumulation**")
-        test_gradient_accumulation()
+        test_gradient_accumulation(accelerator)
     print("**Test `accumulate` gradient accumulation with optimizer and scheduler**")
-    test_gradient_accumulation_with_opt_and_scheduler()
+    test_gradient_accumulation_with_opt_and_scheduler(accelerator)
 
 
 def _mp_fn(index):

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -25,7 +25,7 @@ from accelerate.test_utils import RegressionDataset, RegressionModel
 from accelerate.utils import DistributedType, set_seed
 
 
-def check_model_parameters(model_a,model_b,did_step):
+def check_model_parameters(model_a, model_b, did_step):
     for param, grad_param in zip(model_a.parameters(), model_b.parameters()):
         if not param.requires_grad:
             continue
@@ -209,8 +209,8 @@ def test_gradient_accumulation_with_opt_and_scheduler():
 
         # Learning rates should be the same
         assert opt.param_groups[0]["lr"] == ddp_opt.param_groups[0]["lr"]
-        did_step = (((iteration+1) % 2) == 0) or (iteration == (len(dataloader)-1))
-        check_model_parameters(model,ddp_model,did_step)
+        did_step = (((iteration + 1) % 2) == 0) or (iteration == (len(dataloader) - 1))
+        check_model_parameters(model, ddp_model, did_step)
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)
 

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -25,33 +25,54 @@ from accelerate.test_utils import RegressionDataset, RegressionModel
 from accelerate.utils import DistributedType, set_seed
 
 
-def step_model(model, input, target, accelerator, do_backward=False):
+def step_model(model, input, target, accelerator, do_backward=True):
     model.train()
     output = model(input)
     loss = F.mse_loss(output, target.to(output.device))
-    if do_backward:
-        accelerator.backward(loss)
-    else:
+    if not do_backward:
         loss /= accelerator.gradient_accumulation_steps
         loss.backward()
+    else:
+        accelerator.backward(loss)
 
 
-def get_training_setup(accelerator):
+def get_training_setup(accelerator, sched=False):
     "Returns everything needed to perform basic training"
     set_seed(42)
     model = RegressionModel()
-    model.to(accelerator.device)
-    dset = RegressionDataset(length=80)
+    ddp_model = deepcopy(model)
+    dset = RegressionDataset()
     dataloader = DataLoader(dset, batch_size=16)
+    model.to(accelerator.device)
+    if sched:
+        opt = AdamW(params=model.parameters(), lr=1e-3)
+        ddp_opt = AdamW(params=ddp_model.parameters(), lr=1e-3)
+        sched = LambdaLR(opt, lr_lambda=lambda epoch: epoch**0.65)
+        ddp_sched = LambdaLR(ddp_opt, lr_lambda=lambda epoch: epoch**0.65)
     # Make a copy of `model`
-    ddp_model, dataloader = accelerator.prepare(deepcopy(model), dataloader)
-    return model, ddp_model, dataloader
+    if sched:
+        ddp_model, ddp_opt, ddp_sched, dataloader = accelerator.prepare(ddp_model, ddp_opt, ddp_sched, dataloader)
+    else:
+        ddp_model, dataloader = accelerator.prepare(ddp_model, dataloader)
+    # Use a single batch for all of the tests
+    ddp_input, ddp_target = next(iter(dataloader)).values()
+    if sched:
+        return (
+            model,
+            opt,
+            sched,
+            ddp_model,
+            ddp_opt,
+            ddp_sched,
+            ddp_input,
+            ddp_target,
+        )
+    return model, ddp_model, ddp_input, ddp_target
 
 
 def test_noop_sync(accelerator):
     # Test when on a single CPU or GPU that the context manager does nothing
-    model, ddp_model, dataloader = get_training_setup(accelerator)
-    ddp_input, ddp_target = next(iter(dataloader)).values()
+    model, ddp_model, ddp_input, ddp_target = get_training_setup(accelerator)
     for iteration in range(3):
         # Gather the distributed inputs and targs for the base model
         input, target = accelerator.gather((ddp_input, ddp_target))
@@ -82,8 +103,7 @@ def test_noop_sync(accelerator):
 
 def test_distributed_sync(accelerator):
     # Test on distributed setup that context manager behaves properly
-    model, ddp_model, dataloader = get_training_setup(accelerator)
-    ddp_input, ddp_target = next(iter(dataloader)).values()
+    model, ddp_model, ddp_input, ddp_target = get_training_setup(accelerator)
     for iteration in range(3):
         # Gather the distributed inputs and targs for the base model
         input, target = accelerator.gather((ddp_input, ddp_target))
@@ -119,16 +139,16 @@ def test_distributed_sync(accelerator):
         ddp_input = ddp_input[torch.randperm(16)]
 
 
-def test_gradient_accumulation(accelerator):
+def test_gradient_accumulation():
+    accelerator = Accelerator(gradient_accumulation_steps=2)
     # Test that context manager behaves properly
-    model, ddp_model, dataloader = get_training_setup(accelerator)
-    for iteration, batch in enumerate(dataloader):
+    model, ddp_model, ddp_input, ddp_target = get_training_setup(accelerator)
+    for iteration in range(4):
         # Gather the distributed inputs and targs for the base model
-        ddp_input, ddp_target = batch.values()
         input, target = accelerator.gather((ddp_input, ddp_target))
         input, target = input.to(accelerator.device), target.to(accelerator.device)
         # Perform our initial ground truth step in non "DDP"
-        step_model(model, input, target, accelerator)
+        step_model(model, input, target, accelerator, False)
         # Do "gradient accumulation" (noop)
         with accelerator.accumulate(ddp_model):
             step_model(ddp_model, ddp_input, ddp_target, accelerator)
@@ -137,71 +157,53 @@ def test_gradient_accumulation(accelerator):
         for param, ddp_param in zip(model.parameters(), ddp_model.parameters()):
             if not param.requires_grad:
                 continue
-            if iteration % 2 == 0:
-                # Grads should not be in sync
-                assert (
-                    torch.allclose(param.grad, ddp_param.grad) is False
-                ), f"Gradients in sync when they should not be:\nModel grad ({param.grad}) == DDP grad ({ddp_param.grad})"
-            else:
+            if ((iteration + 1) % 2 == 0) or (iteration == 3):
                 # Grads should be in sync
                 assert (
                     torch.allclose(param.grad, ddp_param.grad) is True
-                ), f"Gradients not in sync when they should be:\nModel grad ({param.grad}) != DDP grad ({ddp_param.grad})"
+                ), f"Gradients not in sync when they should be at iteration {iteration}:\nModel grad ({param.grad}) != DDP grad ({ddp_param.grad})"
+            else:
+                # Grads should not be in sync
+                assert (
+                    torch.allclose(param.grad, ddp_param.grad) is False
+                ), f"Gradients in sync when they should not be at iteration {iteration}:\nModel grad ({param.grad}) == DDP grad ({ddp_param.grad})"
 
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)
         ddp_input = ddp_input[torch.randperm(16)]
 
 
-def test_gradient_accumulation_with_opt_and_scheduler(accelerator):
+def test_gradient_accumulation_with_opt_and_scheduler():
+    accelerator = Accelerator(gradient_accumulation_steps=2)
     # Test that context manager behaves properly
-    model, ddp_model, dataloader = get_training_setup(accelerator)
-    opt = AdamW(params=model.parameters(), lr=1e-3)
-    ddp_opt = AdamW(params=ddp_model.parameters(), lr=1e-3)
-    sched = LambdaLR(opt, lr_lambda=lambda epoch: 0.65**epoch)
-    ddp_sched = LambdaLR(opt, lr_lambda=lambda epoch: 0.65**epoch)
-
-    ddp_opt, ddp_sched = accelerator.prepare(ddp_opt, ddp_sched)
-
-    for iteration, batch in enumerate(dataloader):
-        ddp_input, ddp_target = batch.values()
+    model, opt, sched, ddp_model, ddp_opt, ddp_sched, ddp_input, ddp_target = get_training_setup(accelerator, True)
+    for iteration in range(4):
         # Gather the distributed inputs and targs for the base model
         input, target = accelerator.gather((ddp_input, ddp_target))
         input, target = input.to(accelerator.device), target.to(accelerator.device)
         # Perform our initial ground truth step in non "DDP"
-        step_model(model, input, target, accelerator)
-        opt.step()
-        opt.zero_grad()
-        # Do training
+        model.train()
+        ddp_model.train()
+        step_model(model, input, target, accelerator, False)
+        # Perform normal gradient accumulation
+        if ((iteration + 1) % 2 == 0) or (iteration == 3):
+            opt.step()
+            sched.step()
+            opt.zero_grad()
+        # Perform gradient accumulation under wrapper
         with accelerator.accumulate(ddp_model):
             step_model(ddp_model, ddp_input, ddp_target, accelerator)
             ddp_opt.step()
+            ddp_sched.step()
             ddp_opt.zero_grad()
 
-        # DDP model and model should only be in sync when not (iteration % 2 == 0)
-        for param, ddp_param in zip(model.parameters(), ddp_model.parameters()):
-            if not param.requires_grad:
-                continue
-            if iteration % 2 == 0:
-                # Grads should not be in sync
-                assert (
-                    torch.allclose(param.grad, ddp_param.grad) is False
-                ), f"Gradients in sync when they should not be:\nModel grad ({param.grad}) == DDP grad ({ddp_param.grad})"
-            else:
-                # Grads should be in sync
-                assert (
-                    torch.allclose(param.grad, ddp_param.grad) is True
-                ), f"Gradients not in sync when they should be:\nModel grad ({param.grad}) != DDP grad ({ddp_param.grad})"
+        assert (
+            ddp_opt.optimizer._step_count == opt._step_count
+        ), f"Optimizers were not called the same number of times at iteration {iteration}:\nOptimizer: {opt._step_count}\nDDP Optimizer: {ddp_opt.optimizer._step_count}"
+        assert (
+            ddp_sched.scheduler.last_epoch == sched.last_epoch * accelerator.num_processes
+        ), f"Scheduler was not stepped 2x as much as the base at iteration {iteration}:\nScheduler: {sched.last_epoch}\nDDP: {ddp_sched.scheduler.last_epoch}"
 
-        # DDP schedule and DDP optimizer should only be in sync when not (iteration % 2 == 0)
-        if iteration % 2 == 0:
-            # States should not be in sync
-            assert opt.state != ddp_opt.state
-            assert sched.last_epoch != ddp_sched.last_epoch
-        else:
-            # States should be in sync
-            assert opt.state == ddp_opt.state
-            assert sched.last_epoch == ddp_sched.last_epoch
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)
         ddp_input = ddp_input[torch.randperm(16)]
@@ -212,18 +214,18 @@ def main():
     state = accelerator.state
     if state.distributed_type == DistributedType.NO:
         if state.local_process_index == 0:
-            print("**NOOP `no_sync` gradient accumulation**")
+            print("**Test NOOP `no_sync` gradient accumulation**")
         test_noop_sync(accelerator)
     if state.distributed_type in (DistributedType.MULTI_GPU, DistributedType.MULTI_CPU):
         if state.local_process_index == 0:
-            print("**Distributed `no_sync` gradient accumulation**")
+            print("**Test Distributed `no_sync` gradient accumulation**")
         test_distributed_sync(accelerator)
-    accelerator = Accelerator(gradient_accumulation_steps=2)
-    if state.distributed_type == DistributedType.MULTI_GPU:
-        print("**Test `accumulate` gradient accumulation**")
-        test_gradient_accumulation(accelerator)
-    print("**Test `accumulate` gradient accumulation with optimizer and scheduler**")
-    test_gradient_accumulation_with_opt_and_scheduler(accelerator)
+        if state.local_process_index == 0:
+            print("**Test `accumulate` gradient accumulation**")
+        test_gradient_accumulation()
+    if state.local_process_index == 0:
+        print("**Test `accumulate` gradient accumulation with optimizer and scheduler**")
+    test_gradient_accumulation_with_opt_and_scheduler()
 
 
 def _mp_fn(index):

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -151,7 +151,7 @@ def test_gradient_accumulation():
         for param, ddp_param in zip(model.parameters(), ddp_model.parameters()):
             if not param.requires_grad:
                 continue
-            if ((iteration + 1) % 2 == 0) or (iteration == len(dataloader)-1):
+            if ((iteration + 1) % 2 == 0) or (iteration == len(dataloader) - 1):
                 # Grads should be in sync
                 assert (
                     torch.allclose(param.grad, ddp_param.grad) is True

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -151,7 +151,7 @@ def test_gradient_accumulation():
         for param, ddp_param in zip(model.parameters(), ddp_model.parameters()):
             if not param.requires_grad:
                 continue
-            if ((iteration + 1) % 2 == 0) or (iteration == len(dataloader)):
+            if ((iteration + 1) % 2 == 0) or (iteration == len(dataloader)-1):
                 # Grads should be in sync
                 assert (
                     torch.allclose(param.grad, ddp_param.grad) is True

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -173,7 +173,7 @@ def test_gradient_accumulation_with_opt_and_scheduler(accelerator):
         opt.step()
         opt.zero_grad()
         # Do training
-        with accelerator.accumulate(ddp_model, [0, 1, 2]):
+        with accelerator.accumulate(ddp_model):
             step_model(ddp_model, ddp_input, ddp_target, accelerator)
             ddp_opt.step()
             ddp_opt.zero_grad()

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -143,8 +143,9 @@ def test_distributed_sync(accelerator):
 def test_gradient_accumulation():
     accelerator = Accelerator(gradient_accumulation_steps=2)
     # Test that context manager behaves properly
-    model, ddp_model, ddp_input, ddp_target = get_training_setup(accelerator)
-    for iteration in range(4):
+    model, ddp_model, dataloader = get_training_setup(accelerator)
+    for iteration, batch in enumerate(dataloader):
+        ddp_input, ddp_target = batch.values()
         # Gather the distributed inputs and targs for the base model
         input, target = accelerator.gather((ddp_input, ddp_target))
         input, target = input.to(accelerator.device), target.to(accelerator.device)

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -210,7 +210,8 @@ def test_gradient_accumulation_with_opt_and_scheduler():
         # Learning rates should be the same
         assert opt.param_groups[0]["lr"] == ddp_opt.param_groups[0]["lr"]
         did_step = (((iteration + 1) % 2) == 0) or (iteration == (len(dataloader) - 1))
-        check_model_parameters(model, ddp_model, did_step)
+        if accelerator.num_processes > 1:
+            check_model_parameters(model, ddp_model, did_step)
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)
 

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -37,7 +37,7 @@ class SyncScheduler(unittest.TestCase):
 
     @require_cpu
     def test_gradient_sync_single_cpu_noop(self):
-        debug_launcher(test_sync.main, num_processes=1)
+        test_sync.main()
 
     @require_cpu
     def test_gradient_sync_multi_cpu(self):
@@ -45,7 +45,7 @@ class SyncScheduler(unittest.TestCase):
 
     @require_single_gpu
     def test_gradient_sync_single_gpu(self):
-        debug_launcher(test_sync.main, num_processes=1)
+        test_sync.main()
 
     @require_multi_gpu
     def test_gradient_sync_multi_gpu(self):

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -37,7 +37,6 @@ class SyncScheduler(unittest.TestCase):
 
     @require_cpu
     def test_gradient_sync_single_cpu_noop(self):
-        debug_launcher(test_sync.main)
         debug_launcher(test_sync.main, num_processes=1)
 
     @require_cpu

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -36,19 +36,19 @@ class SyncScheduler(unittest.TestCase):
         self.test_file_path = os.path.sep.join(mod_file.split(os.path.sep)[:-1] + ["scripts", "test_sync.py"])
 
     @require_cpu
-    def test_gradient_sync_single_cpu_noop(self):
+    def test_gradient_sync_cpu_noop(self):
         test_sync.main()
 
     @require_cpu
-    def test_gradient_sync_multi_cpu(self):
+    def test_gradient_sync_cpu_multi(self):
         debug_launcher(test_sync.main)
 
     @require_single_gpu
-    def test_gradient_sync_single_gpu(self):
+    def test_gradient_sync_gpu(self):
         test_sync.main()
 
     @require_multi_gpu
-    def test_gradient_sync_multi_gpu(self):
+    def test_gradient_sync_gpu_multi(self):
         print(f"Found {torch.cuda.device_count()} devices.")
         cmd = get_launch_prefix() + [f"--nproc_per_node={torch.cuda.device_count()}", self.test_file_path]
         with patch_environment(omp_num_threads=1):

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -37,7 +37,7 @@ class SyncScheduler(unittest.TestCase):
 
     @require_cpu
     def test_gradient_sync_cpu_noop(self):
-        test_sync.main()
+        debug_launcher(test_sync.main, num_processes=1)
 
     @require_cpu
     def test_gradient_sync_cpu_multi(self):

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass
 import torch
 
 from accelerate import Accelerator, DistributedDataParallelKwargs, GradScalerKwargs
+from accelerate.state import AcceleratorState
 from accelerate.test_utils import execute_subprocess_async, require_cuda, require_multi_gpu
 from accelerate.utils import KwargsHandler
 
@@ -44,7 +45,8 @@ class DataLoaderTester(unittest.TestCase):
     def test_grad_scaler_kwargs(self):
         # If no defaults are changed, `to_kwargs` returns an empty dict.
         scaler_handler = GradScalerKwargs(init_scale=1024, growth_factor=2)
-        accelerator = Accelerator(fp16=True, kwargs_handlers=[scaler_handler])
+        AcceleratorState._reset_state()
+        accelerator = Accelerator(mixed_precision="fp16", kwargs_handlers=[scaler_handler])
         print(accelerator.use_fp16)
         scaler = accelerator.scaler
 


### PR DESCRIPTION
# Introduce Gradient Accumulation wrapper

## What does this add?

This PR adds:
- An `accelerator.accumulate` context manager that will allow for gradient accumulation automatically without the user having to change **any** code. Simply throw your code under it and call everything as normal. Accelerate will handle properly stepping the scheduler, optimizer, and zeroing.
- A new `_set_state` function to `AcceleratorState` to give the state knowledge of if gradients should be utilized and the optimizer/schedulers should be stepped. This is done internally and the user should never ever need to perform this. As a precautionary only state keys that need to be set in *this* PR have been added. A follow up will likely include the mixed precision.
- Lets `backward` handle the gradient accumulation division since it's tied to the `Accelerator` now
- Accelerate's prepared `DataLoaders` now mark in the `AcceleratorStep` if we are one away from the end. We can safely assume this since all dataloaders have a `__len__` or a way for us to check if we're on the second to last iteration.

## Who is it for?

Users of Accelerate that want a simple API for gradient accumulation

## Why is it needed?

Some feedback on Twitter included some notes that it looks very ugly to do so in its current state and a wrapper would be a very good idea, even in this library where we don't want *too* much wrapping

Also noticed that on a single GPU the script tests were having issues, it's because CUDA will yell at us if we use the `debug_launcher` on `n=1`. Instead we should just call `main` like normal. 

## What parts of the API does this impact?

### User-facing:

* A new `Accelerator.accumulate` function
* Accelerator takes in a `gradient_accumulation_steps` param

### Internal structure:

* `AcceleratorState` can be set/changed via a private function
* `Accelerator` now keeps track of the step we're on
* `step` and `zero_grad` in both Scheduler and Optimizer are now deterministic if they're called by checking `AcceleratorState.sync_gradients`. By default this is set to `True`.

## Basic Usage Example(s):

```python
for batch in dataloader:
    with accelerator.accumulate(model):
        output = model(**batch)
        loss = output.loss
        accelerator.backward(loss)
        optimizer.step()
        lr_scheduler.step()
        optimizer.zero_grad()
```

## When would I use it, and when wouldn't I?

Technically since the default is `1` one could just keep this always on and never know the difference.

## Does a similar feature exist? If so, why is this better?

You can use `no_sync`, but the complexity on the user side is why this PR exists.