### PR TITLE
override DeepSpeed `grad_acc_steps` from `accelerator` obj

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -747,6 +747,12 @@ class Accelerator:
             batch_size_per_device = deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"]
             result = [obj for obj in args]
 
+        if self.gradient_accumulation_steps != deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"]:
+            warnings.warn(
+                f"WARNING: Updating DeepSpeed's gradient accumulation steps to {self.gradient_accumulation_steps} from "
+                f"{deepspeed_plugin.deepspeed_config['gradient_accumulation_steps']}."
+            )
+            deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"] = self.gradient_accumulation_steps
         config_kwargs = {
             "train_micro_batch_size_per_gpu": batch_size_per_device,
             "train_batch_size": batch_size_per_device

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -748,8 +748,8 @@ class Accelerator:
             result = [obj for obj in args]
 
         if self.gradient_accumulation_steps != deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"]:
-            warnings.warn(
-                f"WARNING: Updating DeepSpeed's gradient accumulation steps to {self.gradient_accumulation_steps} from "
+            logger.info(
+                f"Updating DeepSpeed's gradient accumulation steps to {self.gradient_accumulation_steps} from "
                 f"{deepspeed_plugin.deepspeed_config['gradient_accumulation_steps']}."
             )
             deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"] = self.gradient_accumulation_steps


### PR DESCRIPTION
### What does this PR do?
1. Override DeepSpeed `grad_acc_steps` from `accelerator` obj when they aren't same.