### PR TITLE
adding support to return logits and generate for Megatron-LM GPT models

### DIFF
--- a/docs/source/usage_guides/megatron_lm.mdx
+++ b/docs/source/usage_guides/megatron_lm.mdx
@@ -435,6 +435,103 @@ python checkpoint_utils/megatgron_gpt2/checkpoint_reshaping_and_interoperability
 --print-checkpoint-structure
 ```
 
+## Megatron-LM GPT models support returning logits and `megatron_generate` function for text generation
+
+1. Returning logits require setting `require_logits=True` in MegatronLMPlugin as shown below. 
+These would be available on the in the last stage of pipeline.
+```python
+megatron_lm_plugin = MegatronLMPlugin(return_logits=True)
+```
+
+2. `megatron_generate` method for Megatron-LM GPT model: This will use Tensor and Pipeline Parallelism to complete 
+generations for a batch of inputs when using greedy with/without top_k/top_p sampling and for individual prompt inputs when using beam search decoding. 
+Only a subset of features of transformers generate is supported. This will help in using large models via tensor and pipeline parallelism 
+for generation (already does key-value caching and uses fused kernels by default).
+This requires data parallel size to be 1, sequence parallelism and activation checkpointing to be disabled.
+It also requires specifying path to tokenizer's vocab file and merges file. 
+Below example shows how to configure and use `megatron_generate` method for Megatron-LM GPT model.
+```python
+# specifying tokenizer's vocab and merges file
+vocab_file = os.path.join(args.resume_from_checkpoint, "vocab.json")
+merge_file = os.path.join(args.resume_from_checkpoint, "merges.txt")
+other_megatron_args = {"vocab_file": vocab_file, "merge_file": merge_file}
+megatron_lm_plugin = MegatronLMPlugin(other_megatron_args=other_megatron_args)
+
+# inference using `megatron_generate` functionality
+tokenizer.pad_token = tokenizer.eos_token
+max_new_tokens = 64
+batch_texts = [
+    "Are you human?",
+    "The purpose of life is",
+    "The arsenal was constructed at the request of",
+    "How are you doing these days?",
+]
+batch_encodings = tokenizer(batch_texts, return_tensors="pt", padding=True)
+
+# top-p sampling
+generated_tokens = model.megatron_generate(
+    batch_encodings["input_ids"],
+    batch_encodings["attention_mask"],
+    max_new_tokens=max_new_tokens,
+    top_p=0.8,
+    top_p_decay=0.5,
+    temperature=0.9,
+)
+decoded_preds = tokenizer.batch_decode(generated_tokens.cpu().numpy())
+accelerator.print(decoded_preds)
+
+# top-k sampling
+generated_tokens = model.megatron_generate(
+    batch_encodings["input_ids"],
+    batch_encodings["attention_mask"],
+    max_new_tokens=max_new_tokens,
+    top_k=50,
+    temperature=0.9,
+)
+decoded_preds = tokenizer.batch_decode(generated_tokens.cpu().numpy())
+accelerator.print(decoded_preds)
+
+# adding `bos` token at the start
+generated_tokens = model.megatron_generate(
+    batch_encodings["input_ids"], batch_encodings["attention_mask"], max_new_tokens=max_new_tokens, add_BOS=True
+)
+decoded_preds = tokenizer.batch_decode(generated_tokens.cpu().numpy())
+accelerator.print(decoded_preds)
+
+# beam search => only takes single prompt
+batch_texts = ["The purpose of life is"]
+batch_encodings = tokenizer(batch_texts, return_tensors="pt", padding=True)
+generated_tokens = model.megatron_generate(
+    batch_encodings["input_ids"],
+    batch_encodings["attention_mask"],
+    max_new_tokens=max_new_tokens,
+    num_beams=20,
+    length_penalty=1.5,
+)
+decoded_preds = tokenizer.batch_decode(generated_tokens.cpu().numpy())
+accelerator.print(decoded_preds)
+```
+
+3. An end-to-end example of using `megatron_generate` method for Megatron-LM GPT model is available at
+[megatron_gpt2_generation.py](https://github.com/pacman100/accelerate-megatron-test/blob/main/src/inference/megatron_gpt2_generation.py) with 
+config file [megatron_lm_gpt_generate_config.yaml](https://github.com/pacman100/accelerate-megatron-test/blob/main/src/Configs/megatron_lm_gpt_generate_config.yaml).
+The bash script with accelerate launch command is available at [megatron_lm_gpt_generate.sh](https://github.com/pacman100/accelerate-megatron-test/blob/main/megatron_lm_gpt_generate.sh).
+The output logs of the script are available at [megatron_lm_gpt_generate.log](https://github.com/pacman100/accelerate-megatron-test/blob/main/output_logs/megatron_lm_gpt_generate.log).
+
+## Support for ROPE and ALiBi Positional embeddings and Multi-Query Attention
+
+1. For ROPE/ALiBi attention, pass `position_embedding_type` with `("absolute" | "rotary" | "alibi")` to `MegatronLMPlugin` as shown below.
+```python
+other_megatron_args = {"position_embedding_type": "alibi"}
+megatron_lm_plugin = MegatronLMPlugin(other_megatron_args=other_megatron_args)
+```
+
+2. For Multi-Query Attention, pass `attention_head_type` with `("multihead" | "multiquery")` to `MegatronLMPlugin` as shown below.
+```python
+other_megatron_args = {"attention_head_type": "multiquery"}
+megatron_lm_plugin = MegatronLMPlugin(other_megatron_args=other_megatron_args)
+```
+
 ## Caveats
 
 1. Supports Transformers GPT2, Megatron-BERT and T5 models.
@@ -445,8 +542,12 @@ there is quite complex interplay of pipeline, tensor and data parallelsim behind
 The `model(**batch_data)` call return loss(es) averaged across the data parallel ranks.
 This is fine for most cases wherein pre-training jobs are run using Megatron-LM features and
 you can easily compute the `perplexity` using the loss. 
+For GPT model, returning logits in addition to loss(es) is supported. 
+These logits aren't gathered across data prallel ranks. Use `accelerator.utils.gather_across_data_parallel_groups`
+to gather logits across data parallel ranks. These logits along with labels can be used for computing various 
+performance metrics. 
 
-3. The main process is the last rank as the losses are available in the last stage of pipeline.
+3. The main process is the last rank as the losses/logits are available in the last stage of pipeline.
 `accelerator.is_main_process` and `accelerator.is_local_main_process` return `True` for last rank when using 
 Megatron-LM integration.
 

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -107,6 +107,7 @@ from .megatron_lm import (
     MegatronLMSchedulerWrapper,
     T5TrainStep,
     avg_losses_across_data_parallel_group,
+    gather_across_data_parallel_groups,
 )
 from .megatron_lm import initialize as megatron_lm_initialize
 from .megatron_lm import prepare_data_loader as megatron_lm_prepare_data_loader

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib
+import os
 import sys
 from functools import lru_cache
 
@@ -90,10 +91,11 @@ def is_bf16_available(ignore_tpu=False):
 
 
 def is_megatron_lm_available():
-    package_exists = importlib.util.find_spec("megatron") is not None
-    if package_exists:
-        megatron_version = parse(importlib_metadata.version("megatron-lm"))
-        return compare_versions(megatron_version, ">=", "2.2.0")
+    if os.environ.get("USE_MEGATRON_LM", "false") == "true":
+        package_exists = importlib.util.find_spec("megatron") is not None
+        if package_exists:
+            megatron_version = parse(importlib_metadata.version("megatron-lm"))
+            return compare_versions(megatron_version, ">=", "2.2.0")
     return False
 
 

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -15,6 +15,7 @@
 import importlib
 import os
 import sys
+from distutils.util import strtobool
 from functools import lru_cache
 
 import torch
@@ -91,7 +92,7 @@ def is_bf16_available(ignore_tpu=False):
 
 
 def is_megatron_lm_available():
-    if os.environ.get("USE_MEGATRON_LM", "false") == "true":
+    if strtobool(os.environ.get("USE_MEGATRON_LM", "False")) == 1:
         package_exists = importlib.util.find_spec("megatron") is not None
         if package_exists:
             megatron_version = parse(importlib_metadata.version("megatron-lm"))

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -14,7 +14,6 @@
 
 import argparse
 import math
-import os
 from abc import ABC
 from functools import partial
 
@@ -36,7 +35,7 @@ if is_transformers_available():
     )
 
 
-if is_megatron_lm_available() and os.environ.get("USE_MEGATRON_LM", "false") == "true":
+if is_megatron_lm_available():
     from megatron import (
         get_args,
         get_num_microbatches,

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -25,7 +25,7 @@ from torch.nn.parallel.distributed import DistributedDataParallel as torchDDP
 from ..optimizer import AcceleratedOptimizer
 from ..scheduler import AcceleratedScheduler
 from .imports import is_megatron_lm_available, is_transformers_available
-from .operations import send_to_device
+from .operations import recursively_apply, send_to_device
 
 
 if is_transformers_available():
@@ -1417,3 +1417,25 @@ def avg_losses_across_data_parallel_group(losses):
     """
 
     return average_losses_across_data_parallel_group(losses)
+
+
+def gather_across_data_parallel_groups(tensor):
+    """
+    Recursively gather tensor in a nested list/tuple/dictionary of tensors from data parallel ranks.
+
+    Args:
+        tensor (nested list/tuple/dictionary of `torch.Tensor`):
+            The data to gather across data parallel ranks.
+
+    """
+
+    def _gpu_gather_one(tensor):
+        if tensor.ndim == 0:
+            tensor = tensor.clone()[None]
+        output_tensors = [
+            tensor.clone() for _ in range(torch.distributed.get_world_size(group=mpu.get_data_parallel_group()))
+        ]
+        torch.distributed.all_gather(output_tensors, tensor, group=mpu.get_data_parallel_group())
+        return torch.cat(output_tensors, dim=0)
+
+    return recursively_apply(_gpu_gather_one, tensor, error_on_other_type=True)

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -14,7 +14,6 @@
 
 import argparse
 import math
-import warnings
 from abc import ABC
 from functools import partial
 
@@ -1333,9 +1332,6 @@ class MegatronEngine(torch.nn.Module):
 
         if length_penalty is None:
             length_penalty = 1.0
-
-        if inputs.shape[0] % 4 != 0:
-            warnings.warn("Batch size must be a multiple of 4 to leverage fused kernels")
 
         sizes_list = None
         prompts_tokens_tensor = None

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -125,8 +125,8 @@ def prepare_model(accelerator):
             raise ValueError(
                 "You must provide a `custom_model_provider_function` when using a `custom_prepare_model_function`."
             )
-        model_provider_func = accelerator.state.megatron_lm_plugin.custom_model_provider_function
-        model = accelerator.state.megatron_lm_plugin.custom_prepare_model_function(model_provider_func)
+        custom_model_provider_func = accelerator.state.megatron_lm_plugin.custom_model_provider_function
+        model = accelerator.state.megatron_lm_plugin.custom_prepare_model_function(custom_model_provider_func)
     else:
         if args.model_type_name == "bert" or args.model_type_name == "gpt":
             model_type = ModelType.encoder_or_decoder

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -1179,10 +1179,7 @@ class MegatronEngine(torch.nn.Module):
             logits = loss_dict["logits"]
         # loss = reduce(loss)
         if self.train_step_handler.model_output_class is not None:
-            return self.train_step_handler.model_output_class(
-                loss=loss,
-                logits=logits,
-            )
+            return self.train_step_handler.model_output_class(loss=loss, logits=logits)
         return loss
 
     def log_eval_results(self):
@@ -1231,7 +1228,7 @@ class MegatronEngine(torch.nn.Module):
         if args.fp16 and self.iteration == 0:
             self.optimizer.reload_model_params()
 
-    def generate(
+    def megatron_generate(
         self,
         inputs,
         attention_mask=None,


### PR DESCRIPTION
### What does this PR do?
1. Enable returning logits for Megatron-LM GPT models
2. Enable specify custom Megatron-LM based model 
3. Enable specify any Megatron-LM arguments to support things such as ALiBi/ROPE positional embeddings, Multi-Query Attention, tokenizer files etc.
4. Enable `megatron_generate` method for Megatron-LM GPT model, this will use Tensor and Pipeline Parallelism to complete generations for a batch of `inputs` when using greedy with/without top_k/top_p sampling  and for individual prompt `inputs` when using beam search decoding. Only a subset of features of transformers `generate` is supported. This will help in using large models via tensor and pipeline parallelism  for generation (already does key-value caching and uses fused kernels by default). 
5. fixes #809

Below is the run of the example script [megatron_gpt2_generation.py](https://github.com/pacman100/accelerate-megatron-test/blob/main/src/inference/megatron_gpt2_generation.py) with the main parts of output logs given below:
```
The Megatron LM model weights are initialized at random in `accelerator.prepare`. Please use `accelerator.load_checkpoint` to load a pre-trained checkpoint matching the distributed setup.
 > number of parameters on (tensor, pipeline) model parallel rank (0, 0): 102483968
 > number of parameters on (tensor, pipeline) model parallel rank (0, 1): 101437440
 > number of parameters on (tensor, pipeline) model parallel rank (1, 0): 102483968
 > number of parameters on (tensor, pipeline) model parallel rank (1, 1): 101437440
