### PR TITLE
Update CLI docs and use mps rather than mps_device

### DIFF
--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -93,6 +93,7 @@ values. They can also be passed in manually.
 * `--tpu` (`bool`) -- Whether or not this should launch a TPU training.
 
 **Resource Selection Arguments**:
+
 The following arguments are useful for fine-tuning how available hardware should be used
 
 * `--mixed_precision {no,fp16,bf16}` (`str`) -- Whether or not to use mixed precision training. Choose between FP16 and BF16 (bfloat16) training. BF16 training is only supported on Nvidia Ampere GPUs and PyTorch 1.10 or later.
@@ -101,6 +102,7 @@ The following arguments are useful for fine-tuning how available hardware should
 * `--num_cpu_threads_per_process NUM_CPU_THREADS_PER_PROCESS` (`int`) -- The number of CPU threads per process. Can be tuned for optimal performance.
 
 **Training Paradigm Arguments**:
+
 The following arguments are useful for selecting which training paradigm to use.
 
 * `--use_deepspeed` (`bool`) -- Whether or not to use DeepSpeed for training.
@@ -108,6 +110,7 @@ The following arguments are useful for selecting which training paradigm to use.
 * `--use_megatron_lm` (`bool`) -- Whether or not to use Megatron-LM for training.
 
 **Distributed GPU Arguments**:
+
 The following arguments are only useful when `multi_gpu` is passed or multi-gpu training is configured through `accelerate config`: 
 
 * `--gpu_ids` (`str`) -- What GPUs (by id) should be used for training on this machine as a comma-seperated list
@@ -120,12 +123,14 @@ The following arguments are only useful when `multi_gpu` is passed or multi-gpu 
 * `--monitor_interval` (`float`) -- Interval, in seconds, to monitor the state of workers.
 
 **TPU Arguments**:
+
 The following arguments are only useful when `tpu` is passed or TPU training is configured through `accelerate config`: 
 
 * `--main_training_function MAIN_TRAINING_FUNCTION` (`str`) -- The name of the main function to be executed in your script.
 * `--downcast_bf16` (`bool`) -- Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.
 
 **DeepSpeed Arguments**:
+
 The following arguments are only useful when `use_deepspeed` is passed or `deepspeed` is configured through `accelerate config`: 
 
 * `--deepspeed_config_file` (`str`) -- DeepSpeed config file.
