### PR TITLE
Refactor CLI to improve readability

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -68,7 +68,6 @@ _options_to_group = {
     "--use_deepspeed": "DeepSpeed",
     "--use_fsdp": "FSDP",
     "--use_megatron_lm": "Megatron-LM",
-    "AWS": "AWS",
 }
 
 
@@ -107,13 +106,17 @@ class _CustomHelpAction(argparse._HelpAction):
                 if arg.container.title not in titles + used_titles:
                     setattr(opts[i], "help", argparse.SUPPRESS)
                 # If the argument is hardware selection, but not being passed, hide it
-                elif arg.container.title == "Hardware Selection" and set(arg.option_strings).isdisjoint(set(args)):
-                    setattr(opts[i], "help", argparse.SUPPRESS)
+                elif arg.container.title == "Hardware Selection":
+                    if set(arg.option_strings).isdisjoint(set(args)):
+                        setattr(opts[i], "help", argparse.SUPPRESS)
+                    else:
+                        setattr(opts[i], "help", arg.help + " (currently selected)")
                 # If the argument is a training paradigm, but not being passed, hide it
-                elif arg.container.title == "Training Paradigm Selection" and set(arg.option_strings).isdisjoint(
-                    set(used_platforms)
-                ):
-                    setattr(opts[i], "help", argparse.SUPPRESS)
+                elif arg.container.title == "Training Paradigm Selection":
+                    if set(arg.option_strings).isdisjoint(set(used_platforms)):
+                        setattr(opts[i], "help", argparse.SUPPRESS)
+                    else:
+                        setattr(opts[i], "help", arg.help + " (currently selected)")
             for i, group in enumerate(list(parser._action_groups)):
                 # If all arguments in the group are hidden, hide the group
                 if all([arg.help == argparse.SUPPRESS for arg in group._group_actions]):

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -158,29 +158,6 @@ def launch_command_parser(subparsers=None):
         help="Whether or not this should use MPS-enabled GPU device on MacOS machines.",
     )
 
-    # Training paradigm selection arguments
-    paradigm_args = parser.add_argument_group(
-        "Training Paradigm Selection", "Arguments for selecting which training paradigm to be used."
-    )
-    paradigm_args.add_argument(
-        "--use_deepspeed",
-        default=False,
-        action="store_true",
-        help="Whether to use deepspeed.",
-    )
-    paradigm_args.add_argument(
-        "--use_fsdp",
-        default=False,
-        action="store_true",
-        help="Whether to use fsdp.",
-    )
-    paradigm_args.add_argument(
-        "--use_megatron_lm",
-        default=False,
-        action="store_true",
-        help="Whether to use Megatron-LM.",
-    )
-
     # Resource selection arguments
     resource_args = parser.add_argument_group(
         "Resource Selection", "Arguments for fine-tuning how available hardware should be used."
@@ -207,6 +184,29 @@ def launch_command_parser(subparsers=None):
         type=int,
         default=None,
         help="The number of CPU threads per process. Can be tuned for optimal performance.",
+    )
+
+    # Training paradigm selection arguments
+    paradigm_args = parser.add_argument_group(
+        "Training Paradigm Selection", "Arguments for selecting which training paradigm to be used."
+    )
+    paradigm_args.add_argument(
+        "--use_deepspeed",
+        default=False,
+        action="store_true",
+        help="Whether to use deepspeed.",
+    )
+    paradigm_args.add_argument(
+        "--use_fsdp",
+        default=False,
+        action="store_true",
+        help="Whether to use fsdp.",
+    )
+    paradigm_args.add_argument(
+        "--use_megatron_lm",
+        default=False,
+        action="store_true",
+        help="Whether to use Megatron-LM.",
     )
 
     # distributed GPU training arguments

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -86,7 +86,10 @@ class _CustomHelpAction(argparse._HelpAction):
     """
 
     def __call__(self, parser, namespace, values, option_string=None):
-        args = sys.argv[1:]
+        if "accelerate" in sys.argv[0] and "launch" in sys.argv[1:]:
+            args = sys.argv[2:]
+        else:
+            args = sys.argv[1:]
         opts = parser._actions
         titles = [
             "Hardware Selection",
@@ -95,7 +98,7 @@ class _CustomHelpAction(argparse._HelpAction):
             "positional arguments",
             "optional arguments",
         ]
-        if len(args) > 2:
+        if len(args) > 1:
             used_platforms = [arg for arg in args if arg in _options_to_group.keys()]
             args = list(map(_clean_option, args))
             used_titles = [_options_to_group[o] for o in used_platforms]

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -55,8 +55,6 @@ if is_rich_available():
     FORMAT = "%(message)s"
     logging.basicConfig(format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
 
-    from rich import print
-
 
 if is_torch_version(">=", "1.9.0"):
     import torch.distributed.run as distrib_run
@@ -82,10 +80,11 @@ def _clean_option(option):
 
 class _CustomHelpAction(argparse._HelpAction):
     """
