### PR TITLE
update dataloader wrappers to have `total_batch_size` attribute

### DIFF
--- a/docs/source/internal.mdx
+++ b/docs/source/internal.mdx
@@ -26,7 +26,7 @@ The main work on your PyTorch `DataLoader` is done by the following function:
 
 [[autodoc]] data_loader.prepare_data_loader
 
-### BatchSamplerShard
+### DataLoaderShard
 
 [[autodoc]] data_loader.DataLoaderShard
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -39,7 +39,6 @@ if is_tpu_available(check_device=False):
     import torch_xla.distributed.parallel_loader as xpl
 
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
-
         @property
         def total_batch_size(self):
             return self._loader.total_batch_size

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -40,10 +40,10 @@ if is_tpu_available(check_device=False):
 
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
         """
-        Wrapper for the xpl.MpDeviceLoader class. This class is used to add `total_batch_size` property to the
-        xpl.MpDeviceLoader class.
+        Wrapper for the xpl.MpDeviceLoader class that knows the total batch size. 
+        **Available attributes:**
+        - **total_batch_size** (`int`) -- Total batch size of the dataloader across all processes. Equal to the original batch size when `split_batches=True` otherwise the original batch size * the total number of processes
         """
-
         @property
         def total_batch_size(self):
             """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -39,8 +39,6 @@ if is_tpu_available(check_device=False):
     import torch_xla.distributed.parallel_loader as xpl
 
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
-        def __init__(self, loader, device, **kwargs):
-            super().__init__(loader, device, **kwargs)
 
         @property
         def total_batch_size(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -41,7 +41,10 @@ if is_tpu_available(check_device=False):
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
         def __init__(self, loader, device, **kwargs):
             super().__init__(loader, device, **kwargs)
-            self.total_batch_size = loader.total_batch_size
+
+        @property
+        def total_batch_size(self):
+            return self._loader.total_batch_size
 
 
 logger = get_logger(__name__)
@@ -297,13 +300,12 @@ class DataLoaderShard(DataLoader):
             All other keyword arguments to pass to the regular `DataLoader` initialization.
     """
 
-    def __init__(self, dataset, device=None, rng_types=None, generator=None, total_batch_size=None, **kwargs):
+    def __init__(self, dataset, device=None, rng_types=None, generator=None, **kwargs):
         super().__init__(dataset, **kwargs)
         self.device = device
         self.rng_types = rng_types
         self.generator = generator
         self.gradient_state = GradientState()
-        self.total_batch_size = total_batch_size
 
     def __iter__(self):
         if self.rng_types is not None:
@@ -328,6 +330,14 @@ class DataLoaderShard(DataLoader):
                 yield current_batch
                 break
 
+    @property
+    def total_batch_size(self):
+        return (
+            self.batch_sampler.batch_size
+            if self.batch_sampler.split_batches
+            else (self.batch_sampler.batch_size * self.batch_sampler.num_processes)
+        )
+
 
 class DataLoaderDispatcher(DataLoader):
     """
@@ -343,7 +353,7 @@ class DataLoaderDispatcher(DataLoader):
             size of the `dataloader` is a round multiple of `batch_size`.
     """
 
-    def __init__(self, dataset, split_batches: bool = False, total_batch_size=None, **kwargs):
+    def __init__(self, dataset, split_batches: bool = False, **kwargs):
         shuffle = False
         if is_torch_version(">=", "1.11.0"):
             from torch.utils.data.datapipes.iter.combinatorics import ShufflerIterDataPipe
@@ -362,7 +372,6 @@ class DataLoaderDispatcher(DataLoader):
 
         self.gradient_state = GradientState()
         self.state = AcceleratorState()
-        self.total_batch_size = total_batch_size
 
     def __iter__(self):
         state = AcceleratorState()
@@ -439,6 +448,12 @@ class DataLoaderDispatcher(DataLoader):
             return whole_length // self.state.num_processes
         else:
             return math.ceil(whole_length / self.state.num_processes)
