### PR TITLE
fixing deepspeed multi-node launcher

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 from ...utils import ComputeEnvironment, DistributedType, is_deepspeed_available, is_transformers_available
+from ...utils.constants import DEEPSPEED_MULTINODE_LAUNCHERS
 from .config_args import ClusterConfig
 from .config_utils import _ask_field, _convert_distributed_mode, _convert_yes_no_to_bool
 
@@ -143,6 +144,44 @@ def get_cluster_input():
                         "When `zero3_init_flag` is set, it requires Transformers to be installed. "
                         "Please run `pip3 install transformers`."
                     )
+
+            if num_machines > 1:
+                deepspeed_config["deepspeed_hostfile"] = _ask_field(
+                    "DeepSpeed configures multi-node compute resources with hostfile, please specify the location of hostfile: ",
+                    lambda x: str(x),
+                )
+
+                is_exclusion_filter = _ask_field(
+                    "Do you want to specify exclusion filter string? [yes/NO]: ",
+                    _convert_yes_no_to_bool,
+                    default=False,
+                    error_message="Please enter yes or no.",
+                )
+                if is_exclusion_filter:
+                    deepspeed_config["deepspeed_exclusion_filter"] = _ask_field(
+                        "DeepSpeed exclusion filter string: ",
+                        lambda x: str(x),
+                    )
+
+                is_inclusion_filter = _ask_field(
+                    "Do you want to specify inclusion filter string? [yes/NO]: ",
+                    _convert_yes_no_to_bool,
+                    default=False,
+                    error_message="Please enter yes or no.",
+                )
+                if is_inclusion_filter:
+                    deepspeed_config["deepspeed_inclusion_filter"] = _ask_field(
+                        "DeepSpeed inclusion filter string: ",
+                        lambda x: str(x),
+                    )
+
+                launcher_query = "Which Type of launcher do you want to use "
+                for i, launcher in enumerate(DEEPSPEED_MULTINODE_LAUNCHERS):
+                    launcher_query += f"[{i}] {launcher}, "
+                launcher_query = launcher_query[:-2] + ")? [0]: "
+                deepspeed_config["deepspeed_multinode_launcher"] = _ask_field(
+                    launcher_query, lambda x: DEEPSPEED_MULTINODE_LAUNCHERS[int(x)]
+                )
 
     fsdp_config = {}
     if distributed_type in [DistributedType.MULTI_GPU]:

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -180,7 +180,9 @@ def get_cluster_input():
                     launcher_query += f"[{i}] {launcher}, "
                 launcher_query = launcher_query[:-2] + ")? [0]: "
                 deepspeed_config["deepspeed_multinode_launcher"] = _ask_field(
-                    launcher_query, lambda x: DEEPSPEED_MULTINODE_LAUNCHERS[int(x)]
+                    launcher_query,
+                    lambda x: DEEPSPEED_MULTINODE_LAUNCHERS[int(x)],
+                    default=DEEPSPEED_MULTINODE_LAUNCHERS[0],
                 )
 
     fsdp_config = {}

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -146,35 +146,6 @@ def get_cluster_input():
                     )
 
             if num_machines > 1:
-                deepspeed_config["deepspeed_hostfile"] = _ask_field(
-                    "DeepSpeed configures multi-node compute resources with hostfile, please specify the location of hostfile: ",
-                    lambda x: str(x),
-                )
-
-                is_exclusion_filter = _ask_field(
-                    "Do you want to specify exclusion filter string? [yes/NO]: ",
-                    _convert_yes_no_to_bool,
-                    default=False,
-                    error_message="Please enter yes or no.",
-                )
-                if is_exclusion_filter:
-                    deepspeed_config["deepspeed_exclusion_filter"] = _ask_field(
-                        "DeepSpeed exclusion filter string: ",
-                        lambda x: str(x),
-                    )
-
-                is_inclusion_filter = _ask_field(
-                    "Do you want to specify inclusion filter string? [yes/NO]: ",
-                    _convert_yes_no_to_bool,
-                    default=False,
-                    error_message="Please enter yes or no.",
-                )
-                if is_inclusion_filter:
-                    deepspeed_config["deepspeed_inclusion_filter"] = _ask_field(
-                        "DeepSpeed inclusion filter string: ",
-                        lambda x: str(x),
-                    )
-
                 launcher_query = "Which Type of launcher do you want to use "
                 for i, launcher in enumerate(DEEPSPEED_MULTINODE_LAUNCHERS):
                     launcher_query += f"[{i}] {launcher}, "
