### PR TITLE
make `init_trackers` to launch on main process

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1032,6 +1032,7 @@ class Accelerator:
         """
         wait_for_everyone()
 
+    @on_main_process
     def init_trackers(self, project_name: str, config: Optional[dict] = None, init_kwargs: Optional[dict] = {}):
         """
         Initializes a run for all trackers stored in `self.log_with`, potentially with starting configurations


### PR DESCRIPTION
While on distributed setup the `accelerator.init_trackers()` method initializes multiple runs of the tracker on all processes. It should be initialized on the main process. Added a `@on_main_process` decorator to achieve the expected behavior.

@muellerzr @sgugger