### PR TITLE
Add a gather_for_metrics capability

### DIFF
--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -120,13 +120,13 @@ validation_dataloader = accelerator.prepare(validation_dataloader)
 
 As for your training dataloader, it will mean that (should you run your script on multiple devices) each device will
 only see part of the evaluation data. This means you will need to group your predictions together. This is very easy to
-do with the [`~Accelerator.gather_metrics`] method.
+do with the [`~Accelerator.gather_for_metrics`] method.
 
 ```python
 for inputs, targets in validation_dataloader:
     predictions = model(inputs)
     # Gather all predictions and targets
-    all_predictions, all_targets = accelerator.gather_metrics((predictions, targets))
+    all_predictions, all_targets = accelerator.gather_for_metrics((predictions, targets))
     # Example of use with a *Datasets.Metric*
     metric.add_batch(all_predictions, all_targets)
 ```
@@ -141,13 +141,13 @@ Any instruction using your training dataloader length (for instance if you need 
 to create a learning rate scheduler) should go after the call to [`~Accelerator.prepare`].
 
 As some data at the end of the dataset may be duplicated so the batch can divide equally to all workers, metrics should be 
-calculated through the [`~Accelerator.gather_metrics`] method to automatically remove the duplicated data.
+calculated through the [`~Accelerator.gather_for_metrics`] method to automatically remove the duplicated data.
 
 </Tip>
 
 <Tip warning={true}>
 
