### PR TITLE
Pass in config_kwargs to init

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1032,7 +1032,13 @@ class Accelerator:
         """
         wait_for_everyone()
 
-    def init_trackers(self, project_name: str, config: Optional[dict] = None, init_kwargs: Optional[dict] = {}):
+    def init_trackers(
+        self,
+        project_name: str,
+        config: Optional[dict] = None,
+        init_kwargs: Optional[dict] = {},
+        config_kwargs: Optional[dict] = {},
+    ):
         """
         Initializes a run for all trackers stored in `self.log_with`, potentially with starting configurations
 
@@ -1044,6 +1050,12 @@ class Accelerator:
             init_kwargs (`dict`, *optional*):
                 A nested dictionary of kwargs to be passed to a specific tracker's `__init__` function. Should be
                 formatted like this:
+                ```python
+                {"wandb": {"allow_val_change": True}}
+                ```
+            config_kwargs (`dict`, *optional*):
+                A nested dictionary of kwargs to be passed to a specific tracker's experiment configuration function
+                (if supported). Should be formatted like this:
                 ```python
                 {"wandb": {"tags": ["tag_a", "tag_b"]}}
                 ```
@@ -1064,7 +1076,7 @@ class Accelerator:
                     self.trackers.append(tracker_init(project_name, **init_kwargs.get(str(tracker), {})))
         if config is not None:
             for tracker in self.trackers:
-                tracker.store_init_configuration(config)
+                tracker.store_init_configuration(config, **config_kwargs.get(str(tracker), {}))
 
     @on_main_process
     def get_tracker(self, name: str):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -70,7 +70,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         pass
 
     @abstractmethod
-    def store_init_configuration(self, values: dict):
+    def store_init_configuration(self, values: dict, **kwargs):
         """
         Logs `values` as hyperparameters for the run. Implementations should use the experiment configuration
         functionality of a tracking API.
@@ -140,7 +140,7 @@ class TensorBoardTracker(GeneralTracker):
     def tracker(self):
         return self.writer
 
-    def store_init_configuration(self, values: dict):
+    def store_init_configuration(self, values: dict, **kwargs):
         """
         Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
 
@@ -211,7 +211,7 @@ class WandBTracker(GeneralTracker):
     def tracker(self):
         return self.run.run
 
-    def store_init_configuration(self, values: dict):
+    def store_init_configuration(self, values: dict, **kwargs):
         """
         Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
 
@@ -219,8 +219,10 @@ class WandBTracker(GeneralTracker):
             values (Dictionary `str` to `bool`, `str`, `float` or `int`):
                 Values to be stored as initial hyperparameters as key-value pairs. The values need to have type `bool`,
                 `str`, `float`, `int`, or `None`.
+            kwargs:
+                Additional key word arguments passed along to the `wandb.config.update` method.
         """
-        wandb.config.update(values)
+        wandb.config.update(values, **kwargs)
         logger.info("Stored initial configuration hyperparameters to WandB")
 
     def log(self, values: dict, step: Optional[int] = None, **kwargs):
@@ -275,7 +277,7 @@ class CometMLTracker(GeneralTracker):
     def tracker(self):
         return self.writer
 
-    def store_init_configuration(self, values: dict):
+    def store_init_configuration(self, values: dict, **kwargs):
         """
         Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
 


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/597

Lets you pass in a new `config_kwargs` to `init_trackers` that lets you set any config kwargs if they are supported by that tracker kind. (Currently just wandb)