### PR TITLE
Fully remove `subprocess` from the multi-gpu launcher

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -50,8 +50,6 @@ from accelerate.utils.dataclasses import SageMakerDistributedType
 
 if is_torch_version(">=", "1.9.0"):
     import torch.distributed.run as distrib_run
-else:
-    import torch.distributed.launch as distrib_run
 
 
 logger = logging.getLogger(__name__)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -450,10 +450,12 @@ def multi_gpu_launcher(args):
         cmd = get_launch_prefix()
         for k,v in vars(args).items():
             if k in TORCH_LAUNCH_PARAMS and v != False:
-                cmd.extend([
-                    f"--{k}", v
-                ])
-        print(cmd)
+                param = [f'--{k}']
+                if v != True:
+                    param.append(v)
+                cmd.extend(param)
+        for arg in args.training_script_args:
+            cmd.extend(["--"])
         # process = subprocess.Popen(cmd, env=current_env)
         # process.wait()
         # if process.returncode != 0:

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -2,7 +2,7 @@
 # There's no way to ignore "F401 '...' imported but unused" warnings in this
 # module, but to preserve other warnings. So, don't check this module at all
 
-from .constants import MODEL_NAME, OPTIMIZER_NAME, RNG_STATE_NAME, SCALER_NAME, SCHEDULER_NAME
+from .constants import MODEL_NAME, OPTIMIZER_NAME, RNG_STATE_NAME, SCALER_NAME, SCHEDULER_NAME, TORCH_LAUNCH_PARAMS
 from .dataclasses import (
     ComputeEnvironment,
     DeepSpeedPlugin,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -91,7 +91,7 @@ if is_deepspeed_available():
         HfDeepSpeedConfig,
     )
 
