### PR TITLE
Add support for downcasting bf16 on TPUs

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -126,9 +126,6 @@ class Accelerator:
             accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.
-        downcast_bf16 (`bool`, *optional*):
-            If set to `True` and using `mixed_precision="bf16"` then `torch.float` will become `bfloat16` and
-            `torch.double` will remain `float32` on TPUs.
         dispatch_batches (`bool`, *optional*):
             If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process
             and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose
@@ -161,7 +158,7 @@ class Accelerator:
         logging_dir: Optional[Union[str, os.PathLike]] = None,
         downcast_bf16: Optional[bool] = False,
         dispatch_batches: Optional[bool] = None,
-        step_scheduler_with_optimizer: Optional[bool] = True,
+        step_scheduler_with_optimizer: bool = True,
         kwargs_handlers: Optional[List[KwargsHandler]] = None,
     ):
         self.logging_dir = logging_dir
@@ -230,6 +227,7 @@ class Accelerator:
                         self.init_handler = handler
 
         kwargs = self.init_handler.to_kwargs() if self.init_handler is not None else {}
+        downcast_bf16 = os.environ.get("DOWNCAST_BF16", False)
         self.state = AcceleratorState(
             mixed_precision=mixed_precision,
             cpu=cpu,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -237,7 +237,7 @@ class Accelerator:
 
         if (
             (mixed_precision != "bf16")
-            and self.state.downcast_bf16
+            and self.state.downcast_bfloat
             and (self.state.distributedType != DistributedType.TPU)
         ):
             raise ValueError("Can only use `downcast_bf16` when using `mixed_precision='bf16'` and on a TPU")

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -237,7 +237,7 @@ class Accelerator:
 
         if (
             (mixed_precision != "bf16")
-            and self.state.downcast_bfloat
+            and getattr(self.state, "downcast_bfloat", False)
             and (self.state.distributedType != DistributedType.TPU)
         ):
             raise ValueError("Can only use `downcast_bf16` when using `mixed_precision='bf16'` and on a TPU")

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -260,11 +260,18 @@ def get_cluster_input():
     else:
         mixed_precision = "no"
 
+    downcast_bf16 = "no"
+    if distributed_type == DistributedType.TPU and mixed_precision == "bf16":
+        downcast_bf16 = _ask_field(
+            "Should `torch.float` be cast as `bfloat16` and `torch.double` remain `float32` on TPUs?", default="no"
+        )
+
     return ClusterConfig(
         compute_environment=ComputeEnvironment.LOCAL_MACHINE,
         distributed_type=distributed_type,
         num_processes=num_processes,
         mixed_precision=mixed_precision,
+        downcast_bf16=downcast_bf16,
         machine_rank=machine_rank,
         num_machines=num_machines,
         main_process_ip=main_process_ip,

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -69,8 +69,8 @@ class BaseConfig:
     compute_environment: ComputeEnvironment
     distributed_type: Union[DistributedType, SageMakerDistributedType]
     mixed_precision: str
-    downcast_bf16: bool
     use_cpu: bool
+    downcast_bf16: Optional[bool] = False
 
     def to_dict(self):
         result = self.__dict__

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -69,6 +69,7 @@ class BaseConfig:
     compute_environment: ComputeEnvironment
     distributed_type: Union[DistributedType, SageMakerDistributedType]
     mixed_precision: str
+    downcast_bf16: bool
     use_cpu: bool
 
     def to_dict(self):

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -70,7 +70,6 @@ class BaseConfig:
     distributed_type: Union[DistributedType, SageMakerDistributedType]
     mixed_precision: str
     use_cpu: bool
-    downcast_bf16: Optional[bool] = False
 
     def to_dict(self):
         result = self.__dict__
@@ -144,6 +143,8 @@ class ClusterConfig(BaseConfig):
     deepspeed_config: dict = None
     # args for fsdp
     fsdp_config: dict = None
+    # args for TPU
+    downcast_bf16: bool = False
 
     def __post_init__(self):
         if self.deepspeed_config is None:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -116,7 +116,7 @@ class AcceleratorState:
                 self.local_process_index = xm.get_local_ordinal()
                 self.device = xm.xla_device()
                 if mixed_precision == "bf16":
-                    if downcast_bf16:
+                    if os.environ.get("DOWNCAST_BF16"):
                         os.environ["XLA_USE_BF16"] = str(0)
                         os.environ["XLA_DOWNCAST_BF16"] = str(1)
                     else:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -72,7 +72,6 @@ class AcceleratorState:
         deepspeed_plugin=None,
         fsdp_plugin=None,
         _from_accelerator: bool = False,
-        downcast_bf16: bool = False,
         **kwargs,
     ):
         self.__dict__ = self._shared_state
@@ -119,9 +118,11 @@ class AcceleratorState:
                     if os.environ.get("DOWNCAST_BF16"):
                         os.environ["XLA_USE_BF16"] = str(0)
                         os.environ["XLA_DOWNCAST_BF16"] = str(1)
+                        self.downcast_bfloat = True
                     else:
                         os.environ["XLA_USE_BF16"] = str(1)
                         os.environ["XLA_DOWNCAST_BF16"] = str(0)
+                        self.downcast_bfloat = False
                 self.mixed_precision = mixed_precision
             elif os.environ.get("USE_DEEPSPEED", "false") == "true" and not cpu:
                 assert (

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -72,6 +72,7 @@ class AcceleratorState:
         deepspeed_plugin=None,
         fsdp_plugin=None,
         _from_accelerator: bool = False,
+        downcast_bf16: bool = False,
         **kwargs,
     ):
         self.__dict__ = self._shared_state
@@ -115,7 +116,12 @@ class AcceleratorState:
                 self.local_process_index = xm.get_local_ordinal()
                 self.device = xm.xla_device()
                 if mixed_precision == "bf16":
-                    os.environ["XLA_USE_BF16"] = str(1)
+                    if downcast_bf16:
+                        os.environ["XLA_USE_BF16"] = str(0)
+                        os.environ["XLA_DOWNCAST_BF16"] = str(1)
+                    else:
+                        os.environ["XLA_USE_BF16"] = str(1)
+                        os.environ["XLA_DOWNCAST_BF16"] = str(0)
                 self.mixed_precision = mixed_precision
             elif os.environ.get("USE_DEEPSPEED", "false") == "true" and not cpu:
                 assert (


### PR DESCRIPTION
This PR adds downcasting support for bf16 on TPUs. Per the XLA docs:

* By default both torch.float and torch.double are torch.float on TPUs.
* If `XLA_USE_BF16` is set, then `torch.float` and `torch.double` are both `bfloat16` on TPUs.
* If `XLA_DOWNCAST_BF16` is set, then `torch.float` is `bfloat16` on TPUs and `torch.double` is `float32` on TPUs.