+
+    @property
+    def total_batch_size(self):
+        return (
+            self.dataset.batch_size if self.split_batches else (self.dataset.batch_size * self.dataset.num_processes)
+        )
 
 
 def prepare_data_loader(
@@ -583,14 +598,11 @@ def prepare_data_loader(
         kwargs["drop_last"] = dataloader.drop_last
         kwargs["batch_size"] = dataloader.batch_size // num_processes if split_batches else dataloader.batch_size
 
-    total_batch_size = dataloader.batch_size if split_batches else dataloader.batch_size * num_processes
-
     if dispatch_batches:
         dataloader = DataLoaderDispatcher(
             new_dataset,
             split_batches=split_batches,
             batch_sampler=new_batch_sampler,
-            total_batch_size=total_batch_size,
             **kwargs,
         )
     else:
@@ -600,7 +612,6 @@ def prepare_data_loader(
             batch_sampler=new_batch_sampler,
             rng_types=rng_types,
             generator=generator,
-            total_batch_size=total_batch_size,
             **kwargs,
         )
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -583,7 +583,7 @@ def prepare_data_loader(
         kwargs["drop_last"] = dataloader.drop_last
         kwargs["batch_size"] = dataloader.batch_size // num_processes if split_batches else dataloader.batch_size
 
-        total_batch_size = dataloader.batch_size if split_batches else dataloader.batch_size * num_processes
+    total_batch_size = dataloader.batch_size if split_batches else dataloader.batch_size * num_processes
 
     if dispatch_batches:
         dataloader = DataLoaderDispatcher(

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -40,17 +40,17 @@ if is_tpu_available(check_device=False):
 
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
         """
-        Wrapper for the xpl.MpDeviceLoader class that knows the total batch size. 
+        Wrapper for the xpl.MpDeviceLoader class that knows the total batch size.
+
         **Available attributes:**
-        - **total_batch_size** (`int`) -- Total batch size of the dataloader across all processes. Equal to the original batch size when `split_batches=True` otherwise the original batch size * the total number of processes
+
+        - **total_batch_size** (`int`) -- Total batch size of the dataloader across all processes.
+            Equal to the original batch size when `split_batches=True`; otherwise the original batch size * the total
+            number of processes
         """
+
         @property
         def total_batch_size(self):
-            """
-            Get the total batch size of the dataloader. It is the resulting batch size across processes. It is same as
-            the original batch size of the dataloader when `split_batches=True`. Otherwise, it is the product of the
-            orginal batch size of the dataloader and the number of processes.
-            """
             return self._loader.total_batch_size
 
 
@@ -305,6 +305,12 @@ class DataLoaderShard(DataLoader):
             A random number generator to keep synchronized across processes.
         kwargs:
             All other keyword arguments to pass to the regular `DataLoader` initialization.
+
+    **Available attributes:**
+
+        - **total_batch_size** (`int`) -- Total batch size of the dataloader across all processes.
+            Equal to the original batch size when `split_batches=True`; otherwise the original batch size * the total
+            number of processes
     """
 
     def __init__(self, dataset, device=None, rng_types=None, generator=None, **kwargs):
@@ -339,11 +345,6 @@ class DataLoaderShard(DataLoader):
 
     @property
     def total_batch_size(self):
-        """
-        Get the total batch size of the dataloader. It is the resulting batch size across processes. It is same as the
-        original batch size of the dataloader when `split_batches=True`. Otherwise, it is the product of the orginal
-        batch size of the dataloader and the number of processes.
-        """
         return (
             self.batch_sampler.batch_size
             if self.batch_sampler.split_batches
@@ -363,6 +364,12 @@ class DataLoaderDispatcher(DataLoader):
             the same as the initial `dataloader` if this option is set to `True`, the batch size of the initial
             `dataloader` multiplied by `num_processes` otherwise. Setting this option to `True` requires that the batch
             size of the `dataloader` is a round multiple of `batch_size`.
+
+    **Available attributes:**
+
+        - **total_batch_size** (`int`) -- Total batch size of the dataloader across all processes.
+            Equal to the original batch size when `split_batches=True`; otherwise the original batch size * the total
+            number of processes
     """
 
     def __init__(self, dataset, split_batches: bool = False, **kwargs):
@@ -463,11 +470,6 @@ class DataLoaderDispatcher(DataLoader):
 
     @property
     def total_batch_size(self):
-        """
-        Get the total batch size of the dataloader. It is the resulting batch size across processes. It is same as the
-        original batch size of the dataloader when `split_batches=True`. Otherwise, it is the product of the orginal
-        batch size of the dataloader and the number of processes.
-        """
         return (
             self.dataset.batch_size if self.split_batches else (self.dataset.batch_size * self.dataset.num_processes)
         )

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -39,8 +39,18 @@ if is_tpu_available(check_device=False):
     import torch_xla.distributed.parallel_loader as xpl
 
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
+        """
+        Wrapper for the xpl.MpDeviceLoader class. This class is used to add `total_batch_size` property to the
+        xpl.MpDeviceLoader class.
+        """
+
         @property
         def total_batch_size(self):
+            """
+            Get the total batch size of the dataloader. It is the resulting batch size across processes. It is same as
+            the original batch size of the dataloader when `split_batches=True`. Otherwise, it is the product of the
+            orginal batch size of the dataloader and the number of processes.
+            """
             return self._loader.total_batch_size
 
 
@@ -329,6 +339,11 @@ class DataLoaderShard(DataLoader):
 
     @property
     def total_batch_size(self):
+        """
+        Get the total batch size of the dataloader. It is the resulting batch size across processes. It is same as the
+        original batch size of the dataloader when `split_batches=True`. Otherwise, it is the product of the orginal
+        batch size of the dataloader and the number of processes.
+        """
         return (
             self.batch_sampler.batch_size
             if self.batch_sampler.split_batches
@@ -448,6 +463,11 @@ class DataLoaderDispatcher(DataLoader):
 
     @property
     def total_batch_size(self):
+        """
+        Get the total batch size of the dataloader. It is the resulting batch size across processes. It is same as the
+        original batch size of the dataloader when `split_batches=True`. Otherwise, it is the product of the orginal
+        batch size of the dataloader and the number of processes.
+        """
         return (
             self.dataset.batch_size if self.split_batches else (self.dataset.batch_size * self.dataset.num_processes)
         )


### PR DESCRIPTION
### What does this PR do?
1. A requirement was to get resulting batch size post `accelerator.prepare` call. Adding `total_batch_size` to provide the resulting batch_size across devices.

```python
my_dataloader = accelerator.prepare(my_dataloader)
accelerator.print(f"The resulting batch_size across devices is {my_dataloader.total_batch_size}")
```

