### PR TITLE
Fix gather_for_metrics

### DIFF
--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -241,7 +241,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -207,9 +207,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics(
-                    (predictions, batch["labels"]), eval_dataloader
-                )
+                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
                 metric.add_batch(
                     predictions=predictions,
                     references=references,
@@ -228,7 +226,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), test_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
             fold_predictions.append(predictions.cpu())
             if i == 0:
                 # We need all of the test predictions

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -279,9 +279,7 @@ def training_function(config, args):
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
                 # It is slightly faster to call this once, than multiple times
-                predictions, references = accelerator.gather_for_metrics(
-                    (predictions, batch["labels"]), eval_dataloader
-                )
+                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -174,7 +174,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -186,9 +186,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics(
-                    (predictions, batch["labels"]), eval_dataloader
-                )
+                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -191,7 +191,7 @@ def training_function(config, args):
                     # Otherwise we add the number of samples seen
                     samples_seen += references.shape[0]
             # All of this can be avoided if you use `Accelerator.gather_for_metrics` instead of `Accelerator.gather`:
-            # accelerator.gather_for_metrics((predictions, references), eval_dataloader)
+            # accelerator.gather_for_metrics((predictions, references))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -199,7 +199,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -239,7 +239,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, labels = accelerator.gather_for_metrics((predictions, batch["label"]), eval_dataloader)
+            predictions, labels = accelerator.gather_for_metrics((predictions, batch["label"]))
             accurate_preds = predictions == labels
             accurate += accurate_preds.long().sum()
 

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -217,7 +217,7 @@ def training_function(config, args):
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
             # It is slightly faster to call this once, than multiple times
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -173,7 +173,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, labels = accelerator.gather_for_metrics((predictions, batch["label"]), eval_dataloader)
+            predictions, labels = accelerator.gather_for_metrics((predictions, batch["label"]))
             accurate_preds = predictions == labels
             num_elems += accurate_preds.shape[0]
             accurate += accurate_preds.long().sum()

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -158,7 +158,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]), eval_dataloader)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -952,8 +952,7 @@ class Accelerator:
                 if self.gradient_state.end_of_dataloader:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
-                        return tensor[: dataloader.total_dataset_length - self.gradient_state.samples_seen]
-
+                        return tensor[: (self.gradient_state.samples_seen * 2) - (dataloader.total_dataset_length - 4)]
                     return recursively_apply(_adjust_samples, tensor)
                 else:
                     # Not at the end of the dataloader, no need to adjust the tensors

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -934,7 +934,7 @@ class Accelerator:
         """
         return gather(tensor)
 
-    def gather_for_metrics(self, tensor, dataloader):
+    def gather_for_metrics(self, tensor):
         """
         Gathers `tensor` and potentially drops duplicates in the last batch if on a distributed system. Should be used
         for gathering the inputs and targets for metric calculation.
@@ -942,17 +942,21 @@ class Accelerator:
         Args:
             tensor (`torch.Tensor`, or a nested tuple/list/dictionary of `torch.Tensor`):
                 The tensors for calculating metrics across all processes.