@@ -184,6 +155,40 @@ def get_cluster_input():
                     lambda x: DEEPSPEED_MULTINODE_LAUNCHERS[int(x)],
                     default=DEEPSPEED_MULTINODE_LAUNCHERS[0],
                 )
+
+                if deepspeed_config["deepspeed_multinode_launcher"] != DEEPSPEED_MULTINODE_LAUNCHERS[1]:
+                    deepspeed_config["deepspeed_hostfile"] = _ask_field(
+                        "DeepSpeed configures multi-node compute resources with hostfile. "
+                        "Each row is of the format `hostname slots=[num_gpus]`, e.g., `localhost slots=2`; "
+                        "for more information please refer official [documentation]"
+                        "(https://www.deepspeed.ai/getting-started/#resource-configuration-multi-node). "
+                        "Please specify the location of hostfile: ",
+                        lambda x: str(x),
+                    )
+
+                    is_exclusion_filter = _ask_field(
+                        "Do you want to specify exclusion filter string? [yes/NO]: ",
+                        _convert_yes_no_to_bool,
+                        default=False,
+                        error_message="Please enter yes or no.",
+                    )
+                    if is_exclusion_filter:
+                        deepspeed_config["deepspeed_exclusion_filter"] = _ask_field(
+                            "DeepSpeed exclusion filter string: ",
+                            lambda x: str(x),
+                        )
+
+                    is_inclusion_filter = _ask_field(
+                        "Do you want to specify inclusion filter string? [yes/NO]: ",
+                        _convert_yes_no_to_bool,
+                        default=False,
+                        error_message="Please enter yes or no.",
+                    )
+                    if is_inclusion_filter:
+                        deepspeed_config["deepspeed_inclusion_filter"] = _ask_field(
+                            "DeepSpeed inclusion filter string: ",
+                            lambda x: str(x),
+                        )
 
     fsdp_config = {}
     if distributed_type in [DistributedType.MULTI_GPU]:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -389,6 +389,13 @@ def deepspeed_launcher(args):
     current_env["DEEPSPEED_ZERO3_SAVE_16BIT_MODEL"] = str(args.zero3_save_16bit_model).lower()
     current_env["DEEPSPEED_CONFIG_FILE"] = str(args.deepspeed_config_file).lower()
 
+    if args.num_machines > 1:
+        with open(".deepspeed_env", "a") as f:
+            for key, value in current_env.items():
+                if ";" in value or " " in value:
+                    continue
+                f.write(f"{key}={value}\n")
+
     process = subprocess.Popen(cmd, env=current_env)
     process.wait()
     if process.returncode != 0:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -377,6 +377,7 @@ def deepspeed_launcher(args):
         warnings.warn('--fp16 flag is deprecated. Use "--mixed_precision fp16" instead.', DeprecationWarning)
         mixed_precision = "fp16"
 
+    current_env["PYTHONPATH"] = sys.executable
     current_env["MIXED_PRECISION"] = str(mixed_precision)
     current_env["USE_DEEPSPEED"] = "true"
     current_env["DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -24,6 +24,6 @@ SAGEMAKER_PYTORCH_VERSION = "1.10.2"
 SAGEMAKER_PYTHON_VERSION = "py38"
 SAGEMAKER_TRANSFORMERS_VERSION = "4.17.0"
 SAGEMAKER_PARALLEL_EC2_INSTANCES = ["ml.p3.16xlarge", "ml.p3dn.24xlarge", "ml.p4dn.24xlarge"]
-DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "openmpi", "mvapich"]
+DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -24,5 +24,6 @@ SAGEMAKER_PYTORCH_VERSION = "1.10.2"
 SAGEMAKER_PYTHON_VERSION = "py38"
 SAGEMAKER_TRANSFORMERS_VERSION = "4.17.0"
 SAGEMAKER_PARALLEL_EC2_INSTANCES = ["ml.p3.16xlarge", "ml.p3dn.24xlarge", "ml.p4dn.24xlarge"]
+DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}


### PR DESCRIPTION
### What does this PR do?
Fixes issue #498 

