### PR TITLE
Only wrap modules in DDP if they require grad

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -777,10 +777,11 @@ class Accelerator:
         if device_placement:
             model = model.to(self.device)
         if self.distributed_type == DistributedType.MULTI_GPU:
-            kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
-            model = torch.nn.parallel.DistributedDataParallel(
-                model, device_ids=[self.local_process_index], output_device=self.local_process_index, **kwargs
-            )
+            if any(p.requires_grad for p in model.parameters()):
+                kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
+                model = torch.nn.parallel.DistributedDataParallel(
+                    model, device_ids=[self.local_process_index], output_device=self.local_process_index, **kwargs
+                )
         elif self.distributed_type == DistributedType.FSDP:
             from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
 


### PR DESCRIPTION
Like the title says. Fixes #760. 

There is [just such a check](https://github.com/pytorch/pytorch/blob/13cff2ee8ea1d7aea2ad201cbd77ebe2b9a29d25/torch/nn/parallel/distributed.py#L550-L555) in DistributedDataParallel, which I do the opposite of.

I would like to add a test so that this feature doesn't regress, but it's not clear to me how to add a test.

I could add a module with only buffers and add it to the `prepare()` call on line 78, then check that the device is the accelerator's device.

 https://github.com/huggingface/accelerate/blob/693d46826e32507376d44f99967df4710886c984/tests/test_kwargs_handlers.py#L73-L79

