### PR TITLE
Fixup all example CI tests and properly fail

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run examples on GPUs
         run: |
           source activate accelerate
+          pip uninstall comet_ml -y
           make test_examples
 
   run_all_tests_multi_gpu:
@@ -64,4 +65,5 @@ jobs:
       - name: Run examples on GPUs
         run: |
           source activate accelerate
+          pip uninstall comet_ml -y
           make test_examples

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Run examples on GPUs
         run: |
           source activate accelerate
+          pip uninstall comet_ml -y
           make test_examples
 
   run_all_tests_multi_gpu:
@@ -61,4 +62,5 @@ jobs:
       - name: Run examples on GPUs
         run: |
           source activate accelerate
+          pip uninstall comet_ml -y
           make test_examples

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         pip install --upgrade pip
         pip install -e .[test,test_trackers]
+        if [ ${{ matrix.test-kind }} = test_rest ]; then pip uninstall comet_ml -y; fi
     
     - name: Run Tests
       run: |

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -165,8 +165,6 @@ def training_function(config, args):
     if args.with_tracking:
         if accelerator.is_main_process:
             run = os.path.split(__file__)[-1].split(".")[0]
-            if args.logging_dir:
-                run = os.path.join(args.logging_dir, run)
             accelerator.init_trackers(run, config)
 
     # Now we train the model

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -130,7 +130,9 @@ def require_comet_ml(test_case):
     return unittest.skipUnless(is_comet_ml_available(), "test requires comet_ml")(test_case)
 
 
-_atleast_one_tracker_available = any([is_comet_ml_available(), is_wandb_available(), is_tensorboard_available()])
+_atleast_one_tracker_available = (
+    any([is_wandb_available(), is_tensorboard_available()]) and not is_comet_ml_available()
+)
 
 
 def require_trackers(test_case):
@@ -138,9 +140,10 @@ def require_trackers(test_case):
     Decorator marking that a test requires at least one tracking library installed. These tests are skipped when none
     are installed
     """
-    return unittest.skipUnless(_atleast_one_tracker_available, "test requires at least one tracker to be available")(
-        test_case
-    )
+    return unittest.skipUnless(
+        _atleast_one_tracker_available,
+        "test requires at least one tracker to be available and for `comet_ml` to not be installed",
+    )(test_case)
 
 
 class TempDirTestCase(unittest.TestCase):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -15,6 +15,7 @@
 import asyncio
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -127,6 +128,19 @@ def require_comet_ml(test_case):
     Decorator marking a test that requires comet_ml installed. These tests are skipped when comet_ml isn't installed
     """
     return unittest.skipUnless(is_comet_ml_available(), "test requires comet_ml")(test_case)
+
+
+_atleast_one_tracker_available = any([is_comet_ml_available(), is_wandb_available(), is_tensorboard_available()])
+
+
+def require_trackers(test_case):
+    """
+    Decorator marking that a test requires at least one tracking library installed. These tests are skipped when none
+    are installed
+    """
+    return unittest.skipUnless(_atleast_one_tracker_available, "test requires at least one tracker to be available")(
+        test_case
+    )
 
 
 class TempDirTestCase(unittest.TestCase):
@@ -279,3 +293,24 @@ def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False
         )
 
     return result
+
+
+class SubprocessCallException(Exception):
+    pass
+
+
+def run_command(command: List[str], return_stdout=False):
+    """
+    Runs `command` with `subprocess.check_output` and will potentially return the `stdout`. Will also properly capture
+    if an error occured while running `command`
+    """
+    try:
+        output = subprocess.check_output(command, stderr=subprocess.STDOUT)
+        if return_stdout:
+            if hasattr(output, "decode"):
+                output = output.decode("utf-8")
+            return output
+    except subprocess.CalledProcessError as e:
+        raise SubprocessCallException(
+            f"Command `{' '.join(command)}` failed with the following error:\n\n{e.output.decode()}"
+        ) from e


### PR DESCRIPTION
# Fix all example CI

## What does this add?

This pr makes a variety of fixes to the example tests to solve all failures and properly ensure that failures occur when they need to

## Why is it needed?

The entire list of issues I noticed are below:

- We cannot mock `CometMLTracker` to run offline tests with the tracking example script, so the CI now explicitly uninstalls them
- Adds a new `requires_tracking` decorator for the example tests to make sure at least one tracking API is installed and `comet_ml` is not installed
- Creates a new exception class and a new `run_command` function which will properly call a subprocess test function and check its outputs properly as well as fully fail if the call did not work.
- Fixes two bugs in the cross validation example in regards to noting the final prediction score.