### PR TITLE
Fix DispatchDataLoader length when `split_batches=True`

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -463,7 +463,9 @@ class DataLoaderDispatcher(DataLoader):
 
     def __len__(self):
         whole_length = super().__len__()
-        if self.drop_last:
+        if self.split_batches:
+            return whole_length
+        elif self.drop_last:
             return whole_length // self.state.num_processes
         else:
             return math.ceil(whole_length / self.state.num_processes)


### PR DESCRIPTION
This fixes the length of the `DispatchDataLoader` when `split_batches=True`. `split_batches` does not change the length of the DataLoader.