### PR TITLE
refactor(accelerate): readability improvements

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -125,8 +125,8 @@ class Accelerator:
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
-            If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can also
-            accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
+            If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can
+            also accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.
         dispatch_batches (`bool`, *optional*):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -125,7 +125,7 @@ class Accelerator:
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
-            If `"all`" is selected, will pick up all available trackers in the environment and intialize them. Can also
+            If `"all`" is selected, will pick up all available trackers in the environment and initialize them. Can also
             accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.
@@ -643,7 +643,7 @@ class Accelerator:
                     "The model and the optimizer parameters are not on the same device, which probably means you "
                     "created an optimizer around your model **before** putting on the device. Make sure the line "
                     "model.to(device) is before the optimizer creation in your script or remove it entirely and use "
-                    "the flag default value for `devicement_placement` in your `Accelerator` to let it handle that "
+                    "the flag default value for `device_placement` in your `Accelerator` to let it handle that "
                     "part for you."
                 )
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -125,7 +125,7 @@ class Accelerator:
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
-            If `"all`" is selected, will pick up all available trackers in the environment and initialize them. Can also
+            If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can also
             accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -44,7 +44,7 @@ def init_empty_weights(include_buffers: bool = False):
 
     Example:
 
-    ```pyton
+    ```python
     import torch.nn as nn
     from accelerate import init_empty_weights
 
@@ -324,7 +324,7 @@ def load_checkpoint_and_dispatch(
         dtype (`str` or `torch.dtype`, *optional*):
             If provided, the weights will be converted to that type when loaded.
         offload_state_dict (`bool`, *optional*):
-            If `True`, will temporarily offload the CPU state dict on the hard drive to avoig getting out of CPU RAM if
+            If `True`, will temporarily offload the CPU state dict on the hard drive to avoid getting out of CPU RAM if
             the weight of the CPU state dict + the biggest shard does not fit. Will default to `True` if the device map
             picked contains `"disk"` values.
         preload_module_classes (`List[str]`, *optional*):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -424,8 +424,8 @@ def filter_trackers(
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
-            If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can also
-            accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
+            If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can
+            also accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.
     """

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -424,7 +424,7 @@ def filter_trackers(
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
-            If `"all`" is selected, will pick up all available trackers in the environment and initialize them. Can also
+            If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can also
             accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -424,7 +424,7 @@ def filter_trackers(
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
-            If `"all`" is selected, will pick up all available trackers in the environment and intialize them. Can also
+            If `"all`" is selected, will pick up all available trackers in the environment and initialize them. Can also
             accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -617,7 +617,7 @@ def load_checkpoint_in_model(
         dtype (`str` or `torch.dtype`, *optional*):
             If provided, the weights will be converted to that type when loaded.
         offload_state_dict (`bool`, *optional*, defaults to `False`):
-            If `True`, will temporarily offload the CPU state dict on the hard drive to avoig getting out of CPU RAM if
+            If `True`, will temporarily offload the CPU state dict on the hard drive to avoid getting out of CPU RAM if
             the weight of the CPU state dict + the biggest shard does not fit.
     """
     if offload_folder is None and device_map is not None and "disk" in device_map.values():


### PR DESCRIPTION
Signed-off-by: Ryan Russell <git@ryanrussell.org>

### Description
One-off readability fix-ups in `src/accelerate/*.py`

Grew to a few one-off's when grep'ing to check for more occurrences... 

Seemed reasonable to put these together in a PR. 

Fixes:
- `devicement_placement` -> `device_placement`
- `intialize` -> `initialize`
- `pyton` -> `python`
- `avoig` -> `avoid`