### PR TITLE
Fix multi-node issues from launch

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -59,9 +59,9 @@ def get_cluster_input():
                 lambda x: int(x),
             )
             same_network = _ask_field(
-                "Are all the machines on the same network? [yes/NO]: ",
+                "Are all the machines on the same network? [YES/no]: ",
                 _convert_yes_no_to_bool,
-                default=False,
+                default=True,
                 error_message="Please enter yes or no.",
             )
             if not same_network:

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -336,4 +336,5 @@ def get_cluster_input():
         fsdp_config=fsdp_config,
         use_cpu=use_cpu,
         rdzv_backend=rdzv_backend,
+        same_network=same_network,
     )

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -37,7 +37,8 @@ def get_cluster_input():
     num_machines = 1
     main_process_ip = None
     main_process_port = None
-    rdzv_backend = "static"
+    rdzv_backend = None
+    same_network = True
     if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_CPU]:
         num_machines = _ask_field(
             "How many different machines will you use (use more than 1 for multi-node training)? [1]: ",
@@ -57,9 +58,16 @@ def get_cluster_input():
                 "What is the port you will use to communicate with the main process? ",
                 lambda x: int(x),
             )
-            rdzv_backend = _ask_field(
-                "What rendezvous backend will you use? ('static', 'c10d', ...)", default="static"
+            same_network = _ask_field(
+                "Are all the machines on the same network? [yes/NO]: ",
+                _convert_yes_no_to_bool,
+                default=False,
+                error_message="Please enter yes or no.",
             )
+            if not same_network:
+                rdzv_backend = _ask_field(
+                    "What rendezvous backend will you use? ('static', 'c10d', ...): ", default="static"
+                )
 
     if distributed_type == DistributedType.NO:
         use_cpu = _ask_field(

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -37,7 +37,7 @@ def get_cluster_input():
     num_machines = 1
     main_process_ip = None
     main_process_port = None
-    rdzv_backend = None
+    rdzv_backend = "static"
     same_network = True
     if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_CPU]:
         num_machines = _ask_field(

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -137,7 +137,7 @@ class ClusterConfig(BaseConfig):
     num_machines: int = 1
     main_process_ip: Optional[str] = None
     main_process_port: Optional[int] = None
-    rdzv_backend: Optional[str] = None
+    rdzv_backend: Optional[str] = "static"
     same_network: Optional[bool] = False
     main_training_function: str = "main"
 

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -137,7 +137,8 @@ class ClusterConfig(BaseConfig):
     num_machines: int = 1
     main_process_ip: Optional[str] = None
     main_process_port: Optional[int] = None
-    rdzv_backend: Optional[str] = "static"
+    rdzv_backend: Optional[str] = None
+    same_network: Optional[bool] = False
     main_training_function: str = "main"
 
     # args for deepspeed_plugin

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -375,15 +375,21 @@ def simple_launcher(args):
 def multi_gpu_launcher(args):
     num_processes = getattr(args, "num_processes")
     num_machines = getattr(args, "num_machines")
+    main_process_ip = getattr(args, "main_process_ip")
+    main_process_port = getattr(args, "main_process_port")
     if num_machines > 1:
         setattr(args, "nproc_per_node", str(num_processes // num_machines))
         setattr(args, "nnodes", str(num_machines))
         setattr(args, "node_rank", str(args.machine_rank))
-        setattr(args, "rdzv_endpoint", f"{args.main_process_ip}:{args.main_process_port}")
+        if getattr(args, "same_network"):
+            setattr(args, "master_addr", str(main_process_ip))
+            setattr(args, "master_port", str(main_process_port))
+        else:
+            setattr(args, "rdzv_endpoint", f"{main_process_ip}:{main_process_port}")
     else:
         setattr(args, "nproc_per_node", str(num_processes))
-        if args.main_process_port is not None:
-            setattr(args, "master_port", str(args.main_process_port))
+        if main_process_port is not None:
+            setattr(args, "master_port", str(main_process_port))
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -380,7 +380,7 @@ def multi_gpu_launcher(args):
     if num_machines > 1:
         setattr(args, "nproc_per_node", str(num_processes // num_machines))
         setattr(args, "nnodes", str(num_machines))
-        setattr(args, "node_rank", str(args.machine_rank))
+        setattr(args, "node_rank", int(args.machine_rank))
         if getattr(args, "same_network"):
             setattr(args, "master_addr", str(main_process_ip))
             setattr(args, "master_port", str(main_process_port))

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -47,7 +47,7 @@ def _filter_args(args):
     new_args, _ = distrib_args.parse_known_args()
 
     for key, value in vars(args).items():
-        if key in vars(new_args).keys():
+        if key in vars(new_args).keys() and value is not None:
             setattr(new_args, key, value)
     return new_args
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -47,7 +47,7 @@ def _filter_args(args):
     new_args, _ = distrib_args.parse_known_args()
 
     for key, value in vars(args).items():
-        if key in vars(new_args).keys() and value is not None:
+        if key in vars(new_args).keys():
             setattr(new_args, key, value)
     return new_args
 


### PR DESCRIPTION
Solves a few lasting issues with the `torchrun` migration. Noteably:

- When doing multinode on the same network, it would just hang forever. 
- Defaults were not being set properly and overriden for `same_network`
- `node_rank` needs to be an `int`, not a string