### PR TITLE
Improve `init_empty_weights` to override tensor constructor

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -75,15 +75,31 @@ def init_empty_weights(include_buffers: bool = False):
         if buffer is not None:
             module._buffers[name] = module._buffers[name].to(torch.device("meta"))
 
+    tensor_constructors_to_patch = {
+        torch_function_name: getattr(torch, torch_function_name)
+        for torch_function_name in ["empty", "zeros", "ones", "full"]
+    }
+    def patch_tensor_constructor(fn):
+        def wrapper(*args, **kwargs):
+            kwargs["device"] = torch.device("meta")
+            return fn(*args, **kwargs)
+
+        return wrapper
+
     try:
         nn.Module.register_parameter = register_empty_parameter
         if include_buffers:
             nn.Module.register_buffer = register_empty_buffer
+        for torch_function_name in tensor_constructors_to_patch.keys():
+            setattr(torch, torch_function_name, patch_tensor_constructor(getattr(torch, torch_function_name)))
         yield
     finally:
         nn.Module.register_parameter = old_register_parameter
         if include_buffers:
             nn.Module.register_buffer = old_register_buffer
+        for torch_function_name, old_torch_function in tensor_constructors_to_patch.items():
+            setattr(torch, torch_function_name, old_torch_function)
+
 
 
 def cpu_offload(

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -88,22 +88,12 @@ def init_empty_weights(include_buffers: bool = False):
 
         return wrapper
 
-    # Patch `state_dict` loading
-    # old_torch_load = torch.load
-    # import pickle
-    # def torch_load_empty(f, map_location=None, pickle_module=pickle, **pickle_kwargs):
-    #     # Temporary workaround
-    #     return {}
-    #     # Waiting https://github.com/pytorch/pytorch/pull/82603 in order to get `meta` support in `map_location`
-    #     # return old_torch_load(f, map_location="meta", pickle_module=pickle, **pickle_kwargs)
-
     try:
         nn.Module.register_parameter = register_empty_parameter
         if include_buffers:
             nn.Module.register_buffer = register_empty_buffer
         for torch_function_name in tensor_constructors_to_patch.keys():
             setattr(torch, torch_function_name, patch_tensor_constructor(getattr(torch, torch_function_name)))
-        # torch.load = torch_load_empty
         yield
     finally:
         nn.Module.register_parameter = old_register_parameter
@@ -111,7 +101,6 @@ def init_empty_weights(include_buffers: bool = False):
             nn.Module.register_buffer = old_register_buffer
         for torch_function_name, old_torch_function in tensor_constructors_to_patch.items():
             setattr(torch, torch_function_name, old_torch_function)
-        # torch.load = old_torch_load
 
 
 def cpu_offload(

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -75,6 +75,7 @@ def init_empty_weights(include_buffers: bool = False):
         if buffer is not None:
             module._buffers[name] = module._buffers[name].to(torch.device("meta"))
 
+    # Patch tensor creation
     tensor_constructors_to_patch = {
         torch_function_name: getattr(torch, torch_function_name)
         for torch_function_name in ["empty", "zeros", "ones", "full"]
@@ -83,8 +84,17 @@ def init_empty_weights(include_buffers: bool = False):
         def wrapper(*args, **kwargs):
             kwargs["device"] = torch.device("meta")
             return fn(*args, **kwargs)
-
         return wrapper
+
+    # Patch `state_dict` loading
+    old_torch_load = torch.load
+    import pickle
+    def torch_load_empty(f, map_location=None, pickle_module=pickle, **pickle_kwargs):
+        # Temporary workaround
+        return {}
+        # Waiting https://github.com/pytorch/pytorch/pull/82603 in order to get `meta` support in `map_location`
+        # return old_torch_load(f, map_location="meta", pickle_module=pickle_module, **pickle_kwargs)
+
 
     try:
         nn.Module.register_parameter = register_empty_parameter
@@ -92,6 +102,7 @@ def init_empty_weights(include_buffers: bool = False):
             nn.Module.register_buffer = register_empty_buffer
         for torch_function_name in tensor_constructors_to_patch.keys():
             setattr(torch, torch_function_name, patch_tensor_constructor(getattr(torch, torch_function_name)))
+        torch.load = torch_load_empty
         yield
     finally:
         nn.Module.register_parameter = old_register_parameter
@@ -99,7 +110,7 @@ def init_empty_weights(include_buffers: bool = False):
             nn.Module.register_buffer = old_register_buffer
         for torch_function_name, old_torch_function in tensor_constructors_to_patch.items():
             setattr(torch, torch_function_name, old_torch_function)
-
+        torch.load = old_torch_load
 
 
 def cpu_offload(

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -87,14 +87,13 @@ def init_empty_weights(include_buffers: bool = False):
         return wrapper
 
     # Patch `state_dict` loading
-    old_torch_load = torch.load
-    import pickle
-    def torch_load_empty(f, map_location=None, pickle_module=pickle, **pickle_kwargs):
-        # Temporary workaround
-        return {}
-        # Waiting https://github.com/pytorch/pytorch/pull/82603 in order to get `meta` support in `map_location`
-        # return old_torch_load(f, map_location="meta", pickle_module=pickle_module, **pickle_kwargs)
-
+    # old_torch_load = torch.load
+    # import pickle
+    # def torch_load_empty(f, map_location=None, pickle_module=pickle, **pickle_kwargs):
+    #     # Temporary workaround
+    #     return {}
+    #     # Waiting https://github.com/pytorch/pytorch/pull/82603 in order to get `meta` support in `map_location`
+    #     # return old_torch_load(f, map_location="meta", pickle_module=pickle, **pickle_kwargs)
 
     try:
         nn.Module.register_parameter = register_empty_parameter
@@ -102,7 +101,7 @@ def init_empty_weights(include_buffers: bool = False):
             nn.Module.register_buffer = register_empty_buffer
         for torch_function_name in tensor_constructors_to_patch.keys():
             setattr(torch, torch_function_name, patch_tensor_constructor(getattr(torch, torch_function_name)))
-        torch.load = torch_load_empty
+        # torch.load = torch_load_empty
         yield
     finally:
         nn.Module.register_parameter = old_register_parameter
@@ -110,7 +109,7 @@ def init_empty_weights(include_buffers: bool = False):
             nn.Module.register_buffer = old_register_buffer
         for torch_function_name, old_torch_function in tensor_constructors_to_patch.items():
             setattr(torch, torch_function_name, old_torch_function)
-        torch.load = old_torch_load
+        # torch.load = old_torch_load
 
 
 def cpu_offload(

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -80,10 +80,12 @@ def init_empty_weights(include_buffers: bool = False):
         torch_function_name: getattr(torch, torch_function_name)
         for torch_function_name in ["empty", "zeros", "ones", "full"]
     }
+
     def patch_tensor_constructor(fn):
         def wrapper(*args, **kwargs):
             kwargs["device"] = torch.device("meta")
             return fn(*args, **kwargs)
+
         return wrapper
 
     # Patch `state_dict` loading

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -76,10 +76,13 @@ def init_empty_weights(include_buffers: bool = False):
             module._buffers[name] = module._buffers[name].to(torch.device("meta"))
 
     # Patch tensor creation
-    tensor_constructors_to_patch = {
-        torch_function_name: getattr(torch, torch_function_name)
-        for torch_function_name in ["empty", "zeros", "ones", "full"]
-    }
+    if include_buffers:
+        tensor_constructors_to_patch = {
+            torch_function_name: getattr(torch, torch_function_name)
+            for torch_function_name in ["empty", "zeros", "ones", "full"]
+        }
+    else:
+        tensor_constructors_to_patch = {}
 
     def patch_tensor_constructor(fn):
         def wrapper(*args, **kwargs):


### PR DESCRIPTION
# Summary

`init_empty_weights` actually construct tensors in `cpu` and then moves them to `meta`. Instead we propose to construct tensors in `meta` device directly by overriding default constructors. This is inspired from https://github.com/microsoft/DeepSpeed/blob/c199edac8210e730acfd004c6e2bc3a98c0db903/deepspeed/utils/init_on_device.py This results in a faster loading mechanism with using the `init_empty_weights` context manager.

Additionally we override loading mechanism to return empty dictionary as there's no reason to read the checkpoint since everything is in `meta` (This is a hack as `map_location="meta"` doesn't work yet). Not sure if that's considered too hacky to be integrated inside `accelerate`

Running the following gets accelerated:
```python
from timeit import timeit

from accelerate import init_empty_weights
from transformers import AutoModel

def init_empty_model():
    with init_empty_weights():
        AutoModel.from_pretrained("gpt2")

def main():
    print(timeit(init_empty_model, number=10))
    pass

if __name__ == "__main__":
    main()
```

```
without this PR: 16.627875665999998
with this PR: 6.471049583
with this PR (+ torch.load hack): 4.145832625
```