### PR TITLE
[doc] Fix 404'd link in memory usage guides

### DIFF
--- a/docs/source/usage_guides/memory.mdx
+++ b/docs/source/usage_guides/memory.mdx
@@ -48,4 +48,4 @@ def training_function(args):
 +   inner_training_loop()
 ```
 
-To find out more, check the documentation [here](package_reference/utilities#accelerate.find_executable_batch_size)
+To find out more, check the documentation [here](../package_reference/utilities#accelerate.find_executable_batch_size)

--- a/docs/source/usage_guides/memory.mdx
+++ b/docs/source/usage_guides/memory.mdx
@@ -48,4 +48,4 @@ def training_function(args):
 +   inner_training_loop()
 ```
 
-To find out more, check the documentation [here](../package_reference/utilities#accelerate.find_executable_batch_size)
+To find out more, check the documentation [here](../package_reference/utilities#accelerate.find_executable_batch_size).


### PR DESCRIPTION
Hello!

### Pull request overview
* Fix link that currently 404's in https://huggingface.co/docs/accelerate/main/en/usage_guides/memory.

### Details
The link at the bottom of https://huggingface.co/docs/accelerate/main/en/usage_guides/memory points to https://huggingface.co/docs/accelerate/main/en/usage_guides/package_reference/utilities#accelerate.find_executable_batch_size, which gives a 404.

Note the following in that link:
```
https://huggingface.co/docs/accelerate/main/en/usage_guides/package_reference/utilities#accelerate.find_executable_batch_size
                                               ^^^^^^^^^^^^ ^^^^^^^^^^^^^^^^^
```
The desired resource is only under `package_reference`, and not under `usage_guides`. I've replaced the link with https://huggingface.co/docs/accelerate/main/en/package_reference/utilities#accelerate.find_executable_batch_size by adding `../`.

I've also added a dot at the end of the sentence.

- Tom Aarsen