### PR TITLE
Improve docstrings and add examples where it makes sense

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -140,7 +140,7 @@ class Accelerator:
             A list of `KwargHandler` to customize how the objects related to distributed training or mixed precision
             are created. See [kwargs](kwargs) for more information.
 
-    **Attributes:**
+    **Available attributes:**
 
         - **device** (`torch.device`) -- The device to use.
         - **distributed_type** ([`~utils.DistributedType`]) -- The distributed training configuration.
@@ -463,6 +463,28 @@ class Accelerator:
         Args:
             model (`torch.nn.Module`):
                 PyTorch Module that was prepared with `Accelerator.prepare`
+
+        Example:
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator()
+        >>> dataloader, model, optimizer = accelerator.prepare(dataloader, model, optimizer)
+        >>> input_a = next(iter(dataloader))
+        >>> input_b = next(iter(dataloader))
+
+        >>> with accelerator.no_sync():
+        ...     outputs = model(input_a)
+        ...     loss = loss_func(outputs)
+        ...     accelerator.backward(loss)
+        ...     # No synchronization across processes, only accumulate gradients
+        >>> outputs = model(input_b)
+        >>> accelerator.backward(loss)
+        >>> # Synchronization across all processes
+        >>> optimizer.step()
+        >>> optimizer.zero_grad()
+        ```
         """
         context = contextlib.nullcontext
         if self.use_distributed:
@@ -492,6 +514,24 @@ class Accelerator:
         Args:
             model (`torch.nn.Module`):
                 PyTorch Module that was prepared with `Accelerator.prepare`
+
+        Example:
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator(gradient_accumulation_steps=2)
+        >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
+
+        >>> with accelerator.accumulate():
+        ...     for input, output in dataloader:
+        ...         outputs = model(input)
+        ...         loss = loss_func(outputs)
+        ...         loss.backward()
+        ...         optimizer.step()
+        ...         scheduler.step()
+        ...         optimizer.zero_grad()
+        ```
         """
         self._do_sync()
         if self.sync_gradients:
@@ -873,7 +913,10 @@ class Accelerator:
 
     def backward(self, loss, **kwargs):
         """
-        Use `accelerator.backward(loss)` in lieu of `loss.backward()`.
+        Scales the gradients in accordance to `Accelerator.gradient_accumulation_steps` and calls the correct
+        `backward()` based on the configuration.
+
+        Should be used in lieu of `loss.backward()`.
         """
         loss /= self.gradient_accumulation_steps
         if self.distributed_type == DistributedType.DEEPSPEED:
@@ -906,6 +949,24 @@ class Accelerator:
     def clip_grad_norm_(self, parameters, max_norm, norm_type=2):
         """
         Should be used in place of `torch.nn.utils.clip_grad_norm_`.
+
+        Example:
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator(gradient_accumulation_steps=2)
+        >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
+
+        >>> for (input, target) in dataloader:
+        ...     optimizer.zero_grad()
+        ...     output = model(input)
+        ...     loss = loss_func(output, target)
+        ...     accelerator.backward(loss)
+        ...     if accelerator.sync_gradients:
+        ...         accelerator.clip_grad_norm_(model.parameters(), max_grad_norm)
+        ...     optimizer.step()
+        ```
         """
         if self.distributed_type == DistributedType.FSDP:
             self.unscale_gradients()
@@ -923,6 +984,24 @@ class Accelerator:
     def clip_grad_value_(self, parameters, clip_value):
         """
         Should be used in place of `torch.nn.utils.clip_grad_value_`.
+
+        Example:
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator(gradient_accumulation_steps=2)
+        >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
+
+        >>> for (input, target) in dataloader:
+        ...     optimizer.zero_grad()
+        ...     output = model(input)
+        ...     loss = loss_func(output, target)
+        ...     accelerator.backward(loss)
+        ...     if accelerator.sync_gradients:
+        ...         accelerator.clip_grad_value_(model.parameters(), clip_value)
+        ...     optimizer.step()
+        ```
         """
         if self.distributed_type in [DistributedType.DEEPSPEED, DistributedType.FSDP]:
             raise Exception("DeepSpeed and FSDP  do not support `clip_grad_value_`. Use `clip_grad_norm_` instead.")
@@ -1124,6 +1203,13 @@ class Accelerator:
         """
         Saves the current states of the model, optimizer, scaler, RNG generators, and registered objects.
 
