### PR TITLE
Change num_cpu_threads_per_process default

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -319,7 +319,7 @@ def launch_command_parser(subparsers=None):
     parser.add_argument(
         "--num_cpu_threads_per_process",
         type=int,
-        default=None,
+        default=1,
         help="The number of CPU threads per process. Can be tuned for optimal performance.",
     )
     parser.add_argument(
@@ -877,7 +877,7 @@ def launch_command(args):
         if not hasattr(args, "use_cpu"):
             args.use_cpu = args.cpu
 
-    if args.num_cpu_threads_per_process is None:
+    if args.num_cpu_threads_per_process == 1 and args.use_cpu:
         local_size = get_int_from_env(
             ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
         )
@@ -885,7 +885,7 @@ def launch_command(args):
         if args.num_cpu_threads_per_process == 0:
             args.num_cpu_threads_per_process = 1
         warned.append(
-            f"\t`--num_cpu_threads_per_process` was set to `{args.num_cpu_threads_per_process}` to improve out-of-box performance"
+            f"\t`--num_cpu_threads_per_process` was set to `{args.num_cpu_threads_per_process}` to improve out-of-box performance when training on CPUs"
         )
 
     if any(warned):

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -877,7 +877,7 @@ def launch_command(args):
         if not hasattr(args, "use_cpu"):
             args.use_cpu = args.cpu
 
-    if not args.num_cpu_threads_per_process:
+    if args.num_cpu_threads_per_process is None:
         args.num_cpu_threads_per_process = 1
         if args.use_cpu and args.num_processes > 1:
             local_size = get_int_from_env(


### PR DESCRIPTION
Modifies the default cpu_threads_per_process to be 1, and then if training on CPU then we adjust the number of threads based on an optimization to use them all. 

The need for this fix is there was not much of a want to have a high utilization on the CPU when training on GPUs, and when there was a performance gain wasn't really found. As a result we're limiting the tuning in this way to CPU-bound only training.