### PR TITLE
Introduce a clean_traceback helper

### DIFF
--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -20,6 +20,7 @@ from torch.utils.data import DataLoader
 
 import evaluate
 from accelerate import Accelerator, DistributedType
+from accelerate.utils import clean_traceback
 from datasets import load_dataset
 from transformers import AutoModelForSequenceClassification, AutoTokenizer, get_linear_schedule_with_warmup, set_seed
 
@@ -142,6 +143,7 @@ def training_function(config, args):
         for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
+            batch = batch[:1]
             outputs = model(**batch)
             loss = outputs.loss
             loss = loss / gradient_accumulation_steps
@@ -187,4 +189,5 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    with clean_traceback():
+        main()

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -143,7 +143,6 @@ def training_function(config, args):
         for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
-            batch = batch[:1]
             outputs = model(**batch)
             loss = outputs.loss
             loss = loss / gradient_accumulation_steps

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ]
     },
     python_requires=">=3.7.0",
-    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.4.0"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.4.0", "rich"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -92,7 +92,6 @@ if is_deepspeed_available():
 from .launch import PrepareForLaunch, get_launch_prefix
 from .memory import find_executable_batch_size
 from .other import (
-    clean_traceback,
     extract_model_from_parallel,
     get_pretty_name,
     patch_environment,
@@ -101,3 +100,4 @@ from .other import (
     write_basic_config,
 )
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
+from .rich import clean_traceback

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -92,6 +92,7 @@ if is_deepspeed_available():
 from .launch import PrepareForLaunch, get_launch_prefix
 from .memory import find_executable_batch_size
 from .other import (
+    clean_traceback,
     extract_model_from_parallel,
     get_pretty_name,
     patch_environment,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -154,3 +154,17 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
     if not path.exists():
         config = ClusterConfig(**config)
         config.to_json_file(path)
+
+
+@contextmanager
+def clean_traceback():
+    """
+    A context manager that uses `rich` to provide a clean traceback when dealing with multiprocessed logs
+    """
+    from rich.console import Console
+
+    console = Console()
+    try:
+        yield
+    except:
+        console.print_exception()

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -20,7 +20,7 @@ import torch
 
 from ..commands.config.cluster import ClusterConfig
 from ..commands.config.config_args import default_json_config_file
-from ..state import AcceleratorState, get_int_from_env
+from ..state import AcceleratorState
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
 
@@ -154,32 +154,3 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
     if not path.exists():
         config = ClusterConfig(**config)
         config.to_json_file(path)
-
-
-def _is_local_main_process():
-    if is_tpu_available():
-        return xm.get_local_ordinal() == 0
-    elif torch.distributed.is_initialized():
-        return (
-            get_int_from_env(
-                ["LOCAL_RANK", "MPI_LOCALRANKID", "OMPI_COMM_WORLD_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK"], 0
-            )
-            == 0
-        )
-    else:
-        return True
-
-
-@contextmanager
-def clean_traceback():
-    """
-    A context manager that uses `rich` to provide a clean traceback when dealing with multiprocessed logs
-    """
-    from rich.console import Console
-
-    console = Console()
-    try:
-        yield
-    except:
-        if _is_local_main_process():
-            console.print_exception()

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -20,7 +20,7 @@ import torch
 
 from ..commands.config.cluster import ClusterConfig
 from ..commands.config.config_args import default_json_config_file
-from ..state import AcceleratorState
+from ..state import AcceleratorState, get_int_from_env
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
 
@@ -156,6 +156,20 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
         config.to_json_file(path)
 
 
+def _is_local_main_process():
+    if is_tpu_available():
+        return xm.get_local_ordinal() == 0
+    elif torch.distributed.is_initialized():
+        return (
+            get_int_from_env(
+                ["LOCAL_RANK", "MPI_LOCALRANKID", "OMPI_COMM_WORLD_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK"], 0
+            )
+            == 0
+        )
+    else:
+        return True
+
+
 @contextmanager
 def clean_traceback():
     """
@@ -167,4 +181,5 @@ def clean_traceback():
     try:
         yield
     except:
-        console.print_exception()
+        if _is_local_main_process():
+            console.print_exception()

--- a/src/accelerate/utils/rich.py
+++ b/src/accelerate/utils/rich.py
@@ -1,0 +1,54 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+
+import torch
+
+from rich import Console
+
+from ..state import get_int_from_env
+from .imports import is_tpu_available
+
+
+if is_tpu_available(check_device=False):
+    import torch_xla.core.xla_model as xm
+
+
+def _is_local_main_process():
+    if is_tpu_available():
+        return xm.get_local_ordinal() == 0
+    elif torch.distributed.is_initialized():
+        return (
+            get_int_from_env(
+                ["LOCAL_RANK", "MPI_LOCALRANKID", "OMPI_COMM_WORLD_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK"], 0
+            )
+            == 0
+        )
+    else:
+        return True
+
+
+@contextmanager
+def clean_traceback(verbose=False):
+    """
+    A context manager that uses `rich` to provide a clean traceback when dealing with multiprocessed logs
+    """
+
+    console = Console()
+    try:
+        yield
+    except:
+        if _is_local_main_process():
+            console.print_exception(suppress=[__file__], show_locals=verbose)

--- a/src/accelerate/utils/rich.py
+++ b/src/accelerate/utils/rich.py
@@ -16,7 +16,7 @@ from contextlib import contextmanager
 
 import torch
 
-from rich import Console
+from rich.console import Console
 
 from ..state import get_int_from_env
 from .imports import is_tpu_available
@@ -41,7 +41,7 @@ def _is_local_main_process():
 
 
 @contextmanager
-def clean_traceback(show_locals:bool=False):
+def clean_traceback(show_locals: bool = False):
     """
     A context manager that uses `rich` to provide a clean traceback when dealing with multiprocessed logs.
 
@@ -55,4 +55,4 @@ def clean_traceback(show_locals:bool=False):
         yield
     except:
         if _is_local_main_process():
-            console.print_exception(suppress=[__file__], show_locals=verbose)
+            console.print_exception(suppress=[__file__], show_locals=show_locals)

--- a/src/accelerate/utils/rich.py
+++ b/src/accelerate/utils/rich.py
@@ -41,9 +41,13 @@ def _is_local_main_process():
 
 
 @contextmanager
-def clean_traceback(verbose=False):
+def clean_traceback(show_locals:bool=False):
     """
-    A context manager that uses `rich` to provide a clean traceback when dealing with multiprocessed logs
+    A context manager that uses `rich` to provide a clean traceback when dealing with multiprocessed logs.
+
+    Args:
+        show_locals (`bool`, *optional*, defaults to False):
+            Whether to show local objects as part of the final traceback
     """
 
     console = Console()


### PR DESCRIPTION
I discovered that Rich will actually automagically avoid the traceback from torch distributed, and just give us the actual broken code if subprocess (or say `accelerate launch`) errors out. As a result we can avoid those infinitely long stack traces.

This PR introduces a context manager that enables this filtering. To use it, in your main function just add:
```diff
if __name__ == "__main__":
+   with clean_traceback():
        main()
```

Example trace before:
```
Traceback (most recent call last):
  File "nlp_example.py", line 193, in <module>
    main()
  File "nlp_example.py", line 188, in main
    training_function(config, args)
  File "nlp_example.py", line 146, in training_function
    batch = batch[:1]
  File "/home/zach_mueller_huggingface_co/transformers/src/transformers/tokenization_utils_base.py", line 241, in __getitem__
    "Indexing with integers (to access backend Encoding for a given batch index) "
KeyError: 'Indexing with integers (to access backend Encoding for a given batch index) is not available when using Python based tokenizers'
Traceback (most recent call last):
  File "nlp_example.py", line 193, in <module>
    main()
  File "nlp_example.py", line 188, in main
    training_function(config, args)
  File "nlp_example.py", line 146, in training_function
    batch = batch[:1]
  File "/home/zach_mueller_huggingface_co/transformers/src/transformers/tokenization_utils_base.py", line 241, in __getitem__
    "Indexing with integers (to access backend Encoding for a given batch index) "
KeyError: 'Indexing with integers (to access backend Encoding for a given batch index) is not available when using Python based tokenizers'
ERROR:torch.distributed.elastic.multiprocessing.api:failed (exitcode: 1) local_rank: 0 (pid: 14914) of binary: /opt/conda/bin/python3.7
Traceback (most recent call last):
  File "/opt/conda/bin/torchrun", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/elastic/multiprocessing/errors/__init__.py", line 345, in wrapper
    return f(*args, **kwargs)
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/run.py", line 724, in main
    run(args)
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/run.py", line 718, in run
    )(*cmd_args)
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/launcher/api.py", line 131, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/launcher/api.py", line 247, in launch_agent
    failures=result.failures,
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
nlp_example.py FAILED
------------------------------------------------------------
Failures:
[1]:
  time      : 2022-07-22_23:44:41
  host      : zach-multi-gpu.c.huggingface-ml.internal
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 14915)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2022-07-22_23:44:41
  host      : zach-multi-gpu.c.huggingface-ml.internal
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 14914)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
============================================================
Traceback (most recent call last):
  File "/opt/conda/bin/accelerate", line 33, in <module>
    sys.exit(load_entry_point('accelerate', 'console_scripts', 'accelerate')())
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/accelerate_cli.py", line 43, in main
    args.func(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/launch.py", line 734, in launch_command
    multi_gpu_launcher(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/launch.py", line 374, in multi_gpu_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['torchrun', '--nproc_per_node', '2', 'nlp_example.py']' returned non-zero exit status 1.
```

Example trace after:

```
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/rich.py:47 in clean_traceback  │
│                                                                                                  │
│ /home/zach_mueller_huggingface_co/accelerate/examples/nlp_example.py:193 in <module>             │
│                                                                                                  │
│   190                                                                                            │
│   191 if __name__ == "__main__":                                                                 │
│   192 │   with clean_traceback():                                                                │
│ ❱ 193 │   │   main()                                                                             │
│   194                                                                                            │
│                                                                                                  │
│ /home/zach_mueller_huggingface_co/accelerate/examples/nlp_example.py:188 in main                 │
│                                                                                                  │
│   185 │   parser.add_argument("--cpu", action="store_true", help="If passed, will train on the   │
│   186 │   args = parser.parse_args()                                                             │
│   187 │   config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}                   │
│ ❱ 188 │   training_function(config, args)                                                        │
│   189                                                                                            │
│   190                                                                                            │
│   191 if __name__ == "__main__":                                                                 │
│                                                                                                  │
│ /home/zach_mueller_huggingface_co/accelerate/examples/nlp_example.py:146 in training_function    │
│                                                                                                  │
│   143 │   │   for step, batch in enumerate(train_dataloader):                                    │
│   144 │   │   │   # We could avoid this line since we set the accelerator with `device_placeme   │
│   145 │   │   │   batch.to(accelerator.device)                                                   │
│ ❱ 146 │   │   │   batch = batch[:1]                                                              │
│   147 │   │   │   outputs = model(**batch)                                                       │
│   148 │   │   │   loss = outputs.loss                                                            │
│   149 │   │   │   loss = loss / gradient_accumulation_steps                                      │
│                                                                                                  │
│ /home/zach_mueller_huggingface_co/transformers/src/transformers/tokenization_utils_base.py:241   │
│ in __getitem__                                                                                   │
│                                                                                                  │
│    238 │   │   │   return self._encodings[item]                                                  │
│    239 │   │   else:                                                                             │
│    240 │   │   │   raise KeyError(                                                               │
│ ❱  241 │   │   │   │   "Indexing with integers (to access backend Encoding for a given batch in  │
│    242 │   │   │   │   "is not available when using Python based tokenizers"                     │
│    243 │   │   │   )                                                                             │
│    244                                                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
KeyError: 'Indexing with integers (to access backend Encoding for a given batch index) is not available when using Python 
based tokenizers'
```