### PR TITLE
Add compat checker

### DIFF
--- a/.github/workflows/run_upgrade_tests.yml
+++ b/.github/workflows/run_upgrade_tests.yml
@@ -2,6 +2,8 @@ name: New Dependency Versions and Compatibility
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 env:
   HF_HOME: ~/hf_cache

--- a/.github/workflows/run_upgrade_tests.yml
+++ b/.github/workflows/run_upgrade_tests.yml
@@ -1,8 +1,6 @@
 name: New Dependency Versions and Compatibility
 
 on:
-  # schedule:
-  #   - cron: '0 0 * * *'
   workflow_dispatch:
 
 env:
@@ -16,14 +14,15 @@ jobs:
     outputs:
       upgrades: ${{ steps.step1.outputs.upgrades }}
     steps:
-    - uses: actions/checkout
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
     - name: Install dependencies
       run: |
-        pip install -e .
+        pip install -e . --no-deps
+        pip install PyGithub importlib_metadata packaging
     - name: Check for dependency upgrades
       id: step1
       run: |
@@ -32,27 +31,65 @@ jobs:
   
   run-upgrade-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test-kind: [
+          test_prod,
+          test_core,
+          test_cli,
+          test_big_modeling,
+          test_deepspeed,
+          test_fsdp,
+          test_example_differences,
+          test_checkpoint_step,
+          test_checkpoint_epoch,
+          test_rest
+        ]
+
     needs: check-upgrades
+    permissions:
+      issues: write
     if: ${{ needs.check-upgrades.outputs.upgrades != '' }}
     env:
       UPGRADES: ${{ needs.check-upgrades.outputs.upgrades }}
     steps:
-    - uses: actions/checkout
+    - uses: actions/checkout@v3
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
         python-version: 3.7
