### PR TITLE
Introduce a pod-config command

### DIFF
--- a/src/accelerate/commands/accelerate_cli.py
+++ b/src/accelerate/commands/accelerate_cli.py
@@ -19,6 +19,7 @@ from argparse import ArgumentParser
 from accelerate.commands.config import config_command_parser
 from accelerate.commands.env import env_command_parser
 from accelerate.commands.launch import launch_command_parser
+from accelerate.commands.pod import pod_command_parser
 from accelerate.commands.test import test_command_parser
 
 
@@ -31,6 +32,7 @@ def main():
     launch_command_parser(subparsers=subparsers)
     test_command_parser(subparsers=subparsers)
     env_command_parser(subparsers=subparsers)
+    pod_command_parser(subparsers=subparsers)
 
     # Let's go
     args = parser.parse_args()

--- a/src/accelerate/commands/accelerate_cli.py
+++ b/src/accelerate/commands/accelerate_cli.py
@@ -29,10 +29,10 @@ def main():
 
     # Register commands
     config_command_parser(subparsers=subparsers)
-    launch_command_parser(subparsers=subparsers)
-    test_command_parser(subparsers=subparsers)
     env_command_parser(subparsers=subparsers)
+    launch_command_parser(subparsers=subparsers)
     pod_command_parser(subparsers=subparsers)
+    test_command_parser(subparsers=subparsers)
 
     # Let's go
     args = parser.parse_args()

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -41,6 +41,8 @@ def get_cluster_input():
     main_process_port = None
     rdzv_backend = "static"
     same_network = True
+    tpu_name = None
+    tpu_zone = None
     if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_CPU]:
         num_machines = _ask_field(
             "How many different machines will you use (use more than 1 for multi-node training)? [1]: ",
@@ -341,6 +343,23 @@ def get_cluster_input():
             "What is the name of the function in your script that should be launched in all parallel scripts? [main]: ",
             default="main",
         )
+        use_cluster = _ask_field(
+            "Are you using a TPU cluster? [yes/NO]: ",
+            _convert_yes_no_to_bool,
+            default=False,
+            error_message="Please enter yes or no.",
+        )
+        if use_cluster:
+            tpu_name = _ask_field(
+                "What is the name of your TPU cluster? ",
+                default=None,
+                error_message="Please enter the name of your TPU cluster.",
+            )
+            tpu_zone = _ask_field(
+                "What is the zone of your TPU cluster? ",
+                default=None,
+                error_message="Please enter the zone of your TPU cluster.",
+            )
     else:
         main_training_function = "main"
 
@@ -408,4 +427,6 @@ def get_cluster_input():
         use_cpu=use_cpu,
         rdzv_backend=rdzv_backend,
         same_network=same_network,
