### PR TITLE
Correct dtype casting

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -677,7 +677,7 @@ def load_checkpoint_in_model(
         else:
             for param_name, param in checkpoint.items():
                 module_name = param_name
-                if dtype is not None:
+                if dtype is not None and not str(param.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):
                     param = param.to(dtype)
                 while len(module_name) > 0 and module_name not in device_map:
                     module_name = ".".join(module_name.split(".")[:-1])


### PR DESCRIPTION
# What does this PR do?

This PR fixes a small "pre-bug" where in some very niche cases model buffers are saved in `int`, `uint` or `bool`. Therefore sometimes there is no need to cast their `dtype` to the desired `dtype` and we want to keep them in their native `dtype`.

I don't know if this is relevant but I ran `tests/test_big_modeling.py` slow tests to make sure this does not break anything on a multi-GPU setup (2x Tesla T4 16GB)

cc @sgugger @muellerzr 