+
+    - name: Activate python cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.pythonLocation }}
+          ${{ env.HF_HOME }}
+        key: ${{ env.pythonLocation }}-${{ matrix.pytorch-version }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
+    
     - name: Install the library
       run: |
         pip install --upgrade pip
-        pip install -e . -U
+        if [[ ${{ matrix.test-kind }} = test_prod ]]; then pip install -e .[test_prod] -U; fi
+        if [[ ${{ matrix.test-kind }} != test_prod ]]; then pip install -e .[testing,test_trackers] -U; fi
+        if [[ ${{ matrix.test-kind }} = test_rest ]]; then pip uninstall comet_ml -y; fi
+        if [[ ${{ matrix.pytorch-version }} = minimum ]]; then pip install torch==1.6.0 -U; fi
         pip install pytest-reportlog
     
     - name: Run Tests
+      env: 
+        PYTORCH_VERSION: ${{ matrix.pytorch-version }}
       run: |
-        make test
+        make ${{ matrix.test-kind }}
+    - name: Run Tests
+      run: |
+        make test_core
 
     - name: Generate Report
+      if: always()
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cd utils
         python -c 'from upgrade import comment_failures; comment_failures()'

--- a/.github/workflows/run_upgrade_tests.yml
+++ b/.github/workflows/run_upgrade_tests.yml
@@ -1,0 +1,58 @@
+name: New Dependency Versions and Compatibility
+
+on:
+  # schedule:
+  #   - cron: '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  HF_HOME: ~/hf_cache
+  TESTING_MOCKED_DATALOADERS: "1"
+  IS_GITHUB_CI: "1"
+
+jobs:
+  check-upgrades:
+    runs-on: ubuntu-latest 
+    outputs:
+      upgrades: ${{ steps.step1.outputs.upgrades }}
+    steps:
+    - uses: actions/checkout
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        pip install -e .
+    - name: Check for dependency upgrades
+      id: step1
+      run: |
+        cd utils
+        python -c 'from upgrade import post_upgrades; post_upgrades()'
+  
+  run-upgrade-tests:
+    runs-on: ubuntu-latest
+    needs: check-upgrades
+    if: ${{ needs.check-upgrades.outputs.upgrades != '' }}
+    env:
+      UPGRADES: ${{ needs.check-upgrades.outputs.upgrades }}
+    steps:
+    - uses: actions/checkout
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Install the library
+      run: |
+        pip install --upgrade pip
+        pip install -e . -U
+        pip install pytest-reportlog
+    
+    - name: Run Tests
+      run: |
+        make test
+
+    - name: Generate Report
+      run: |
+        cd utils
+        python -c 'from upgrade import comment_failures; comment_failures()'

--- a/utils/upgrade.py
+++ b/utils/upgrade.py
@@ -74,7 +74,7 @@ def comment_failures():
             failed_table += ' | '.join(test[0].split("::"))
         result += failed_table
         g = Github(os.environ["GITHUB_TOKEN"])
-        repo = g.get_repo("muellerzr/accelerate")
+        repo = g.get_repo("huggingface/accelerate")
         issue = repo.create_issue(
             title="New Dependency Version Released, Failed Tests", 
             body=f'A new version of: {os.environ["UPGRADES"]} was released, but the tests failed. Please check the logs for more details [here](https://github.com/muellerzr/accelerate/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n{result}',

--- a/utils/upgrade.py
+++ b/utils/upgrade.py
@@ -77,5 +77,6 @@ def comment_failures():
         repo = g.get_repo("muellerzr/accelerate")
         issue = repo.create_issue(
             title="New Dependency Version Released, Failed Tests", 
-            body=f'A new version of: {os.environ["UPGRADES"]} was released, but the tests failed. Please check the logs for more details [here](https://github.com/muellerzr/accelerate/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n{result}'
+            body=f'A new version of: {os.environ["UPGRADES"]} was released, but the tests failed. Please check the logs for more details [here](https://github.com/muellerzr/accelerate/actions/runs/{os.environ["GITHUB_RUN_ID"]}):\n{result}',
+            labels=["bug"]
         )

--- a/utils/upgrade.py
+++ b/utils/upgrade.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+# Copyright 2020 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Util to check if a new version of a library dependency is available. """
+
+import os
+from github import Github
+from pathlib import Path
+import subprocess
+import importlib_metadata, requests, re, json
+from datetime import datetime
+from packaging.requirements  import Requirement
+
+def get_core_requirements(package:str):
+    reqs = importlib_metadata.requires(package)
+    reqs = list(map(Requirement, reqs))
+    reqs = [r.name for r in reqs if r.marker is None]
+    return reqs
+
+def get_latest_upload_time(package:str):
+    url = f"https://pypi.org/pypi/{package}/json"
+    r = requests.get(url)
+    data = r.json()
+    latest_version = data["info"]["version"]
+    latest_upload = data["releases"][latest_version][0]["upload_time"]
+    match = re.search(r'\d{4}-\d{2}-\d{2}', latest_upload)
+    release = datetime.strptime(match.group(), '%Y-%m-%d').date()
+    return release
+
+def post_upgrades():
+    upgraded = []
+    for package in get_core_requirements("accelerate"):
+        latest_release = get_latest_upload_time(package)
+        if latest_release - datetime.now().date() > -1:
+            upgraded.append(package)
+
+    # Call subprocess 
+    if upgraded:
+        subprocess.run(["echo", f"UPGRADES={upgraded}", ">>", "$GITHUB_OUTPUT"], check=True)
+    else:
+        subprocess.run(["echo", f"UPGRADES=''", ">>", "$GITHUB_OUTPUT"], check=True)
+
+def comment_failures():
+    failed = []
+
+    for log in Path().glob("*.log"):
+        with open(log, "r") as f:
+            for line in f:
+                line = json.loads(line)
+                if line.get("nodeid", "") != "":
+                    test = line["nodeid"]
+                    if line.get("duration", None) is not None:
+                        duration = f'{line["duration"]:.4f}'
+                        if line.get("outcome", "") == "failed":
+                            failed.append([test, duration, log.name.split('_')[0]])
+
+    if len(failed) > 0:
+        result = "## Failed Tests:\n"
+        failed_table = '| Test Location | Test Class | Test Name |\n|---|---|---|\n| '
+        for test in failed:
+            failed_table += ' | '.join(test[0].split("::"))
+        result += failed_table
+        g = Github(os.environ["GITHUB_TOKEN"])
+        repo = g.get_repo("huggingface/accelerate")
+        issue = repo.create_issue(
+            title="New Dependency Version Released, Failed Tests", 
+            body=f'A new version of: {os.environ["UPGRADED"]} was released, but the tests failed. Please check the logs for more details:\n{result}'
+        )


### PR DESCRIPTION
This PR adds a compatibility checker that will run nightly looking to see if a new version of a core dependency was released and if so runs tests against it, while also reporting what that new library was to help us narrow down issues faster :) 

A report looks like [so](https://github.com/muellerzr/accelerate/issues/6) 
![image](https://user-images.githubusercontent.com/7831895/199312367-26a4be9f-dbe0-4147-8d93-66ee4d440b6f.png)

With a "Bug" added to the label. 

While there were not any issues in this release, this will help us in the future in case it or any other deps happen to release a breaking change and we can find out about it first and better trust we know exactly if/when there's an incompatibility issue :) (and if we know a release happened not at midnight UTC this action can be ran manually)

LMK what we think, it's okay if this is an "overengineering" thing and we don't worry about it :) 