### PR TITLE
Create value errror in cli when accelerate config hasn't been run

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -693,6 +693,10 @@ def launch_command(args):
     else:
         if args.num_processes is None:
             args.num_processes = 1
+    if not hasattr(args, "use_cpu"):
+        raise ValueError(
+            "Tried to run `accelerate launch` without running `accelerate config` first. Please configure Accelerate and rerun this command"
+        )
 
     # Use the proper launcher
     if args.use_deepspeed and not args.cpu:


### PR DESCRIPTION
Since `accelerate launch` *requires* `accelerate config` right now to be ran or a config file to be made, this PR raises a value error if a parameter specifically in the config wasn't passed, and if it wasn't found alerts the user to run `accelerate config` first.

This is a temporary fix for now, as technically a user should be able to run accelerate without `accelerate config` if they pass all the right parameters