### PR TITLE
Add balanced option for auto device map creation

### DIFF
--- a/docs/source/big_modeling.mdx
+++ b/docs/source/big_modeling.mdx
@@ -213,7 +213,9 @@ You can derive all sizes of the model (and thus compute a `device_map`) on a mod
 
 </Tip>
 
-All the options will produce the same result when you don't have enough GPU memory to accomodate the whole model (which is to fit everything that can on the GPU, then offload weights on the CPU or even on the disk if there is not enough RAM). When you have more GPU memory available than the model size, here the difference between each option:
+All the options will produce the same result when you don't have enough GPU memory to accomodate the whole model (which is to fit everything that can on the GPU, then offload weights on the CPU or even on the disk if there is not enough RAM). 
+
+When you have more GPU memory available than the model size, here the difference between each option:
 - `"auto"` and `"balanced"` evenly split the model on all available GPUs, making it possible for you to use a batch size greater than 1.
 - `"balanced_low_0"` evenly splits the model on all GPUs except the first one, and only puts on GPU 0 what does not fit on the others. This option is great when you need to use GPU 0 for some processing of the outputs, like when using the `generate` function for Transformers models
 - `"sequential"` will fit what it can on GPU 0, then move on GPU 1 and so forth (so won't use the last GPUs if it doesn't need to).

--- a/docs/source/big_modeling.mdx
+++ b/docs/source/big_modeling.mdx
@@ -205,11 +205,22 @@ This only supports inference of your model, not training. Most of the computatio
 
 ## Designing a device map
 
-You can let 🤗 Accelerate handle the device map computation by setting `device_map="auto"` or create one yourself, if you want more control over where each layer should go.
+You can let 🤗 Accelerate handle the device map computation by setting `device_map` to one of the supported options (`"auto"`, `"balanced"`, `"balanced_low_0"`, `"sequential"`) or create one yourself, if you want more control over where each layer should go.
 
 <Tip>
 
 You can derive all sizes of the model (and thus compute a `device_map`) on a model that is on the meta device.
+
+</Tip>
+
+All the options will produce the same result when you don't have enough GPU memory to accomodate the whole model (which is to fit everything that can on the GPU, then offload weights on the CPU or even on the disk if there is not enough RAM). When you have more GPU memory available than the model size, here the difference between each option:
+- `"auto"` and `"balanced"` evenly split the model on all available GPUs, making it possible for you to use a batch size greater than 1.
+- `"balanced_low_0"` evenly splits the model on all GPUs except the first one, and only puts on GPU 0 what does not fit on the others. This option is great when you need to use GPU 0 for some processing of the outputs, like when using the `generate` function for Transformers models
+- `"sequential"` will fit what it can on GPU 0, then move on GPU 1 and so forth (so won't use the last GPUs if it doesn't need to).
+
+<Tip>
+
+The options `"auto"` and `"balanced"` produce the same results for now, but the behavior of `"auto"` might change in the future if we find a strategy that makes more sense, while `"balanced"` will stay stable.
 
 </Tip>
 

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -279,7 +279,8 @@ def load_checkpoint_and_dispatch(
             A map that specifies where each submodule should go. It doesn't need to be refined to each parameter/buffer
             name, once a given module name is inside, every submodule of it will be sent to the same device.
 
-            To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`.
+            To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For more
+            information about each option see [here](big_modeling#designing-a-device-map).
         max_memory (`Dict`, *optional*):
             A dictionary device identifier to maximum memory. Will default to the maximum memory available for each GPU
             and the available CPU RAM if unset.

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -24,6 +24,7 @@ from .utils import (
     OffloadedWeightsLoader,
     check_device_map,
     extract_submodules_state_dict,
+    get_balanced_memory,
     infer_auto_device_map,
     load_checkpoint_in_model,
     offload_state_dict,
@@ -302,6 +303,13 @@ def load_checkpoint_and_dispatch(
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
             `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
     """
+    if isinstance(device_map, str) and device_map not in ["auto", "balanced"]:
+        raise ValueError("If passing a string for `device_map`, please choose 'auto' or 'balanced'")
+    if device_map == "balanced":
+        max_memory = get_balanced_memory(
+            model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
+        )
+        device_map = "auto"
     if device_map == "auto":
         device_map = infer_auto_device_map(
             model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -303,14 +303,13 @@ def load_checkpoint_and_dispatch(
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
             `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
     """
-    if isinstance(device_map, str) and device_map not in ["auto", "balanced"]:
-        raise ValueError("If passing a string for `device_map`, please choose 'auto' or 'balanced'")
-    if device_map == "balanced":
+    if isinstance(device_map, str) and device_map not in ["auto", "balanced", "sequential"]:
+        raise ValueError("If passing a string for `device_map`, please choose 'auto', 'balanced' or 'sequential'.")
+    if device_map != "sequential":
         max_memory = get_balanced_memory(
             model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
         )
-        device_map = "auto"
-    if device_map == "auto":
+    if isinstance(device_map, str):
         device_map = infer_auto_device_map(
             model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
         )

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -303,11 +303,18 @@ def load_checkpoint_and_dispatch(
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
             `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
     """
-    if isinstance(device_map, str) and device_map not in ["auto", "balanced", "sequential"]:
-        raise ValueError("If passing a string for `device_map`, please choose 'auto', 'balanced' or 'sequential'.")
+    if isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
+        raise ValueError(
+            "If passing a string for `device_map`, please choose 'auto', 'balanced', 'balanced_low_0' or "
+            "'sequential'."
+        )
     if device_map != "sequential":
         max_memory = get_balanced_memory(
-            model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
+            model,
+            max_memory=max_memory,
+            no_split_module_classes=no_split_module_classes,
+            dtype=dtype,
+            low_zero=(device_map == "balanced_low_0"),
         )
     if isinstance(device_map, str):
         device_map = infer_auto_device_map(

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -37,6 +37,7 @@ from .modeling import (
     convert_file_size_to_int,
     dtype_byte_size,
     find_tied_parameters,
+    get_balanced_memory,
     get_max_layer_size,
     get_max_memory,
     infer_auto_device_map,

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -360,6 +360,7 @@ class ModelingUtilsTester(unittest.TestCase):
         expected = {"0": 0, "2.linear2": 0, "1": 1, "2.linear1": 1, "2.batchnorm": 1}
         self.assertDictEqual(device_map, expected)
 
+    @require_cuda
     def test_get_balanced_memory(self):
         model = ModelForTest()
         # model has size 236: linear1 64, batchnorm 72, linear2 100


### PR DESCRIPTION
This PR adds an new option to `device_map` creation, to have something that balances the GPUs when several are available and their combined space is bigger than the model size. This then permits users to handle a batch size greater than 1.

Since there is no downside, this balanced way becomes the new "auto" behavior. The user can still get the old behavior with the "sequential" option and can also use "balanced" for the balanced way (in case auto becomes something different in the future). There is also "blanced_low_0" when we want to minimize the weights on GPU 0 if it's used for generation (cc @stas00 )

@younesbelkada This was something you requested so cc-ing you here.

TODO:
- [ ] Documentation (once #530 is merged)
- [ ] Tests