### PR TITLE
Allow for kwargs to be passed to trackers

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -938,7 +938,7 @@ class Accelerator:
                 Optional starting configuration to be logged.
             init_kwargs (`dict`, *optional*):
                 A nested dictionary of kwargs to be passed to a specific tracker's `__init__` function. Should be
-                formatted as {tracker_name:{kwarg_a:value_a}}, such as:
+                formatted like this:
                 ```python
                 {"wandb": {"tags": ["tag_a", "tag_b"]}}
                 ```
@@ -972,7 +972,7 @@ class Accelerator:
                 The run step. If included, the log will be affiliated with this step.
             log_kwargs (`dict`, *optional*):
                 A nested dictionary of kwargs to be passed to a specific tracker's `log` function. Should be formatted
-                as {tracker_name:{kwarg_a:value_a}}, such as:
+                like this:
                 ```python
                 {"wandb": {"tags": ["tag_a", "tag_b"]}}
                 ```

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -8,7 +8,7 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY name, either express or implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
@@ -53,7 +53,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
     """
     A base Tracker class to be used for all logging integration implementations.
 
-    Each function should take in `**kwargs` that will automatically be passed in from a base dictionary in Accelerator
+    Each function should take in `**kwargs` that will automatically be passed in from a base dictionary provided to [`Accelerator`]
     """
 
     @abstractproperty

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -70,7 +70,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def store_init_configuration(self, values: dict, **kwargs):
+    def store_init_configuration(self, values: dict):
         """
         Logs `values` as hyperparameters for the run. Implementations should use the experiment configuration
         functionality of a tracking API.
@@ -96,7 +96,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         """
         pass
 
-    def finish(self, **kwargs):
+    def finish(self):
         """
         Should run any finalizing functions within the tracking API. If the API should not have one, just don't
         overwrite that method.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -53,7 +53,8 @@ class GeneralTracker(object, metaclass=ABCMeta):
     """
     A base Tracker class to be used for all logging integration implementations.
 
-    Each function should take in `**kwargs` that will automatically be passed in from a base dictionary provided to [`Accelerator`]
+    Each function should take in `**kwargs` that will automatically be passed in from a base dictionary provided to
+    [`Accelerator`]
     """
 
     @abstractproperty

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -100,6 +100,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         project_name = "test_project_with_config"
         accelerator = Accelerator(log_with="wandb")
         config = {"num_iterations": 12, "learning_rate": 1e-2, "some_boolean": False, "some_string": "some_value"}
+        kwargs = {"wandb":{"tags":["my_tag"]}}
         accelerator.init_trackers(project_name, config)
         accelerator.end_training()
         # The latest offline log is stored at wandb/latest-run/*.wandb
@@ -116,6 +117,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         self.assertEqual(self.get_value_from_log("learning_rate", cleaned_log), "0.01")
         self.assertEqual(self.get_value_from_log("some_boolean", cleaned_log), "false")
         self.assertEqual(self.get_value_from_log("some_string", cleaned_log), "some_value")
+        self.assertEqual(self.get_value_from_log("tags", cleaned_log), "my_tag")
 
     def test_log(self):
         project_name = "test_project_with_log"

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -101,7 +101,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         accelerator = Accelerator(log_with="wandb")
         config = {"num_iterations": 12, "learning_rate": 1e-2, "some_boolean": False, "some_string": "some_value"}
         kwargs = {"wandb":{"tags":["my_tag"]}}
-        accelerator.init_trackers(project_name, config)
+        accelerator.init_trackers(project_name, config, kwargs)
         accelerator.end_training()
         # The latest offline log is stored at wandb/latest-run/*.wandb
         for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
@@ -117,7 +117,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         self.assertEqual(self.get_value_from_log("learning_rate", cleaned_log), "0.01")
         self.assertEqual(self.get_value_from_log("some_boolean", cleaned_log), "false")
         self.assertEqual(self.get_value_from_log("some_string", cleaned_log), "some_value")
-        self.assertEqual(self.get_value_from_log("tags", cleaned_log), "my_tag")
+        self.assertIn("my_tag", cleaned_log)
 
     def test_log(self):
         project_name = "test_project_with_log"

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -100,7 +100,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         project_name = "test_project_with_config"
         accelerator = Accelerator(log_with="wandb")
         config = {"num_iterations": 12, "learning_rate": 1e-2, "some_boolean": False, "some_string": "some_value"}
-        kwargs = {"wandb":{"tags":["my_tag"]}}
+        kwargs = {"wandb": {"tags": ["my_tag"]}}
         accelerator.init_trackers(project_name, config, kwargs)
         accelerator.end_training()
         # The latest offline log is stored at wandb/latest-run/*.wandb
@@ -216,6 +216,7 @@ class MyCustomTracker(GeneralTracker):
         "some_string",
     ]
 
+    name = "my_custom_tracker"
     requires_logging_directory = False
 
     def __init__(self, dir: str):


### PR DESCRIPTION
This PR lets kwargs be trickled down into each tracker's `__init__` and `log` method. Example:

```python
kwargs = {"wandb":{"name":"some_name", "tags":["tag_a","tag_b"]}}
accelerator.init_trackers("run_name", init_kwargs=kwargs)
```