### PR TITLE
Fix flakey wandb test

### DIFF
--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -115,11 +115,11 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         # The latest offline log is stored at wandb/latest-run/*.wandb
         for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
             if child.is_file() and child.suffix == ".wandb":
-                print(f'Using log {str(child)}')
                 content = subprocess.check_output(
                     ["wandb", "sync", "--view", "--verbose", str(child)], env=os.environ.copy()
                 ).decode("utf8", "ignore")
                 break
+        print(content)
 
         # Check HPS through careful parsing and cleaning
         logged_items = self.parse_log(content, "config")

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -114,7 +114,6 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         accelerator.end_training()
         # The latest offline log is stored at wandb/latest-run/*.wandb
         for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
-            logger.info(child)
             if child.is_file() and child.suffix == ".wandb":
                 content = subprocess.check_output(
                     ["wandb", "sync", "--view", "--verbose", str(child)], env=os.environ.copy()

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -115,6 +115,7 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         # The latest offline log is stored at wandb/latest-run/*.wandb
         for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
             if child.is_file() and child.suffix == ".wandb":
+                print(f'Using log {str(child)}')
                 content = subprocess.check_output(
                     ["wandb", "sync", "--view", "--verbose", str(child)], env=os.environ.copy()
                 ).decode("utf8", "ignore")


### PR DESCRIPTION
Completely redo's the wandb tests to run a single experiment that then checks that init and the logs worked fine. Uses a new processing system the wandb team shared with me that is **infinitely** more reliable and we can successfully parse from repeatedly without trouble