### PR TITLE
:bug: fix

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -745,6 +745,7 @@ class Accelerator:
                 )
         else:
             batch_size_per_device = deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"]
+            result = [obj for obj in args]
 
         config_kwargs = {
             "train_micro_batch_size_per_gpu": batch_size_per_device,


### PR DESCRIPTION
### What does this PR do?

1. PR #676 introduced :bug: and resulted in DeepSpeed tests failing on hosted GPU runners. This PR fixes it as seen below

![Screenshot 2022-09-06 at 9 24 54 PM](https://user-images.githubusercontent.com/13534540/188681029-271dcdf3-131c-4ffb-b53a-d0616273c4ca.png)