1. Fixes deepspeed multinode launcher support. It uses `hostfile` as specified in the Official DeepSpeed documentation [Resource Configuration (multi-node)](https://www.deepspeed.ai/getting-started/#resource-configuration-multi-node)
```
DeepSpeed configures multi-node compute resources with hostfiles that
are compatible with [OpenMPI](https://www.open-mpi.org/) and [Horovod](https://github.com/horovod/horovod). 
A hostfile is a list of hostnames (or SSH aliases), which are machines accessible via passwordless SSH,
and slot counts, which specify the number of GPUs available on the system
```
An example of a `hostfile` is given below:
```
localhost slots=2
brutasse slots=2
```
2. Example of the accelerate env after answering `accelerate config` questionnaire:
```
- `Accelerate` version: 0.11.0.dev0
- Platform: Linux-5.4.0-121-generic-x86_64-with-glibc2.29
- Python version: 3.8.10
- Numpy version: 1.23.0
- PyTorch version (GPU?): 1.12.0+cu102 (True)
- `Accelerate` default config:
        - compute_environment: LOCAL_MACHINE
        - distributed_type: DEEPSPEED
        - mixed_precision: fp16
        - use_cpu: False
        - num_processes: 4
        - machine_rank: 0
        - num_machines: 2
        - main_process_ip: 
        - main_process_port: 8888
        - main_training_function: main
        - deepspeed_config: {
                 'deepspeed_hostfile': '/home/sourab/hostfile', 
                 'deepspeed_multinode_launcher': 'pdsh', 
                 'gradient_accumulation_steps': 1, 
                 'gradient_clipping': 1.0, 
                 'offload_optimizer_device': 'none', 
                 'offload_param_device': 'none', 
                 'zero3_init_flag': False, 
                 'zero_stage': 2
        }
        - fsdp_config: {}
``` 

3. Sample output when running modified `nlp_complete_example.py` through command `accelerate launch nlp_complete_example.py`.
```
[2022-07-13 09:11:42,881] [INFO] [runner.py:378:main] Using IP address of 192.XXX.X.XX for node localhost                      
[2022-07-13 09:11:42,882] [INFO] [multinode_runner.py:65:get_cmd] Running on the following workers: localhost,brutasse         
[2022-07-13 09:11:42,882] [INFO] [runner.py:457:main] cmd = pdsh -f 1024 -w localhost,brutasse export PYTHONPATH=/home/sourab/d
ev/bin/python; export NCCL_IB_DISABLE=1; export NCCL_SOCKET_IFNAME=enp6s0; export SHELL=/bin/bash; export TMUX=/tmp/tmux-1037/d
efault,1983171,2; export PWD=/home/sourab/accelerate/examples; export LOGNAME=sourab; export XDG_SESSION_TYPE=tty; export MOTD_
SHOWN=pam; export HOME=/home/sourab; export LANG=C.UTF-8; export VIRTUAL_ENV=/home/sourab/dev; export XDG_SESSION_CLASS=user; e
xport TERM=screen; export USER=sourab; export TMUX_PANE=%2; export SHLVL=2; export XDG_SESSION_ID=24; export LD_LIBRARY_PATH=/u
sr/local/cuda/lib64:/usr/local/cuda-10.2/lib64:/usr/local/cuda-10.1/lib64:/usr/local/cuda-10.0/lib64:/usr/local/cuda/lib64:/usr
/local/cuda-10.2/lib64:/usr/local/cuda-10.1/lib64:/usr/local/cuda-10.0/lib64:; export LC_CTYPE=C.UTF-8; export XDG_RUNTIME_DIR=
/run/user/1037; export XDG_DATA_DIRS=/usr/local/share:/usr/share:/var/lib/snapd/desktop; export PATH=/home/sourab/dev/bin:/home
/sourab/.local/bin:/usr/local/cuda-10.2/bin:/home/sourab/.local/bin:/usr/local/cuda-10.2/bin:/usr/local/sbin:/usr/local/bin:/us
r/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin; export DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1037/bus;
 export SSH_TTY=/dev/pts/1; export _=/home/sourab/dev/bin/accelerate; export OLDPWD=/home/sourab; export MIXED_PRECISION=fp16; 
export USE_DEEPSPEED=true; export DEEPSPEED_ZERO_STAGE=2; export GRADIENT_ACCUMULATION_STEPS=1; export GRADIENT_CLIPPING=1.0; e
xport DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE=none; export DEEPSPEED_OFFLOAD_PARAM_DEVICE=none; export DEEPSPEED_ZERO3_INIT=false; e
xport DEEPSPEED_ZERO3_SAVE_16BIT_MODEL=none; export DEEPSPEED_CONFIG_FILE=none;  cd /home/sourab/accelerate/examples; /home/sou
rab/dev/bin/python -u -m deepspeed.launcher.launch --world_info=eyJsb2NhbGhvc3QiOiBbMCwgMV0sICJicnV0YXNzZSI6IFswLCAxXX0= --node
_rank=%n --master_addr=192.XXX.X.XX --master_port=29500 --no_local_rank complete_nlp_example.py                                
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:96:main] 0 NCCL_SOCKET_IFNAME=enp6s0                                    
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:96:main] 0 NCCL_IB_DISABLE=1                                            
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:103:main] WORLD INFO DICT: {'localhost': [0, 1], 'brutasse': [0, 1]}    
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:109:main] nnodes=2, num_local_procs=2, node_rank=0                      
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:122:main] global_rank_mapping=defaultdict(<class 'list'>, {'localhost': 
[0, 1], 'brutasse': [2, 3]})                                                                                                   
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:123:main] dist_world_size=4                                             
localhost: [2022-07-13 09:11:43,755] [INFO] [launch.py:125:main] Setting CUDA_VISIBLE_DEVICES=0,1                              
brutasse: [2022-07-13 09:11:43,903] [INFO] [launch.py:96:main] 1 NCCL_SOCKET_IFNAME=enp6s0                                     
brutasse: [2022-07-13 09:11:43,903] [INFO] [launch.py:96:main] 1 NCCL_IB_DISABLE=1                                             
brutasse: [2022-07-13 09:11:43,903] [INFO] [launch.py:103:main] WORLD INFO DICT: {'localhost': [0, 1], 'brutasse': [0, 1]}     
brutasse: [2022-07-13 09:11:43,903] [INFO] [launch.py:110:main] nnodes=2, num_local_procs=2, node_rank=1                       
brutasse: [2022-07-13 09:11:43,903] [INFO] [launch.py:122:main] global_rank_mapping=defaultdict(<class 'list'>, {'localhost': [
0, 1], 'brutasse': [2, 3]})      


...
localhost: [INFO] [config.py:1065:print]   json = { 
localhost:     "train_batch_size": 64,                                                                                 
localhost:     "train_micro_batch_size_per_gpu": 16,                                                                           
localhost:     "gradient_accumulation_steps": 1, 
localhost:     "zero_optimization": {
localhost:         "stage": 2,  
localhost:         "offload_optimizer": {
localhost:             "device": "none"
localhost:         }, 
localhost:         "offload_param": {
localhost:             "device": "none"
localhost:         }, 
localhost:         "stage3_gather_16bit_weights_on_model_save": false
localhost:     }, 
localhost:     "gradient_clipping": 1.0, 
localhost:     "steps_per_print": inf, 
localhost:     "zero_allow_untested_optimizer": true
localhost: }
localhost: Using /home/sourab/.cache/torch_extensions/py38_cu102 as PyTorch extensions root...
localhost: No modifications detected for re-loaded extension module utils, skipping build step...
localhost: Loading extension module utils...
localhost: Time to load utils op: 0.0002067089080810547 seconds 
localhost: after prepare
localhost: Distributed environment: DEEPSPEED  Backend: nccl
localhost: Num processes: 4
localhost: Process index: 0
localhost: Local process index: 0
localhost: Device: cuda:0
localhost: ds_config: {'train_batch_size': 64, 'train_micro_batch_size_per_gpu': 16, 'gradient_accumulation_steps': 1, 'zero_op
timization': {'stage': 2, 'offload_optimizer': {'device': 'none'}, 'offload_param': {'device': 'none'}, 'stage3_gather_16bit_we
ights_on_model_save': False}, 'gradient_clipping': 1.0, 'steps_per_print': inf, 'zero_allow_untested_optimizer': True}
localhost: 
brutasse: loss: 0.44637179374694824, step: 0
localhost: loss: 0.6673623919487, step: 0
brutasse: loss: 0.5470665693283081, step: 0
localhost: loss: 0.47117069363594055, step: 0                                                      
```
