### PR TITLE
Fix scheduler bug on TPUs

### DIFF
--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -17,6 +17,7 @@
 import warnings
 
 from .state import AcceleratorState
+from .utils import DistributedType
 
 
 warnings.filterwarnings("ignore", category=UserWarning, module="torch.optim.lr_scheduler")
@@ -51,7 +52,7 @@ class AcceleratedScheduler:
         self.step_with_optimizer = step_with_optimizer
 
     def step(self, *args, **kwargs):
-        if not self.step_with_optimizer:
+        if not self.step_with_optimizer or AcceleratorState().distributed_type == DistributedType.TPU:
             # No link between scheduler and optimizer -> just step
             self.scheduler.step(*args, **kwargs)
             return

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -52,7 +52,7 @@ class AcceleratedScheduler:
         self.step_with_optimizer = step_with_optimizer
 
     def step(self, *args, **kwargs):
-        if not self.step_with_optimizer or AcceleratorState().distributed_type == DistributedType.TPU:
+        if not self.step_with_optimizer:
             # No link between scheduler and optimizer -> just step
             self.scheduler.step(*args, **kwargs)
             return
@@ -61,7 +61,7 @@ class AcceleratedScheduler:
         for opt in self.optimizers:
             if opt.step_was_skipped:
                 return
-        if self.split_batches:
+        if self.split_batches or AcceleratorState().distributed_type == DistributedType.TPU:
             # Split batches -> the training dataloader batch size is not changed so one step per training step
             self.scheduler.step(*args, **kwargs)
         else:


### PR DESCRIPTION
TPUs should not be stepped n times like we do on GPUs. This will result in a *severe* performance degradation, and was the source of this issue https://github.com/huggingface/accelerate/issues/526

As a result, this PR adds a hard check if we `step_with_optimizer` to have it also perform the step if we are on the TPU.

Fixes https://github.com/huggingface/accelerate/issues/526