### PR TITLE
Move io_same_device hook to before attach_align_device hook on cpu_offload and disk_offload.

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -144,6 +144,7 @@ def cpu_offload(
     if state_dict is None:
         state_dict = {n: p.to("cpu") for n, p in model.state_dict().items()}
 
+    add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
     attach_align_device_hook(
         model,
         execution_device=execution_device,
@@ -152,7 +153,6 @@ def cpu_offload(
         weights_map=state_dict,
         preload_module_classes=preload_module_classes,
     )
-    add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
 
     return model
 
@@ -192,6 +192,7 @@ def disk_offload(
         execution_device = next(iter(model.parameters())).device
     weights_map = OffloadedWeightsLoader(save_folder=offload_dir)
 
+    add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
     attach_align_device_hook(
         model,
         execution_device=execution_device,
@@ -200,7 +201,6 @@ def disk_offload(
         weights_map=weights_map,
         preload_module_classes=preload_module_classes,
     )
-    add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
 
     return model
 

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -144,7 +144,6 @@ def cpu_offload(
     if state_dict is None:
         state_dict = {n: p.to("cpu") for n, p in model.state_dict().items()}
 
-    add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     attach_align_device_hook(
         model,
         execution_device=execution_device,
@@ -153,6 +152,8 @@ def cpu_offload(
         weights_map=state_dict,
         preload_module_classes=preload_module_classes,
     )
+    add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
+
     return model
 
 
@@ -191,7 +192,6 @@ def disk_offload(
         execution_device = next(iter(model.parameters())).device
     weights_map = OffloadedWeightsLoader(save_folder=offload_dir)
 
-    add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     attach_align_device_hook(
         model,
         execution_device=execution_device,
@@ -200,6 +200,8 @@ def disk_offload(
         weights_map=weights_map,
         preload_module_classes=preload_module_classes,
     )
+    add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
+
     return model
 
 

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -143,6 +143,8 @@ def cpu_offload(
         execution_device = next(iter(model.parameters())).device
     if state_dict is None:
         state_dict = {n: p.to("cpu") for n, p in model.state_dict().items()}
+
+    add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     attach_align_device_hook(
         model,
         execution_device=execution_device,
@@ -151,7 +153,6 @@ def cpu_offload(
         weights_map=state_dict,
         preload_module_classes=preload_module_classes,
     )
-    add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     return model
 
 
@@ -189,6 +190,8 @@ def disk_offload(
     if execution_device is None:
         execution_device = next(iter(model.parameters())).device
     weights_map = OffloadedWeightsLoader(save_folder=offload_dir)
+
+    add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     attach_align_device_hook(
         model,
         execution_device=execution_device,
@@ -197,7 +200,6 @@ def disk_offload(
         weights_map=weights_map,
         preload_module_classes=preload_module_classes,
     )
-    add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
     return model
 
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -123,6 +123,7 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False)
     Args:
         module (`torch.nn.Module`): The module to attach a hook to.
         hook (`ModelHook`): The hook to attach.
+        append (`bool`): Whether, if module already contains a hook, should chain the new one with SequentialHook
 
     Returns:
         `torch.nn.Module`: The same module, with the hook attached (the module is modified in place, so the result can

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -108,7 +108,7 @@ class SequentialHook(ModelHook):
         return module
 
 
-def add_hook_to_module(module: nn.Module, hook: ModelHook):
+def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False):
     """
     Adds a hook to a given module. This will rewrite the `forward` method of the module to include the hook, to remove
     this behavior and restore the original `forward` method, use `remove_hook_from_module`.
@@ -128,6 +128,15 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook):
         `torch.nn.Module`: The same module, with the hook attached (the module is modified in place, so the result can
         be discarded).
     """
+
+    if append:
+        if hasattr(module, "_hf_hook") and (module._hf_hook is not None):
+            old_hook = module._hf_hook
+            remove_hook_from_module(module)
+
+            hooks = [old_hook, hook]
+            hook = SequentialHook(*hooks)
+
     if hasattr(module, "_hf_hook") and hasattr(module, "_old_forward"):
         # If we already put some hook on this module, we replace it with the new one.
         old_forward = module._old_forward

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -360,7 +360,7 @@ def attach_align_device_hook(
             offload_buffers=offload_buffers,
             place_submodules=full_offload,
         )
-        add_hook_to_module(module, hook)
+        add_hook_to_module(module, hook, append=True)
 
     # We stop the recursion in case we hit the full offload.
     if full_offload:

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -115,28 +115,26 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False)
 
     <Tip warning={true}>
 
-    If the module already contains a hook, this will replace it with the new hook passed. To chain two hooks together,
-    use the `SequentialHook` class.
+    If the module already contains a hook, this will replace it with the new hook passed by default. To chain two hooks
+    together, pass `append=True`, so it chains the current and new hook into an instance of the `SequentialHook` class.
 
     </Tip>
 
     Args:
         module (`torch.nn.Module`): The module to attach a hook to.
         hook (`ModelHook`): The hook to attach.
-        append (`bool`): Whether, if module already contains a hook, should chain the new one with SequentialHook
+        append (`bool`, *optional*, defaults to `False`):
+            Whether the hook should be chained with an existing one (if module already contains a hook) or not.
 
     Returns:
         `torch.nn.Module`: The same module, with the hook attached (the module is modified in place, so the result can
         be discarded).
     """
 
-    if append:
-        if hasattr(module, "_hf_hook") and (module._hf_hook is not None):
-            old_hook = module._hf_hook
-            remove_hook_from_module(module)
-
-            hooks = [old_hook, hook]
-            hook = SequentialHook(*hooks)
+    if append and (getattr(module, "_hf_hook", None) is not None):
+        old_hook = module._hf_hook
+        remove_hook_from_module(module)
+        hook = SequentialHook(old_hook, hook)
 
     if hasattr(module, "_hf_hook") and hasattr(module, "_old_forward"):
         # If we already put some hook on this module, we replace it with the new one.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -69,6 +69,25 @@ class HooksModelTester(unittest.TestCase):
         self.assertFalse(hasattr(test_model, "_hf_hook"))
         self.assertFalse(hasattr(test_model, "_old_forward"))
 
+    def test_append_and_remove_hooks(self):
+        test_model = ModelForTest()
+        test_hook = ModelHook()
+
+        add_hook_to_module(test_model, test_hook)
+        add_hook_to_module(test_model, test_hook, append=True)
+
+        self.assertEqual(isinstance(test_model._hf_hook, SequentialHook), True)
+        self.assertEqual(len(test_model._hf_hook.hooks), 2)
+        self.assertTrue(hasattr(test_model, "_old_forward"))
+
+        # Check adding the hook did not change the name or the signature
+        self.assertEqual(test_model.forward.__name__, "forward")
+        self.assertListEqual(list(inspect.signature(test_model.forward).parameters), ["x"])
+
+        remove_hook_from_module(test_model)
+        self.assertFalse(hasattr(test_model, "_hf_hook"))
+        self.assertFalse(hasattr(test_model, "_old_forward"))
+
     def test_pre_forward_hook_is_executed(self):
         test_model = ModelForTest()
         x = torch.randn(2, 3)


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/767.

Moves the AlignDevicesHook with `io_same_device` from `accelerate.cpu_offload` and `accelerate.disk_offload` to before the `attach_align_device_hook`.

That way we can keep the changes on forward method for the whole module without deleting the hook we want to keep: the one with execution device and configurations on how to move the tensors between devices.