### PR TITLE
Add `even_batches` keyword to Accelerator

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -153,6 +153,10 @@ class Accelerator:
             If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process
             and then the batches are split and broadcast to each process. Will default to `True` for `DataLoader` whose
             underlying dataset is an `IterableDataset`, `False` otherwise.
+        even_batches ('bool', defaults to `True`):
+            If set to `True`, in cases where the total batch size across all processes does not exactly divide the
+            dataset, samples at the start of the dataset will be duplicated so the batch can be divided equally among
+            all workers.
         step_scheduler_with_optimizer (`bool`, *optional`, defaults to `True`):
             Set `True` if the learning rate scheduler is stepped at the same time as the optimizer, `False` if only
             done under certain circumstances (at the end of each epoch, for instance).
@@ -191,6 +195,7 @@ class Accelerator:
         log_with: Optional[List[Union[str, LoggerType, GeneralTracker]]] = None,
         logging_dir: Optional[Union[str, os.PathLike]] = None,
         dispatch_batches: Optional[bool] = None,
+        even_batches: bool = True,
         step_scheduler_with_optimizer: bool = True,
         kwargs_handlers: Optional[List[KwargsHandler]] = None,
     ):
@@ -305,6 +310,7 @@ class Accelerator:
             raise ImportError(
                 "Using `DataLoaderDispatcher` requires PyTorch 1.8.0 minimum. You have {torch.__version__}."
             )
+        self.even_batches = even_batches
         self.step_scheduler_with_optimizer = step_scheduler_with_optimizer
 
         # Mixed precision attributes
@@ -1109,6 +1115,7 @@ class Accelerator:
             put_on_device=device_placement,
             rng_types=self.rng_types.copy(),
             dispatch_batches=self.dispatch_batches,
+            even_batches=self.even_batches,
         )
 
     def prepare_optimizer(self, optimizer: torch.optim.Optimizer, device_placement=None):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -119,7 +119,7 @@ class BatchSamplerShard(BatchSampler):
     <Tip warning={true}>
 
     `BatchSampler`s with varying batch sizes are not enabled by default. To enable this behaviour, set `even_batches`
-    equal to `True`
+    equal to `False`
 
     </Tip>"""
 
@@ -628,7 +628,7 @@ def prepare_data_loader(
     <Tip warning={true}>
 
     `BatchSampler`s with varying batch sizes are not enabled by default. To enable this behaviour, set `even_batches`
-    equal to `True`
+    equal to `False`
 
     </Tip>
     """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -118,7 +118,8 @@ class BatchSamplerShard(BatchSampler):
 
     <Tip warning={true}>
 
-    This does not support `BatchSampler` with varying batch size yet.
+    `BatchSampler`s with varying batch sizes are not enabled by default. To enable this behaviour, set `even_batches`
+    equal to `True`
 
     </Tip>"""
 
@@ -624,6 +625,12 @@ def prepare_data_loader(
     Returns:
         `torch.utils.data.dataloader.DataLoader`: A new data loader that will yield the portion of the batches
 
+    <Tip warning={true}>
+
+    `BatchSampler`s with varying batch sizes are not enabled by default. To enable this behaviour, set `even_batches`
+    equal to `True`
+
+    </Tip>
     """
     if dispatch_batches is None:
         if is_torch_version("<", "1.8.0") or not put_on_device:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -570,6 +570,7 @@ def prepare_data_loader(
     put_on_device: bool = False,
     rng_types: Optional[List[Union[str, RNGType]]] = None,
     dispatch_batches: Optional[bool] = None,
+    even_batches: bool = True,
 ) -> DataLoader:
     """
     Wraps a PyTorch `DataLoader` to generate batches for one of the processes only.
@@ -615,15 +616,15 @@ def prepare_data_loader(
             If set to `True`, the datalaoder prepared is only iterated through on the main process and then the batches
             are split and broadcast to each process. Will default to `True` when the underlying dataset is an
             `IterableDataset`, `False` otherwise.
+        even_batches ('bool', defaults to `True`):
+            If set to `True`, in cases where the total batch size across all processes does not exactly divide the
+            dataset, samples at the start of the dataset will be duplicated so the batch can be divided equally among
+            all workers.
 
     Returns:
         `torch.utils.data.dataloader.DataLoader`: A new data loader that will yield the portion of the batches
 
-    <Tip warning={true}>
-
-    This does not support `BatchSampler` with varying batch size yet.
-
-    </Tip>"""
+    """
     if dispatch_batches is None:
         if is_torch_version("<", "1.8.0") or not put_on_device:
             dispatch_batches = False
@@ -683,6 +684,7 @@ def prepare_data_loader(
                 num_processes=num_processes,
                 process_index=process_index,
                 split_batches=split_batches,
+                even_batches=even_batches,
             )
 
     # We ignore all of those since they are all dealt with by our new_batch_sampler

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -19,7 +19,6 @@ from typing import List
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
-from accelerate import accelerator
 from accelerate.accelerator import Accelerator
 
 

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from accelerate import accelerator
+from accelerate.accelerator import Accelerator
+
+
+def create_dataloader(accelerator: Accelerator, dataset_size: int, batch_size: int):
+    """
+    Create a simple DataLoader to use during the test cases
+    """
+    accelerator.free_memory()
+    dataset = TensorDataset(torch.as_tensor(range(dataset_size)))
+
+    dl = DataLoader(dataset, batch_size=batch_size)
+    dl = accelerator.prepare(dl)
+
+    return dl
+
+
+def verify_dataloader_batch_sizes(
+    accelerator: Accelerator,
+    dataset_size: int,
+    batch_size: int,
+    process_0_expected_batch_sizes: List[int],
+    process_1_expected_batch_sizes: List[int],
+):
+    """
+    A helper function for verifying the batch sizes coming from a prepared dataloader in each process
+    """
+    dl = create_dataloader(accelerator=accelerator, dataset_size=dataset_size, batch_size=batch_size)
+
+    batch_sizes = [len(batch[0]) for batch in dl]
+
+    if accelerator.process_index == 0:
+        assert batch_sizes == process_0_expected_batch_sizes
+    elif accelerator.process_index == 1:
+        assert batch_size == process_1_expected_batch_sizes
+
+
+def test_default_ensures_even_batch_sizes(accelerator):
+
+    # without padding, we would expect a different number of batches
+    verify_dataloader_batch_sizes(
+        accelerator,
+        dataset_size=3,
+        batch_size=1,
+        process_0_expected_batch_sizes=[1, 1],
+        process_1_expected_batch_sizes=[1, 1],
+    )
+
+    # without padding, we would expect the same number of batches, but different sizes
+    verify_dataloader_batch_sizes(
+        accelerator,
+        dataset_size=5,
+        batch_size=2,
+        process_0_expected_batch_sizes=[2, 2],
+        process_1_expected_batch_sizes=[2, 2],
+    )
+
+
+def test_can_disable_even_batches(accelerator):
+    verify_dataloader_batch_sizes(
+        accelerator,
+        dataset_size=3,
+        batch_size=1,
+        process_0_expected_batch_sizes=[1, 1],
+        process_1_expected_batch_sizes=[1],
+    )
+
+    verify_dataloader_batch_sizes(
+        accelerator,
+        dataset_size=5,
+        batch_size=2,
+        process_0_expected_batch_sizes=[2, 2],
+        process_1_expected_batch_sizes=[2, 1],
+    )
+
+
+if __name__ == "__main__":
+    accelerator = Accelerator()
+    assert accelerator.num_processes == 2, "this script expects that two GPUs are available"
+
+    test_default_ensures_even_batch_sizes(accelerator)
+    test_can_disable_even_batches(Accelerator(even_batches=False))

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -32,7 +32,6 @@ def create_dataloader(accelerator: Accelerator, dataset_size: int, batch_size: i
     """
     Create a simple DataLoader to use during the test cases
     """
-    # accelerator.free_memory()
     dataset = TensorDataset(torch.as_tensor(range(dataset_size)))
 
     dl = DataLoader(dataset, batch_size=batch_size)

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -101,3 +101,13 @@ def test_can_disable_even_batches():
         process_0_expected_batch_sizes=[2, 2],
         process_1_expected_batch_sizes=[2, 1],
     )
+
+
+if __name__ == "__main__":
+    accelerator = create_accelerator()
+
+    accelerator.print("Test that even_batches variable ensures uniform batches across processes")
+    test_default_ensures_even_batch_sizes()
+
+    accelerator.print("Run tests with even_batches disabled")
+    test_can_disable_even_batches()

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -52,7 +52,7 @@ class MultiGPUTester(unittest.TestCase):
         when the batch size does not evenly divide the dataset size.
         """
         print(f"Found {torch.cuda.device_count()} devices, using 2 devices only")
-        cmd = get_launch_prefix() + [self.data_loop_file_path]
+        cmd = get_launch_prefix() + [f"--nproc_per_node={torch.cuda.device_count()}", self.data_loop_file_path]
         with patch_environment(omp_num_threads=1, cuda_visible_devices="0,1"):
             execute_subprocess_async(cmd, env=os.environ.copy())
 


### PR DESCRIPTION
This PR enables the option of configuring the Accelerator to disable prepared DataLoaders ensuring that an even number of batches are observed across all processes. 

This continues the work described in: https://github.com/huggingface/accelerate/issues/684