-from .launch import PrepareForLaunch, get_launch_prefix
+from .launch import PrepareForLaunch, _filter_args, get_launch_prefix
 from .memory import find_executable_batch_size
 from .other import (
     extract_model_from_parallel,

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -32,4 +32,4 @@ DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
 
-TORCH_LAUNCH_PARAMS = """nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port,training_script,training_script_args""".split(",") 
+TORCH_LAUNCH_PARAMS = """nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port,training_script""".split(",") 

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -33,6 +33,28 @@ DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
 
 # These are the args for `torch.distributed.launch` for pytorch < 1.9
-TORCH_LAUNCH_PARAMS = """nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port""".split(
-    ","
-)
+TORCH_LAUNCH_PARAMS = [
+    "nnodes",
+    "nproc_per_node",
+    "rdzv_backend",
+    "rdzv_endpoint",
+    "rdzv_id",
+    "rdzv_conf",
+    "standalone",
+    "max_restarts",
+    "monitor_interval",
+    "start_method",
+    "role",
+    "module",
+    "m",
+    "no_python",
+    "run_path",
+    "log_dir",
+    "r",
+    "redirects",
+    "t",
+    "tee",
+    "node_rank",
+    "master_addr",
+    "master_port",
+]

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -31,3 +31,5 @@ FSDP_STATE_DICT_TYPE = ["FULL_STATE_DICT", "LOCAL_STATE_DICT", "SHARDED_STATE_DI
 DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
+
+TORCH_LAUNCH_PARAMS = """nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port,training_script,training_script_args""".split(",") 

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -31,5 +31,3 @@ FSDP_STATE_DICT_TYPE = ["FULL_STATE_DICT", "LOCAL_STATE_DICT", "SHARDED_STATE_DI
 DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
-
-TORCHRUN_PARAMS = "nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port,training_script,training_script_args"

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -32,4 +32,7 @@ DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
 
-TORCH_LAUNCH_PARAMS = """nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port,training_script""".split(",") 
+# These are the args for `torch.distributed.launch` for pytorch < 1.9
+TORCH_LAUNCH_PARAMS = """nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port""".split(
+    ","
+)

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -31,3 +31,5 @@ FSDP_STATE_DICT_TYPE = ["FULL_STATE_DICT", "LOCAL_STATE_DICT", "SHARDED_STATE_DI
 DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich"]
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
+
+TORCHRUN_PARAMS = "nnodes,nproc_per_node,rdzv_backend,rdzv_endpoint,rdzv_id,rdzv_conf,standalone,max_restarts,monitor_interval,start_method,role,module,m,no_python,run_path,log_dir,r,redirects,t,tee,node_rank,master_addr,master_port,training_script,training_script_args"

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -16,10 +16,15 @@ import os
 import sys
 
 import torch
-import torch.distributed.run as distrib_run
 
 from ..utils import is_torch_version
 from .dataclasses import DistributedType
+
+
+if is_torch_version(">=", "1.9.0"):
+    import torch.distributed.run as distrib_run
+else:
+    import torch.distributed.launch as distrib_run
 
 
 def get_launch_prefix():

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -48,6 +48,8 @@ def _filter_args(args):
     distrib_args = distrib_run.parse_args(vars(args))
     for key, value in vars(args).items():
         setattr(distrib_args, key, value)
+    if is_torch_version("<", "1.9.0"):
+        setattr(distrib_args, "use_env", True)
     return distrib_args
 
 


### PR DESCRIPTION
# Completely remove all `subprocess` from `multi_gpu_launcher`

## What does this add?

This PR removes the subprocess parts of the `multi_gpu` launcher code and replaces it with raw torchrun. This reduces the number of subprocesses had (2 to 1, just torchrun's), and lets us actually get a readable stack trace now that isn't overwhelmed with subprocess bits (so we can play with them now! 🥳 )

## Who is it for?

Users of Accelerate

## Why is it needed?

Old stack traces were very hard to read and parse through, especially to play with since it's a double-nesting of subprocess. Now only one instance of subprocess is used, leaving us with the following new stack trace example:

```bash
(base) zach_mueller_huggingface_co@zach-multi-gpu:~/accelerate/examples$ accelerate launch nlp_example.py 
The following values were not passed to `accelerate launch` and had defaults used instead:
        `--num_cpu_threads_per_process` was set to `2` to improve out-of-box performance
To avoid this warning pass in values for each of the problematic parameters or run `accelerate config`.
Traceback (most recent call last):
  File "nlp_example.py", line 193, in <module>
    main()
  File "nlp_example.py", line 189, in main
    training_function(config, args)
  File "nlp_example.py", line 100, in training_function
    raise ValueError()
ValueError
Traceback (most recent call last):
  File "nlp_example.py", line 193, in <module>
    main()
  File "nlp_example.py", line 189, in main
    training_function(config, args)
  File "nlp_example.py", line 100, in training_function
    raise ValueError()
ValueError
ERROR:torch.distributed.elastic.multiprocessing.api:failed (exitcode: 1) local_rank: 0 (pid: 165573) of binary: /opt/conda/bin/python3.7
Traceback (most recent call last):
  File "/opt/conda/bin/accelerate", line 33, in <module>
    sys.exit(load_entry_point('accelerate', 'console_scripts', 'accelerate')())
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/accelerate_cli.py", line 43, in main
    args.func(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/launch.py", line 823, in launch_command
    multi_gpu_launcher(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/launch.py", line 442, in multi_gpu_launcher
    distrib_run.run(distrib_args)
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/run.py", line 755, in run
    )(*cmd_args)
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/launcher/api.py", line 131, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/opt/conda/lib/python3.7/site-packages/torch/distributed/launcher/api.py", line 247, in launch_agent
    failures=result.failures,
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
nlp_example.py FAILED
------------------------------------------------------------
Failures:
[1]:
  time      : 2022-08-09_23:17:00
  host      : zach-multi-gpu.c.huggingface-ml.internal
  rank      : 1 (local_rank: 1)
  exitcode  : 1 (pid: 165574)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2022-08-09_23:17:00
  host      : zach-multi-gpu.c.huggingface-ml.internal
  rank      : 0 (local_rank: 0)
  exitcode  : 1 (pid: 165573)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
============================================================
```

A follow-up PR will help with the repeating structure of this stack trace via rich

It would also be a good idea to see what the other launchers would take to run them via native python to launch rather than calling subprocess to call the script/entrypoint

## What parts of the API does this impact?

### User-facing:

Absolutely nothing

### Internal structure:

Functionally nothing

## TODO:

- Support non torchrun (torch.distributed)