### PR TITLE
Fixing support for Apple Silicon GPU in `notebook_launcher`

### DIFF
--- a/docs/source/usage_guides/mps.mdx
+++ b/docs/source/usage_guides/mps.mdx
@@ -19,7 +19,7 @@ This will map computational graphs and primitives on the MPS Graph framework and
 For more information please refer official documents [Introducing Accelerated PyTorch Training on Mac](https://pytorch.org/blog/introducing-accelerated-pytorch-training-on-mac/)
 and [MPS BACKEND](https://pytorch.org/docs/stable/notes/mps.html).
 
-### Benefits of Training and Inference using Apple M1 Chips
+### Benefits of Training and Inference using Apple Silicon Chips
 
 1. Enables users to train larger networks or batch sizes locally
 2. Reduces data retrieval latency and provides the GPU with direct access to the full memory store due to unified memory architecture. 

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -121,12 +121,17 @@ def notebook_launcher(function, args=(), num_processes=None, use_fp16=False, mix
                 start_processes(launcher, args=args, nprocs=num_processes, start_method="fork")
 
         else:
-            # No need for a distributed launch otherwise as it's either CPU or one GPU.
-            if torch.cuda.is_available():
+            # No need for a distributed launch otherwise as it's either CPU, GPU or MPS.
+            use_mps_device = "false"
+            if torch.backends.mps.is_available():
+                print("Launching training on MPS.")
+                use_mps_device = "true"
+            elif torch.cuda.is_available():
                 print("Launching training on one GPU.")
             else:
                 print("Launching training on CPU.")
-            function(*args)
+            with patch_environment(use_mps_device=use_mps_device):
+                function(*args)
 
 
 def debug_launcher(function, args=(), num_processes=2):


### PR DESCRIPTION
# What does this PR do?
1. Fixes #692 . 

Running [accelerate_examples/simple_nlp_example.ipynb](https://github.com/huggingface/notebooks/blob/main/examples/accelerate_examples/simple_nlp_example.ipynb) now runs on Mac Apple Silicon when available as shown below.

![Screenshot 2022-09-10 at 7 27 01 PM](https://user-images.githubusercontent.com/13534540/189590410-3dd21b15-eeed-4e0c-9443-6db556a29056.png)

<img width="316" alt="Screenshot 2022-09-10 at 7 46 50 PM" src="https://user-images.githubusercontent.com/13534540/189590795-d1d05ab5-ef21-4a0f-a07a-7bf5535b82da.png">

