### PR TITLE
Small fixes for balanced device maps

### DIFF
--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -365,7 +365,11 @@ class ModelingUtilsTester(unittest.TestCase):
         model = ModelForTest()
         # model has size 236: linear1 64, batchnorm 72, linear2 100
         max_memory = get_balanced_memory(model, max_memory={0: 200, 1: 200})
-        self.assertDictEqual({0: 118, 1: 200}, max_memory)
+        self.assertDictEqual({0: 200, 1: 200}, max_memory)
 
         max_memory = get_balanced_memory(model, max_memory={0: 300, 1: 300})
-        self.assertDictEqual({0: 118, 1: 215}, max_memory)
+        self.assertDictEqual({0: 215, 1: 300}, max_memory)
+
+        # Last device always get max memory to give more buffer and avoid accidental CPU offload
+        max_memory = get_balanced_memory(model, max_memory={0: 300, 1: 500})
+        self.assertDictEqual({0: 215, 1: 500}, max_memory)


### PR DESCRIPTION
This PR adds a couple of fixes to the balanced device map API, as using it on small models has given me a couple of errors.
- First the GPU 0 should also have the buffer (contrarily to the initial implementation) because it always saves memory for the largest layer inside `infer_auto_device_map` (so if we don't give it the buffer, we end up with way less on the GPU 0).
- Then we need to give extra room on the last GPU to avoid accidental CPU offload if one or two parameters end up without device at the end. The easiest way is just to leave it with the max memory.

