### PR TITLE
Fix tests, add wandb to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Mac .DS_Store
 .DS_Store
+
+# More test things
+wandb

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,9 +17,10 @@ import os
 import re
 import shutil
 import tempfile
-import torch
 import unittest
 from unittest import mock
+
+import torch
 
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import TempDirTestCase, require_trackers, run_command, slow

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -17,6 +17,7 @@ import os
 import re
 import shutil
 import tempfile
+import torch
 import unittest
 from unittest import mock
 
@@ -169,8 +170,16 @@ class FeatureExamplesTests(TempDirTestCase):
         --resume_from_checkpoint {os.path.join(self.tmpdir, "step_2")}
         """.split()
         output = run_command(self._launch_args + testargs, return_stdout=True)
-        self.assertNotIn("epoch 0:", output)
-        self.assertIn("epoch 1:", output)
+        if torch.cuda.is_available():
+            num_processes = torch.cuda.device_count()
+        else:
+            num_processes = 1
+        if num_processes > 1:
+            self.assertNotIn("epoch 0:", output)
+            self.assertIn("epoch 1:", output)
+        else:
+            self.assertIn("epoch 0:", output)
+            self.assertIn("epoch 1:", output)
 
     @slow
     def test_cross_validation(self):


### PR DESCRIPTION
Actually fixes the multi-gpu examples, also added the `wandb` folder to the gitignore since it may be run when testing the tracking and create a `wandb` folder in the repo. 