Preparing optimizer
> learning rate decay style: linear
Preparing scheduler
...

11/04/2022 14:47:18 - INFO - __main__ - ***** Running training *****
11/04/2022 14:47:18 - INFO - __main__ -   Num examples = 2318
11/04/2022 14:47:18 - INFO - __main__ -   Num Epochs = 2
11/04/2022 14:47:18 - INFO - __main__ -   Instantaneous batch size per device = 24
11/04/2022 14:47:18 - INFO - __main__ -   Total train batch size (w. parallel, distributed & accumulation) = 48
11/04/2022 14:47:18 - INFO - __main__ -   Gradient Accumulation steps = 1
11/04/2022 14:47:18 - INFO - __main__ -   Total optimization steps = 96
  0%|                                                                        | 0/96 [00:00<?, ?it/s]
Resumed from checkpoint: /home/sourab/temp/megatron_lm_checkpoint
11/04/2022 14:47:18 - INFO - accelerate.accelerator - Loading states from /home/sourab/temp/megatron_lm_checkpoint
11/04/2022 14:47:18 - INFO - accelerate.accelerator - Loading Megatron-LM Model, Optimizer and Scheduler
Resuming from /home/sourab/temp/megatron_lm_checkpoint
 loading release checkpoint from /home/sourab/temp/megatron_lm_checkpoint
  Warning, trying to load an old checkpoint: 'types.SimpleNamespace' object has no attribute 'position_embedding_type'
 checkpoint version 3.0
  successfully loaded checkpoint from /home/sourab/temp/megatron_lm_checkpoint at iteration 0