-            dataloader (`torch.utils.data.DataLoader`):
-                A dataloader prepared with `Accelerator.prepare`
         """
         tensor = self.gather(tensor)
         if self.use_distributed:
+            if self.gradient_state.remainder == -1:
+                logger.warn(
+                    "The used dataset had no length, returning gathered tensors. You should drop the remainder yourself."
+                )
+                return tensor
             try:
                 # Then see if we're on the last batch of our eval dataloader
                 if self.gradient_state.end_of_dataloader:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
-                        return tensor[: (self.gradient_state.samples_seen * 2) - (dataloader.total_dataset_length - 4)]
+                        return tensor[: self.gradient_state.remainder]
+
                     return recursively_apply(_adjust_samples, tensor)
                 else:
                     # Not at the end of the dataloader, no need to adjust the tensors

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -946,7 +946,7 @@ class Accelerator:
         tensor = self.gather(tensor)
         if self.use_distributed:
             if self.gradient_state.remainder == -1:
-                logger.warn(
+                logger.info(
                     "The used dataset had no length, returning gathered tensors. You should drop the remainder yourself."
                 )
                 return tensor

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -138,6 +138,10 @@ class BatchSamplerShard(BatchSampler):
         self.batch_size = batch_sampler.batch_size
         self.drop_last = batch_sampler.drop_last
 
+    @property
+    def total_length(self):
+        return len(self.batch_sampler)
+
     def __len__(self):
         if self.split_batches:
             return len(self.batch_sampler)
@@ -332,7 +336,11 @@ class DataLoaderShard(DataLoader):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.generator)
         self.gradient_state._set_end_of_dataloader(False)
-        self.gradient_state._set_samples_seen(0)
+        try:
+            length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
+            self.gradient_state._set_remainder(length % self.batch_size)
+        except:
+            self.gradient_state._set_remainder(-1)
         dataloader_iter = super().__iter__()
         # We iterate one batch ahead to check when we are at the end
         try:
@@ -346,12 +354,10 @@ class DataLoaderShard(DataLoader):
                 if self.device is not None:
                     current_batch = send_to_device(current_batch, self.device)
                 next_batch = next(dataloader_iter)
-                self.gradient_state._iterate_samples_seen(find_batch_size(current_batch))
                 yield current_batch
                 current_batch = next_batch
             except StopIteration:
                 self.gradient_state._set_end_of_dataloader(True)
-                self.gradient_state._iterate_samples_seen(find_batch_size(current_batch))
                 yield current_batch
                 break
 
@@ -365,7 +371,10 @@ class DataLoaderShard(DataLoader):
 
     @property
     def total_dataset_length(self):
-        return len(self.dataset)
+        if hasattr("total_length", self.dataset):
+            return self.dataset.total_length
+        else:
+            return len(self.dataset)
 
 
 class DataLoaderDispatcher(DataLoader):
@@ -453,7 +462,11 @@ class DataLoaderDispatcher(DataLoader):
 
     def __iter__(self):
         self.gradient_state._set_end_of_dataloader(False)
-        self.gradient_state._set_samples_seen(0)
+        try:
+            length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
+            self.gradient_state._set_remainder(length % self.batch_size)
+        except:
+            self.gradient_state._set_remainder(-1)
         main_iterator = None
         if self.state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
@@ -487,11 +500,9 @@ class DataLoaderDispatcher(DataLoader):
             next_batch, next_batch_info, next_skip = self._fetch_batches(main_iterator)
             batch = slice_tensors(batch, data_slice)
             if not self._stop_iteration:
-                self.gradient_state._iterate_samples_seen(batch_size)
                 yield batch
                 batch, batch_info, skip = next_batch, next_batch_info, next_skip
             else:
-                self.gradient_state._iterate_samples_seen(batch_size)
                 self.gradient_state._set_end_of_dataloader(True)
                 yield batch
                 break

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -338,9 +338,10 @@ class DataLoaderShard(DataLoader):
         self.gradient_state._set_end_of_dataloader(False)
         try:
             length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
-            self.gradient_state._set_remainder(length % self.batch_size)
+            self.gradient_state._set_remainder(length % self.total_batch_size)
         except:
-            self.gradient_state._set_remainder(-1)
+            # We can safely pass because the default is -1
+            pass
         dataloader_iter = super().__iter__()
         # We iterate one batch ahead to check when we are at the end
         try:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -339,7 +339,7 @@ class DataLoaderShard(DataLoader):
         try:
             length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
             self.gradient_state._set_remainder(length % self.total_batch_size)
-        except:
+        except Exception:
             # We can safely pass because the default is -1
             pass
         dataloader_iter = super().__iter__()

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -258,6 +258,7 @@ class GradientState:
 
         - **sync_gradients** (`bool`) -- Whether the gradients should be synced
         - **end_of_dataloader** (`bool`) -- Whether we have reached the end the current dataloader
+        - **remainder** (`int`) -- The number of extra samples that were added from padding the dataloader
     """
 
     _shared_state = {}
@@ -267,14 +268,14 @@ class GradientState:
         if not getattr(self, "initialized", False):
             self.sync_gradients = True
             self.end_of_dataloader = False
-            self.samples_seen = 0
+            self.remainder = 0
         self.initialized = True
 
     def __repr__(self):
         return (
             f"Sync Gradients: {self.sync_gradients}\n"
             f"At end of current dataloader: {self.end_of_dataloader}\n"
-            f"Samples seen: {self.samples_seen}"
+            f"Extra samples added: {self.remainder}"
         )
 
     def _set_sync_gradients(self, sync_gradients):
@@ -285,10 +286,6 @@ class GradientState:
         "Private function that sets whether the end of the current dataloader has been reached. Users should not have to call this."
         self.end_of_dataloader = end_of_dataloader
 
-    def _set_samples_seen(self, samples_seen):
-        "Private function that sets the number of samples iterated over. Users should not have to call this."
-        self.samples_seen = samples_seen
-
-    def _iterate_samples_seen(self, iteration: int = 1):
-        "Private function that iterates the number of samples seen by an iteration. Users should not have to call this."
-        self._set_samples_seen(self.samples_seen + iteration)
+    def _set_remainder(self, remainder):
+        "Private function that sets the number of remaining samples at the end of the dataloader"
+        self.remainder = remainder

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -268,7 +268,7 @@ class GradientState:
         if not getattr(self, "initialized", False):
             self.sync_gradients = True
             self.end_of_dataloader = False
-            self.remainder = 0
+            self.remainder = -1
         self.initialized = True
 
     def __repr__(self):


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/575 by completely changing how we check for the number of samples to drop. Instead uses modulo to learn how many extra samples there are initially, allowing us to simplify the logic.