### PR TITLE
Fix memory leak

### DIFF
--- a/docs/source/usage_guides/memory.mdx
+++ b/docs/source/usage_guides/memory.mdx
@@ -25,16 +25,20 @@ training script. To use it, restructure your training function to include an inn
 and build your dataloaders inside it. At a minimum, this could look like 4 new lines of code. 
 > Note: The inner function *must* take in the batch size as the first parameter, but we do not pass one to it when called. The wrapper handles this for us
 
+It should also be noted that anything which will consume CUDA memory and passed to the `accelerator` **must** be declared inside the inner function,
+such as models and optimizers.
+
 ```diff
 def training_function(args):
     accelerator = Accelerator()
-    model = get_model()
-    model.to(accelerator.device)
-    optimizer = get_optimizer()
 
 +   @find_executable_batch_size(starting_batch_size=args.batch_size)
 +   def inner_training_loop(batch_size):
-+       nonlocal model, optimizer # Ensure they can be used in our context
++       nonlocal accelerator # Ensure they can be used in our context
++       accelerator.free_memory() # Free all lingering references
+        model = get_model()
+        model.to(accelerator.device)
+        optimizer = get_optimizer()
         train_dataloader, eval_dataloader = get_dataloaders(accelerator, batch_size)
         lr_scheduler = get_scheduler(
             optimizer, 

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -212,7 +212,7 @@ def main():
     )
     parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
     args = parser.parse_args()
-    config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 256}
+    config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}
     training_function(config, args)
 
 


### PR DESCRIPTION
Fixes a memory leak in the memory example. The `accelerator` should be the only one defined out of the loop, and `accelerator.free_memory()` should be the first thing called in the loop. This way all memory is actually freed and lingering references can be wiped.