### PR TITLE
[ds launcher] un-hijack PYTHONPATH

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -574,7 +574,7 @@ def deepspeed_launcher(args):
         warnings.warn('--fp16 flag is deprecated. Use "--mixed_precision fp16" instead.', DeprecationWarning)
         mixed_precision = "fp16"
 
-    current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", sys.executable)
+    current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath('.'))
     current_env["MIXED_PRECISION"] = str(mixed_precision)
     current_env["USE_DEEPSPEED"] = "true"
     current_env["DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -574,7 +574,7 @@ def deepspeed_launcher(args):
         warnings.warn('--fp16 flag is deprecated. Use "--mixed_precision fp16" instead.', DeprecationWarning)
         mixed_precision = "fp16"
 
-    current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath('.'))
+    current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath("."))
     current_env["MIXED_PRECISION"] = str(mixed_precision)
     current_env["USE_DEEPSPEED"] = "true"
     current_env["DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -45,6 +45,7 @@ from accelerate.utils import (
 )
 from accelerate.utils.constants import DEEPSPEED_MULTINODE_LAUNCHERS
 from accelerate.utils.dataclasses import SageMakerDistributedType
+from accelerate.utils.launch import env_var_path_add
 
 
 if is_rich_available():
@@ -573,13 +574,7 @@ def deepspeed_launcher(args):
         warnings.warn('--fp16 flag is deprecated. Use "--mixed_precision fp16" instead.', DeprecationWarning)
         mixed_precision = "fp16"
 
-    def env_path_add(env_var_name, new_path):
-        """extend path-based env variable with a new path"""
-        paths = [p for p in os.environ.get(env_var_name, "").split(":") if len(p) > 0]
-        paths.append(str(new_path))
-        return ":".join(paths)
-
-    current_env["PYTHONPATH"] = env_path_add("PYTHONPATH", sys.executable)
+    current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", sys.executable)
     current_env["MIXED_PRECISION"] = str(mixed_precision)
     current_env["USE_DEEPSPEED"] = "true"
     current_env["DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -573,7 +573,13 @@ def deepspeed_launcher(args):
         warnings.warn('--fp16 flag is deprecated. Use "--mixed_precision fp16" instead.', DeprecationWarning)
         mixed_precision = "fp16"
 
-    current_env["PYTHONPATH"] = sys.executable
+    def env_path_add(env_var_name, new_path):
+        """extend path-based env variable with a new path"""
+        paths = [p for p in os.environ.get(env_var_name, "").split(":") if len(p) > 0]
+        paths.append(str(new_path))
+        return ":".join(paths)
+
+    current_env["PYTHONPATH"] = env_path_add("PYTHONPATH", sys.executable)
     current_env["MIXED_PRECISION"] = str(mixed_precision)
     current_env["USE_DEEPSPEED"] = "true"
     current_env["DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -52,6 +52,15 @@ def _filter_args(args):
     return new_args
 
 
+def env_var_path_add(env_var_name, new_path):
+    """
+    Extends path-based env variable with a new path
+    """
+    paths = [p for p in os.environ.get(env_var_name, "").split(":") if len(p) > 0]
+    paths.append(str(new_path))
+    return ":".join(paths)
+
+
 class PrepareForLaunch:
     """
     Prepare a function that will launched in a distributed setup.

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -54,7 +54,7 @@ def _filter_args(args):
 
 def env_var_path_add(env_var_name, path_to_add):
     """
-    Extends path-based environment variable's value with a new path and returns the updated value. It's up to the
+    Extends a path-based environment variable's value with a new path and returns the updated value. It's up to the
     caller to set it in os.environ.
     """
     paths = [p for p in os.environ.get(env_var_name, "").split(":") if len(p) > 0]

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -52,12 +52,13 @@ def _filter_args(args):
     return new_args
 
 
-def env_var_path_add(env_var_name, new_path):
+def env_var_path_add(env_var_name, path_to_add):
     """
-    Extends path-based env variable with a new path
+    Extends path-based environment variable's value with a new path and returns the updated value. It's up to the
+    caller to set it in os.environ.
     """
     paths = [p for p in os.environ.get(env_var_name, "").split(":") if len(p) > 0]
-    paths.append(str(new_path))
+    paths.append(str(path_to_add))
     return ":".join(paths)
 
 


### PR DESCRIPTION
I'm not sure why `PYTHONPATH` is set to python executable here as it expects dirs and not files:
https://github.com/huggingface/accelerate/pull/514/files#r987305929

but regardless accelerate shouldn't hijack `PYTHONPATH` 

This PR extends the `PYTHONPATH` instead if it was preset.

Thank you