### PR TITLE
Build and Release docker images on a release

### DIFF
--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -1,4 +1,4 @@
-name: Build Docker images (scheduled)
+name: Build Docker images (releases)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -1,0 +1,62 @@
+name: Build Docker images (scheduled)
+
+on:
+  workflow_dispatch:
+  release:
+
+concurrency:
+  group: docker-image-builds
+  cancel-in-progress: false
+
+jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.step1.outputs.version }}
+    steps:
+      - id: step1
+        run: echo "::set-output name=version::$(python setup.py --version)"
+
+  version-cpu:
+    name: "Latest Accelerate CPU [version]"
+    runs-on: ubuntu-latest
+    needs: get-version
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push CPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-cpu
+          push: true
+          tags: huggingface/accelerate-cpu:${{needs.get-version.outputs.version}}
+
+  version-cuda:
+    name: "Latest Accelerate GPU [version]"
+    runs-on: ubuntu-latest
+    needs: get-version
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/accelerate-gpu
+          push: true
+          tags: huggingface/accelerate-gpu:${{needs.get-version.outputs.version}}

--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -3,6 +3,7 @@ name: Build Docker images (releases)
 on:
   workflow_dispatch:
   release:
+    types: [published]
 
 concurrency:
   group: docker-image-builds

--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       version: ${{ steps.step1.outputs.version }}
     steps:
+      - uses: actions/checkout@v3
       - id: step1
         run: echo "::set-output name=version::$(python setup.py --version)"
 

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,19 +1,26 @@
-name: Build Docker images (scheduled)
+name: Build Docker images (releases)
 
 on:
   workflow_dispatch:
-  workflow_call:
-  schedule:
-    - cron: "0 1 * * *"
+  release:
 
 concurrency:
   group: docker-image-builds
   cancel-in-progress: false
 
 jobs:
-  latest-cpu:
-    name: "Latest Accelerate CPU [dev]"
+  get-version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.step1.outputs.version }}
+    steps:
+      - id: step1
+        run: echo "::set-output name=version::$(python setup.py --version)"
+
+  version-cpu:
+    name: "Latest Accelerate CPU [version]"
+    runs-on: ubuntu-latest
+    needs: get-version
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -30,11 +37,12 @@ jobs:
         with:
           context: ./docker/accelerate-cpu
           push: true
-          tags: huggingface/accelerate-cpu
+          tags: huggingface/accelerate-cpu:${{needs.get-version.outputs.version}}
 
-  latest-cuda:
-    name: "Latest Accelerate GPU [dev]"
+  version-cuda:
+    name: "Latest Accelerate GPU [version]"
     runs-on: ubuntu-latest
+    needs: get-version
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -51,4 +59,4 @@ jobs:
         with:
           context: ./docker/accelerate-gpu
           push: true
-          tags: huggingface/accelerate-gpu
+          tags: huggingface/accelerate-gpu:${{needs.get-version.outputs.version}}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -2,26 +2,18 @@ name: Build Docker images (scheduled)
 
 on:
   workflow_dispatch:
-  release:
+  workflow_call:
+  schedule:
+    - cron: "0 1 * * *"
 
 concurrency:
   group: docker-image-builds
   cancel-in-progress: false
 
 jobs:
-  get-version:
+  latest-cpu:
+    name: "Latest Accelerate CPU [dev]"
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.step1.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-      - id: step1
-        run: echo "::set-output name=version::$(python setup.py --version)"
-
-  version-cpu:
-    name: "Latest Accelerate CPU [version]"
-    runs-on: ubuntu-latest
-    needs: get-version
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -38,12 +30,11 @@ jobs:
         with:
           context: ./docker/accelerate-cpu
           push: true
-          tags: huggingface/accelerate-cpu:${{needs.get-version.outputs.version}}
+          tags: huggingface/accelerate-cpu
 
-  version-cuda:
-    name: "Latest Accelerate GPU [version]"
+  latest-cuda:
+    name: "Latest Accelerate GPU [dev]"
     runs-on: ubuntu-latest
-    needs: get-version
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -60,4 +51,4 @@ jobs:
         with:
           context: ./docker/accelerate-gpu
           push: true
-          tags: huggingface/accelerate-gpu:${{needs.get-version.outputs.version}}
+          tags: huggingface/accelerate-gpu

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -1,4 +1,4 @@
-name: Build Docker images (releases)
+name: Build Docker images (scheduled)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -14,6 +14,7 @@ jobs:
     outputs:
       version: ${{ steps.step1.outputs.version }}
     steps:
+      - uses: actions/checkout@v3
       - id: step1
         run: echo "::set-output name=version::$(python setup.py --version)"
 


### PR DESCRIPTION
Introduces a workflow that releases a docker image based on when a Github release has been made. It will pull the version id from the setup.py and that state

Relevant gh docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

Tested this on a separate branch using the current dev version. 

CPU tag can be seen here: https://hub.docker.com/r/huggingface/accelerate-cpu/tags
GPU tag can be seen here: https://hub.docker.com/r/huggingface/accelerate-gpu/tags

FFT, should we just merge these two release workflows together and check if 'dev' is in the version to automatically tag the `latest` tag? Or maybe just publish the prerelease tags? WDYT? 