### PR TITLE
Allow BatchSamplerShard to not even out batches

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -114,7 +114,7 @@ class BatchSamplerShard(BatchSampler):
               then `[6, 7]` if this argument is set to `True`.
         even_batches (`bool`, *optional*, defaults to `True`):
             Whether or not to loop back at the beginning of the sampler when the number of samples is not a round
-            multiple of the batch size/number of processes.
+            multiple of (original batch size / number of processes).
 
     <Tip warning={true}>
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -112,6 +112,9 @@ class BatchSamplerShard(BatchSampler):
               this argument is set to `False`.
             - the sampler on process 0 to yield `[0, 1]` then `[4, 5]` and the sampler on process 1 to yield `[2, 3]`
               then `[6, 7]` if this argument is set to `True`.
+        even_batches (`bool`, *optional*, defaults to `True`):
+            Whether or not to loop back at the beginning of the sampler when the number of samples is not a round
+            multiple of the batch size/number of processes.
 
     <Tip warning={true}>
 
@@ -125,6 +128,7 @@ class BatchSamplerShard(BatchSampler):
         num_processes: int = 1,
         process_index: int = 0,
         split_batches: bool = False,
+        even_batches: bool = True,
     ):
         if split_batches and batch_sampler.batch_size % num_processes != 0:
             raise ValueError(
@@ -135,8 +139,9 @@ class BatchSamplerShard(BatchSampler):
         self.num_processes = num_processes
         self.process_index = process_index
         self.split_batches = split_batches
-        self.batch_size = batch_sampler.batch_size
-        self.drop_last = batch_sampler.drop_last
+        self.even_batches = even_batches
+        self.batch_size = getattr(batch_sampler, "batch_size", None)
+        self.drop_last = getattr(batch_sampler, "drop_last", False)
 
     @property
     def total_length(self):
@@ -144,11 +149,21 @@ class BatchSamplerShard(BatchSampler):
 
     def __len__(self):
         if self.split_batches:
+            # Split batches does not change the length of the batch sampler
             return len(self.batch_sampler)
         if len(self.batch_sampler) % self.num_processes == 0:
+            # If the length is a round multiple of the number of processes, it's easy.
             return len(self.batch_sampler) // self.num_processes
         length = len(self.batch_sampler) // self.num_processes
-        return length if self.drop_last else length + 1
+        if self.drop_last:
+            # Same if we drop the remainder.
+            return length
+        elif self.even_batches:
+            # When we even batches we always get +1
+            return length + 1
+        else:
+            # Otherwise it depends on the process index.
+            return length + 1 if self.process_index < len(self.batch_sampler) % self.num_processes else length
 
     def __iter__(self):
         return self._iter_with_split() if self.split_batches else self._iter_with_no_split()
@@ -165,11 +180,15 @@ class BatchSamplerShard(BatchSampler):
 
         # If drop_last is True of the last batch was full, iteration is over, otherwise...
         if not self.drop_last and len(initial_data) > 0 and len(batch) < self.batch_size:
-            # For degenerate cases where the dataset has less than num_process * batch_size samples
-            while len(initial_data) < self.batch_size:
-                initial_data += initial_data
-            batch = batch + initial_data
-            yield batch[batch_length * self.process_index : batch_length * (self.process_index + 1)]
+            if not self.even_batches:
+                if len(batch) > batch_length * self.process_index:
+                    yield batch[batch_length * self.process_index : batch_length * (self.process_index + 1)]
+            else:
+                # For degenerate cases where the dataset has less than num_process * batch_size samples
+                while len(initial_data) < self.batch_size:
+                    initial_data += initial_data
+                batch = batch + initial_data
+                yield batch[batch_length * self.process_index : batch_length * (self.process_index + 1)]
 
     def _iter_with_no_split(self):
         initial_data = []
@@ -182,35 +201,41 @@ class BatchSamplerShard(BatchSampler):
             # yielding it.
             if idx % self.num_processes == self.process_index:
                 batch_to_yield = batch
-            if idx % self.num_processes == self.num_processes - 1 and len(batch) == self.batch_size:
+            if idx % self.num_processes == self.num_processes - 1 and (
+                self.batch_size is None or len(batch) == self.batch_size
+            ):
                 yield batch_to_yield
                 batch_to_yield = []
 
         # If drop_last is True, iteration is over, otherwise...
         if not self.drop_last and len(initial_data) > 0:
-            # ... we yield the complete batch we had saved before if it has the proper length
-            if len(batch_to_yield) == self.batch_size:
-                yield batch_to_yield
+            if not self.even_batches:
+                if len(batch_to_yield) > 0:
+                    yield batch_to_yield
+            else:
+                # ... we yield the complete batch we had saved before if it has the proper length
+                if len(batch_to_yield) == self.batch_size:
+                    yield batch_to_yield
 
-            # For degenerate cases where the dataset has less than num_process * batch_size samples
-            while len(initial_data) < self.num_processes * self.batch_size:
-                initial_data += initial_data
+                # For degenerate cases where the dataset has less than num_process * batch_size samples
+                while len(initial_data) < self.num_processes * self.batch_size:
+                    initial_data += initial_data
 
-            # If the last batch seen was of the proper size, it has been yielded by its process so we move to the next
-            if len(batch) == self.batch_size:
-                batch = []
-                idx += 1
+                # If the last batch seen was of the proper size, it has been yielded by its process so we move to the next
+                if len(batch) == self.batch_size:
+                    batch = []
+                    idx += 1
 
-            # Make sure we yield a multiple of self.num_processes batches
-            cycle_index = 0
-            while idx % self.num_processes != 0 or len(batch) > 0:
-                end_index = cycle_index + self.batch_size - len(batch)
-                batch += initial_data[cycle_index:end_index]
-                if idx % self.num_processes == self.process_index:
-                    yield batch
-                cycle_index = end_index
-                batch = []
-                idx += 1
+                # Make sure we yield a multiple of self.num_processes batches
+                cycle_index = 0
+                while idx % self.num_processes != 0 or len(batch) > 0:
+                    end_index = cycle_index + self.batch_size - len(batch)
+                    batch += initial_data[cycle_index:end_index]
+                    if idx % self.num_processes == self.process_index:
+                        yield batch
+                    cycle_index = end_index
+                    batch = []
+                    idx += 1
 
 
 class IterableDatasetShard(IterableDataset):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -142,6 +142,8 @@ class BatchSamplerShard(BatchSampler):
         self.even_batches = even_batches
         self.batch_size = getattr(batch_sampler, "batch_size", None)
         self.drop_last = getattr(batch_sampler, "drop_last", False)
+        if self.batch_size is None and self.even_batches:
+            raise ValueError("You need to use `even_batches=False` when the batch sampler has no batch size.")
 
     @property
     def total_length(self):


### PR DESCRIPTION
This is the first PR to deal with #684 and begins the work of allowing the data loaders not to loop back at the beginning when there is non-even number of samples compared to the number of processes.

It introduces a new argument (that will eventually trickle down all the way up to the Accelerator main class) `even_batches` that can be set to `False`, in which case each process will see a different number of batches.

In this PR, we focus on the `BatchSamplerShard`.