### PR TITLE
Add `join_uneven_inputs` context manager to Accelerator

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -615,7 +615,7 @@ class Accelerator:
     @contextmanager
     def join_uneven_inputs(self, joinables, even_batches=None):
         """
-        TODO: docstring
+        A context manager that facilitates distributed training on uneven inputs, which acts as a wrapper around `torch.distributed.algorithms.join`.
         """
         if is_torch_version("<", "1.10.0"):
             raise ValueError(f"Joining uneven inputs requires PyTorch >= 1.10.0, You have {torch.__version__}.")

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -356,6 +356,7 @@ class Accelerator:
         self._optimizers = []
         self._models = []
         self._schedulers = []
+        self._dataloaders = []
         self._custom_objects = []
 
         # RNG Types
@@ -1136,7 +1137,7 @@ class Accelerator:
         """
         if device_placement is None:
             device_placement = self.device_placement if self.distributed_type != DistributedType.TPU else False
-        return prepare_data_loader(
+        prepared_data_loader = prepare_data_loader(
             data_loader,
             self.device,
             num_processes=self.num_processes,
@@ -1147,6 +1148,8 @@ class Accelerator:
             dispatch_batches=self.dispatch_batches,
             even_batches=self.even_batches,
         )
+        self._dataloaders.append(prepared_data_loader)
+        return prepared_data_loader
 
     def prepare_optimizer(self, optimizer: torch.optim.Optimizer, device_placement=None):
         """
@@ -1630,6 +1633,7 @@ class Accelerator:
         self._schedulers = []
         self._optimizers = []
         self._models = []
+        self._dataloaders = []
         self.deepspeed_engine_wrapped = None
         gc.collect()
         torch.cuda.empty_cache()

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -618,7 +618,8 @@ class Accelerator:
 
         if self.distributed_type == DistributedType.NO:
             # Even when disabled, Join expects models to subclass Joinable, so skip entirely for single process runs
-            yield
+            with contextlib.nullcontext(joinables):
+                yield
         elif self.distributed_type == DistributedType.MULTI_GPU:
             enable_join = False if self.even_batches else True
             with Join(joinables, enable=enable_join, throw_on_early_termination=False):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -627,7 +627,7 @@ class Accelerator:
 
         elif self.distributed_type == DistributedType.MULTI_GPU:
             dl_even_batches_values = []
-            
+
             if even_batches is not None:
                 for dl in self._dataloaders:
                     if not hasattr(dl, "even_batches"):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -23,7 +23,6 @@ from functools import wraps
 from typing import List, Optional, Union
 
 import torch
-from torch.distributed.algorithms.join import Join
 
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import prepare_data_loader
@@ -87,6 +86,9 @@ if is_megatron_lm_available():
         megatron_lm_prepare_optimizer,
         megatron_lm_prepare_scheduler,
     )
+
+if is_torch_version(">", "1.10.0"):
+    from torch.distributed.algorithms.join import Join
 
 
 if is_tpu_available(check_device=False):
@@ -611,8 +613,8 @@ class Accelerator:
 
     @contextmanager
     def join_uneven_inputs(self, joinables):
-        if is_torch_version("<", "1.10.0"):
-            raise ValueError("Joining uneven inputs requires PyTorch >= 1.10.0")
+        if is_torch_version(">", "1.10.0"):
+            raise ValueError("Joining uneven inputs requires PyTorch >= 1.10.0, You have {torch.__version__}.")
 
         if self.distributed_type == DistributedType.NO:
             # Even when disabled, Join expects models to subclass Joinable, so skip entirely for single process runs

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -612,7 +612,7 @@ class Accelerator:
     @contextmanager
     def join_uneven_inputs(self, joinables):
         if is_torch_version("<", "1.10.0"):
-            raise ValueError("Joining uneven inputs requires PyTorch >= 1.10.0")    
+            raise ValueError("Joining uneven inputs requires PyTorch >= 1.10.0")
 
         if self.distributed_type == DistributedType.NO:
             # Even when disabled, Join expects models to subclass Joinable, so skip entirely for single process runs
@@ -623,9 +623,6 @@ class Accelerator:
                 yield
         else:
             raise ValueError("Joining uneven inputs is only supported for DistributedDataParallel training")
