### PR TITLE
Fix DeepSpeed CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Run test on GPUs
         run: |
           source activate accelerate
-          make test
+          make test_big_modeling
+          make test_core
+          make test_integrations
 
       - name: Run examples on GPUs
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -57,11 +57,15 @@ jobs:
           git fetch && git checkout ${{ github.sha }}
           pip install -e . --no-deps
 
-      - name: Run test on GPUs
+      - name: Run core and big modeling tests on GPUs
         run: |
           source activate accelerate
           make test_big_modeling
           make test_core
+
+      - name: Run Integration tests on GPUs
+        run: |
+          source activate accelerate
           make test_integrations
 
       - name: Run examples on GPUs

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test_examples:
 
 # Broken down example tests for the CI runners
 test_integrations:
-	python -m pytest -s -v ./tests/deepspeed ./tests/fdsp
+	python -m pytest -s -v ./tests/deepspeed ./tests/fsdp
 test_example_differences:
 	python -m pytest -s -v ./tests/test_examples.py::ExampleDifferenceTests
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,8 @@ test_examples:
 	python -m pytest -s -v ./tests/test_examples.py
 
 # Broken down example tests for the CI runners
+test_integrations:
+	python -m pytest -s -v ./tests/deepspeed ./tests/fdsp
 test_example_differences:
 	python -m pytest -s -v ./tests/test_examples.py::ExampleDifferenceTests
 

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -35,7 +35,6 @@ from accelerate.test_utils.testing import (
     require_cuda,
     require_deepspeed,
     require_multi_gpu,
-    skip,
     slow,
 )
 from accelerate.test_utils.training import RegressionDataset
@@ -697,7 +696,6 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
             with patch_environment(omp_num_threads=1):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
-    @skip
     def test_checkpointing(self):
         self.test_file_path = os.path.join(self.test_scripts_folder, "test_checkpointing.py")
         cmd = [


### PR DESCRIPTION
Fixes the DeepSpeed CI on the runner by just separating out the integration tests to be ran in a later python process, avoiding the lockup and issues.

Passed CI can be seen here on multi-gpu: https://github.com/huggingface/accelerate/actions/runs/2819545133