### PR TITLE
Make gather API consistent with prepare

### DIFF
--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -126,7 +126,7 @@ do with the [`~Accelerator.gather_for_metrics`] method.
 for inputs, targets in validation_dataloader:
     predictions = model(inputs)
     # Gather all predictions and targets
-    all_predictions, all_targets = accelerator.gather_for_metrics((predictions, targets))
+    all_predictions, all_targets = accelerator.gather_for_metrics(predictions, targets)
     # Example of use with a *Datasets.Metric*
     metric.add_batch(all_predictions, all_targets)
 ```

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -242,7 +242,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -209,7 +209,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -280,7 +280,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -176,7 +176,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -183,7 +183,7 @@ def training_function(config, args):
                 with torch.no_grad():
                     outputs = model(**batch)
                 predictions = outputs.logits.argmax(dim=-1)
-                predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+                predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
                 metric.add_batch(
                     predictions=predictions,
                     references=references,

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -193,7 +193,7 @@ def training_function(config, args):
                     # Otherwise we add the number of samples seen
                     samples_seen += references.shape[0]
             # All of this can be avoided if you use `Accelerator.gather_for_metrics` instead of `Accelerator.gather`:
-            # accelerator.gather_for_metrics((predictions, batch["labels"]))
+            # accelerator.gather_for_metrics(predictions, batch["labels"])
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -200,7 +200,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -237,7 +237,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["label"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["label"])
             accurate_preds = predictions == references
             accurate += accurate_preds.long().sum()
 

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -216,7 +216,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -173,7 +173,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(inputs)
             predictions = outputs.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["label"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["label"])
             accurate_preds = predictions == references
             num_elems += accurate_preds.shape[0]
             accurate += accurate_preds.long().sum()

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -160,7 +160,7 @@ def training_function(config, args):
             with torch.no_grad():
                 outputs = model(**batch)
             predictions = outputs.logits.argmax(dim=-1)
-            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+            predictions, references = accelerator.gather_for_metrics(predictions, batch["labels"])
             metric.add_batch(
                 predictions=predictions,
                 references=references,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1088,10 +1088,11 @@ class Accelerator:
         self.unscale_gradients()
         torch.nn.utils.clip_grad_value_(parameters, clip_value)
 
-    def gather(self, tensor):
+    def gather(self, *tensor):
         """
-        Gather the values in *tensor* across all processes and concatenate them on the first dimension. Useful to
-        regroup the predictions from all processes when doing evaluation.
+        Gather the values from *tensor* across all processes and concatenate them on the first dimension. Useful to
+        regroup the predictions from all processes when doing evaluation. If multiple values are passed, will gather 
+        each and return them in the same order.
 
         Note:
             This gather happens in all processes.
@@ -1106,10 +1107,11 @@ class Accelerator:
         """
         return gather(tensor)
 
-    def gather_for_metrics(self, tensor):
+    def gather_for_metrics(self, *tensor):
         """
         Gathers `tensor` and potentially drops duplicates in the last batch if on a distributed system. Should be used
-        for gathering the inputs and targets for metric calculation.
+        for gathering the inputs and targets for metric calculation. If multiple values are passed, will gather 
+        each and return them in the same order
 
         Args:
             tensor (`torch.Tensor`, or a nested tuple/list/dictionary of `torch.Tensor`):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1091,7 +1091,7 @@ class Accelerator:
     def gather(self, *tensor):
         """
         Gather the values from *tensor* across all processes and concatenate them on the first dimension. Useful to
-        regroup the predictions from all processes when doing evaluation. If multiple values are passed, will gather 
+        regroup the predictions from all processes when doing evaluation. If multiple values are passed, will gather
         each and return them in the same order.
 
         Note:
@@ -1110,8 +1110,8 @@ class Accelerator:
     def gather_for_metrics(self, *tensor):
         """
         Gathers `tensor` and potentially drops duplicates in the last batch if on a distributed system. Should be used
-        for gathering the inputs and targets for metric calculation. If multiple values are passed, will gather 
-        each and return them in the same order
+        for gathering the inputs and targets for metric calculation. If multiple values are passed, will gather each
+        and return them in the same order
 
         Args:
             tensor (`torch.Tensor`, or a nested tuple/list/dictionary of `torch.Tensor`):

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -81,7 +81,7 @@ def generate_predictions(model, dataloader, accelerator):
         input, target = batch.values()
         with torch.no_grad():
             logit = model(input)
-            logit, target = accelerator.gather_for_metrics((logit, target))
+            logit, target = accelerator.gather_for_metrics(logit, target)
             logits_and_targets.append((logit, target))
     logits, targs = [], []
     for (logit, targ) in logits_and_targets:
@@ -122,7 +122,7 @@ def test_mrpc(dispatch_batches: bool = False, split_batches: bool = False):
             outputs = model(**batch)
         preds = outputs.logits.argmax(dim=-1)
         references = batch["labels"]
-        preds, references = accelerator.gather_for_metrics((preds, references))
+        preds, references = accelerator.gather_for_metrics(preds, references)
         metric.add_batch(predictions=preds, references=references)
     distributed = metric.compute()
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -235,7 +235,7 @@ def gather(*tensor):
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
     if len(tensor) == 1:
         (results,) = results
-    return results if len(tensor) > 1 else results[0]
+    return results if len(results) > 1 else results[0]
 
 
 def _gpu_gather_object(object: Any):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -233,7 +233,7 @@ def gather(*tensor):
 
     results = [recursively_apply(_gather_one, t) for t in tensor]
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
-    if len(tensor) == 1 and len(tensor[1]) > 1:
+    if len(tensor) == 1 and len(tensor[0]) > 1:
         (results,) = results
         results = list(results)
     return results if len(results) > 1 else results[0]

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -210,7 +210,7 @@ def gather(*tensor):
     tensors.
 
     Args:
-        *tensors (nested list/tuple/dictionary of `torch.Tensor`):
+        *tensor (nested list/tuple/dictionary of `torch.Tensor`):
             The data to gather.
 
     Returns:
@@ -232,6 +232,9 @@ def gather(*tensor):
             return tensor
 
     results = [recursively_apply(_gather_one, t) for t in tensor]
+    # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
+    if len(tensor) == 1:
+        (results,) = results
     return results if len(tensor) > 1 else results[0]
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -233,7 +233,7 @@ def gather(*tensor):
 
     results = [recursively_apply(_gather_one, t) for t in tensor]
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
-    if len(tensor) == 1:
+    if len(tensor) == 1 and len(tensor[1]) > 1:
         (results,) = results
         results = list(results)
     return results if len(results) > 1 else results[0]

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -232,7 +232,7 @@ def gather(*tensor):
             return tensor
 
     if len(tensor) == 1: 
-        return _gather_one(tensor)
+        return (_gather_one(tensor))
     else: 
         return recursively_apply(_gather_one, tensor)
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -235,7 +235,7 @@ def gather(*tensor):
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
     if len(results) == 1 and len(results[0]) > 1:
         (results,) = results
-        results = list(results)
+        # results = list(results)
     return results if len(results) > 1 else results[0]
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -231,8 +231,8 @@ def gather(*tensor):
         else:
             return tensor
 
-    result = recursively_apply(_gather_one, tensor)
-    return result if len(result) > 1 else result[0]
+    results = [recursively_apply(_gather_one, t) for t in tensor]
+    return results if len(results) > 1 else results[0]
 
 
 def _gpu_gather_object(object: Any):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -235,6 +235,7 @@ def gather(*tensor):
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
     if len(tensor) == 1:
         (results,) = results
+        results = list(results)
     return results if len(results) > 1 else results[0]
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -231,7 +231,10 @@ def gather(*tensor):
         else:
             return tensor
 
-    return recursively_apply(_gather_one, tensor)
+    if len(tensor) == 1: 
+        return _gather_one(tensor)
+    else: 
+        return recursively_apply(_gather_one, tensor)
 
 
 def _gpu_gather_object(object: Any):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -206,8 +206,8 @@ _cpu_gather = _gpu_gather
 
 def gather(*tensor):
     """
-    Recursively gathers all tensors passed from all devices. Each tensor can be a nested 
-    list/tuple/dictionary of tensors.
+    Recursively gathers all tensors passed from all devices. Each tensor can be a nested list/tuple/dictionary of
+    tensors.
 
     Args:
         *tensors (nested list/tuple/dictionary of `torch.Tensor`):
@@ -216,6 +216,7 @@ def gather(*tensor):
     Returns:
         The same data structure as `tensor` with all tensors sent to the proper device.
     """
+
     def _gather_one(tensor):
         if AcceleratorState().distributed_type == DistributedType.TPU:
             return _tpu_gather(tensor, name="accelerate.utils.gather")
@@ -229,7 +230,7 @@ def gather(*tensor):
             return _cpu_gather(tensor)
         else:
             return tensor
-    
+
     return recursively_apply(_gather_one, tensor)
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -231,11 +231,11 @@ def gather(*tensor):
         else:
             return tensor
 
-    results = [_gather_one(t) for t in tensor]
+    results = _gather_one(*tensor)
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
-    if len(tensor) == 1 and len(tensor[0]) > 1:
+    if len(results) == 1 and len(results[0]) > 1:
         (results,) = results
-        # results = list(results)
+        results = list(results)
     return results if len(results) > 1 else results[0]
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -231,10 +231,8 @@ def gather(*tensor):
         else:
             return tensor
 
-    if len(tensor) == 1: 
-        return (_gather_one(tensor))
-    else: 
-        return recursively_apply(_gather_one, tensor)
+    result = recursively_apply(_gather_one, tensor)
+    return result if len(result) > 1 else result[0]
 
 
 def _gpu_gather_object(object: Any):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -233,9 +233,9 @@ def gather(*tensor):
 
     results = [_gather_one(t) for t in tensor]
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
-    # if len(tensor) == 1 and len(tensor[0]) > 1:
-    #     (results,) = results
-    #     results = list(results)
+    if len(tensor) == 1 and len(tensor[0]) > 1:
+        (results,) = results
+        # results = list(results)
     return results if len(results) > 1 else results[0]
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -231,11 +231,11 @@ def gather(*tensor):
         else:
             return tensor
 
-    results = [recursively_apply(_gather_one, t) for t in tensor]
+    results = [_gather_one(t) for t in tensor]
     # For backward compatibility of someone passing tensor = ((tensor_a, tensor_b))
-    if len(tensor) == 1 and len(tensor[0]) > 1:
-        (results,) = results
-        results = list(results)
+    # if len(tensor) == 1 and len(tensor[0]) > 1:
+    #     (results,) = results
+    #     results = list(results)
     return results if len(results) > 1 else results[0]
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -232,7 +232,7 @@ def gather(*tensor):
             return tensor
 
     results = [recursively_apply(_gather_one, t) for t in tensor]
-    return results if len(results) > 1 else results[0]
+    return results if len(tensor) > 1 else results[0]
 
 
 def _gpu_gather_object(object: Any):


### PR DESCRIPTION
Keeps `accelerator.gather` and `accelerator.prepare` consistent when it comes to how they can take in values to be prepared and how they are returned. Now you can just do `predictions, references = accelerator.gather_for_metrics(predictions, labels)` directly.

`test_metrics` tests the new version, `test_grad_sync` tests the old to ensure that tests for both exist