### PR TITLE
Rename test extras to testing

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -25,7 +25,7 @@ jobs:
           source activate accelerate
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
-          pip install -e .[test,test_trackers]
+          pip install -e .[testing,test_trackers]
 
       - name: Run test on GPUs
         run: |
@@ -52,7 +52,7 @@ jobs:
           source activate accelerate
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
-          pip install -e .[test,test_trackers]
+          pip install -e .[testing,test_trackers]
 
       - name: Run test on GPUs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        pip install -e .[test,test_trackers]
+        pip install -e .[testing,test_trackers]
         if [ ${{ matrix.test-kind }} = test_rest ]; then pip uninstall comet_ml -y; fi
     
     - name: Run Tests

--- a/docker/accelerate-cpu/Dockerfile
+++ b/docker/accelerate-cpu/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /workspace
 RUN python3 -m pip install --upgrade --no-cache-dir pip
 RUN python3 -m pip install --no-cache-dir \
     jupyter \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[test,test_trackers] \
+    git+https://github.com/huggingface/accelerate#egg=accelerate[testing,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cpu
     
 # Stage 2

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[test,test_trackers] \
+    git+https://github.com/huggingface/accelerate#egg=accelerate[testing,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
 # Stage 2

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import find_packages
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3", "hf-doc-builder >= 0.3.0"]
 extras["docs"] = []
-extras["test"] = [
+extras["testing"] = [
     "pytest",
     "pytest-xdist",
     "pytest-subtests",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ extras["testing"] = [
 ]
 
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard"]
-extras["dev"] = extras["quality"] + extras["test"]
+extras["dev"] = extras["quality"] + extras["testing"]
 
 extras["sagemaker"] = [
     "sagemaker",  # boto3 is a required package in sagemaker


### PR DESCRIPTION
Super tiny nit, but keeps it inline with how transformers has their extras setup for tests. Mostly so I don't have to keep digging to see if I need to do `pip install -e .[tests]` `pip install -e .[testing]` `pip install -e .[test]` when bouncing back and forth between testing transformers and accelerate