### PR TITLE
Add aim tracker for accelerate

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -20,7 +20,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import List, Optional, Union
 
 from .logging import get_logger
-from .utils import LoggerType, is_comet_ml_available, is_tensorboard_available, is_wandb_available
+from .utils import LoggerType, is_aim_available, is_comet_ml_available, is_tensorboard_available, is_wandb_available
 
 
 _available_trackers = []
@@ -39,6 +39,11 @@ if is_comet_ml_available():
     from comet_ml import Experiment
 
     _available_trackers.append(LoggerType.COMETML)
+
+if is_aim_available():
+    from aim import Run
+
+    _available_trackers.append(LoggerType.AIM)
 
 
 logger = get_logger(__name__)
@@ -320,7 +325,74 @@ class CometMLTracker(GeneralTracker):
         logger.info("CometML run closed")
 
 
-LOGGER_TYPE_TO_CLASS = {"tensorboard": TensorBoardTracker, "wandb": WandBTracker, "comet_ml": CometMLTracker}
+class AimTracker(GeneralTracker):
+    """
+    A `Tracker` class that supports `aim`. Should be initialized at the start of your script.
+
+    Args:
+        run_name (`str`):
+            The name of the experiment run.
+        kwargs:
+            Additional key word arguments passed along to the `Run.__init__` method.
+    """
+
+    name = "aim"
+    requires_logging_directory = True
+
+    def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
+        self.run_name = run_name
+        self.writer = Run(repo=logging_dir, experiment=run_name, **kwargs)
+        logger.info(f"Initialized Aim project {self.run_name}")
+        logger.info(
+            "Make sure to log any initial configurations with `self.store_init_configuration` before training!"
+        )
+
+    @property
+    def tracker(self):
+        return self.writer
+
+    def store_init_configuration(self, values: dict):
+        """
+        Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
+
+        Args:
+            values (`dict`):
+                Values to be stored as initial hyperparameters as key-value pairs.
+        """
+        self.writer["hparams"].update(values)
+
+    def log(self, values: dict, step: Optional[int], **kwargs):
+        """
+        Logs `values` to the current run.
+
+        Args:
+            values (`dict`):
+                Values to be logged as key-value pairs.
+            step (`int`, *optional*):
+                The run step. If included, the log will be affiliated with this step.
+            kwargs (`dict`, *optional*):
+                Additional key word arguments passed along to the `Run.track` method. Valid keys include `context` and
+                `epoch`.
+        """
+        # Note: replace this with the dictionary support when merged
+        context = kwargs.pop("context", {})
+        epoch = kwargs.pop("epoch", None)
+        for key, value in values.items():
+            self.writer.track(value, key, step=step, epoch=epoch, context=context)
+
+    def finish(self):
+        """
+        Closes `aim` writer
+        """
+        self.writer.finalize()
+
+
+LOGGER_TYPE_TO_CLASS = {
+    "aim": AimTracker,
+    "comet_ml": CometMLTracker,
+    "tensorboard": TensorBoardTracker,
+    "wandb": WandBTracker,
+}
 
 
 def filter_trackers(

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -341,7 +341,8 @@ class AimTracker(GeneralTracker):
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
         self.run_name = run_name
-        self.writer = Run(run_hash=run_name, repo=logging_dir, **kwargs)
+        self.writer = Run(repo=logging_dir, **kwargs)
+        self.writer.name = self.run_name
         logger.info(f"Initialized Aim project {self.run_name}")
         logger.info(
             "Make sure to log any initial configurations with `self.store_init_configuration` before training!"

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -341,7 +341,7 @@ class AimTracker(GeneralTracker):
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
         self.run_name = run_name
-        self.writer = Run(repo=logging_dir, experiment=run_name, **kwargs)
+        self.writer = Run(run_hash=run_name, repo=logging_dir, **kwargs)
         logger.info(f"Initialized Aim project {self.run_name}")
         logger.info(
             "Make sure to log any initial configurations with `self.store_init_configuration` before training!"
@@ -370,15 +370,12 @@ class AimTracker(GeneralTracker):
                 Values to be logged as key-value pairs.
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
-            kwargs (`dict`, *optional*):
-                Additional key word arguments passed along to the `Run.track` method. Valid keys include `context` and
-                `epoch`.
+            kwargs:
+                Additional key word arguments passed along to the `Run.track` method.
         """
         # Note: replace this with the dictionary support when merged
-        context = kwargs.pop("context", {})
-        epoch = kwargs.pop("epoch", None)
         for key, value in values.items():
-            self.writer.track(value, name=key, step=step, epoch=epoch, context=context)
+            self.writer.track(value, name=key, step=step, **kwargs)
 
     def finish(self):
         """

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -378,13 +378,13 @@ class AimTracker(GeneralTracker):
         context = kwargs.pop("context", {})
         epoch = kwargs.pop("epoch", None)
         for key, value in values.items():
-            self.writer.track(value, key, step=step, epoch=epoch, context=context)
+            self.writer.track(value, name=key, step=step, epoch=epoch, context=context)
 
     def finish(self):
         """
         Closes `aim` writer
         """
-        self.writer.finalize()
+        self.writer.close()
 
 
 LOGGER_TYPE_TO_CLASS = {

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -343,8 +343,8 @@ class AimTracker(GeneralTracker):
         self.run_name = run_name
         self.writer = Run(repo=logging_dir, **kwargs)
         self.writer.name = self.run_name
-        logger.info(f"Initialized Aim project {self.run_name}")
-        logger.info(
+        logger.debug(f"Initialized Aim project {self.run_name}")
+        logger.debug(
             "Make sure to log any initial configurations with `self.store_init_configuration` before training!"
         )
 
@@ -360,7 +360,7 @@ class AimTracker(GeneralTracker):
             values (`dict`):
                 Values to be stored as initial hyperparameters as key-value pairs.
         """
-        self.writer["hparams"].update(values)
+        self.writer["hparams"] = values
 
     def log(self, values: dict, step: Optional[int], **kwargs):
         """

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -20,6 +20,7 @@ from .dataclasses import (
 )
 from .imports import (
     get_ccl_version,
+    is_aim_available,
     is_apex_available,
     is_bf16_available,
     is_boto3_available,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -196,6 +196,7 @@ class LoggerType(BaseEnum):
     """
 
     ALL = "all"
+    AIM = "aim"
     TENSORBOARD = "tensorboard"
     WANDB = "wandb"
     COMETML = "comet_ml"

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -93,6 +93,10 @@ def is_datasets_available():
     return importlib.util.find_spec("datasets") is not None
 
 
+def is_aim_available():
+    return importlib.util.find_spec("aim") is not None
+
+
 def is_tensorboard_available():
     return importlib.util.find_spec("tensorboard") is not None or importlib.util.find_spec("tensorboardX") is not None
 


### PR DESCRIPTION
Adds support for [Aim](https://github.com/aimhubio/aim)

cc @gorarakelyan to make sure it all seems alright with you! I thought about an easy `set_context` func but since our trackers all work off an abstract base class, seemed easier to just leave it as a kwarg. Let me know if there's something I seem to have missed! (Based this off my no-accelerate training script I wrote)

`Accelerator` will automatically only log on the main process and initialize the trackers on the main process, hence why there isn't any special "Are we on the main process" things in this PR. 