### PR TITLE
Allow for GPU-ID specification on CLI

### DIFF
--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -94,6 +94,7 @@ The following arguments are useful for customization of worker machines
 * `--machine_rank MACHINE_RANK` (`int`) -- The rank of the machine on which this script is launched.
 * `--num_machines NUM_MACHINES` (`int`) -- The total number of machines used in this training.
 * `--num_processes NUM_PROCESSES` (`int`) -- The total number of processes to be launched in parallel.
+* `--gpu-ids` (`str`) -- What GPUs (by id) should be used for training on this machine as a comma-seperated list
 * `--main_process_ip MAIN_PROCESS_IP` (`str`) -- The IP address of the machine of rank 0.
 * `--main_process_port MAIN_PROCESS_PORT` (`int`) -- The port to use to communicate with the machine of rank 0.
 * `--num_cpu_threads_per_process NUM_CPU_THREADS_PER_PROCESS` (`int`) -- The number of CPU threads per process. Can be tuned for optimal performance.

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -35,6 +35,7 @@ def get_cluster_input():
 
     machine_rank = 0
     num_machines = 1
+    gpu_ids = None
     main_process_ip = None
     main_process_port = None
     rdzv_backend = "static"
@@ -293,6 +294,12 @@ def get_cluster_input():
             default=1,
             error_message="Please enter an integer.",
         )
+
+    if distributed_type in [DistributedType.MULTI_GPU, DistributedType.NO] and not use_cpu:
+        gpu_ids = _ask_field(
+            "What GPU(s) (by id) should be used for training on this machine as a comma-seperated list? [all]:",
+            default="all",
+        )
     elif distributed_type in [DistributedType.FSDP, DistributedType.DEEPSPEED]:
         num_processes = _ask_field(
             "How many GPU(s) should be used for distributed training? [1]:",
@@ -325,6 +332,7 @@ def get_cluster_input():
         compute_environment=ComputeEnvironment.LOCAL_MACHINE,
         distributed_type=distributed_type,
         num_processes=num_processes,
+        gpu_ids=gpu_ids,
         mixed_precision=mixed_precision,
         downcast_bf16=downcast_bf16,
         machine_rank=machine_rank,

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -135,6 +135,7 @@ class ClusterConfig(BaseConfig):
     num_processes: int
     machine_rank: int = 0
     num_machines: int = 1
+    gpu_ids: Optional[str] = None
     main_process_ip: Optional[str] = None
     main_process_port: Optional[int] = None
     rdzv_backend: Optional[str] = "static"

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -262,7 +262,7 @@ def launch_command_parser(subparsers=None):
     parser.add_argument(
         "--gpu_ids",
         default="all",
-        help="What GPUs (by id) should be used for training as a comma-seperated list",
+        help="What GPUs (by id) should be used for training on this machine as a comma-seperated list",
     )
     parser.add_argument(
         "--machine_rank", type=int, default=None, help="The rank of the machine on which this script is launched."
@@ -827,6 +827,8 @@ def launch_command(args):
             args.tpu = defaults.distributed_type == DistributedType.TPU
             args.use_fsdp = defaults.distributed_type == DistributedType.FSDP
             args.use_mps_device = defaults.distributed_type == DistributedType.MPS
+        if len(args.gpu_ids.split(",")) < 2 and args.multi_gpu and args.gpu_ids != "all":
+            args.multi_gpu = False
         if defaults.compute_environment == ComputeEnvironment.LOCAL_MACHINE:
             # Update args with the defaults
             for name, attr in defaults.__dict__.items():

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -405,7 +405,6 @@ def multi_gpu_launcher(args):
     num_machines = getattr(args, "num_machines")
     main_process_ip = getattr(args, "main_process_ip")
     main_process_port = getattr(args, "main_process_port")
-    gpu_ids = getattr(args, "gpu_ids")
     if num_machines > 1:
         setattr(args, "nproc_per_node", str(num_processes // num_machines))
         setattr(args, "nnodes", str(num_machines))
@@ -428,6 +427,7 @@ def multi_gpu_launcher(args):
         setattr(args, "no_python", True)
 
     current_env = os.environ.copy()
+    gpu_ids = getattr(args, "gpu_ids")
     if gpu_ids != "all":
         current_env["CUDA_VISIBLE_DEVICES"] = gpu_ids
     mixed_precision = args.mixed_precision.lower()
@@ -550,6 +550,10 @@ def deepspeed_launcher(args):
         setattr(args, "nproc_per_node", str(num_processes))
         if main_process_port is not None:
             setattr(args, "master_port", str(main_process_port))
+    
+    gpu_ids = getattr(args, "gpu_ids")
+    if gpu_ids != "all":
+        current_env["CUDA_VISIBLE_DEVICES"] = gpu_ids
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -427,7 +427,7 @@ def multi_gpu_launcher(args):
         setattr(args, "no_python", True)
 
     current_env = os.environ.copy()
-    gpu_ids = getattr(args, "gpu_ids")
+    gpu_ids = getattr(args, "gpu_ids", "all")
     if gpu_ids != "all":
         current_env["CUDA_VISIBLE_DEVICES"] = gpu_ids
     mixed_precision = args.mixed_precision.lower()
@@ -550,10 +550,6 @@ def deepspeed_launcher(args):
         setattr(args, "nproc_per_node", str(num_processes))
         if main_process_port is not None:
             setattr(args, "master_port", str(main_process_port))
-    
-    gpu_ids = getattr(args, "gpu_ids")
-    if gpu_ids != "all":
-        current_env["CUDA_VISIBLE_DEVICES"] = gpu_ids
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")
@@ -563,6 +559,9 @@ def deepspeed_launcher(args):
         setattr(args, "no_python", True)
 
     current_env = os.environ.copy()
+    gpu_ids = getattr(args, "gpu_ids", "all")
+    if gpu_ids != "all":
+        current_env["CUDA_VISIBLE_DEVICES"] = gpu_ids
     try:
         mixed_precision = PrecisionType(args.mixed_precision.lower())
     except ValueError:


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/543 by adding a `--gpu_ids` param to both the CLI as well as config, and has the CLI launcher utilize it as a result. This essentially just sets `CUDA_VISIBLE_DEVICES` dynamically before launching code

If need for it to occur in `notebook_launcher` is desired, I'll expand this further