### PR TITLE
Add production testing + fix failing CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         test-kind: [
           test_prod,
-          test,
+          test_core,
           test_deepspeed,
           test_example_differences,
           test_checkpoint_step,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         test-kind: [
+          test_prod,
           test,
           test_deepspeed,
           test_example_differences,
@@ -37,7 +38,8 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        pip install -e .[test,test_trackers]
+        if [ ${{ matrix.test-kind }} = test_prod]; then pip install -e .[test_prod]
+        if [ ${{ matrix.test-kind }} != test_prod]; then pip install -e .[test,test_trackers]
         if [ ${{ matrix.test-kind }} = test_rest ]; then pip uninstall comet_ml -y; fi
     
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         test-kind: [
           test_prod,
           test_core,
+          test_big_modeling,
           test_deepspeed,
           test_example_differences,
           test_checkpoint_step,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        if [[ ${{ matrix.test-kind }} = test_prod]]
+        if [[ ${{ matrix.test-kind }} = test_prod ]]
         then 
           pip install -e .[test_prod]
         fi
-        if [[ ${{ matrix.test-kind }} != test_prod]]
+        if [[ ${{ matrix.test-kind }} != test_prod ]]
         then 
           pip install -e .[test,test_trackers]
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         then 
           pip install -e .[test_prod]
         fi
-        if [[ ${{ matrix.test-kind }} != test_prod]]; 
+        if [[ ${{ matrix.test-kind }} != test_prod]]
         then 
           pip install -e .[test,test_trackers]
         fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,18 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        if [ ${{ matrix.test-kind }} = test_prod]; then [pip install -e .[test_prod]]; fi
-        if [ ${{ matrix.test-kind }} != test_prod]; then [pip install -e .[test,test_trackers]]; fi
-        if [ ${{ matrix.test-kind }} = test_rest ]; then [pip uninstall comet_ml -y]; fi
+        if [[ ${{ matrix.test-kind }} = test_prod]]
+        then 
+          pip install -e .[test_prod]
+        fi
+        if [[ ${{ matrix.test-kind }} != test_prod]]; 
+        then 
+          pip install -e .[test,test_trackers]
+        fi
+        if [[ ${{ matrix.test-kind }} = test_rest ]]
+        then 
+          pip uninstall comet_ml -y
+        fi
     
     - name: Run Tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 env:
   HF_HOME: ~/hf_cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests
 
-on: [pull_request, workflow_dispatch]
+on: [pull_request]
 
 env:
   HF_HOME: ~/hf_cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        if [ ${{ matrix.test-kind }} = test_prod]; then pip install -e .[test_prod]
-        if [ ${{ matrix.test-kind }} != test_prod]; then pip install -e .[test,test_trackers]
+        if [ ${{ matrix.test-kind }} = test_prod]; then pip install -e .[test_prod]; fi
+        if [ ${{ matrix.test-kind }} != test_prod]; then pip install -e .[test,test_trackers]; fi
         if [ ${{ matrix.test-kind }} = test_rest ]; then pip uninstall comet_ml -y; fi
     
     - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        if [ ${{ matrix.test-kind }} = test_prod]; then pip install -e .[test_prod]; fi
-        if [ ${{ matrix.test-kind }} != test_prod]; then pip install -e .[test,test_trackers]; fi
-        if [ ${{ matrix.test-kind }} = test_rest ]; then pip uninstall comet_ml -y; fi
+        if [ ${{ matrix.test-kind }} = test_prod]; then [pip install -e .[test_prod]]; fi
+        if [ ${{ matrix.test-kind }} != test_prod]; then [pip install -e .[test,test_trackers]]; fi
+        if [ ${{ matrix.test-kind }} = test_rest ]; then [pip uninstall comet_ml -y]; fi
     
     - name: Run Tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,18 +39,9 @@ jobs:
     - name: Install the library
       run: |
         pip install --upgrade pip
-        if [[ ${{ matrix.test-kind }} = test_prod ]]
-        then 
-          pip install -e .[test_prod]
-        fi
-        if [[ ${{ matrix.test-kind }} != test_prod ]]
-        then 
-          pip install -e .[test,test_trackers]
-        fi
-        if [[ ${{ matrix.test-kind }} = test_rest ]]
-        then 
-          pip uninstall comet_ml -y
-        fi
+        if [[ ${{ matrix.test-kind }} = test_prod ]]; then pip install -e .[test_prod]; fi
+        if [[ ${{ matrix.test-kind }} != test_prod ]]; then pip install -e .[test,test_trackers]; fi
+        if [[ ${{ matrix.test-kind }} = test_rest ]]; then pip uninstall comet_ml -y; fi
     
     - name: Run Tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,11 @@ style:
 test:
 	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py
 
+test_big_modeling:
+	python -m pytest -s -v ./tests/test_big_modeling.py
+
 test_core:
-	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py --ignore=./tests/deepspeed
+	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py --ignore=./tests/deepspeed --ignore=./tests/test_big_modeling.py
 
 test_deepspeed:
 	python -m pytest -s -v ./tests/deepspeed

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test_checkpoint_step:
 
 # Same as test but used to install only the base dependencies
 test_prod:
-	test_core
+	$(MAKE) test_core
 
 test_rest:
 	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "not by_step and not by_epoch"

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ style:
 test:
 	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py
 
+test_core:
+	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py --ignore=./tests/deepspeed
+
 test_deepspeed:
 	python -m pytest -s -v ./tests/deepspeed
 
@@ -45,7 +48,7 @@ test_checkpoint_step:
 
 # Same as test but used to install only the base dependencies
 test_prod:
-	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py
+	test_core
 
 test_rest:
 	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "not by_step and not by_epoch"

--- a/Makefile
+++ b/Makefile
@@ -43,5 +43,9 @@ test_checkpoint_epoch:
 test_checkpoint_step:
 	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "by_step"
 
+# Same as test but used to install only the base dependencies
+test_prod:
+	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py
+
 test_rest:
 	python -m pytest -s -v ./tests/test_examples.py::FeatureExamplesTests -k "not by_step and not by_epoch"

--- a/setup.py
+++ b/setup.py
@@ -18,18 +18,9 @@ from setuptools import find_packages
 extras = {}
 extras["quality"] = ["black ~= 22.0", "isort >= 5.5.4", "flake8 >= 3.8.3", "hf-doc-builder >= 0.3.0"]
 extras["docs"] = []
-extras["test"] = [
-    "pytest",
-    "pytest-xdist",
-    "pytest-subtests",
-    "datasets<=2.2.2",
-    "evaluate",
-    "transformers",
-    "scipy",
-    "sklearn",
-    "parameterized",
-    "deepspeed",
-]
+extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
+extras["test_dev"] = ["datasets<=2.2.2", "evaluate", "transformers", "scipy", "sklearn", "deepspeed"]
+extras["test"] = extras["test_prod"] + extras["test_dev"]
 
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard"]
 extras["dev"] = extras["quality"] + extras["test"]

--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -17,7 +17,6 @@ from copy import deepcopy
 import torch
 from torch.utils.data import DataLoader
 
-import evaluate
 from accelerate import Accelerator
 from accelerate.test_utils import RegressionDataset, RegressionModel
 from accelerate.utils import set_seed
@@ -59,27 +58,6 @@ def test_torch_metrics():
             logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
             accuracy_multi = accuracy(logits.argmax(dim=-1), target)
         assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
-
-
-def test_evaluate_metrics():
-    metric = evaluate.load("accuracy")
-    accelerator = Accelerator()
-    model, ddp_model, dataloader = get_setup(accelerator)
-    for batch in dataloader:
-        ddp_input, ddp_target = batch.values()
-        # First do single process
-        input, target = accelerator.gather((ddp_input, ddp_target))
-        input, target = input.to(accelerator.device), target.to(accelerator.device)
-        with torch.no_grad():
-            logits = model(input)
-            accuracy_single = metric.compute(logits, target)
-        # Then do multiprocess
-        with torch.no_grad():
-            logits = ddp_model(ddp_input)
-            logits, target = accelerator.gather_for_metrics((logits, ddp_target), dataloader)
-            accuracy_multi = metric.compute(logits, target)
-        assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
-
 
 def main():
     accelerator = Accelerator()

--- a/src/accelerate/test_utils/scripts/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/test_metrics.py
@@ -59,6 +59,7 @@ def test_torch_metrics():
             accuracy_multi = accuracy(logits.argmax(dim=-1), target)
         assert torch.allclose(accuracy_single, accuracy_multi), "The two accuracies were not the same!"
 
+
 def main():
     accelerator = Accelerator()
     state = accelerator.state


### PR DESCRIPTION
Adds a production stage to the CI so that barebones testing without any added dependencies can be checked on the git ci first to ensure that trickle-down breakages cannot occur. 

Specifically breaks down the `big_modeling` into its own ci matrix and adds a `core` to the matrix

Also removes unused evaluate test since it adds a dep to the main library. Not wondering if it'd be good for us soon to leave `test_script` in the main lib but migrate out all the other test scripts that might want or need external deps to a seperate folder at some point