### PR TITLE
ensure megatron is 2.2.0+

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -16,9 +16,11 @@ import importlib
 import sys
 from functools import lru_cache
 
+from packaging.version import parse
+
 import torch
 
-from .versions import is_torch_version
+from .versions import is_torch_version, compare_versions
 
 
 # The package importlib_metadata is in a different place, depending on the Python version.
@@ -88,7 +90,12 @@ def is_bf16_available(ignore_tpu=False):
 
 
 def is_megatron_lm_available():
-    return importlib.util.find_spec("megatron") is not None
+    package_exists = importlib.util.find_spec("megatron") is not None
+    if package_exists:
+        megatron_version = parse(importlib_metadata.version("megatron-lm"))
+        return compare_versions(megatron_version, ">=", "2.2.0")
+    else:
+        return False
 
 
 def is_transformers_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -94,8 +94,7 @@ def is_megatron_lm_available():
     if package_exists:
         megatron_version = parse(importlib_metadata.version("megatron-lm"))
         return compare_versions(megatron_version, ">=", "2.2.0")
-    else:
-        return False
+    return False
 
 
 def is_transformers_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -16,11 +16,11 @@ import importlib
 import sys
 from functools import lru_cache
 
-from packaging.version import parse
-
 import torch
 
-from .versions import is_torch_version, compare_versions
+from packaging.version import parse
+
+from .versions import compare_versions, is_torch_version
 
 
 # The package importlib_metadata is in a different place, depending on the Python version.


### PR DESCRIPTION
We just noticed the new Megatron support in Accelerate (https://github.com/huggingface/accelerate/pull/667). This is great! :slightly_smiling_face:

Unfortunately, I think this PR has broken our transformers and accelerate unit tests in DeepSpeed. Several of our unit tests depend on megatron==1.1.5 which is the version of [Megatron-DeepSpeed](https://github.com/microsoft/megatron-deepspeed). It appears this feature in accelerate requires megatron 2.2.0+ and we are seeing errors in our CI when megatron 1.1.5 is installed. This PR aims at addressing this issue.

https://github.com/microsoft/DeepSpeed/actions/runs/3244132853/jobs/5319868166#step:6:958

/cc @pacman100, @sgugger