-
-      
-        
 
     def print(self, *args, **kwargs):
         """

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -691,7 +691,7 @@ class Accelerator:
             # Even when disabled, Join expects models to subclass Joinable, so skip entirely for single process runs
             if self.distributed_type != DistributedType.NO:
                 warnings.warn(
-                    "Joining uneven inputs is only supported for DistributedDataParallel training, join_unenven_inputs has no effect."
+                    "Joining uneven inputs is only supported for multi-GPU training, as a result `join_uneven_inputs` will have no effect."
                 )
 
             with contextlib.nullcontext(joinables):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -665,16 +665,18 @@ class Accelerator:
             dl_even_batches_values = []
 
             if even_batches is not None:
+                iterable_dl_seen = False
                 # override value in batch sampler for map-style datasets
                 for dl_idx, dl in enumerate(self._dataloaders):
                     if isinstance(dl, DataLoaderDispatcher):
+                        iterable_dl_seen = True
                         continue
                     dl_even_batches_values.append((dl_idx, dl.batch_sampler.even_batches))
                     dl.batch_sampler.even_batches = even_batches
 
-                if len(dl_even_batches_values) == 0:
+                if iterable_dl_seen:
                     warnings.warn(
-                        "Overridding even_batches is only supported for map-style datasets, yet all dataloaders given were iterable"
+                        "Overridding even_batches is only supported for map-style datasets, yet some dataloaders given were iterable"
                     )
             else:
                 even_batches = self.even_batches

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -178,14 +178,14 @@ def test_join_can_override_for_mixed_type_dataloaders():
     accelerator = create_accelerator(even_batches=default_even_batches)
     model = torch.nn.Linear(1, 1)
     ddp_model = accelerator.prepare(model)
-    iter_dl = create_dataloader(accelerator, dataset_size=3, batch_size=1, iterable=True)
+    create_dataloader(accelerator, dataset_size=3, batch_size=1, iterable=True)
     batch_dl = create_dataloader(accelerator, dataset_size=3, batch_size=1)
 
     try:
         with accelerator.join_uneven_inputs([ddp_model], even_batches=overridden_even_batches):
             batch_dl_overridden_value = batch_dl.batch_sampler.even_batches
     except AttributeError:
-        # ensure attribute error is not raised when processing iter_dl
+        # ensure attribute error is not raised when processing iterable dl
         raise AssertionError
 
     assert batch_dl_overridden_value == overridden_even_batches
@@ -196,7 +196,7 @@ def test_join_raises_warning_for_all_iterable_when_overriding_even_batches():
     accelerator = create_accelerator()
     model = torch.nn.Linear(1, 1)
     ddp_model = accelerator.prepare(model)
-    train_dl = create_dataloader(accelerator, dataset_size=3, batch_size=1, iterable=True)
+    create_dataloader(accelerator, dataset_size=3, batch_size=1, iterable=True)
 
     with warnings.catch_warnings(record=True) as w:
         with accelerator.join_uneven_inputs([ddp_model], even_batches=False):

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -103,6 +103,30 @@ def test_can_disable_even_batches():
     )
 
 
+def test_can_join_uneven_inputs():
+    accelerator = create_accelerator(even_batches=False)
+
+    model = torch.nn.Linear(1, 1)
+    ddp_model = accelerator.prepare(model)
+
+    dl = create_dataloader(accelerator, dataset_size=3, batch_size=1)
+
+    batch_idxs = []
+    with accelerator.join_uneven_inputs([ddp_model]):
+        for batch_idx, batch in enumerate(dl):
+            output = ddp_model(batch[0].float())
+            loss = output.sum()
+            loss.backward()
+            batch_idxs.append(batch_idx)
+
+    accelerator.wait_for_everyone()
+
+    if accelerator.process_index == 0:
+        assert batch_idxs == [0, 1]
+    elif accelerator.process_index == 1:
+        assert batch_idxs == [0]
+
+
 if __name__ == "__main__":
     accelerator = create_accelerator()
 
@@ -111,3 +135,6 @@ if __name__ == "__main__":
 
     accelerator.print("Run tests with even_batches disabled")
     test_can_disable_even_batches()
+
+    accelerator.print("Test joining uneven inputs")
+    test_can_join_uneven_inputs()

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -23,7 +23,6 @@ import torch
 from torch.utils.data import DataLoader, IterableDataset, TensorDataset
 
 from accelerate.accelerator import Accelerator
-from accelerate.launchers import notebook_launcher
 from accelerate.utils.dataclasses import DistributedType
 
 
@@ -238,5 +237,4 @@ def main():
 
 
 if __name__ == "__main__":
-    notebook_launcher(main, num_processes=2)
-    # main()
+    main()

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -23,7 +23,6 @@ import torch
 from torch.utils.data import DataLoader, IterableDataset, TensorDataset
 
 from accelerate.accelerator import Accelerator
-from accelerate.launchers import notebook_launcher
 from accelerate.utils.dataclasses import DistributedType
 
 
@@ -236,5 +235,4 @@ def main():
 
 
 if __name__ == "__main__":
-    notebook_launcher(main, num_processes=2)
-    # main()
+    main()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -304,6 +304,7 @@ def training_check():
         print("BF16 training check.")
         AcceleratorState._reset_state()
         accelerator = Accelerator(mixed_precision="bf16")
+        accelerator.free_memory()
         train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
         model = RegressionModel()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -304,7 +304,6 @@ def training_check():
         print("BF16 training check.")
         AcceleratorState._reset_state()
         accelerator = Accelerator(mixed_precision="bf16")
-        accelerator.free_memory()
         train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
         model = RegressionModel()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1,0 +1,48 @@
+import unittest
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from accelerate.accelerator import Accelerator
+
+
+def create_components():
+    model = torch.nn.Linear(2, 4)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1.0)
+    scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=0.01, steps_per_epoch=2, epochs=1)
+    train_dl = DataLoader(TensorDataset(torch.tensor([1, 2, 3])))
+    valid_dl = DataLoader(TensorDataset(torch.tensor([4, 5, 6])))
+
+    return model, optimizer, scheduler, train_dl, valid_dl
+
+
+class AcceleratorTester(unittest.TestCase):
+    def test_prepared_objects_are_referenced(self):
+        accelerator = Accelerator()
+        model, optimizer, scheduler, train_dl, valid_dl = create_components()
+
+        (
+            prepared_model,
+            prepared_optimizer,
+            prepared_scheduler,
+            prepared_train_dl,
+            prepared_valid_dl,
+        ) = accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
+
+        self.assertTrue(prepared_model in accelerator._models)
+        self.assertTrue(prepared_optimizer in accelerator._optimizers)
+        self.assertTrue(prepared_scheduler in accelerator._schedulers)
+        self.assertTrue(prepared_train_dl in accelerator._dataloaders)
+        self.assertTrue(prepared_valid_dl in accelerator._dataloaders)
+
+    def test_free_memory_dereferences_prepared_components(self):
+        accelerator = Accelerator()
+        model, optimizer, scheduler, train_dl, valid_dl = create_components()
+        accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
+
+        accelerator.free_memory()
+
+        self.assertTrue(len(accelerator._models) == 0)
+        self.assertTrue(len(accelerator._optimizers) == 0)
+        self.assertTrue(len(accelerator._schedulers) == 0)
+        self.assertTrue(len(accelerator._dataloaders) == 0)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -4,6 +4,7 @@ import torch
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate.accelerator import Accelerator
+from accelerate.state import AcceleratorState
 
 
 def create_components():
@@ -34,6 +35,7 @@ class AcceleratorTester(unittest.TestCase):
         self.assertTrue(prepared_scheduler in accelerator._schedulers)
         self.assertTrue(prepared_train_dl in accelerator._dataloaders)
         self.assertTrue(prepared_valid_dl in accelerator._dataloaders)
+        AcceleratorState._reset_state()
 
     def test_free_memory_dereferences_prepared_components(self):
         accelerator = Accelerator()
@@ -46,3 +48,4 @@ class AcceleratorTester(unittest.TestCase):
         self.assertTrue(len(accelerator._optimizers) == 0)
         self.assertTrue(len(accelerator._schedulers) == 0)
         self.assertTrue(len(accelerator._dataloaders) == 0)
+        AcceleratorState._reset_state()


### PR DESCRIPTION
This PR adds a context manager which acts as a simple wrapper around [Join](https://pytorch.org/docs/stable/distributed.algorithms.join.html) to enable training with uneven inputs when using DDP.


This continues the work described in: https://github.com/huggingface/accelerate/issues/684