+        tpu_name=tpu_name,
+        tpu_zone=tpu_zone,
     )

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -365,7 +365,7 @@ def get_cluster_input():
                 error_message="Please enter the zone of your TPU cluster.",
             )
             run_commands = _ask_field(
-                "Do you have code you wish to be ran on startup in each pod? [yes/NO]: ",
+                "Do you have code you wish to run on startup in each pod? [yes/NO]: ",
                 _convert_yes_no_to_bool,
                 default=False,
                 error_message="Please enter yes or no.",

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 from ...utils import ComputeEnvironment, DistributedType, is_deepspeed_available, is_transformers_available
 from ...utils.constants import (
     DEEPSPEED_MULTINODE_LAUNCHERS,
@@ -43,6 +45,8 @@ def get_cluster_input():
     same_network = True
     tpu_name = None
     tpu_zone = None
+    commands = None
+    command_file = None
     if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_CPU]:
         num_machines = _ask_field(
             "How many different machines will you use (use more than 1 for multi-node training)? [1]: ",
@@ -360,6 +364,33 @@ def get_cluster_input():
                 default=None,
                 error_message="Please enter the zone of your TPU cluster.",
             )
+            run_commands = _ask_field(
+                "Do you have code you wish to be ran on startup in each pod? [yes/NO]: ",
+                _convert_yes_no_to_bool,
+                default=False,
+                error_message="Please enter yes or no.",
+            )
+            if run_commands:
+                use_command_file = _ask_field(
+                    "Is this code located in a bash script? [yes/NO]: ",
+                    _convert_yes_no_to_bool,
+                    default=False,
+                    error_message="Please enter yes or no.",
+                )
+                if use_command_file:
+                    command_file = _ask_field(
+                        "What is the path to your bash script? ",
+                        default=None,
+                        error_message="Please enter the path to your bash script.",
+                    )
+                    command_file = os.path.abspath(command_file)
+                else:
+                    commands = _ask_field(
+                        "What commands do you wish to run on startup in each pod? ",
+                        default=None,
+                        error_message="Please enter the commands you wish to run on startup in each pod as a single string.",
+                    )
+
     else:
         main_training_function = "main"
 
@@ -429,4 +460,6 @@ def get_cluster_input():
         same_network=same_network,
         tpu_name=tpu_name,
         tpu_zone=tpu_zone,
+        commands=commands,
+        command_file=command_file,
     )

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -32,7 +32,6 @@ hf_cache_home = os.path.expanduser(
 cache_dir = os.path.join(hf_cache_home, "accelerate")
 default_json_config_file = os.path.join(cache_dir, "default_config.yaml")
 default_yaml_config_file = os.path.join(cache_dir, "default_config.yaml")
-default_pod_config_file = os.path.join(cache_dir, "default_pod_config.yaml")
 
 # For backward compatibility: the default config is the json one if it's the only existing file.
 if os.path.isfile(default_yaml_config_file) or not os.path.isfile(default_json_config_file):

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -163,6 +163,8 @@ class ClusterConfig(BaseConfig):
             self.deepspeed_config = {}
         if self.fsdp_config is None:
             self.fsdp_config = {}
+        if self.megatron_lm_config is None:
+            self.megatron_lm_config = {}
         return super().__post_init__()
 
 
@@ -174,6 +176,7 @@ class SageMakerConfig(BaseConfig):
     profile: Optional[str] = None
     region: str = "us-east-1"
     num_machines: int = 1
+    gpu_ids: str = "all"
     base_job_name: str = f"accelerate-sagemaker-{num_machines}"
     pytorch_version: str = SAGEMAKER_PYTORCH_VERSION
     transformers_version: str = SAGEMAKER_TRANSFORMERS_VERSION

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -65,13 +65,6 @@ def load_config_from_file(config_file):
             return config_class.from_yaml_file(yaml_file=config_file)
 
 
-def load_pod_config_from_file(pod_config_file):
-    if pod_config_file.endswith(".json"):
-        return PodConfig.from_json_file(json_file=pod_config_file)
-    else:
-        return PodConfig.from_yaml_file(yaml_file=pod_config_file)
-
-
 @dataclass
 class BaseConfig:
     compute_environment: ComputeEnvironment
@@ -139,33 +132,6 @@ class BaseConfig:
 
 
 @dataclass
-class PodConfig:
-    command_file: str
-    commands: List[str]
-
-    @classmethod
-    def from_json_file(cls, json_file):
-        with open(json_file, "r", encoding="utf-8") as f:
-            config_dict = json.load(f)
-        return cls(**config_dict)
-
-    def to_json_file(self, json_file):
-        with open(json_file, "w", encoding="utf-8") as f:
-            content = json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
-            f.write(content)
-
-    @classmethod
-    def from_yaml_file(cls, yaml_file):
-        with open(yaml_file, "r", encoding="utf-8") as f:
-            config_dict = yaml.safe_load(f)
-        return cls(**config_dict)
-
-    def to_yaml_file(self, yaml_file):
-        with open(yaml_file, "w", encoding="utf-8") as f:
-            yaml.safe_dump(self.to_dict(), f)
-
-
-@dataclass
 class ClusterConfig(BaseConfig):
     num_processes: int
     machine_rank: int = 0
@@ -181,12 +147,16 @@ class ClusterConfig(BaseConfig):
     deepspeed_config: dict = None
     # args for fsdp
     fsdp_config: dict = None
+    # args for megatron_lm
+    megatron_lm_config: dict = None
     # args for TPU
     downcast_bf16: bool = False
 
     # args for TPU pods
     tpu_name: str = None
     tpu_zone: str = None
+    command_file: str = None
+    command: List[str] = None
 
     def __post_init__(self):
         if self.deepspeed_config is None:

--- a/src/accelerate/commands/env.py
+++ b/src/accelerate/commands/env.py
@@ -1,3 +1,19 @@
+#!/usr/bin/env python
+
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import os
 import platform

--- a/src/accelerate/commands/pod.py
+++ b/src/accelerate/commands/pod.py
@@ -67,6 +67,11 @@ def pod_command_parser(subparsers=None):
         help="The zone of the TPU to use. If not specified, will use the zone specified in the config file.",
     )
     parser.add_argument(
+        "--install_accelerate",
+        action="store_true",
+        help="Whether to install accelerate on the pod. Defaults to False.",
+    )
+    parser.add_argument(
         "--accelerate_version",
         default="latest",
         help="The version of accelerate to install on the pod. If not specified, will use the latest pypi version. Specify 'dev' to install from GitHub.",
@@ -111,8 +116,11 @@ def pod_launcher(args):
     # To turn list of lists into list of strings
     args.command = [line for cmd in args.command for line in cmd]
     # Default to the shared folder and install accelerate
-    args.command = ["cd /usr/share", f"pip install {args.accelerate_version}"] + args.command
-    args.command = "; ".join(args.command)
+    new_cmd = ["cd /usr/share"]
+    if args.install_accelerate:
+        new_cmd += [f"pip install {args.accelerate_version}"]
+    new_cmd += args.command
+    args.command = "; ".join(new_cmd)
 
     # Then send it to gcloud
     # Eventually try to use google-api-core to do this instead of subprocess

--- a/src/accelerate/commands/pod.py
+++ b/src/accelerate/commands/pod.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import subprocess
+
+from accelerate.commands.config.config_args import (
+    default_pod_config_file,
+    load_config_from_file,
+    load_pod_config_from_file,
+)
+from packaging.version import Version, parse
+
+
+def pod_command_parser(subparsers=None):
+    if subparsers is not None:
+        parser = subparsers.add_subparsers(help="pod-config")
+    else:
+        parser = argparse.ArgumentParser("Accelerate pod-config command")
+
+    parser.add_argument(
+        "--config_file",
+        type=str,
+        default=None,
+        help="Path to the config file to use for accelerate.",
+    )
+
+    parser.add_argument(
+        "--pod_config_file",
+        type=str,
+        default=None,
+        help="Path to the config file to use for the pod.",
+    )
+
+    parser.add_argument(
+        "--command_file",
+        default=None,
+        help="The path to the file containing the commands to run on the pod on startup.",
+    )
+    parser.add_argument(
+        "--command",
+        action="append",
+        nargs="+",
+        help="A command to run on the pod. If not specified, will use the command specified in the command file.",
+    )
+    parser.add_argument(
+        "--tpu_name",
+        default=None,
+        help="The name of the TPU to use. If not specified, will use the TPU specified in the config file.",
+    )
+    parser.add_argument(
+        "--tpu_zone",
+        default=None,
+        help="The zone of the TPU to use. If not specified, will use the TPU specified in the config file.",
+    )
+    parser.add_argument(
+        "--accelerate_version",
+        default="latest",
+        help="The version of accelerate to install on the pod. If not specified, will use the latest pypi version. Specify 'dev' to install from GitHub.",
+    )
+
+    if subparsers is not None:
+        parser.set_defaults(func=pod_launcher)
+    return parser
+
+
+def pod_launcher(args):
+    defaults = None
+    pod_defaults = None
+
+    # Get the default from the config file if it exists.
+    if args.pod_config_file is not None or os.path.isfile(default_pod_config_file):
+        pod_defaults = load_pod_config_from_file(args.pod_config_file)
+        defaults = load_config_from_file(args.config_file)
+        if not args.command_file and pod_defaults.command_file is not None:
+            args.command_file = pod_defaults.command_file
+        elif not args.command and pod_defaults.command is not None:
+            args.command = pod_defaults.command
+        if not args.tpu_name:
+            args.tpu_name = defaults.tpu_name
+        if not args.tpu_zone:
+            args.tpu_zone = defaults.tpu_zone
+    if args.accelerate_version == "dev":
+        args.accelerate_version = "git+https://github.com/huggingface/accelerate.git"
+    elif args.accelerate_version == "latest":
+        args.accelerate_version = "accelerate -U"
+    elif isinstance(parse(args.accelerate_version), Version):
+        args.accelerate_version = f"accelerate=={args.accelerate_version}"
+
+    if not args.command_file and not args.command:
+        raise ValueError("You must specify either a command file or a command to run on the pod.")
+
+    if args.command_file:
+        with open(args.command_file, "r") as f:
+            args.command = f.read().splitlines()
+    # Install Accelerate first
+    args.command = ["cd /usr/share", f"pip install {args.accelerate_version}"] + args.command
+
+    # Then send it to gcloud
+    # Eventually try to use google-api-core to do this instead of subprocess
+    subprocess.run(
+        f"gcloud compute tpus tpu-vm ssh {args.tpu_name} --zone {args.tpu_zone} --command '{';'.join(args.command)}' --worker=all".split(
+            " "
+        )
+    )
+    print("Successfully setup pod.")
+
+
+def main():
+    parser = pod_command_parser()
+    args = parser.parse_args()
+
+    pod_launcher(args)

--- a/src/accelerate/commands/pod.py
+++ b/src/accelerate/commands/pod.py
@@ -139,7 +139,7 @@ def pod_launcher(args):
         "all",
     ]
     if args.debug:
