### PR TITLE
accelerate requires torch 1.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         ]
     },
     python_requires=">=3.7.0",
-    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.4.0", "rich"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.9.0", "rich"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
We noticed our DeepSpeed + Accelerate unit tests are failing on torch 1.8. `torch.distributed.run` requires torch 1.9+ so bumping your min torch version to 1.9. If you'd rather guard the torch run import depending on torch version feel free to close this PR :)

https://github.com/microsoft/DeepSpeed/runs/7810439796?check_suite_focus=true