### PR TITLE
fix transformers tests

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -409,7 +409,7 @@ def get_balanced_memory(
 
     max_memory = get_max_memory(max_memory)
     # The last device is left with max_memory just in case the buffer is not enough.
-    for i in range(len(max_memory) - 1):
+    for i in range(num_devices - 1):
         max_memory[i] = min(0 if low_zero and i == 0 else per_gpu, max_memory[i])
 
     if low_zero:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -408,8 +408,9 @@ def get_balanced_memory(
     per_gpu += buffer
 
     max_memory = get_max_memory(max_memory)
+    last_gpu = max(i for i in max_memory if isinstance(i, int) and max_memory[i] > 0)
     # The last device is left with max_memory just in case the buffer is not enough.
-    for i in range(num_devices - 1):
+    for i in range(last_gpu):
         max_memory[i] = min(0 if low_zero and i == 0 else per_gpu, max_memory[i])
 
     if low_zero:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -376,6 +376,10 @@ class ModelingUtilsTester(unittest.TestCase):
         max_memory = get_balanced_memory(model, max_memory={0: 300, 1: 500})
         self.assertDictEqual({0: 215, 1: 500}, max_memory)
 
+        # Last device always get max memory to give more buffer, even if CPU is provided
+        max_memory = get_balanced_memory(model, max_memory={0: 300, "cpu": 1000})
+        self.assertDictEqual({0: 300, "cpu": 1000}, max_memory)
+
         # If we set a device to 0, it's not counted.
         max_memory = get_balanced_memory(model, max_memory={0: 0, 1: 300, 2: 300})
         self.assertDictEqual({0: 0, 1: 215, 2: 300}, max_memory)


### PR DESCRIPTION
# Fix Transformer `test_model_parallelism` tests
Will add accelerate tests for that asap. 
For the mean time, 
The last device is not left with `max_memory`. This cause the `test_model_parallelism` to fail in transformers. 
