### PR TITLE
deepspeed version hotfix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extras["test"] = [
     "scipy",
     "sklearn",
     "parameterized",
-    "deepspeed",
+    "deepspeed==0.6.5",
 ]
 
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard"]


### PR DESCRIPTION
### What does this PR do?

1. DeepSpeed integration is broken when using the latest deepspeed 0.6.7 version. Using version 0.6.5 for time being till there is resolution for https://github.com/microsoft/DeepSpeed/issues/2117 in order to not have failing test