### PR TITLE
Fix failing ci for evaluate

### DIFF
--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -55,7 +55,7 @@ def test_torch_metrics():
         # Then do multiprocess
         with torch.no_grad():
             logits = ddp_model(ddp_input)
-            logits, target = accelerator.gather_metrics((logits, ddp_target), dataloader)
+            logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
             accuracy_multi = accuracy(logits.argmax(dim=-1), target)
         assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
 

--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -17,7 +17,6 @@ from copy import deepcopy
 import torch
 from torch.utils.data import DataLoader
 
-import evaluate
 from accelerate import Accelerator
 from accelerate.test_utils import RegressionDataset, RegressionModel
 from accelerate.utils import set_seed
@@ -56,28 +55,8 @@ def test_torch_metrics():
         # Then do multiprocess
         with torch.no_grad():
             logits = ddp_model(ddp_input)
-            logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
+            logits, target = accelerator.gather_metrics((logits, ddp_target), dataloader)
             accuracy_multi = accuracy(logits.argmax(dim=-1), target)
-        assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
-
-
-def test_evaluate_metrics():
-    metric = evaluate.load("accuracy")
-    accelerator = Accelerator()
-    model, ddp_model, dataloader = get_setup(accelerator)
-    for batch in dataloader:
-        ddp_input, ddp_target = batch.values()
-        # First do single process
-        input, target = accelerator.gather((ddp_input, ddp_target))
-        input, target = input.to(accelerator.device), target.to(accelerator.device)
-        with torch.no_grad():
-            logits = model(input)
-            accuracy_single = metric.compute(logits, target)
-        # Then do multiprocess
-        with torch.no_grad():
-            logits = ddp_model(ddp_input)
-            logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
-            accuracy_multi = metric.compute(logits, target)
         assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
 
 


### PR DESCRIPTION
Removes added dep from the test scripts with evaluate and leaves just the torch test in. If we want to include evaluate I'll add it as a test dep but I think it's fine just testing the single metric as we were. 