-The [`~Accelerator.gather`] and [`~Accelerator.gather_metrics`] methods require the tensors to be all the same size on each process. If
+The [`~Accelerator.gather`] and [`~Accelerator.gather_for_metrics`] methods require the tensors to be all the same size on each process. If
 you have tensors of different sizes on each process (for instance when dynamically padding to the maximum length in
 a batch), you should use the [`~Accelerator.pad_across_processes`] method to pad you tensor to the
 biggest size across processes.

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -143,6 +143,9 @@ to create a learning rate scheduler) should go after the call to [`~Accelerator.
 As some data at the end of the dataset may be duplicated so the batch can divide equally to all workers, metrics should be 
 calculated through the [`~Accelerator.gather_for_metrics`] method to automatically remove the duplicated data.
 
+If for some reason you don't wish to have this automatically done, [`~Accelerator.gather`] can be used instead to gather 
+the data across all processes and this can manually be done instead.
+
 </Tip>
 
 <Tip warning={true}>

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -147,7 +147,7 @@ calculated through the [`~Accelerator.gather_metrics`] method to automatically r
 
 <Tip warning={true}>
 
-The [`~Accelerator.gather`] and [`~Accelerator.gather_metrics`] methods requires the tensors to be all the same size on each process. If
+The [`~Accelerator.gather`] and [`~Accelerator.gather_metrics`] methods require the tensors to be all the same size on each process. If
 you have tensors of different sizes on each process (for instance when dynamically padding to the maximum length in
 a batch), you should use the [`~Accelerator.pad_across_processes`] method to pad you tensor to the
 biggest size across processes.

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -120,14 +120,13 @@ validation_dataloader = accelerator.prepare(validation_dataloader)
 
 As for your training dataloader, it will mean that (should you run your script on multiple devices) each device will
 only see part of the evaluation data. This means you will need to group your predictions together. This is very easy to
-do with the [`~Accelerator.gather`] method.
+do with the [`~Accelerator.gather_metrics`] method.
 
 ```python
 for inputs, targets in validation_dataloader:
     predictions = model(inputs)
     # Gather all predictions and targets
-    all_predictions = accelerator.gather(predictions)
-    all_targets = accelerator.gather(targets)
+    all_predictions, all_targets = accelerator.gather_metrics((predictions, targets))
     # Example of use with a *Datasets.Metric*
     metric.add_batch(all_predictions, all_targets)
 ```
@@ -141,11 +140,14 @@ As for the training dataloader, passing your validation dataloader through
 Any instruction using your training dataloader length (for instance if you need the number of total training steps
 to create a learning rate scheduler) should go after the call to [`~Accelerator.prepare`].
 
+As some data at the end of the dataset may be duplicated so the batch can divide equally to all workers, metrics should be 
+calculated through the [`~Accelerator.gather_metrics`] method to automatically remove the duplicated data.
+
 </Tip>
 
 <Tip warning={true}>
 
-The [`~Accelerator.gather`] method requires the tensors to be all the same size on each process. If
+The [`~Accelerator.gather`] and [`~Accelerator.gather_metrics`] methods requires the tensors to be all the same size on each process. If
 you have tensors of different sizes on each process (for instance when dynamically padding to the maximum length in
 a batch), you should use the [`~Accelerator.pad_across_processes`] method to pad you tensor to the
 biggest size across processes.

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -238,7 +238,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -238,7 +238,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -238,7 +238,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -207,7 +207,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
                 metric.add_batch(
                     predictions=predictions,
                     references=references,
@@ -226,7 +226,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), test_dataloader)
             fold_predictions.append(predictions.cpu())
             if i == 0:
                 # We need all of the test predictions

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -207,7 +207,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
                 metric.add_batch(
                     predictions=predictions,
                     references=references,
@@ -226,7 +226,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), test_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), test_dataloader)
             fold_predictions.append(predictions.cpu())
             if i == 0:
                 # We need all of the test predictions

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -207,7 +207,9 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+                predictions, references = accelerator.gather_for_metrics(
+                    (predictions, batch["labels"]), eval_dataloader
+                )
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -207,7 +207,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
                 metric.add_batch(
                     predictions=predictions,
                     references=references,
@@ -226,7 +226,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits
-            predictions, references = accelerator.gather((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
             fold_predictions.append(predictions.cpu())
             if i == 0:
                 # We need all of the test predictions

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -270,7 +270,6 @@ def training_function(config, args):
         # context manager to track the peak memory usage during the evaluation
         with TorchTracemalloc() as tracemalloc:
             model.eval()
-            samples_seen = 0
             for step, batch in enumerate(eval_dataloader):
                 # We could avoid this line since we set the accelerator with `device_placement=True`.
                 batch.to(accelerator.device)
@@ -278,15 +277,7 @@ def training_function(config, args):
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
                 # It is slightly faster to call this once, than multiple times
-                predictions, references = accelerator.gather(
-                    (predictions, batch["labels"])
-                )  # If we are in a multiprocess environment, the last batch has duplicates
-                if accelerator.use_distributed:
-                    if step == len(eval_dataloader) - 1:
-                        predictions = predictions[: len(eval_dataloader.dataset) - samples_seen]
-                        references = references[: len(eval_dataloader.dataset) - samples_seen]
-                    else:
-                        samples_seen += references.shape[0]
+                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -277,7 +277,7 @@ def training_function(config, args):
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
                 # It is slightly faster to call this once, than multiple times
-                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -277,7 +277,9 @@ def training_function(config, args):
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
                 # It is slightly faster to call this once, than multiple times
-                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+                predictions, references = accelerator.gather_for_metrics(
+                    (predictions, batch["labels"]), eval_dataloader
+                )
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -277,7 +277,7 @@ def training_function(config, args):
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
                 # It is slightly faster to call this once, than multiple times
-                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -171,7 +171,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -171,7 +171,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -171,7 +171,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -183,7 +183,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -183,7 +183,9 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+                predictions, references = accelerator.gather_for_metrics(
+                    (predictions, batch["labels"]), eval_dataloader
+                )
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -183,7 +183,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -183,7 +183,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -187,6 +187,8 @@ def training_function(config, args):
                 else:
                     # Otherwise we add the number of samples seen
                     samples_seen += references.shape[0]
+            # All of this can be avoided if you use `Accelerate.gather_metrics` instead of `Accelerate.gather`:
+            # accelerate.gather_metrics((predictions, references))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -187,8 +187,8 @@ def training_function(config, args):
                 else:
                     # Otherwise we add the number of samples seen
                     samples_seen += references.shape[0]
-            # All of this can be avoided if you use `Accelerate.gather_for_metrics` instead of `Accelerate.gather`:
-            # accelerate.gather_for_metrics((predictions, references), eval_dataloader)
+            # All of this can be avoided if you use `Accelerator.gather_for_metrics` instead of `Accelerator.gather`:
+            # accelerator.gather_for_metrics((predictions, references), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -188,7 +188,7 @@ def training_function(config, args):
                     # Otherwise we add the number of samples seen
                     samples_seen += references.shape[0]
             # All of this can be avoided if you use `Accelerate.gather_metrics` instead of `Accelerate.gather`:
-            # accelerate.gather_metrics((predictions, references))
+            # accelerate.gather_metrics((predictions, references), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -187,8 +187,8 @@ def training_function(config, args):
                 else:
                     # Otherwise we add the number of samples seen
                     samples_seen += references.shape[0]
-            # All of this can be avoided if you use `Accelerate.gather_metrics` instead of `Accelerate.gather`:
-            # accelerate.gather_metrics((predictions, references), eval_dataloader)
+            # All of this can be avoided if you use `Accelerate.gather_for_metrics` instead of `Accelerate.gather`:
+            # accelerate.gather_for_metrics((predictions, references), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -197,7 +197,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -197,7 +197,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -197,7 +197,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -240,7 +240,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]), eval_dataloader)
+            predictions, labels = accelerator.gather_for_metrics((predictions, batch["label"]), eval_dataloader)
             accurate_preds = predictions == labels
             accurate += accurate_preds.long().sum()
 

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -240,7 +240,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]))
+            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]), eval_dataloader)
             accurate_preds = predictions == labels
             accurate += accurate_preds.long().sum()
 

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -218,7 +218,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -218,7 +218,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -173,7 +173,8 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            accurate_preds = accelerator.gather(predictions) == accelerator.gather(batch["label"])
+            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]))
+            accurate_preds = predictions == labels
             num_elems += accurate_preds.shape[0]
             accurate += accurate_preds.long().sum()
 

--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -173,7 +173,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]))
+            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]), eval_dataloader)
             accurate_preds = predictions == labels
             num_elems += accurate_preds.shape[0]
             accurate += accurate_preds.long().sum()

--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -173,7 +173,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, labels = accelerator.gather_metrics((predictions, batch["label"]), eval_dataloader)
+            predictions, labels = accelerator.gather_for_metrics((predictions, batch["label"]), eval_dataloader)
             accurate_preds = predictions == labels
             num_elems += accurate_preds.shape[0]
             accurate += accurate_preds.long().sum()

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -158,7 +158,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -158,7 +158,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -158,7 +158,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_metrics((predictions, batch["labels"]), eval_dataloader)
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -875,7 +875,7 @@ class Accelerator:
         """
         return gather(tensor)
 
-    def gather_metrics(self, tensor, dataloader):
+    def gather_for_metrics(self, tensor, dataloader):
         """
         Gathers `tensor` and potentially drops duplicates in the last batch if on a distributed system. Should be used
         for gathering the inputs and targets for metric calculation.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -889,7 +889,7 @@ class Accelerator:
         tensor = self.gather(tensor)
         if self.use_distributed:
             # Then see if we're on the last batch of our eval dataloader
-            if self.gradient_state.end_of_dataloader:
+            if self.gradient_state.end_of_dataloader and dataloader.total_dataset_length:
                 # Last batch needs to be truncated on distributed systems as it contains additional samples
                 def _adjust_samples(tensor):
                     return tensor[: dataloader.total_dataset_length - self.gradient_state.samples_seen]

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -882,7 +882,7 @@ class Accelerator:
 
         Args:
             tensor (`torch.Tensor`, or a nested tuple/list/dictionary of `torch.Tensor`):
-                The tensors to reduce across all processes.
+                The tensors for calculating metrics across all processes.
             dataloader (`torch.utils.data.DataLoader`):
                 A dataloader prepared with `Accelerator.prepare`
         """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -47,7 +47,7 @@ if is_tpu_available(check_device=False):
         - **total_batch_size** (`int`) -- Total batch size of the dataloader across all processes.
             Equal to the original batch size when `split_batches=True`; otherwise the original batch size * the total
             number of processes
-        
+
         - **total_dataset_length** (`int`) -- Total length of the inner dataset across all processes.
         """
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -365,7 +365,9 @@ class DataLoaderShard(DataLoader):
 
     @property
     def total_dataset_length(self):
-        return len(self.dataset)
+        if hasattr(self.dataset, "__len__"):
+            return len(self.dataset)
+        return False
 
 
 class DataLoaderDispatcher(DataLoader):
@@ -513,7 +515,9 @@ class DataLoaderDispatcher(DataLoader):
 
     @property
     def total_dataset_length(self):
-        return len(self.dataset)
+        if hasattr(self.dataset, "__len__"):
+            return len(self.dataset)
+        return False
 
 
 def prepare_data_loader(

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -365,9 +365,7 @@ class DataLoaderShard(DataLoader):
 
     @property
     def total_dataset_length(self):
-        if hasattr(self.dataset, "__len__"):
-            return len(self.dataset)
-        return False
+        return len(self.dataset)
 
 
 class DataLoaderDispatcher(DataLoader):
@@ -515,9 +513,7 @@ class DataLoaderDispatcher(DataLoader):
 
     @property
     def total_dataset_length(self):
-        if hasattr(self.dataset, "__len__"):
-            return len(self.dataset)
-        return False
+        return len(self.dataset)
 
 
 def prepare_data_loader(

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -453,6 +453,7 @@ class DataLoaderDispatcher(DataLoader):
 
     def __iter__(self):
         self.gradient_state._set_end_of_dataloader(False)
+        self.gradient_state._set_samples_seen(0)
         main_iterator = None
         if self.state.process_index == 0:
             # We only iterate through the DataLoader on process 0.

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -255,10 +255,11 @@ class GradientState:
         if not getattr(self, "initialized", False):
             self.sync_gradients = True
             self.end_of_dataloader = False
+            self.samples_seen = 0
         self.initialized = True
 
     def __repr__(self):
-        return f"Sync Gradients: {self.sync_gradients}\n" f"At end of current dataloader: {self.end_of_dataloader}\n"
+        return f"Sync Gradients: {self.sync_gradients}\n" f"At end of current dataloader: {self.end_of_dataloader}\n" f"Samples seen: {self.samples_seen}"
 
     def _set_sync_gradients(self, sync_gradients):
         "Private function that sets whether gradients should be synchronized. Users should not have to call this."
@@ -267,3 +268,13 @@ class GradientState:
     def _set_end_of_dataloader(self, end_of_dataloader):
         "Private function that sets whether the end of the current dataloader has been reached. Users should not have to call this."
         self.end_of_dataloader = end_of_dataloader
+
+    def _set_samples_seen(self, samples_seen):
+        "Private function that sets the number of samples iterated over. Users should not have to call this."
+        self.samples_seen = samples_seen
+
+    def _iterate_samples_seen(self, iteration:int=1):
+        "Private function that iterates the number of samples seen by an iteration. Users should not have to call this."
+        self._set_samples_seen(self.samples_seen + iteration)
+
+

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -259,7 +259,11 @@ class GradientState:
         self.initialized = True
 
     def __repr__(self):
-        return f"Sync Gradients: {self.sync_gradients}\n" f"At end of current dataloader: {self.end_of_dataloader}\n" f"Samples seen: {self.samples_seen}"
+        return (
+            f"Sync Gradients: {self.sync_gradients}\n"
+            f"At end of current dataloader: {self.end_of_dataloader}\n"
+            f"Samples seen: {self.samples_seen}"
+        )
 
     def _set_sync_gradients(self, sync_gradients):
         "Private function that sets whether gradients should be synchronized. Users should not have to call this."
@@ -273,8 +277,6 @@ class GradientState:
         "Private function that sets the number of samples iterated over. Users should not have to call this."
         self.samples_seen = samples_seen
 
-    def _iterate_samples_seen(self, iteration:int=1):
+    def _iterate_samples_seen(self, iteration: int = 1):
         "Private function that iterates the number of samples seen by an iteration. Users should not have to call this."
         self._set_samples_seen(self.samples_seen + iteration)
-
-

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -15,4 +15,4 @@ from .testing import (
 from .training import RegressionDataset, RegressionModel
 
 
-from .scripts import test_script, test_sync  # isort:skip
+from .scripts import test_metrics, test_script, test_sync  # isort:skip

--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -56,7 +56,7 @@ def test_torch_metrics():
         # Then do multiprocess
         with torch.no_grad():
             logits = ddp_model(ddp_input)
-            logits, target = accelerator.gather_metrics((logits, ddp_target), dataloader)
+            logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
             accuracy_multi = accuracy(logits.argmax(dim=-1), target)
         assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
 
@@ -76,7 +76,7 @@ def test_evaluate_metrics():
         # Then do multiprocess
         with torch.no_grad():
             logits = ddp_model(ddp_input)
-            logits, target = accelerator.gather_metrics((logits, ddp_target), dataloader)
+            logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
             accuracy_multi = metric.compute(logits, target)
         assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
 

--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -15,16 +15,13 @@
 from copy import deepcopy
 
 import torch
-
-import torch
-import torch.nn.functional as F
-from torch.optim import AdamW
-from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader
 
+import evaluate
 from accelerate import Accelerator
 from accelerate.test_utils import RegressionDataset, RegressionModel
-from accelerate.state import GradientState
+from accelerate.utils import set_seed
+
 
 def get_setup(accelerator):
     "Returns everything needed to perform basic training"
@@ -37,33 +34,52 @@ def get_setup(accelerator):
     ddp_model, dataloader = accelerator.prepare(ddp_model, dataloader)
     return model, ddp_model, dataloader
 
+
 def accuracy(predictions, labels) -> float:
     """
     Get the accuracy with respect to the most likely label
     """
     return (predictions == labels).float().mean()
 
+
 def test_torch_metrics():
     accelerator = Accelerator()
-    state = GradientState()
     model, ddp_model, dataloader = get_setup(accelerator)
     for batch in dataloader:
+        ddp_input, ddp_target = batch.values()
         # First do single process
         input, target = accelerator.gather((ddp_input, ddp_target))
         input, target = input.to(accelerator.device), target.to(accelerator.device)
         with torch.no_grad():
             logits = model(input)
-            accuracy_single = accuracy(logits.argmax(dim=1), targets)
+            accuracy_single = accuracy(logits.argmax(dim=-1), target)
         # Then do multiprocess
         with torch.no_grad():
-            logits = ddp_model(input)
-            logits, targets = accelerator.gather_metrics((logits, targets))
-            accuracy_multi = accuracy(logits.argmax(dim=1), targets)
-        assert torch.all_close(
-            accuracy_single, 
-            accuracy_multi,
-            "The two accuracies were not the same!"
-        )
+            logits = ddp_model(ddp_input)
+            logits, target = accelerator.gather_metrics((logits, ddp_target), dataloader)
+            accuracy_multi = accuracy(logits.argmax(dim=-1), target)
+        assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
+
+
+def test_evaluate_metrics():
+    metric = evaluate.load("accuracy")
+    accelerator = Accelerator()
+    model, ddp_model, dataloader = get_setup(accelerator)
+    for batch in dataloader:
+        ddp_input, ddp_target = batch.values()
+        # First do single process
+        input, target = accelerator.gather((ddp_input, ddp_target))
+        input, target = input.to(accelerator.device), target.to(accelerator.device)
+        with torch.no_grad():
+            logits = model(input)
+            accuracy_single = metric.compute(logits, target)
+        # Then do multiprocess
+        with torch.no_grad():
+            logits = ddp_model(ddp_input)
+            logits, target = accelerator.gather_metrics((logits, ddp_target), dataloader)
+            accuracy_multi = metric.compute(logits, target)
+        assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
+
 
 def main():
     accelerator = Accelerator()
@@ -72,9 +88,11 @@ def main():
         print("**Test torch metrics**")
     test_torch_metrics()
 
+
 def _mp_fn(index):
     # For xla_spawn (TPUs)
     main()
+
 
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -1,0 +1,80 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from copy import deepcopy
+
+import torch
+
+import torch
+import torch.nn.functional as F
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import LambdaLR
+from torch.utils.data import DataLoader
+
+from accelerate import Accelerator
+from accelerate.test_utils import RegressionDataset, RegressionModel
+from accelerate.state import GradientState
+
+def get_setup(accelerator):
+    "Returns everything needed to perform basic training"
+    set_seed(42)
+    model = RegressionModel()
+    ddp_model = deepcopy(model)
+    dset = RegressionDataset(length=80)
+    dataloader = DataLoader(dset, batch_size=16)
+    model.to(accelerator.device)
+    ddp_model, dataloader = accelerator.prepare(ddp_model, dataloader)
+    return model, ddp_model, dataloader
+
+def accuracy(predictions, labels) -> float:
+    """
+    Get the accuracy with respect to the most likely label
+    """
+    return (predictions == labels).float().mean()
+
+def test_torch_metrics():
+    accelerator = Accelerator()
+    state = GradientState()
+    model, ddp_model, dataloader = get_setup(accelerator)
+    for batch in dataloader:
+        # First do single process
+        input, target = accelerator.gather((ddp_input, ddp_target))
+        input, target = input.to(accelerator.device), target.to(accelerator.device)
+        with torch.no_grad():
+            logits = model(input)
+            accuracy_single = accuracy(logits.argmax(dim=1), targets)
+        # Then do multiprocess
+        with torch.no_grad():
+            logits = ddp_model(input)
+            logits, targets = accelerator.gather_metrics((logits, targets))
+            accuracy_multi = accuracy(logits.argmax(dim=1), targets)
+        assert torch.all_close(
+            accuracy_single, 
+            accuracy_multi,
+            "The two accuracies were not the same!"
+        )
+
+def main():
+    accelerator = Accelerator()
+    state = accelerator.state
+    if state.local_process_index == 0:
+        print("**Test torch metrics**")
+    test_torch_metrics()
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,55 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import os
+import unittest
+
+import torch
+
+import accelerate
+from accelerate import debug_launcher
+from accelerate.test_utils import (
+    execute_subprocess_async,
+    require_cpu,
+    require_multi_gpu,
+    require_single_gpu,
+    test_metrics,
+)
+from accelerate.utils import get_launch_prefix, patch_environment
+
+
+class MetricTester(unittest.TestCase):
+    def setUp(self):
+        mod_file = inspect.getfile(accelerate.test_utils)
+        self.test_file_path = os.path.sep.join(mod_file.split(os.path.sep)[:-1] + ["scripts", "test_metrics.py"])
+
+    @require_cpu
+    def test_metric_cpu_noop(self):
+        debug_launcher(test_metrics.main, num_processes=1)
+
+    @require_cpu
+    def test_metric_cpu_multi(self):
+        debug_launcher(test_metrics.main)
+
+    @require_single_gpu
+    def test_metric_gpu(self):
+        test_metrics.main()
+
+    @require_multi_gpu
+    def test_metric_gpu_multi(self):
+        print(f"Found {torch.cuda.device_count()} devices.")
+        cmd = get_launch_prefix() + [f"--nproc_per_node={torch.cuda.device_count()}", self.test_file_path]
+        with patch_environment(omp_num_threads=1):
+            execute_subprocess_async(cmd, env=os.environ.copy())


### PR DESCRIPTION
# Introduce a `gather_for_metrics` function

## What does this add?

This PR adds a new function to `Accelerator` called `gather_for_metrics`, which assists with calculating the right metric in distributed setups

## Who is it for?

Users of accelerate that want to ensure that their reported metrics are fully accurate

## Why is it needed?

To assist with making sure all the batches have the right batch size, Accelerate will pad the length on the last batch to be duplicates of the last sample. These need to be dropped when calculating the final metrics on the last batch, and currently it looks something like:
```python
if accelerator.use_distributed:
    # Then see if we're on the last batch of our eval dataloader
    if step == len(eval_dataloader) - 1:
        # Last batch needs to be truncated on distributed systems as it contains additional samples
        predictions = predictions[: len(eval_dataloader.dataset) - samples_seen]
        references = references[: len(eval_dataloader.dataset) - samples_seen]
    else:
        # Otherwise we add the number of samples seen
        samples_seen += references.shape[0]
```
This PR adds a new utility called `accelerate.gather_for_metrics` which will handle this check for us, entirely thanks to the `GradientState` capability. 

> Note: this method currently doesn't work for TPU's, as it needs to be `eval_dataloader._loader.dataset`. This PR fixes this as well

## What parts of the API does this impact?

### User-facing:

- A new `Accelerator.gather_for_metrics` function was added 

### Internal structure:

- Preprocessed dataloaders now have a new `total_dataset_length` attribute
- `GradientState` now keeps track of the number of samples seen

## Basic Usage Example(s):

When calculating metrics, users can now do the following to properly calculate their metrics:

```python
input, target = next(iter(dataloader))
with torch.no_grad():
    logits = ddp_model(ddp_input)
    logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
    accuracy_multi = accuracy(logits.argmax(dim=-1), target)
```

## When would I use it, and when wouldn't I?

Since this works on distributed and non-distributed systems, always if the evaluation dataset has been prepared by Accelerator. Users should just add this to any script that calculates metrics.

TODO:
- [x] Update the other examples to use this new API. multiprocess_metrics will serve as a lower-level example