### PR TITLE
Create good defaults in `accelerate launch`

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -686,7 +686,6 @@ def launch_command(args):
                     and getattr(args, name, None) is None
                 ):
                     setattr(args, name, attr)
-
         if not args.mixed_precision:
             if args.fp16:
                 args.mixed_precision = "fp16"
@@ -701,6 +700,9 @@ def launch_command(args):
             args.mixed_precision = "no"
         if not hasattr(args, "use_cpu"):
             args.use_cpu = torch.cuda.is_available()
+
+    if args.multi_gpu and args.num_processes == 1:
+        args.num_processes = torch.cuda.device_count()
 
     # Use the proper launcher
     if args.use_deepspeed and not args.cpu:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -693,6 +693,10 @@ def launch_command(args):
     else:
         if args.num_processes is None:
             args.num_processes = 1
+    if not hasattr(args, "use_cpu"):
+        raise ValueError(
+            "Tried to run `accelerate launch` without running `accelerate config` first. Please configure Accelerate and rerun this command"
+        )
 
     # Use the proper launcher
     if args.use_deepspeed and not args.cpu:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -24,6 +24,8 @@ from ast import literal_eval
 from pathlib import Path
 from typing import Dict, List
 
+import torch
+
 from accelerate.commands.config import default_config_file, load_config_from_file
 from accelerate.commands.config.config_args import SageMakerConfig
 from accelerate.utils import (
@@ -693,10 +695,12 @@ def launch_command(args):
     else:
         if args.num_processes is None:
             args.num_processes = 1
-    if not hasattr(args, "use_cpu"):
-        raise ValueError(
-            "Tried to run `accelerate launch` without running `accelerate config` first. Please configure Accelerate and rerun this command"
-        )
+        if args.num_machines is None:
+            args.num_machines = 1
+        if args.mixed_precision is None:
+            args.mixed_precision = "no"
+        if not hasattr(args, "use_cpu"):
+            args.use_cpu = torch.cuda.is_available()
 
     # Use the proper launcher
     if args.use_deepspeed and not args.cpu:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -710,7 +710,12 @@ def launch_command(args):
             args.use_cpu = args.cpu
     if args.multi_gpu and args.num_processes == 1:
         args.num_processes = torch.cuda.device_count()
-        warned.append(f"\t`--num_processes` was set to `{args.num_processes}`")
+        if not any("--num_processes" in warn for warn in warned):
+            warned.append(f"\t`--num_processes` was set to `{args.num_processes}`")
+        else:
+            for i, warn in enumerate(warned):
+                if "--num_processes" in warn:
+                    warned[i] = warn.replace("`1`", f"`{args.num_processes}`")
 
     if any(warned):
         message = "The following values were not passed to `accelerate launch` and had defaults used instead:\n"


### PR DESCRIPTION
Creates good defaults for unconfigured `accelerate launch` usage so that the user doesn't have to think much on it. (and actually support not needing to do `accelerate config` again) 