### PR TITLE
Consider top-level buffers when computing `infer_auto_device_map` 

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -475,10 +475,11 @@ def infer_auto_device_map(
     current_device = 0
     current_memory_used = 0
 
-    # Direct submodules and parameters
-    modules_to_treat = (
-        list(model.named_parameters(recurse=False)) + list(model.named_children()) + list(model.named_buffers())
-    )
+    # Direct submodules and parameters, including tensors that are registered as buffers
+    # but excluding buffers such as `running_mean` for batch_norm
+    filtered_buffers = list((m[0], m[1]) for m in model.named_buffers() if m[0] in model._buffers)
+    modules_to_treat = list(model.named_parameters(recurse=False)) + list(model.named_children()) + filtered_buffers
+
     # Initialize maximum largest layer, to know which space to keep in memory
     max_layer_size, max_layer_names = get_max_layer_size(modules_to_treat, module_sizes, no_split_module_classes)
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -476,7 +476,9 @@ def infer_auto_device_map(
     current_memory_used = 0
 
     # Direct submodules and parameters
-    modules_to_treat = list(model.named_parameters(recurse=False)) + list(model.named_children())
+    modules_to_treat = (
+        list(model.named_parameters(recurse=False)) + list(model.named_children()) + list(model.named_buffers())
+    )
     # Initialize maximum largest layer, to know which space to keep in memory
     max_layer_size, max_layer_names = get_max_layer_size(modules_to_treat, module_sizes, no_split_module_classes)
 


### PR DESCRIPTION
# What does this PR do?

This PR adds `list(model._buffers)` inside `modules_to_treat` when computing the `auto_device_map`. This scenario occured when I tried to add `accelerate` support for `BART`-like models when the [`final_logits_bias` is registered as a buffer and is different than a `uint` type](https://github.com/huggingface/transformers/blob/76296569266fbc238defbe68d06ad720b3a544e3/src/transformers/models/bart/modeling_bart.py#L1286). It seems that we need to assign a device to this buffer. 

The other solution is to "force-ignore" the buffer in `check_device_map` [here](https://github.com/huggingface/accelerate/blob/a5525406fcba79523fc5edf1051360e15447ef6a/src/accelerate/utils/modeling.py#L577) since the tensors that are in `model._buffers` are stored in the state_dict. 

cc @sgugger @muellerzr 

slow tests from `tests/test_bigmodeling.py` pass!