### PR TITLE
Fix log error and add log level to get_logger

### DIFF
--- a/docs/source/package_reference/logging.mdx
+++ b/docs/source/package_reference/logging.mdx
@@ -23,7 +23,7 @@ To utilize this replace cases of `logging` with `accelerate.logging`:
 
 ## Setting the log level
 
-The log level can be set with the `LOG_LEVEL` environment variable or by passing 
+The log level can be set with the `ACCELERATE_LOG_LEVEL` environment variable or by passing 
 `log_level` to `get_logger`:
 ```python
 from accelerate.logging import get_logger

--- a/docs/source/package_reference/logging.mdx
+++ b/docs/source/package_reference/logging.mdx
@@ -21,4 +21,14 @@ To utilize this replace cases of `logging` with `accelerate.logging`:
 + logger = get_logger(__name__)
 ```
 
+## Setting the log level
+
+The log level can be set with the `LOG_LEVEL` environment variable or by passing 
+`log_level` to `get_logger`:
+```python
+from accelerate.logging import get_logger
+
+logger = get_logger(__name__, log_level="INFO")
+```
+
 [[autodoc]] logging.get_logger

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -207,11 +207,6 @@ class Accelerator:
         dynamo_backend: Union[DynamoBackend, str] = None,
     ):
         self.logging_dir = logging_dir
-        trackers = filter_trackers(log_with, self.logging_dir)
-        if len(trackers) < 1 and log_with is not None:
-            warnings.warn(f"`log_with={log_with}` was passed but no supported trackers are currently installed.")
-        self.log_with = trackers
-
         if mixed_precision is not None:
             mixed_precision = str(mixed_precision)
             if mixed_precision not in PrecisionType:
@@ -302,6 +297,11 @@ class Accelerator:
             _from_accelerator=True,
             **kwargs,
         )
+
+        trackers = filter_trackers(log_with, self.logging_dir)
+        if len(trackers) < 1 and log_with is not None:
+            warnings.warn(f"`log_with={log_with}` was passed but no supported trackers are currently installed.")
+        self.log_with = trackers
 
         if (
             (mixed_precision != "bf16")

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import os
 
 from .state import AcceleratorState
 from .utils import DistributedType
@@ -49,7 +50,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
             self.logger.log(level, msg, *args, **kwargs)
 
 
-def get_logger(name: str):
+def get_logger(name: str, log_level: str = None):
     """
     Returns a `logging.Logger` for `name` that can handle multiprocessing.
 
@@ -58,6 +59,8 @@ def get_logger(name: str):
     Args:
         name (`str`):
             The name for the logger, such as `__file__`
+        log_level (`str`, `optional`, defaults to `None`):
+            The log level to use. If not passed, will default to the `LOG_LEVEL` environment variable, or `INFO` if not
 
     Example:
 
@@ -68,7 +71,14 @@ def get_logger(name: str):
 
     >>> logger.info("My log", main_process_only=False)
     >>> logger.debug("My log", main_process_only=True)
+
+    >>> logger = get_logger(__name__, log_level="DEBUG")
+    >>> logger.info("My log")
+    >>> logger.debug("My second log")
     ```
     """
+    if log_level is None:
+        log_level = os.environ.get("LOG_LEVEL", "INFO")
     logger = logging.getLogger(name)
+    logging.basicConfig(level=log_level.upper())
     return MultiProcessAdapter(logger, {})

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -60,7 +60,8 @@ def get_logger(name: str, log_level: str = None):
         name (`str`):
             The name for the logger, such as `__file__`
         log_level (`str`, `optional`, defaults to `None`):
-            The log level to use. If not passed, will default to the `LOG_LEVEL` environment variable, or `INFO` if not
+            The log level to use. If not passed, will default to the `ACCELERATE_LOG_LEVEL` environment variable, or
+            `INFO` if not
 
     Example:
 
@@ -72,13 +73,13 @@ def get_logger(name: str, log_level: str = None):
     >>> logger.info("My log", main_process_only=False)
     >>> logger.debug("My log", main_process_only=True)
 
-    >>> logger = get_logger(__name__, log_level="DEBUG")
+    >>> logger = get_logger(__name__, accelerate_log_level="DEBUG")
     >>> logger.info("My log")
     >>> logger.debug("My second log")
     ```
     """
     if log_level is None:
-        log_level = os.environ.get("LOG_LEVEL", "INFO")
+        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "INFO")
     logger = logging.getLogger(name)
     logging.basicConfig(level=log_level.upper())
     return MultiProcessAdapter(logger, {})

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -577,7 +577,6 @@ def filter_trackers(
     if log_with is not None:
         if not isinstance(log_with, (list, tuple)):
             log_with = [log_with]
-            logger.debug(f"{log_with}")
         if "all" in log_with or LoggerType.ALL in log_with:
             loggers = [o for o in log_with if issubclass(type(o), GeneralTracker)] + get_available_trackers()
         else:


### PR DESCRIPTION
Fixes https://github.com/huggingface/accelerate/issues/835
Fixes https://github.com/huggingface/accelerate/issues/834

The first comes from the fact that there is a `logger.debug` that could get called in `filter_trackers` before `AccelerateState()` was created, leading to the error mentioned. This PR moves it down in `__init__` to where it should be to allow for this to work. 

The second was solved by introducing a convenience `log_level` parameter to `accelerator.logging.get_logger()` 