### PR TITLE
minor tracker fixes for complete* examples

### DIFF
--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -105,8 +105,6 @@ def training_function(config, args):
     # We need to initialize the trackers we use, and also store our configuration
     if args.with_tracking and accelerator.is_main_process:
         run = os.path.split(__file__)[-1].split(".")[0]
-        if args.logging_dir:
-            run = os.path.join(args.logging_dir, run)
         accelerator.init_trackers(run, config)
 
     # Grab all the image filenames

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -77,8 +77,6 @@ def training_function(config, args):
     # We need to initialize the trackers we use, and also store our configuration
     if args.with_tracking and accelerator.is_main_process:
         run = os.path.split(__file__)[-1].split(".")[0]
-        if args.logging_dir:
-            run = os.path.join(args.logging_dir, run)
         accelerator.init_trackers(run, config)
 
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -251,7 +251,7 @@ class AcceleratorState:
         if self.distributed_type == DistributedType.DEEPSPEED:
             repr += f"ds_config: {self.deepspeed_plugin.deepspeed_config}\n"
         else:
-            f"Mixed precision type: {mixed_precision}\n"
+            repr += f"Mixed precision type: {mixed_precision}\n"
         return repr
 
     # For backward compatibility


### PR DESCRIPTION
# What does this PR do?
1. `with_tracking` was failing for complete example scripts with error `/ in name of the run` (logs/complete_... was being used as run). This fixes it.
2. A minor fix in printing accelerate state's mixed precision