### PR TITLE
Remove redundant `.run` in `WandBTracker`.

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -209,7 +209,7 @@ class WandBTracker(GeneralTracker):
 
     @property
     def tracker(self):
-        return self.run.run
+        return self.run
 
     def store_init_configuration(self, values: dict):
         """


### PR DESCRIPTION
Fix the "AttributeError: 'Run' object has no attribute 'run'" error caused by the redundant `.run` in `WandBTracker`.