### PR TITLE
Fix all github actions issues + depreciations

### DIFF
--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: step1
-        run: echo "::set-output name=version::$(python setup.py --version)"
+        run: echo "version=$(python setup.py --version)" >> $GITHUB_ENV
 
   version-cpu:
     name: "Latest Accelerate CPU [version]"

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
             if [ `basename "${file}"` == "setup.py" ]; then
-              echo ::set-output name=changed::"1"
+              echo "changed=1" >> $GITHUB_ENV
             fi
           done
           

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
         path: |
           ${{ env.pythonLocation }}
           ${{ env.HF_HOME }}
-        key: ${{ env.pythonLocation }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
+        key: ${{ env.pythonLocation }}-${{ matrix.pytorch-version}}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
     
     - name: Install the library
       run: |


### PR DESCRIPTION
Fixes a duplicate of writing to the same cache location that was causing a partial slowdown. Also goes ahead and changes `set-output` to `$GITHUB_ENV` as this will be githubs new way of modifying bits like that safer.

cc @ydshieh so you're aware of it, docs are here: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files