-        print(cmd)
+        print(f"Running {' '.join(cmd)}")
         return
     subprocess.run(cmd)
     print("Successfully setup pod.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,17 +72,17 @@ class PodConfigTester(unittest.TestCase):
     Test case for verifying the `accelerate pod-config` CLI passes the right `gcloud` command.
     """
 
-    _tpu_name = "test-tpu"
-    _tpu_zone = "us-central1-a"
+    tpu_name = "test-tpu"
+    tpu_zone = "us-central1-a"
     _command = "ls"
     cmd = ["accelerate", "pod-config"]
     _base_output = "cd /usr/share"
-    _command_file = "tests/test_samples/test_command_file.sh"
+    command_file = "tests/test_samples/test_command_file.sh"
 
     def test_base(self):
         output = run_command(
             self.cmd
-            + ["--command", self._command, "--tpu_zone", self._tpu_zone, "--tpu_name", self._tpu_name, "--debug"],
+            + ["--command", self._command, "--tpu_zone", self._tpu_zone, "--tpu_name", self.tpu_name, "--debug"],
             return_stdout=True,
         )
         output = ast.literal_eval(output)
@@ -102,7 +102,7 @@ class PodConfigTester(unittest.TestCase):
                 "--tpu_zone",
                 self._tpu_zone,
                 "--tpu_name",
-                self._tpu_name,
+                self.tpu_name,
                 "--debug",
             ],
             return_stdout=True,
@@ -157,7 +157,7 @@ class PodConfigTester(unittest.TestCase):
     def test_with_config_file_and_command_file(self):
         output = run_command(
             self.cmd
-            + ["--config_file", "tests/test_configs/latest.yaml", "--command_file", self._command_file, "--debug"],
+            + ["--config_file", "tests/test_configs/latest.yaml", "--command_file", self.command_file, "--debug"],
             return_stdout=True,
         )
         output = ast.literal_eval(output)
@@ -173,11 +173,11 @@ class PodConfigTester(unittest.TestCase):
                 "--config_file",
                 "tests/test_configs/0_12_0.yaml",
                 "--command_file",
-                self._command_file,
+                self.command_file,
                 "--tpu_zone",
                 self._tpu_zone,
                 "--tpu_name",
-                self._tpu_name,
+                self.tpu_name,
                 "--debug",
             ],
             return_stdout=True,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,8 +82,8 @@ class PodConfigTester(unittest.TestCase):
 
     def test_base(self):
         output = run_command(
-            self.cmd
-            + ["--command", self._command, "--tpu_zone", self._tpu_zone, "--tpu_name", self.tpu_name, "--debug"],
+            self.cmd_command
+            + ["--command", self.command, "--tpu_zone", self.tpu_zone, "--tpu_name", self.tpu_name, "--debug"],
             return_stdout=True,
         )
         output = ast.literal_eval(output)
@@ -99,9 +99,9 @@ class PodConfigTester(unittest.TestCase):
                 "--config_file",
                 "tests/test_configs/0_12_0.yaml",
                 "--command",
-                self._command,
+                self.command,
                 "--tpu_zone",
-                self._tpu_zone,
+                self.tpu_zone,
                 "--tpu_name",
                 self.tpu_name,
                 "--debug",
@@ -126,7 +126,7 @@ class PodConfigTester(unittest.TestCase):
 
     def test_with_config_file_and_command(self):
         output = run_command(
-            self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--command", self._command, "--debug"],
+            self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--command", self.command, "--debug"],
             return_stdout=True,
         )
         output = ast.literal_eval(output)
@@ -142,7 +142,7 @@ class PodConfigTester(unittest.TestCase):
                 "--config_file",
                 "tests/test_configs/latest.yaml",
                 "--command",
-                self._command,
+                self.command,
                 "--command",
                 'echo "Hello World"',
                 "--debug",
@@ -176,7 +176,7 @@ class PodConfigTester(unittest.TestCase):
                 "--command_file",
                 self.command_file,
                 "--tpu_zone",
-                self._tpu_zone,
+                self.tpu_zone,
                 "--tpu_name",
                 self.tpu_name,
                 "--debug",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,10 +74,11 @@ class PodConfigTester(unittest.TestCase):
 
     tpu_name = "test-tpu"
     tpu_zone = "us-central1-a"
-    _command = "ls"
+    command = "ls"
     cmd = ["accelerate", "pod-config"]
-    _base_output = "cd /usr/share"
+    base_output = "cd /usr/share"
     command_file = "tests/test_samples/test_command_file.sh"
+    gcloud = "Running gcloud compute tpus tpu-vm ssh "
 
     def test_base(self):
         output = run_command(
@@ -88,7 +89,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f"gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; ls --worker all",
+            f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
         )
 
     def test_base_backward_compatibility(self):
@@ -110,7 +111,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f"gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; ls --worker all",
+            f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
         )
 
     def test_with_config_file(self):
@@ -120,7 +121,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; echo "hello world"; echo "this is a second command" --worker all',
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
         )
 
     def test_with_config_file_and_command(self):
@@ -131,7 +132,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f"gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; ls --worker all",
+            f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
         )
 
     def test_with_config_file_and_multiple_command(self):
@@ -151,7 +152,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; ls; echo "Hello World" --worker all',
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls; echo "Hello World" --worker all',
         )
 
     def test_with_config_file_and_command_file(self):
@@ -163,7 +164,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; echo "hello world"; echo "this is a second command" --worker all',
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
         )
 
     def test_with_config_file_and_command_file_backward_compatibility(self):
@@ -185,7 +186,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; echo "hello world"; echo "this is a second command" --worker all',
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
         )
 
     def test_accelerate_install(self):
@@ -196,7 +197,7 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; pip install accelerate -U; echo "hello world"; echo "this is a second command" --worker all',
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate -U; echo "hello world"; echo "this is a second command" --worker all',
         )
 
     def test_accelerate_install_version(self):
@@ -215,5 +216,5 @@ class PodConfigTester(unittest.TestCase):
         output = ast.literal_eval(output)
         self.assertEqual(
             " ".join(output),
-            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; pip install accelerate==12.0.0; echo "hello world"; echo "this is a second command" --worker all',
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate==12.0.0; echo "hello world"; echo "this is a second command" --worker all',
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,6 +134,26 @@ class PodConfigTester(unittest.TestCase):
             f"gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; ls --worker all",
         )
 
+    def test_with_config_file_and_multiple_command(self):
+        output = run_command(
+            self.cmd
+            + [
+                "--config_file",
+                "tests/test_configs/latest.yaml",
+                "--command",
+                self._command,
+                "--command",
+                'echo "Hello World"',
+                "--debug",
+            ],
+            return_stdout=True,
+        )
+        output = ast.literal_eval(output)
+        self.assertEqual(
+            " ".join(output),
+            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; ls; echo "Hello World" --worker all',
+        )
+
     def test_with_config_file_and_command_file(self):
         output = run_command(
             self.cmd

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,7 +76,7 @@ class PodConfigTester(unittest.TestCase):
     _tpu_zone = "us-central1-a"
     _command = "ls"
     cmd = ["accelerate", "pod-config"]
-    _base_output = "cd /usr/share; pip install accelerate -U"
+    _base_output = "cd /usr/share"
     _command_file = "tests/test_samples/test_command_file.sh"
 
     def test_base(self):
@@ -166,4 +166,34 @@ class PodConfigTester(unittest.TestCase):
         self.assertEqual(
             " ".join(output),
             f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; echo "hello world"; echo "this is a second command" --worker all',
+        )
+
+    def test_accelerate_install(self):
+        output = run_command(
+            self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--install_accelerate", "--debug"],
+            return_stdout=True,
+        )
+        output = ast.literal_eval(output)
+        self.assertEqual(
+            " ".join(output),
+            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; pip install accelerate -U; echo "hello world"; echo "this is a second command" --worker all',
+        )
+
+    def test_accelerate_install_version(self):
+        output = run_command(
+            self.cmd
+            + [
+                "--config_file",
+                "tests/test_configs/latest.yaml",
+                "--install_accelerate",
+                "--accelerate_version",
+                "12.0.0",
+                "--debug",
+            ],
+            return_stdout=True,
+        )
+        output = ast.literal_eval(output)
+        self.assertEqual(
+            " ".join(output),
+            f'gcloud compute tpus tpu-vm ssh test-tpu --zone us-central1-a --command {self._base_output}; pip install accelerate==12.0.0; echo "hello world"; echo "this is a second command" --worker all',
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ast
 import inspect
 import os
 import unittest
@@ -78,17 +77,20 @@ class PodConfigTester(unittest.TestCase):
     cmd = ["accelerate", "pod-config"]
     base_output = "cd /usr/share"
     command_file = "tests/test_samples/test_command_file.sh"
-    gcloud = "Running gcloud compute tpus tpu-vm ssh "
+    gcloud = "Running gcloud compute tpus tpu-vm ssh"
+
+    @staticmethod
+    def clean_output(output):
+        return "".join(output).rstrip()
 
     def test_base(self):
         output = run_command(
-            self.cmd_command
+            self.cmd
             + ["--command", self.command, "--tpu_zone", self.tpu_zone, "--tpu_name", self.tpu_name, "--debug"],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
         )
 
@@ -108,9 +110,8 @@ class PodConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
         )
 
@@ -118,9 +119,8 @@ class PodConfigTester(unittest.TestCase):
         output = run_command(
             self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--debug"], return_stdout=True
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
         )
 
@@ -129,9 +129,8 @@ class PodConfigTester(unittest.TestCase):
             self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--command", self.command, "--debug"],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
         )
 
@@ -149,9 +148,8 @@ class PodConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls; echo "Hello World" --worker all',
         )
 
@@ -161,9 +159,8 @@ class PodConfigTester(unittest.TestCase):
             + ["--config_file", "tests/test_configs/latest.yaml", "--command_file", self.command_file, "--debug"],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
         )
 
@@ -183,9 +180,8 @@ class PodConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
         )
 
@@ -194,9 +190,8 @@ class PodConfigTester(unittest.TestCase):
             self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--install_accelerate", "--debug"],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate -U; echo "hello world"; echo "this is a second command" --worker all',
         )
 
@@ -213,8 +208,7 @@ class PodConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        output = ast.literal_eval(output)
         self.assertEqual(
-            " ".join(output),
+            self.clean_output(output),
             f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate==12.0.0; echo "hello world"; echo "this is a second command" --worker all',
         )

--- a/tests/test_configs/latest.yaml
+++ b/tests/test_configs/latest.yaml
@@ -15,3 +15,7 @@ num_processes: 1
 rdzv_backend: static
 same_network: true
 use_cpu: false
+tpu_name: 'test-tpu'
+tpu_zone: 'us-central1-a'
+command: null
+command_file: tests/test_samples/test_command_file.sh

--- a/tests/test_samples/test_command_file.sh
+++ b/tests/test_samples/test_command_file.sh
@@ -1,0 +1,2 @@
+echo "hello world"
+echo "this is a second command"


### PR DESCRIPTION
# Introduce a pod-config command to setup TPU pods

## What does this add?

This PR introduces a new command `accelerate pod-config` which will first ask the user for commands they wish to run across all TPU nodes in a GCP TPU cluster, before then running all of them in along with installing `accelerate` if specified

## Who is it for?

Part of https://github.com/huggingface/accelerate/issues/501

## Why is it needed?

When dealing with TPU pods, they need to have initial configurations across all of their processes with all the main data being available there and initial setups. This provides an easy tool to do so without having the user need to enter their own startup script, and can be run at any point in time.

## What parts of the API does this impact?

### User-facing:

Adds a new `accelerate pod-config` command which can accept both a bash script of commands to run at once, or an unlimited amount of regular commands passed in

### Internal structure:

Configs now store both types of commands and users are prompted for these during `accelerate config`

## Basic Usage Example(s):

With an old `accelerate` config file:

```bash
accelerate pod-config --command "echo 'Hello World'" --tpu_zone "us-central1-a" --tpu_name "test-tpu"
```
With a new one fully configured:
```bash
accelerate pod-config
```
To install Accelerate in the new environment on all processes:
```bash
accelerate pod-config --install_accelerate
```
