### PR TITLE
Fix number of devices in get_balanced_memory

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -409,7 +409,7 @@ def get_balanced_memory(
 
     max_memory = get_max_memory(max_memory)
     # The last device is left with max_memory just in case the buffer is not enough.
-    for i in range(num_devices - 1):
+    for i in range(len(max_memory) - 1):
         max_memory[i] = min(0 if low_zero and i == 0 else per_gpu, max_memory[i])
 
     if low_zero:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -375,3 +375,7 @@ class ModelingUtilsTester(unittest.TestCase):
         # Last device always get max memory to give more buffer and avoid accidental CPU offload
         max_memory = get_balanced_memory(model, max_memory={0: 300, 1: 500})
         self.assertDictEqual({0: 215, 1: 500}, max_memory)
+
+        # If we set a device to 0, it's not counted.
+        max_memory = get_balanced_memory(model, max_memory={0: 0, 1: 300, 2: 300})
+        self.assertDictEqual({0: 0, 1: 215, 2: 300}, max_memory)


### PR DESCRIPTION
Fixes #762 

When a user explicitly excludes one GPU when setting its `max_memory` to 0, we shouldn't count it in `get_balanced_memory`.