### PR TITLE
Remove auto-bug label in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,5 @@
 name: "\U0001F41B Bug Report"
 description: Submit a bug report to help us improve Accelerate
-labels: [ "bug" ]
 body:
   - type: textarea
     id: system-info


### PR DESCRIPTION
Same as in Transformers, it irks em to see the bug label auto-added whenever a user files an issue, since lots of them are just questions or issues within the user's code and not a bug in the library.