### PR TITLE
Fix issue with one-cycle logic

### DIFF
--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -69,7 +69,7 @@ class AcceleratedScheduler:
             num_processes = AcceleratorState().num_processes
             for _ in range(num_processes):
                 # Special case when using OneCycle and `drop_last` was not used
-                if getattr(self.scheduler, "total_steps", 0) <= self.scheduler.last_epoch:
+                if self.scheduler.last_epoch <= getattr(self.scheduler, "total_steps", 0):
                     self.scheduler.step(*args, **kwargs)
 
     # Passthroughs

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -69,7 +69,9 @@ class AcceleratedScheduler:
             num_processes = AcceleratorState().num_processes
             for _ in range(num_processes):
                 # Special case when using OneCycle and `drop_last` was not used
-                if self.scheduler.last_epoch <= getattr(self.scheduler, "total_steps", 0):
+                if hasattr(self.scheduler, "total_steps") and self.scheduler._step_count <= self.scheduler.total_steps:
+                    self.scheduler.step(*args, **kwargs)
+                else:
                     self.scheduler.step(*args, **kwargs)
 
     # Passthroughs


### PR DESCRIPTION
Turns out the logic for one-cycle on the scheduler was backwards so `step` was never called.

Fixes https://github.com/huggingface/accelerate/issues/690 and adds some tests