### PR TITLE
Fix if/else in AcceleratedScheduler

### DIFF
--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -69,8 +69,9 @@ class AcceleratedScheduler:
             num_processes = AcceleratorState().num_processes
             for _ in range(num_processes):
                 # Special case when using OneCycle and `drop_last` was not used
-                if hasattr(self.scheduler, "total_steps") and self.scheduler._step_count <= self.scheduler.total_steps:
-                    self.scheduler.step(*args, **kwargs)
+                if hasattr(self.scheduler, "total_steps"):
+                    if self.scheduler._step_count <= self.scheduler.total_steps:
+                        self.scheduler.step(*args, **kwargs)
                 else:
                     self.scheduler.step(*args, **kwargs)
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/accelerate/issues/843

The issue arises when using `OneCyclePolicy` and the `scheduler.step_count` > `scheduler.total_steps`. Current behavior is it will just move to the `else` statement and call `step()` regardless, which is not what we want. Instead this adds it in as a second if statement with no else. 