11/04/2022 14:47:18 - INFO - accelerate.accelerator - Megatron-LM Model , Optimizer and Scheduler loaded from input dir /home/sourab/temp/megatron_lm_checkpoint
11/04/2022 14:47:18 - INFO - accelerate.checkpointing - All model weights loaded successfully
11/04/2022 14:47:18 - INFO - accelerate.checkpointing - All optimizer states loaded successfully
11/04/2022 14:47:18 - INFO - accelerate.checkpointing - All scheduler states loaded successfully
11/04/2022 14:47:18 - INFO - accelerate.checkpointing - Could not load random states
11/04/2022 14:47:18 - INFO - accelerate.accelerator - Loading in 0 custom states
  0%|                                                                        | 0/96 [00:00<?, ?it/s]
accelerator.process_index=3 outputs.logits=tensor([[[ 4.4648,  3.7715, -3.1172,  ...,  1.4053,  1.4053,  1.4053],
         [ 0.6279,  3.5449, -1.7275,  ...,  0.9048,  0.9048,  0.9048],
         [ 3.1074,  5.1484, -2.4570,  ...,  3.0684,  3.0684,  3.0684],
         ...,
       device='cuda:3', grad_fn=<CatBackward0>)
 50%|███████████████████████████████▌                               | 48/96 [00:40<00:36,  1.33it/s]11/04/2022 14:48:00 - INFO - __main__ - epoch 0: perplexity: 14.762350004624928 eval_loss: 2.692080020904541
epoch 0 training + evaluation took 0.708652 minutes
100%|███████████████████████████████████████████████████████████████| 96/96 [01:19<00:00,  1.32it/s]11/04/2022 14:48:39 - INFO - __main__ - epoch 1: perplexity: 14.325097285606006 eval_loss: 2.662013053894043
epoch 1 training + evaluation took 0.648274 minutes
Total Training + Evaluation took 1.356926 minutes

...
Greedy generation on a batch of 4 below with adding `bos` token at the start
['<|endoftext|>Are you human or are you... conventional?: What the heck is being called ` `... from television\'together? * Smiles * " "\' ( BBC ) ” [ 64 Bill Atkinson, Ep. 77 ], the stage play\'[ 61 G.A.U.S.L.D.\'], based on Jack Lee\'s Animal Volumes \'',

 '<|endoftext|>The purpose of life is to make you think, not to glorify. I try to live as I want to live ; I live at broke bread and frugal with my excess. There are times when you might not like what you see painted on a work of art, but you have to accept it when you have the opportunity to see the full light of happiness.', 

'<|endoftext|>The arsenal was constructed at the request of Germany in the mid @-@ 1930s, first in the Frankfurt @-@ Burgess Conservatory for the Erkenau Expedition and then in the Kattegat Protectorate, unused since Eastern Front. About twenty guns were taken from the Levant and transferred to the modern arsenal. The first Heinkel Bf 110 dive bombers were', 

'<|endoftext|>How are you doing these days? Last night you were really really quiet for a while, no mean feat for a baby of your age. Has that dog been around for years? " How are you doing, Baby? That is a really interesting question, " says my daughter, matter of factly, actually giving me the space to actually reassure her that everything and everyone is']

Beam generation on an individual input below
['The purpose of life is to make the world a better place. " \n = = = Education = = = \n = = = = Education = = = = \n = = = = Education = = = = \n = = = = Education = = = = \n = = = = Education = = = = \n = = =']
100%|███████████████████████████████████████████████████████████████| 96/96 [01:30<00:00,  1.06it/s]
wandb: Waiting for W&B process to finish... (success).
wandb:                                                                                
wandb: 
wandb: Run history:
wandb:      epoch ▁█
wandb:  eval_loss █▁
wandb: perplexity █▁
wandb:       step ▁█
wandb: train_loss █▁
wandb: 
wandb: Run summary:
wandb:      epoch 1
wandb:  eval_loss 2.66201
wandb: perplexity 14.3251
wandb:       step 96
wandb: train_loss 2.68363
```