### PR TITLE
Fix extraction of state dict in offload

### DIFF
--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -178,5 +178,13 @@ def extract_submodules_state_dict(state_dict: Dict[str, torch.Tensor], submodule
     """
     result = {}
     for module_name in submodule_names:
-        result.update({key: param for key, param in state_dict.items() if key.startswith(module_name)})
+        # We want to catch module_name parameter (module_name.xxx) or potentially module_name, but not any of the
+        # submodules that could being like module_name (transformers.h.1 and transformers.h.10 for instance)
+        result.update(
+            {
+                key: param
+                for key, param in state_dict.items()
+                if key == module_name or key.startswith(module_name + ".")
+            }
+        )
     return result

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 
 from accelerate.utils import (
     OffloadedWeightsLoader,
+    extract_submodules_state_dict,
     is_torch_version,
     load_offloaded_weight,
     offload_state_dict,
@@ -105,3 +106,12 @@ class OffloadTester(unittest.TestCase):
             self.assertEqual(sorted(weight_map), sorted(state_dict.keys()))
             for key, param in state_dict.items():
                 self.assertTrue(torch.allclose(param, weight_map[key]))
+
+    def test_extract_submodules_state_dict(self):
+        state_dict = {"a.1": 0, "a.10": 1, "a.2": 2}
+        extracted = extract_submodules_state_dict(state_dict, ["a.1", "a.2"])
+        self.assertDictEqual(extracted, {"a.1": 0, "a.2": 2})
+
+        state_dict = {"a.1.a": 0, "a.10.a": 1, "a.2.a": 2}
+        extracted = extract_submodules_state_dict(state_dict, ["a.1", "a.2"])
+        self.assertDictEqual(extracted, {"a.1.a": 0, "a.2.a": 2})


### PR DESCRIPTION
When we end up with weights offloaded on CPU and disk, there is a little bug in the function that extracts the CPU state dict. In the added tests, it would catch the submodules beginning like the one passed (so `a.10` because `a.1` is in the list).