@@ -142,6 +147,7 @@ The following arguments are only useful when `use_deepspeed` is passed or `deeps
 * `--deepspeed_multinode_launcher` (`str`) -- DeepSpeed multi-node launcher to use.
 
 **Fully Sharded Data Parallelism Arguments**:
+
 The following arguments are only useful when `use_fdsp` is passed or Fully Sharded Data Parallelism is configured through `accelerate config`:
 
 * `--fsdp_offload_params` (`str`) -- Decides Whether (true|false) to offload parameters and gradients to CPU.
@@ -153,6 +159,7 @@ The following arguments are only useful when `use_fdsp` is passed or Fully Shard
 * `--fsdp_state_dict_type` (`str`) -- FSDP's state dict type.
 
 **Megatron-LM Arguments**:
+
 The following arguments are only useful when `use_megatron_lm` is passed or Megatron-LM is configured through `accelerate config`:
 
 * `--megatron_lm_tp_degree` (``) -- Megatron-LM's Tensor Parallelism (TP) degree.
@@ -164,6 +171,7 @@ The following arguments are only useful when `use_megatron_lm` is passed or Mega
 * `--megatron_lm_gradient_clipping` (``) -- Megatron-LM's gradient clipping value based on global L2 Norm (0 to disable).
 
 **AWS SageMaker Arguments**:
+
 The following arguments are only useful when training in SageMaker
 
 * `--aws_access_key_id AWS_ACCESS_KEY_ID` (`str`) -- The AWS_ACCESS_KEY_ID used to launch the Amazon SageMaker training job

--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -78,63 +78,94 @@ accelerate launch [arguments] {training_script} --{training_script-argument-1} -
 
 * `-h`, `--help` (`bool`) -- Show a help message and exit
 * `--config_file CONFIG_FILE` (`str`)-- The config file to use for the default values in the launching script.
-* `--cpu` (`bool`) -- Whether or not to force the training on the CPU.
-* `--mixed_precision {no,fp16,bf16}` (`str`) -- Whether or not to use mixed precision training. Choose between FP16 and BF16 (bfloat16) training. BF16 training is only supported on
-                    Nvidia Ampere GPUs and PyTorch 1.10 or later.
-* `--multi_gpu` (`bool`, defaults to `False`) -- Whether or not this should launch a distributed GPU training.
 * `-m`, `--module` (`bool`) -- Change each process to interpret the launch script as a Python module, executing with the same behavior as 'python -m'.
 * `--no_python` (`bool`) -- Skip prepending the training script with 'python' - just execute it directly. Useful when the script is not a Python script.
+* `--debug` (`bool`) -- Whether to print out the torch.distributed stack trace when something fails.
 
 The rest of these arguments are configured through `accelerate config` and are read in from the specified `--config_file` (or default configuration) for their 
 values. They can also be passed in manually.
 
-**Machine Configuration Arguments**:
+**Hardware Selection Arguments**:
 
-The following arguments are useful for customization of worker machines
-* `--machine_rank MACHINE_RANK` (`int`) -- The rank of the machine on which this script is launched.
-* `--num_machines NUM_MACHINES` (`int`) -- The total number of machines used in this training.
+* `--cpu` (`bool`) -- Whether or not to force the training on the CPU.
+* `--multi_gpu` (`bool`) -- Whether or not this should launch a distributed GPU training.
+* `--mps` (`bool`) -- Whether or not this should use MPS-enabled GPU device on MacOS machines.
+* `--tpu` (`bool`) -- Whether or not this should launch a TPU training.
+
+**Resource Selection Arguments**:
+The following arguments are useful for fine-tuning how available hardware should be used
+
+* `--mixed_precision {no,fp16,bf16}` (`str`) -- Whether or not to use mixed precision training. Choose between FP16 and BF16 (bfloat16) training. BF16 training is only supported on Nvidia Ampere GPUs and PyTorch 1.10 or later.
 * `--num_processes NUM_PROCESSES` (`int`) -- The total number of processes to be launched in parallel.
+* `--num_machines NUM_MACHINES` (`int`) -- The total number of machines used in this training.
+* `--num_cpu_threads_per_process NUM_CPU_THREADS_PER_PROCESS` (`int`) -- The number of CPU threads per process. Can be tuned for optimal performance.
+
+**Training Paradigm Arguments**:
+The following arguments are useful for selecting which training paradigm to use.
+
+* `--use_deepspeed` (`bool`) -- Whether or not to use DeepSpeed for training.
+* `--use_fsdp` (`bool`) -- Whether or not to use FullyShardedDataParallel for training.
+* `--use_megatron_lm` (`bool`) -- Whether or not to use Megatron-LM for training.
+
+**Distributed GPU Arguments**:
+The following arguments are only useful when `multi_gpu` is passed or multi-gpu training is configured through `accelerate config`: 
+
 * `--gpu_ids` (`str`) -- What GPUs (by id) should be used for training on this machine as a comma-seperated list
 * `--same_network` (`bool`) -- Whether all machines used for multinode training exist on the same local network.
+* `--machine_rank MACHINE_RANK` (`int`) -- The rank of the machine on which this script is launched.
 * `--main_process_ip MAIN_PROCESS_IP` (`str`) -- The IP address of the machine of rank 0.
 * `--main_process_port MAIN_PROCESS_PORT` (`int`) -- The port to use to communicate with the machine of rank 0.
 * `--rdzv_conf` (`str`) -- Additional rendezvous configuration (<key1>=<value1>,<key2>=<value2>,...).
-* `--num_cpu_threads_per_process NUM_CPU_THREADS_PER_PROCESS` (`int`) -- The number of CPU threads per process. Can be tuned for optimal performance.
 * `--max_restarts` (`int`) -- Maximum number of worker group restarts before failing.
 * `--monitor_interval` (`float`) -- Interval, in seconds, to monitor the state of workers.
 
-**DeepSpeed Arguments**:
-
-The following arguments are only useful when `use_deepspeed` is passed: 
-* `--use_deepspeed` (`bool`) -- Whether to use deepspeed.
-* `--deepspeed_config_file DEEPSPEED_CONFIG_FILE` (`str`) -- DeepSpeed config file.
-* `--zero_stage ZERO_STAGE` (`str`) -- DeepSpeed's ZeRO optimization stage
-* `--offload_optimizer_device OFFLOAD_OPTIMIZER_DEVICE` (`str`) -- Decides where (none|cpu|nvme) to offload optimizer states
-* `--offload_param_device OFFLOAD_PARAM_DEVICE` (`str`) -- Decides where (none|cpu|nvme) to offload parameters
-* `--gradient_accumulation_steps GRADIENT_ACCUMULATION_STEPS` (`int`) -- Number of gradient_accumulation_steps used in your training script
-* `--gradient_clipping GRADIENT_CLIPPING` (`float`) -- gradient clipping value used in your training script
-The following arguments are related to using ZeRO Stage-3
-* `--zero3_init_flag ZERO3_INIT_FLAG` (`bool`) -- Decides Whether (true|false) to enable `deepspeed.zero.Init` for constructing massive models
-* `--zero3_save_16bit_model ZERO3_SAVE_16BIT_MODEL` (`bool`) -- Decides Whether (true|false) to save 16-bit model weights when using ZeRO Stage-3
-
-**Fully Sharded Data Parallelism Arguments**:
-
-The following arguments are only useful when `use_fdsp` is passed:
-* `--use_fsdp` (`bool`) -- Whether to use fsdp.
-* `--offload_params OFFLOAD_PARAMS` (`bool`) -- Decides Whether (true|false) to offload parameters and gradients to CPU.
-* `--min_num_params MIN_NUM_PARAMS` (`int`) -- FSDP's minimum number of parameters for Default Auto Wrapping.
-* `--sharding_strategy SHARDING_STRATEGY` (`str`) -- FSDP's Sharding Strategy.
-
 **TPU Arguments**:
+The following arguments are only useful when `tpu` is passed or TPU training is configured through `accelerate config`: 
 
-The following arguments are only useful when `tpu` is passed:
-* `--tpu` (`bool`) -- Whether or not this should launch a TPU training.
 * `--main_training_function MAIN_TRAINING_FUNCTION` (`str`) -- The name of the main function to be executed in your script.
 * `--downcast_bf16` (`bool`) -- Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.
 
-**AWS SageMaker Arguments**:
+**DeepSpeed Arguments**:
+The following arguments are only useful when `use_deepspeed` is passed or `deepspeed` is configured through `accelerate config`: 
 
+* `--deepspeed_config_file` (`str`) -- DeepSpeed config file.
+* `--zero_stage` (`int`) -- DeepSpeed's ZeRO optimization stage.
+* `--offload_optimizer_device` (`str`) -- Decides where (none|cpu|nvme) to offload optimizer states.
+* `--offload_param_device` (`str`) -- Decides where (none|cpu|nvme) to offload parameters.
+* `--gradient_accumulation_steps` (`int`) -- No of gradient_accumulation_steps used in your training script.
+* `--gradient_clipping` (`float`) -- Gradient clipping value used in your training script.
+* `--zero3_init_flag` (`str`) -- Decides Whether (true|false) to enable `deepspeed.zero.Init` for constructing massive models. Only applicable with DeepSpeed ZeRO Stage-3.
+* `--zero3_save_16bit_model` (`str`) -- Decides Whether (true|false) to save 16-bit model weights when using ZeRO Stage-3. Only applicable with DeepSpeed ZeRO Stage-3.
+* `--deepspeed_hostfile` (`str`) -- DeepSpeed hostfile for configuring multi-node compute resources.
+* `--deepspeed_exclusion_filter` (`str`) -- DeepSpeed exclusion filter string when using mutli-node setup.
+* `--deepspeed_inclusion_filter` (`str`) -- DeepSpeed inclusion filter string when using mutli-node setup.
+* `--deepspeed_multinode_launcher` (`str`) -- DeepSpeed multi-node launcher to use.
+
+**Fully Sharded Data Parallelism Arguments**:
+The following arguments are only useful when `use_fdsp` is passed or Fully Sharded Data Parallelism is configured through `accelerate config`:
+
+* `--fsdp_offload_params` (`str`) -- Decides Whether (true|false) to offload parameters and gradients to CPU.
+* `--fsdp_min_num_params` (`int`) -- FSDP's minimum number of parameters for Default Auto Wrapping.
+* `--fsdp_sharding_strategy` (`int`) -- FSDP's Sharding Strategy.
+* `--fsdp_auto_wrap_policy` (`str`) -- FSDP's auto wrap policy.
+* `--fsdp_transformer_layer_cls_to_wrap` (`str`) -- Transformer layer class name (case-sensitive) to wrap, e.g, `BertLayer`, `GPTJBlock`, `T5Block` ...
+* `--fsdp_backward_prefetch_policy` (`str`) -- FSDP's backward prefetch policy.
+* `--fsdp_state_dict_type` (`str`) -- FSDP's state dict type.
+
+**Megatron-LM Arguments**:
+The following arguments are only useful when `use_megatron_lm` is passed or Megatron-LM is configured through `accelerate config`:
+
+* `--megatron_lm_tp_degree` (``) -- Megatron-LM's Tensor Parallelism (TP) degree.
+* `--megatron_lm_pp_degree` (``) -- Megatron-LM's Pipeline Parallelism (PP) degree.
+* `--megatron_lm_num_micro_batches` (``) -- Megatron-LM's number of micro batches when PP degree > 1.
+* `--megatron_lm_sequence_parallelism` (``) -- Decides Whether (true|false) to enable Sequence Parallelism when TP degree > 1.
+* `--megatron_lm_recompute_activations` (``) -- Decides Whether (true|false) to enable Selective Activation Recomputation.
+* `--megatron_lm_use_distributed_optimizer` (``) -- Decides Whether (true|false) to use distributed optimizer which shards optimizer state and gradients across Data Pralellel (DP) ranks.
+* `--megatron_lm_gradient_clipping` (``) -- Megatron-LM's gradient clipping value based on global L2 Norm (0 to disable).
+
+**AWS SageMaker Arguments**:
 The following arguments are only useful when training in SageMaker
+
 * `--aws_access_key_id AWS_ACCESS_KEY_ID` (`str`) -- The AWS_ACCESS_KEY_ID used to launch the Amazon SageMaker training job
 * `--aws_secret_access_key AWS_SECRET_ACCESS_KEY` (`str`) -- The AWS_SECRET_ACCESS_KEY used to launch the Amazon SageMaker training job
 

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -514,7 +514,7 @@ def simple_launcher(args):
     current_env = os.environ.copy()
     current_env["USE_CPU"] = str(args.cpu or args.use_cpu)
     if args.use_mps_device:
-        warnings.warn('--use_mps_device flag is deprecated. Use "--mps" instead.', FutureWarning)
+        warnings.warn('`use_mps_device` flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mps" instead.', FutureWarning)
         args.mps = True
     current_env["USE_MPS_DEVICE"] = str(args.mps)
     if args.mps:
@@ -714,7 +714,7 @@ def deepspeed_launcher(args):
         )
 
     if args.fp16:
-        warnings.warn('--fp16 flag is deprecated. Use "--mixed_precision fp16" instead.', FutureWarning)
+        warnings.warn('--fp16 flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mixed_precision fp16" instead.', FutureWarning)
         mixed_precision = "fp16"
 
     current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath("."))

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -64,6 +64,7 @@ logger = logging.getLogger(__name__)
 options_to_group = {
     "--multi-gpu": "Distributed GPUs",
     "--tpu": "TPU",
+    "--mps": "MPS",
     "--use_mps_device": "MPS",
     "--use_deepspeed": "DeepSpeed Arguments",
     "--use_fsdp": "FSDP Arguments",
@@ -145,6 +146,12 @@ def launch_command_parser(subparsers=None):
         "--cpu", default=False, action="store_true", help="Whether or not to force the training on the CPU."
     )
     hardware_args.add_argument(
+        "--mps",
+        default=False,
+        action="store_true",
+        help="Whether or not this should use MPS-enabled GPU device on MacOS machines.",
+    )
+    hardware_args.add_argument(
         "--multi_gpu",
         default=False,
         action="store_true",
@@ -157,7 +164,7 @@ def launch_command_parser(subparsers=None):
         "--use_mps_device",
         default=False,
         action="store_true",
-        help="Whether or not this should use MPS-enabled GPU device on MacOS machines.",
+        help="This argument is deprecated, use `--mps` instead.",
     )
 
     # Resource selection arguments
@@ -506,8 +513,11 @@ def simple_launcher(args):
 
     current_env = os.environ.copy()
     current_env["USE_CPU"] = str(args.cpu or args.use_cpu)
-    current_env["USE_MPS_DEVICE"] = str(args.use_mps_device)
     if args.use_mps_device:
+        warnings.warn('--use_mps_device flag is deprecated. Use "--mps" instead.', FutureWarning)
+        args.mps = True
+    current_env["USE_MPS_DEVICE"] = str(args.mps)
+    if args.mps:
         current_env["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
     elif args.gpu_ids != "all" and args.gpu_ids is not None:
         current_env["CUDA_VISIBLE_DEVICES"] = args.gpu_ids
@@ -955,18 +965,18 @@ def launch_command(args):
         if (
             not args.multi_gpu
             and not args.tpu
+            and not args.mps
             and not args.use_deepspeed
             and not args.use_fsdp
-            and not args.use_mps_device
             and not args.use_megatron_lm
         ):
             args.use_deepspeed = defaults.distributed_type == DistributedType.DEEPSPEED
             args.multi_gpu = defaults.distributed_type == DistributedType.MULTI_GPU
             args.tpu = defaults.distributed_type == DistributedType.TPU
             args.use_fsdp = defaults.distributed_type == DistributedType.FSDP
-            args.use_mps_device = defaults.distributed_type == DistributedType.MPS
+            args.mps = defaults.distributed_type == DistributedType.MPS
             args.use_megatron_lm = defaults.distributed_type == DistributedType.MEGATRON_LM
-        if not args.use_mps_device:
+        if not args.mps:
             if args.gpu_ids is None:
                 if defaults.gpu_ids is not None:
                     args.gpu_ids = defaults.gpu_ids

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -514,7 +514,10 @@ def simple_launcher(args):
     current_env = os.environ.copy()
     current_env["USE_CPU"] = str(args.cpu or args.use_cpu)
     if args.use_mps_device:
-        warnings.warn('`use_mps_device` flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mps" instead.', FutureWarning)
+        warnings.warn(
+            '`use_mps_device` flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mps" instead.',
+            FutureWarning,
+        )
         args.mps = True
     current_env["USE_MPS_DEVICE"] = str(args.mps)
     if args.mps:
@@ -714,7 +717,10 @@ def deepspeed_launcher(args):
         )
 
     if args.fp16:
-        warnings.warn('--fp16 flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mixed_precision fp16" instead.', FutureWarning)
+        warnings.warn(
+            '--fp16 flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mixed_precision fp16" instead.',
+            FutureWarning,
+        )
         mixed_precision = "fp16"
 
     current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath("."))


### PR DESCRIPTION
We have the following naming convention for device vs training schema:

Device: 
  - Use device name, such as `--tpu`, `--multi_gpu`, `--cpu`

Training Schema
  - Use schema name with "use" in the front, such as `--use_megatron_lm` and `--use_deepspeed`

Since MPS is a torch device rather than a schema, this PR changes the flag to be `--mps` and adds in a future warning for `--use_mps` so we can be consistent 🤗 

Also updates the CLI docs to reflect the latest refactorization. 