### PR TITLE
Use torchrun for multinode

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -37,6 +37,7 @@ def get_cluster_input():
     num_machines = 1
     main_process_ip = None
     main_process_port = None
+    rdzv_backend = "static"
     if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_CPU]:
         num_machines = _ask_field(
             "How many different machines will you use (use more than 1 for multi-node training)? [1]: ",

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -56,6 +56,9 @@ def get_cluster_input():
                 "What is the port you will use to communicate with the main process? ",
                 lambda x: int(x),
             )
+            rdzv_backend = _ask_field(
+                "What rendezvous backend will you use? ('static', 'c10d', ...)", default="static"
+            )
 
     if distributed_type == DistributedType.NO:
         use_cpu = _ask_field(
@@ -323,4 +326,5 @@ def get_cluster_input():
         deepspeed_config=deepspeed_config,
         fsdp_config=fsdp_config,
         use_cpu=use_cpu,
+        rdzv_backend=rdzv_backend,
     )

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -137,6 +137,7 @@ class ClusterConfig(BaseConfig):
     num_machines: int = 1
     main_process_ip: Optional[str] = None
     main_process_port: Optional[int] = None
+    rdzv_backend: Optional[str] = "static"
     main_training_function: str = "main"
 
     # args for deepspeed_plugin

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -376,8 +376,7 @@ def multi_gpu_launcher(args):
         setattr(args, "nproc_per_node", str(num_processes // num_machines))
         setattr(args, "nnodes", str(num_machines))
         setattr(args, "node_rank", str(args.machine_rank))
-        setattr(args, "master_addr", str(args.main_process_ip))
-        setattr(args, "master_port", str(args.main_process_port))
+        setattr(args, "rdzv_endpoint", f"{args.main_process_ip}:{args.main_process_port}")
     else:
         setattr(args, "nproc_per_node", str(num_processes))
         if args.main_process_port is not None:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import torch
+import torch.distributed.run as distrib_run
 
 import psutil
 from accelerate.commands.config import default_config_file, load_config_from_file
@@ -48,7 +49,6 @@ from accelerate.utils.dataclasses import SageMakerDistributedType
 from rich import get_console
 from rich.logging import RichHandler
 
-import torch.distributed.run as distrib_run
 
 FORMAT = "%(message)s"
 logging.basicConfig(format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
@@ -448,14 +448,13 @@ def multi_gpu_launcher(args):
             current_env["FSDP_STATE_DICT_TYPE"] = str(args.fsdp_state_dict_type)
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
     if is_torch_version("<", "1.9.0"):
-        raise NotImplementedError(f'Multi-node training requires pytorch>=1.9.0')
+        raise NotImplementedError("Multi-node training requires pytorch>=1.9.0")
 
     debug = getattr(args, "debug", False)
     args = _filter_args(args)
     with patch_environment(**current_env):
         try:
-            print(args)
-            # distrib_run.run(args)
+            distrib_run.run(args)
         except:
             if debug:
                 console = get_console()

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -32,7 +32,6 @@ from accelerate.commands.config import default_config_file, load_config_from_fil
 from accelerate.commands.config.config_args import SageMakerConfig
 from accelerate.state import get_int_from_env
 from accelerate.utils import (
-    TORCH_LAUNCH_PARAMS,
     ComputeEnvironment,
     DistributedType,
     PrecisionType,
@@ -49,9 +48,7 @@ from accelerate.utils.dataclasses import SageMakerDistributedType
 from rich import get_console
 from rich.logging import RichHandler
 
-
-if is_torch_version(">=", "1.9.0"):
-    import torch.distributed.run as distrib_run
+import torch.distributed.run as distrib_run
 
 FORMAT = "%(message)s"
 logging.basicConfig(format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
@@ -451,33 +448,20 @@ def multi_gpu_launcher(args):
         if args.fsdp_state_dict_type is not None:
             current_env["FSDP_STATE_DICT_TYPE"] = str(args.fsdp_state_dict_type)
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
-    if is_torch_version(">=", "1.9.0"):
-        debug = getattr(args, "debug", False)
-        args = _filter_args(args)
-        with patch_environment(**current_env):
-            console = get_console()
+    if is_torch_version("<", "1.9.0"):
+        raise NotImplementedError(f'Multi-node training requires pytorch>=1.9.0')
 
-            try:
-                distrib_run.run(args)
-            except:
-                if debug:
-                    console.print("\n[bold red]Using --debug, `torch.distributed` Stack Trace:[/bold red]")
-                    console.print_exception(suppress=[__file__], show_locals=False)
-    else:
-        # We still have to use subprocess, the user won't get a clean traceback as a result
-        cmd = get_launch_prefix()
-        for k, v in vars(args).items():
-            if k in TORCH_LAUNCH_PARAMS and v:
-                param = [f"--{k}"]
-                if type(v) != bool:
-                    param.append(v)
-                cmd.extend(param)
-        cmd.append(args.training_script)
-        cmd.extend(args.training_script_args)
-        process = subprocess.Popen(cmd, env=current_env)
-        process.wait()
-        if process.returncode != 0:
-            raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
+    debug = getattr(args, "debug", False)
+    args = _filter_args(args)
+    with patch_environment(**current_env):
+        try:
+            print(args)
+            # distrib_run.run(args)
+        except:
+            if debug:
+                console = get_console()
+                console.print("\n[bold red]Using --debug, `torch.distributed` Stack Trace:[/bold red]")
+                console.print_exception(suppress=[__file__], show_locals=False)
 
 
 def deepspeed_launcher(args):


### PR DESCRIPTION
Sets `torchrun` to be the only way to run multi-node, and adds a `rdvz_endpoint` param during config setup. 