### PR TITLE
Deepspeed example should use gather_for_metrics

### DIFF
--- a/examples/by_feature/deepspeed_with_config_support.py
+++ b/examples/by_feature/deepspeed_with_config_support.py
@@ -288,7 +288,6 @@ def evaluate(args, model, eval_dataloader, accelerator, eval_dataset):
         losses.append(accelerator.gather_for_metrics(loss.repeat(args.per_device_eval_batch_size)))
 
     losses = torch.cat(losses)
-    losses = losses[: len(eval_dataset)]
     try:
         eval_loss = torch.mean(losses)
         perplexity = math.exp(eval_loss)

--- a/examples/by_feature/deepspeed_with_config_support.py
+++ b/examples/by_feature/deepspeed_with_config_support.py
@@ -285,7 +285,7 @@ def evaluate(args, model, eval_dataloader, accelerator, eval_dataset):
             outputs = model(**batch)
 
         loss = outputs.loss
-        losses.append(accelerator.gather(loss.repeat(args.per_device_eval_batch_size)))
+        losses.append(accelerator.gather_for_metrics(loss.repeat(args.per_device_eval_batch_size)))
 
     losses = torch.cat(losses)
     losses = losses[: len(eval_dataset)]


### PR DESCRIPTION
I believe this example should be using gather_for_metrics here instead of gather to work correctly on distributed setups.