-    This is a custom help action that will hide all arguments that are not used in the command line 
-    when the help is called. This is useful for the case where the user is using a specific platform
-    and only wants to see the arguments for that platform.
+    This is a custom help action that will hide all arguments that are not used in the command line when the help is
+    called. This is useful for the case where the user is using a specific platform and only wants to see the arguments
+    for that platform.
     """
+
     def __call__(self, parser, namespace, values, option_string=None):
         args = sys.argv[1:]
         opts = parser._actions

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -95,7 +95,7 @@ class _CustomHelpAction(argparse._HelpAction):
             "positional arguments",
             "optional arguments",
         ]
-        if len(args) > 1:
+        if len(args) > 2:
             used_platforms = [arg for arg in args if arg in _options_to_group.keys()]
             args = list(map(_clean_option, args))
             used_titles = [_options_to_group[o] for o in used_platforms]

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -61,17 +61,17 @@ if is_torch_version(">=", "1.9.0"):
 
 logger = logging.getLogger(__name__)
 
-_options_to_group = {
+options_to_group = {
     "--multi-gpu": "Distributed GPUs",
     "--tpu": "TPU",
     "--use_mps_device": "MPS",
-    "--use_deepspeed": "DeepSpeed",
-    "--use_fsdp": "FSDP",
-    "--use_megatron_lm": "Megatron-LM",
+    "--use_deepspeed": "DeepSpeed Arguments",
+    "--use_fsdp": "FSDP Arguments",
+    "--use_megatron_lm": "Megatron-LM Arguments",
 }
 
 
-def _clean_option(option):
+def clean_option(option):
     "Finds all cases of - after the first two characters and changes them to _"
     if option.startswith("--"):
         return option[:3] + option[3:].replace("-", "_")
@@ -91,28 +91,28 @@ class _CustomHelpAction(argparse._HelpAction):
             args = sys.argv[1:]
         opts = parser._actions
         titles = [
-            "Hardware Selection",
-            "Resource Selection",
-            "Training Paradigm Selection",
+            "Hardware Selection Arguments",
+            "Resource Selection Arguments",
+            "Training Paradigm Arguments",
             "positional arguments",
             "optional arguments",
         ]
         if len(args) > 1:
-            used_platforms = [arg for arg in args if arg in _options_to_group.keys()]
-            args = list(map(_clean_option, args))
-            used_titles = [_options_to_group[o] for o in used_platforms]
+            used_platforms = [arg for arg in args if arg in options_to_group.keys()]
+            args = list(map(clean_option, args))
+            used_titles = [options_to_group[o] for o in used_platforms]
             for i, arg in enumerate(opts):
                 # If the argument's container is outside of the used titles, hide it
                 if arg.container.title not in titles + used_titles:
                     setattr(opts[i], "help", argparse.SUPPRESS)
                 # If the argument is hardware selection, but not being passed, hide it
-                elif arg.container.title == "Hardware Selection":
+                elif arg.container.title == "Hardware Selection Arguments":
                     if set(arg.option_strings).isdisjoint(set(args)):
                         setattr(opts[i], "help", argparse.SUPPRESS)
                     else:
                         setattr(opts[i], "help", arg.help + " (currently selected)")
                 # If the argument is a training paradigm, but not being passed, hide it
-                elif arg.container.title == "Training Paradigm Selection":
+                elif arg.container.title == "Training Paradigm Arguments":
                     if set(arg.option_strings).isdisjoint(set(used_platforms)):
                         setattr(opts[i], "help", argparse.SUPPRESS)
                     else:
@@ -138,7 +138,9 @@ def launch_command_parser(subparsers=None):
         "--config_file", default=None, help="The config file to use for the default values in the launching script."
     )
     # Hardware selection arguments
-    hardware_args = parser.add_argument_group("Hardware Selection", "Arguments for selecting the hardware to be used.")
+    hardware_args = parser.add_argument_group(
+        "Hardware Selection Arguments", "Arguments for selecting the hardware to be used."
+    )
     hardware_args.add_argument(
         "--cpu", default=False, action="store_true", help="Whether or not to force the training on the CPU."
     )
@@ -160,7 +162,7 @@ def launch_command_parser(subparsers=None):
 
     # Resource selection arguments
     resource_args = parser.add_argument_group(
-        "Resource Selection", "Arguments for fine-tuning how available hardware should be used."
+        "Resource Selection Arguments", "Arguments for fine-tuning how available hardware should be used."
     )
     resource_args.add_argument(
         "--mixed_precision",
@@ -186,9 +188,9 @@ def launch_command_parser(subparsers=None):
         help="The number of CPU threads per process. Can be tuned for optimal performance.",
     )
 
-    # Training paradigm selection arguments
+    # Training Paradigm arguments
     paradigm_args = parser.add_argument_group(
-        "Training Paradigm Selection", "Arguments for selecting which training paradigm to be used."
+        "Training Paradigm Arguments", "Arguments for selecting which training paradigm to be used."
     )
     paradigm_args.add_argument(
         "--use_deepspeed",
@@ -280,7 +282,7 @@ def launch_command_parser(subparsers=None):
     )
 
     # DeepSpeed arguments
-    deepspeed_args = parser.add_argument_group("DeepSpeed", "Arguments related to DeepSpeed.")
+    deepspeed_args = parser.add_argument_group("DeepSpeed Arguments", "Arguments related to DeepSpeed.")
     deepspeed_args.add_argument(
         "--deepspeed_config_file",
         default=None,
@@ -357,7 +359,7 @@ def launch_command_parser(subparsers=None):
     )
 
     # fsdp arguments
-    fsdp_args = parser.add_argument_group("FSDP", "Arguments related to Fully Shared Data Parallelism.")
+    fsdp_args = parser.add_argument_group("FSDP Arguments", "Arguments related to Fully Shared Data Parallelism.")
     fsdp_args.add_argument(
         "--fsdp_offload_params",
         default="false",
@@ -427,7 +429,7 @@ def launch_command_parser(subparsers=None):
     )
 
     # megatron_lm args
-    megatron_lm_args = parser.add_argument_group("Megatron-LM", "Arguments related to Megatron-LM.")
+    megatron_lm_args = parser.add_argument_group("Megatron-LM Arguments", "Arguments related to Megatron-LM.")
     megatron_lm_args.add_argument(
         "--megatron_lm_tp_degree",
         type=int,
@@ -477,7 +479,7 @@ def launch_command_parser(subparsers=None):
     )
 
     # AWS arguments
-    aws_args = parser.add_argument_group("AWS", "Arguments related to AWS.")
+    aws_args = parser.add_argument_group("AWS Arguments", "Arguments related to AWS.")
     aws_args.add_argument(
         "--aws_access_key_id",
         type=str,


### PR DESCRIPTION
This PR refactors the `launch` CLI to make their arguments infinitely more readable and organizes it in such a way that users can quickly get arguments to their specific needs without having to comb through a million options. We do this two different ways

## Method 1, Grouping 

Argparse allows for [ArgumentGrouping](https://docs.python.org/3/library/argparse.html#argument-groups) which we should utilize much more. This allows for much cleaner renderings with `--help` for the user. 

E.g. Before:
```bash
positional arguments:
  training_script       The full path to the script to be launched in parallel, followed by all the arguments for the training script.
  training_script_args  Arguments of the training script.

optional arguments:
  -h, --help            show this help message and exit
  --config_file CONFIG_FILE
                        The config file to use for the default values in the launching script.
  --multi_gpu           Whether or not this should launch a distributed GPU training.
  --use_mps_device      Whether or not this should use MPS-enabled GPU device on MacOS machines.
  --use_deepspeed       Whether to use deepspeed.
  --deepspeed_config_file DEEPSPEED_CONFIG_FILE
                        DeepSpeed config file.
  --zero_stage ZERO_STAGE
                        DeepSpeed's ZeRO optimization stage (useful only when `use_deepspeed` flag is passed).
  --offload_optimizer_device OFFLOAD_OPTIMIZER_DEVICE
                        Decides where (none|cpu|nvme) to offload optimizer states (useful only when `use_deepspeed` flag is passed).
  --offload_param_device OFFLOAD_PARAM_DEVICE
                        Decides where (none|cpu|nvme) to offload parameters (useful only when `use_deepspeed` flag is passed).
...
```
After:
```bash
positional arguments:
  training_script       The full path to the script to be launched in parallel, followed by all the arguments for the training script.
  training_script_args  Arguments of the training script.

optional arguments:
  -h, --help            show this help message and exit
  --config_file CONFIG_FILE
                        The config file to use for the default values in the launching script.
  -m, --module          Change each process to interpret the launch script as a Python module, executing with the same behavior as 'python -m'.
  --no_python           Skip prepending the training script with 'python' - just execute it directly. Useful when the script is not a Python script.
  --debug               Whether to print out the torch.distributed stack trace when something fails.

Hardware Selection:
  Arguments for selecting the hardware to be used.

  --cpu                 Whether or not to force the training on the CPU.
  --multi_gpu           Whether or not this should launch a distributed GPU training.
  --tpu                 Whether or not this should launch a TPU training.
  --use_mps_device      Whether or not this should use MPS-enabled GPU device on MacOS machines.

Resource Selection:
  Arguments for fine-tuning how available hardware should be used.

  --mixed_precision {no,fp16,bf16}
                        Whether or not to use mixed precision training. Choose between FP16 and BF16 (bfloat16) training. BF16 training is only supported on Nvidia Ampere GPUs and PyTorch 1.10 or
                        later.
  --fp16                Whether or not to use mixed precision training.
  --num_processes NUM_PROCESSES
                        The total number of processes to be launched in parallel.
  --num_machines NUM_MACHINES
                        The total number of machines used in this training.
  --num_cpu_threads_per_process NUM_CPU_THREADS_PER_PROCESS
                        The number of CPU threads per process. Can be tuned for optimal performance.

Training Paradigm Selection:
  Arguments for selecting which training paradigm to be used.

  --use_deepspeed       Whether to use deepspeed.
  --use_fsdp            Whether to use fsdp.
  --use_megatron_lm     Whether to use Megatron-LM.
...
```

This already cleans up our help *quite a bit*. 

## Method 2, Custom `help` to fine-tune what the user would want

If the user passes in `accelerate launch --use_deepspeed -h` currently it would just show them all the things they can do *totally*, including bits like TPU, FSDP, etc. Which isn't very helpful and cluttering. Now if doing so it will only show the core parameters + `deepspeed` (this can also be combined, such as `accelerate launch --use_deepspeed --multigpu -h`):

```bash
positional arguments:
  training_script       The full path to the script to be launched in parallel, followed by all the arguments for the training script.
  training_script_args  Arguments of the training script.

optional arguments:
  -h, --help            Show this help message and exit.
  --config_file CONFIG_FILE
                        The config file to use for the default values in the launching script.
  -m, --module          Change each process to interpret the launch script as a Python module, executing with the same behavior as 'python -m'.
  --no_python           Skip prepending the training script with 'python' - just execute it directly. Useful when the script is not a Python script.
  --debug               Whether to print out the torch.distributed stack trace when something fails.

Resource Selection:
  Arguments for fine-tuning how available hardware should be used.

  --mixed_precision {no,fp16,bf16}
                        Whether or not to use mixed precision training. Choose between FP16 and BF16 (bfloat16) training. BF16 training is only supported on Nvidia Ampere GPUs and PyTorch 1.10 or
                        later.
  --fp16                Whether or not to use mixed precision training.
  --num_processes NUM_PROCESSES
                        The total number of processes to be launched in parallel.
  --num_machines NUM_MACHINES
                        The total number of machines used in this training.
  --num_cpu_threads_per_process NUM_CPU_THREADS_PER_PROCESS
                        The number of CPU threads per process. Can be tuned for optimal performance.

Training Paradigm Selection:
  Arguments for selecting which training paradigm to be used.

  --use_deepspeed       Whether to use deepspeed. (currently selected)

DeepSpeed:
  Arguments related to DeepSpeed.

  --deepspeed_config_file DEEPSPEED_CONFIG_FILE
                        DeepSpeed config file.
  --zero_stage ZERO_STAGE
                        DeepSpeed's ZeRO optimization stage (useful only when `use_deepspeed` flag is passed).
  --offload_optimizer_device OFFLOAD_OPTIMIZER_DEVICE
                        Decides where (none|cpu|nvme) to offload optimizer states (useful only when `use_deepspeed` flag is passed).
...
```

## How to add new options
If a new device or training regiment option is added and it has parameters specific for it here is how to add a new group and set it up:

1. Add the new group to the `_options_to_group` dictionary where `key:value` is based on the device name (like `--multi-gpu`) and the value is the category name that is expected to be presented for it (such as `"Distributed GPUs"`)
2. Add the specific hardware to be added to the `hardware_args` argument group
For example:
```diff
     # Hardware selection arguments
     hardware_args = parser.add_argument_group("Hardware Selection", "Arguments for selecting the hardware to be used.")
+   hardware_args.add_argument(
+        "--cpu", default=False, action="store_true", help="Whether or not to force the training on the CPU."
+    )
```
4. If needed, create a new argument group based on the name mentioned earlier and add your arguments to it under a labelled section:
```python
    # distributed GPU training arguments
    distributed_args = parser.add_argument_group("Distributed GPUs", "Arguments related to distributed GPU training.")
    distributed_args.add_argument(
        "--gpu_ids",
        default=None,
        help="What GPUs (by id) should be used for training on this machine as a comma-seperated list",
    )
```

Eventually I hope to be able to have autodoc grab the parsing from a CLI arg and just plop it into the docs since apparently that's helpful and wanted, with some formatting to make it presentable. 
