### PR TITLE
Add gpu_ids to SageMakerConfig though it should never be set

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -165,6 +165,7 @@ class SageMakerConfig(BaseConfig):
     profile: Optional[str] = None
     region: str = "us-east-1"
     num_machines: int = 1
+    gpu_ids: str = "all"
     base_job_name: str = f"accelerate-sagemaker-{num_machines}"
     pytorch_version: str = SAGEMAKER_PYTORCH_VERSION
     transformers_version: str = SAGEMAKER_TRANSFORMERS_VERSION


### PR DESCRIPTION
Fixes issue reported here: https://discuss.huggingface.co/t/sagemakerconfig-object-has-no-attribute-gpu-ids/24174