+        <Tip>
+
+        Should only be used when wanting to save a checkpoint during training and restoring the state in the same
+        environment.
+
+        </Tip>
+
         Args:
             output_dir (`str` or `os.PathLike`):
                 The name of the folder to save all relevant weights and states.
@@ -1178,6 +1264,12 @@ class Accelerator:
     def load_state(self, input_dir: str):
         """
         Loads the current states of the model, optimizer, scaler, RNG generators, and registered objects.
+
+        <Tip>
+
+        Should only be used in conjunction with [`Accelerator.save_state`].
+
+        </Tip>
 
         Args:
             input_dir (`str` or `os.PathLike`):

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -49,15 +49,20 @@ def get_logger(name: str):
 
     If a log should be called on all processes, pass `main_process_only=False`
 
-    E.g.
-    ```python
-    logger.info("My log", main_process_only=False)
-    logger.debug("My log", main_process_only=False)
-    ```
-
     Args:
         name (`str`):
             The name for the logger, such as `__file__`
+
+    Example:
+
+    ```python
+    >>> from accelerate.logging import get_logger
+
+    >>> logger = get_logger(__name__)
+
+    >>> logger.info("My log", main_process_only=False)
+    >>> logger.debug("My log", main_process_only=True)
+    ```
     """
     logger = logging.getLogger(name)
     return MultiProcessAdapter(logger, {})

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -28,7 +28,7 @@ class AcceleratedScheduler:
     to avoid making a scheduler step too fast when gradients went overflow and there was no training step (in mixed
     precision training)
 
-    When performing gradient accumulation scheduler lengths should not be changed accordingly, accelerate will always
+    When performing gradient accumulation scheduler lengths should not be changed accordingly, Accelerate will always
     step the scheduler to account for it.
 
     Args:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -50,14 +50,14 @@ class AcceleratorState:
     """
     Singleton class that has information about the current training environment.
 
-    **Attributes:**
+    **Available attributes:**
 
         - **device** (`torch.device`) -- The device to use.
         - **distributed_type** ([`~accelerate.state.DistributedType`]) -- The type of distributed environment currently
           in use.
         - **local_process_index** (`int`) -- The index of the current process on the current server.
-        - **mixed_precision** (`str`) -- Whether or not the current script will use mixed precision. If you are using
-          mixed precision, define if you want to use FP16 or BF16 (bfloat16) as the floating point.
+        - **mixed_precision** (`str`) -- Whether or not the current script will use mixed precision, and if so the type
+          of mixed precision being performed.
         - **num_processes** (`int`) -- The number of processes currently launched in parallel.
         - **process_index** (`int`) -- The index of the current process.
     """
@@ -278,10 +278,11 @@ class GradientState:
     """
     Singleton class that has information related to gradient synchronization for gradient accumulation
 
-    **Attributes:**
+    **Available attributes:**
 
         - **end_of_dataloader** (`bool`) -- Whether we have reached the end the current dataloader
         - **remainder** (`int`) -- The number of extra samples that were added from padding the dataloader
+        - **sync_gradients** (`bool`) -- Whether the gradients should be synced across all devices
     """
 
     _shared_state = {}
@@ -310,5 +311,5 @@ class GradientState:
         self.end_of_dataloader = end_of_dataloader
 
     def _set_remainder(self, remainder):
-        "Private function that sets the number of remaining samples at the end of the dataloader"
+        "Private function that sets the number of remaining samples at the end of the dataloader. Users should not have to call this."
         self.remainder = remainder


### PR DESCRIPTION
This PR fixes a few nits in the docstrings (such as the Attributes issue discussed awhile ago in more places), as well as adds a few examples to places where users could get confused on the usage, or it is not extremely straightforward to use from the documentation. 

These specific cases are ones where numerous issues have been opened, asking how to use the specific item. 

This helps us document it in two places: the official documentation/tutorials for folks who need more information, and the docstring for folks who do not and just need the boilerplate.