### PR TITLE
Saving hyperparams in yaml file for Tensorboard for #521

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -19,6 +19,7 @@ import os
 import time
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import List, Optional, Union
+
 import yaml
 
 from .logging import get_logger
@@ -144,8 +145,8 @@ class TensorBoardTracker(GeneralTracker):
 
     def store_init_configuration(self, values: dict):
         """
-        Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
-        Stores the hyperparameters in a yaml file for future use.
+        Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment. Stores the
+        hyperparameters in a yaml file for future use.
 
         Args:
             values (Dictionary `str` to `bool`, `str`, `float` or `int`):
@@ -155,11 +156,12 @@ class TensorBoardTracker(GeneralTracker):
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
         project_run_name = time.time()
-        with open(os.path.join(self.logging_dir, project_run_name,  "hparams.yml"), "w") as outfile:
+        with open(os.path.join(self.logging_dir, project_run_name, "hparams.yml"), "w") as outfile:
             try:
                 yaml.dump(values, outfile)
             except yaml.representer.RepresenterError:
-                logger.info("Serialization to store hyperparmeters failed")
+                logger.error("Serialization to store hyperparameters failed")
+                raise
         logger.info("Stored initial configuration hyperparameters to TensorBoard and hparams yaml file")
 
     def log(self, values: dict, step: Optional[int] = None, **kwargs):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -153,7 +153,7 @@ class TensorBoardTracker(GeneralTracker):
         """
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
-        with open("hparams.yaml", "w") as outfile:
+        with open("self.logging_dir/hparams.yaml", "w") as outfile:
             yaml.dump(values, outfile)
         logger.info("Stored initial configuration hyperparameters to TensorBoard and hparams yaml file")
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -19,6 +19,8 @@ import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import List, Optional, Union
 
+import yaml
+
 from .logging import get_logger
 from .utils import LoggerType, is_comet_ml_available, is_tensorboard_available, is_wandb_available
 
@@ -151,7 +153,9 @@ class TensorBoardTracker(GeneralTracker):
         """
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
-        logger.info("Stored initial configuration hyperparameters to TensorBoard")
+        with open("hparams.yaml", "w") as outfile:
+            yaml.dump(values, outfile)
+        logger.info("Stored initial configuration hyperparameters to TensorBoard and hparams yaml file")
 
     def log(self, values: dict, step: Optional[int] = None, **kwargs):
         """

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -156,7 +156,7 @@ class TensorBoardTracker(GeneralTracker):
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
         project_run_name = time.time()
-        with open(os.path.join(self.logging_dir, project_run_name, "hparams.yml"), "w") as outfile:
+        with open(os.path.join(self.logging_dir, str(project_run_name), "hparams.yml"), "w") as outfile:
             try:
                 yaml.dump(values, outfile)
             except yaml.representer.RepresenterError:

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -153,7 +153,7 @@ class TensorBoardTracker(GeneralTracker):
         """
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
-        with open("self.logging_dir/hparams.yaml", "w") as outfile:
+        with open(os.path.join(self.logging_dir, "hparams.yml"), "w") as outfile:
             yaml.dump(values, outfile)
         logger.info("Stored initial configuration hyperparameters to TensorBoard and hparams yaml file")
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -16,9 +16,9 @@
 # Provide a project dir name, then each type of logger gets stored in project/{`logging_dir`}
 
 import os
+import time
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import List, Optional, Union
-
 import yaml
 
 from .logging import get_logger
@@ -145,6 +145,7 @@ class TensorBoardTracker(GeneralTracker):
     def store_init_configuration(self, values: dict):
         """
         Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
+        Stores the hyperparameters in a yaml file for future use.
 
         Args:
             values (Dictionary `str` to `bool`, `str`, `float` or `int`):
@@ -153,8 +154,12 @@ class TensorBoardTracker(GeneralTracker):
         """
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
-        with open(os.path.join(self.logging_dir, "hparams.yml"), "w") as outfile:
-            yaml.dump(values, outfile)
+        project_run_name = time.time()
+        with open(os.path.join(self.logging_dir, project_run_name,  "hparams.yml"), "w") as outfile:
+            try:
+                yaml.dump(values, outfile)
+            except yaml.representer.RepresenterError:
+                logger.info("Serialization to store hyperparmeters failed")
         logger.info("Stored initial configuration hyperparameters to TensorBoard and hparams yaml file")
 
     def log(self, values: dict, step: Optional[int] = None, **kwargs):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -156,7 +156,9 @@ class TensorBoardTracker(GeneralTracker):
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
         project_run_name = time.time()
-        with open(os.path.join(self.logging_dir, str(project_run_name), "hparams.yml"), "w") as outfile:
+        dir_name = os.path.join(self.logging_dir, str(project_run_name))
+        os.makedirs(dir_name, exist_ok=True)
+        with open(os.path.join(dir_name, "hparams.yml"), "w") as outfile:
             try:
                 yaml.dump(values, outfile)
             except yaml.representer.RepresenterError:


### PR DESCRIPTION
This PR saves the hyperparameters in a YAML file for Tensorboard tracker. By default, the HParams dashboard currently requires at least one hparam and at least one metric defined in the hparams configuration but since we have no metric, the hyperparameters will be stored in a YAML file . The changes have been implemented in `tracking.py`.