### PR TITLE
Refactor Accelerate config and introduce a multi-argument CLI interface

### DIFF
--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -35,11 +35,11 @@ accelerate config [arguments]
                         (`~/.cache` or the content of `XDG_CACHE_HOME`) suffixed with `huggingface`.
 * `-h`, `--help` (`bool`) -- Show a help message and exit
 
-## accelerate default-config 
+## accelerate config default
 
 **Command**:
 
-`accelerate default-config` or `accelerate-default-config`
+`accelerate config default` or `accelerate-config default`
 
 Create a default config file for Accelerate with only a few flags set.
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
             "accelerate=accelerate.commands.accelerate_cli:main",
             "accelerate-config=accelerate.commands.config:main",
             "accelerate-launch=accelerate.commands.launch:main",
-            "accelerate-default-config=accelerate.commands.config.default:main",
         ]
     },
     python_requires=">=3.7.0",

--- a/src/accelerate/commands/accelerate_cli.py
+++ b/src/accelerate/commands/accelerate_cli.py
@@ -16,8 +16,7 @@
 
 from argparse import ArgumentParser
 
-from accelerate.commands.config import config_command_parser
-from accelerate.commands.config.default import default_command_parser
+from accelerate.commands.config import get_config_parser
 from accelerate.commands.env import env_command_parser
 from accelerate.commands.launch import launch_command_parser
 from accelerate.commands.test import test_command_parser
@@ -29,8 +28,7 @@ def main():
     subparsers = parser.add_subparsers(help="accelerate command helpers")
 
     # Register commands
-    config_command_parser(subparsers=subparsers)
-    default_command_parser(subparsers=subparsers)
+    get_config_parser(subparsers=subparsers)
     env_command_parser(subparsers=subparsers)
     launch_command_parser(subparsers=subparsers)
     tpu_command_parser(subparsers=subparsers)

--- a/src/accelerate/commands/config/__init__.py
+++ b/src/accelerate/commands/config/__init__.py
@@ -25,7 +25,6 @@ def filter_command_args(args: dict, args_prefix: str):
     "Filters args while only keeping ones that are prefixed with `{args_prefix}.`"
     new_args = argparse.Namespace()
     for key, value in vars(args).items():
-        print(key, value)
         if key.startswith(args_prefix):
             setattr(new_args, key.replace(f"{args_prefix}.", ""), value)
     return new_args

--- a/src/accelerate/commands/config/__init__.py
+++ b/src/accelerate/commands/config/__init__.py
@@ -15,73 +15,42 @@
 # limitations under the License.
 
 import argparse
-import os
 
-from accelerate.utils import ComputeEnvironment
-
-from .cluster import get_cluster_input
-from .config_args import cache_dir, default_config_file, default_yaml_config_file, load_config_from_file  # noqa: F401
-from .config_utils import _ask_field, _ask_options, _convert_compute_environment  # noqa: F401
-from .sagemaker import get_sagemaker_input
+from .config import config_command, config_command_parser
+from .config_args import default_config_file, load_config_from_file  # noqa: F401
+from .default import default_command_parser, default_config_command
 
 
-description = "Launches a series of prompts to create and save a `default_config.yaml` configuration file for your training system. Should always be ran first on your machine"
+def filter_command_args(args: dict, args_prefix: str):
+    "Filters args while only keeping ones that are prefixed with `{args_prefix}.`"
+    new_args = argparse.Namespace()
+    for key, value in vars(args).items():
+        print(key, value)
+        if key.startswith(args_prefix):
+            setattr(new_args, key.replace(f"{args_prefix}.", ""), value)
+    return new_args
 
 
-def get_user_input():
-    compute_environment = _ask_options(
-        "In which compute environment are you running?",
-        ["This machine", "AWS (Amazon SageMaker)"],
-        _convert_compute_environment,
-    )
-    if compute_environment == ComputeEnvironment.AMAZON_SAGEMAKER:
-        config = get_sagemaker_input()
-    else:
-        config = get_cluster_input()
-    return config
+def get_config_parser(subparsers=None):
+    parent_parser = argparse.ArgumentParser(add_help=False)
+    # The main config parser
+    config_parser = config_command_parser(subparsers)
 
+    # Then add other parsers with the parent parser
+    default_parser = default_command_parser(config_parser, parents=[parent_parser])  # noqa: F841
 
-def config_command_parser(subparsers=None):
-    if subparsers is not None:
-        parser = subparsers.add_parser("config", description=description)
-    else:
-        parser = argparse.ArgumentParser("Accelerate config command", description=description)
-
-    parser.add_argument(
-        "--config_file",
-        default=None,
-        help=(
-            "The path to use to store the config file. Will default to a file named default_config.yaml in the cache "
-            "location, which is the content of the environment `HF_HOME` suffixed with 'accelerate', or if you don't have "
-            "such an environment variable, your cache directory ('~/.cache' or the content of `XDG_CACHE_HOME`) suffixed "
-            "with 'huggingface'."
-        ),
-    )
-
-    if subparsers is not None:
-        parser.set_defaults(func=config_command)
-    return parser
-
-
-def config_command(args):
-    config = get_user_input()
-    if args.config_file is not None:
-        config_file = args.config_file
-    else:
-        if not os.path.isdir(cache_dir):
-            os.makedirs(cache_dir)
-        config_file = default_yaml_config_file
-
-    if config_file.endswith(".json"):
-        config.to_json_file(config_file)
-    else:
-        config.to_yaml_file(config_file)
+    return config_parser
 
 
 def main():
-    parser = config_command_parser()
-    args = parser.parse_args()
-    config_command(args)
+    config_parser = get_config_parser()
+    args = config_parser.parse_args()
+    if not args.default:
+        args = filter_command_args(args, "config_args")
+        config_command(args)
+    elif args.default:
+        args = filter_command_args(args, "default_args")
+        default_config_command(args)
 
 
 if __name__ == "__main__":

--- a/src/accelerate/commands/config/config.py
+++ b/src/accelerate/commands/config/config.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+
+from accelerate.utils import ComputeEnvironment
+
+from .cluster import get_cluster_input
+from .config_args import cache_dir, default_config_file, default_yaml_config_file, load_config_from_file  # noqa: F401
+from .config_utils import GroupedAction, _ask_field, _ask_options, _convert_compute_environment  # noqa: F401
+from .sagemaker import get_sagemaker_input
+
+
+description = "Launches a series of prompts to create and save a `default_config.yaml` configuration file for your training system. Should always be ran first on your machine"
+
+
+def get_user_input():
+    compute_environment = _ask_options(
+        "In which compute environment are you running?",
+        ["This machine", "AWS (Amazon SageMaker)"],
+        _convert_compute_environment,
+    )
+    if compute_environment == ComputeEnvironment.AMAZON_SAGEMAKER:
+        config = get_sagemaker_input()
+    else:
+        config = get_cluster_input()
+    return config
+
+
+class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """
+    A custom formatter that will remove the usage line from the help message for subcommands.
+    """
+
+    def _format_action(self, action):
+        parts = super()._format_action(action)
+        if action.nargs == argparse.PARSER:
+            parts = "\n".join(parts.split("\n")[1:])
+        return parts
+
+    def _format_usage(self, usage, actions, groups, prefix):
+        usage = super()._format_usage(usage, actions, groups, prefix)
+        usage = usage.replace("<command> [<args>] ", "")
+        return usage
+
+
+def config_command_parser(subparsers=None):
+    if subparsers is not None:
+        parser = subparsers.add_parser("config", description=description, formatter_class=SubcommandHelpFormatter)
+    else:
+        parser = argparse.ArgumentParser(
+            "Accelerate config command", description=description, formatter_class=SubcommandHelpFormatter
+        )
+
+    parser.add_argument(
+        "--config_file",
+        default=None,
+        dest="config_args.config_file",
+        metavar="CONFIG_FILE",
+        action=GroupedAction,
+        help=(
+            "The path to use to store the config file. Will default to a file named default_config.yaml in the cache "
+            "location, which is the content of the environment `HF_HOME` suffixed with 'accelerate', or if you don't have "
+            "such an environment variable, your cache directory ('~/.cache' or the content of `XDG_CACHE_HOME`) suffixed "
+            "with 'huggingface'."
+        ),
+    )
+
+    if subparsers is not None:
+        parser.set_defaults(func=config_command)
+    return parser
+
+
+def config_command(args):
+    config = get_user_input()
+    if args.config_file is not None:
+        config_file = args.config_file
+    else:
+        if not os.path.isdir(cache_dir):
+            os.makedirs(cache_dir)
+        config_file = default_yaml_config_file
+
+    if config_file.endswith(".json"):
+        config.to_json_file(config_file)
+    else:
+        config.to_yaml_file(config_file)
+
+
+def main():
+    parser = config_command_parser()
+    args = parser.parse_args()
+    config_command(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/accelerate/commands/config/config.py
+++ b/src/accelerate/commands/config/config.py
@@ -21,7 +21,13 @@ from accelerate.utils import ComputeEnvironment
 
 from .cluster import get_cluster_input
 from .config_args import cache_dir, default_config_file, default_yaml_config_file, load_config_from_file  # noqa: F401
-from .config_utils import GroupedAction, _ask_field, _ask_options, _convert_compute_environment  # noqa: F401
+from .config_utils import (  # noqa: F401
+    GroupedAction,
+    SubcommandHelpFormatter,
+    _ask_field,
+    _ask_options,
+    _convert_compute_environment,
+)
 from .sagemaker import get_sagemaker_input
 
 
@@ -39,23 +45,6 @@ def get_user_input():
     else:
         config = get_cluster_input()
     return config
-
-
-class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
-    """
-    A custom formatter that will remove the usage line from the help message for subcommands.
-    """
-
-    def _format_action(self, action):
-        parts = super()._format_action(action)
-        if action.nargs == argparse.PARSER:
-            parts = "\n".join(parts.split("\n")[1:])
-        return parts
-
-    def _format_usage(self, usage, actions, groups, prefix):
-        usage = super()._format_usage(usage, actions, groups, prefix)
-        usage = usage.replace("<command> [<args>] ", "")
-        return usage
 
 
 def config_command_parser(subparsers=None):

--- a/src/accelerate/commands/config/config_utils.py
+++ b/src/accelerate/commands/config/config_utils.py
@@ -89,8 +89,29 @@ def _convert_yes_no_to_bool(value):
 
 
 class GroupedAction(argparse.Action):
+    """
+    Filters arguments into seperate namespace groups based on the first part of the argument name.
+    """
+
     def __call__(self, parser, namespace, values, option_string=None):
         group, dest = self.dest.split(".", 2)
         groupspace = getattr(namespace, group, argparse.Namespace())
         setattr(groupspace, dest, values)
         setattr(namespace, group, groupspace)
+
+
+class SubcommandHelpFormatter(argparse.RawDescriptionHelpFormatter):
+    """
+    A custom formatter that will remove the usage line from the help message for subcommands.
+    """
+
+    def _format_action(self, action):
+        parts = super()._format_action(action)
+        if action.nargs == argparse.PARSER:
+            parts = "\n".join(parts.split("\n")[1:])
+        return parts
+
+    def _format_usage(self, usage, actions, groups, prefix):
+        usage = super()._format_usage(usage, actions, groups, prefix)
+        usage = usage.replace("<command> [<args>] ", "")
+        return usage

--- a/src/accelerate/commands/config/config_utils.py
+++ b/src/accelerate/commands/config/config_utils.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+
 from ...utils.dataclasses import (
     ComputeEnvironment,
     DistributedType,
@@ -84,3 +86,11 @@ def _convert_sagemaker_distributed_mode(value):
 
 def _convert_yes_no_to_bool(value):
     return {"yes": True, "no": False}[value.lower()]
+
+
+class GroupedAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        group, dest = self.dest.split(".", 2)
+        groupspace = getattr(namespace, group, argparse.Namespace())
+        setattr(groupspace, dest, values)
+        setattr(namespace, group, groupspace)

--- a/src/accelerate/commands/config/default.py
+++ b/src/accelerate/commands/config/default.py
@@ -15,21 +15,69 @@
 # limitations under the License.
 
 import argparse
+from pathlib import Path
 
-from accelerate.utils import write_basic_config
+import torch
 
-from .config_args import default_json_config_file
+from .config_args import ClusterConfig, default_json_config_file
+from .config_utils import GroupedAction
+
+
+def write_basic_config(mixed_precision="no", save_location: str = default_json_config_file, dynamo_backend="no"):
+    """
+    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
+    set CPU if it is a CPU-only machine.
+
+    Args:
+        mixed_precision (`str`, *optional*, defaults to "no"):
+            Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
+        save_location (`str`, *optional*, defaults to `default_json_config_file`):
+            Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
+            location is inside the huggingface cache folder (`~/.cache/huggingface`) but can be overriden by setting
+            the `HF_HOME` environmental variable, followed by `accelerate/default_config.yaml`.
+    """
+    path = Path(save_location)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        print(
+            f"Configuration already exists at {save_location}, will not override. Run `accelerate config` manually or pass a different `save_location`."
+        )
+        return
+    mixed_precision = mixed_precision.lower()
+    if mixed_precision not in ["no", "fp16", "bf16"]:
+        raise ValueError(f"`mixed_precision` should be one of 'no', 'fp16', or 'bf16'. Received {mixed_precision}")
+    config = {
+        "compute_environment": "LOCAL_MACHINE",
+        "mixed_precision": mixed_precision,
+        "dynamo_backend": dynamo_backend,
+    }
+    if torch.cuda.is_available():
+        num_gpus = torch.cuda.device_count()
+        config["num_processes"] = num_gpus
+        config["use_cpu"] = False
+        if num_gpus > 1:
+            config["distributed_type"] = "MULTI_GPU"
+        else:
+            config["distributed_type"] = "NO"
+    else:
+        num_gpus = 0
+        config["use_cpu"] = True
+        config["num_processes"] = 1
+        config["distributed_type"] = "NO"
+    if not path.exists():
+        config = ClusterConfig(**config)
+        config.to_json_file(path)
 
 
 description = "Create a default config file for Accelerate with only a few flags set."
 
 
-def default_command_parser(subparsers=None):
-    if subparsers is not None:
-        parser = subparsers.add_parser("default-config", description=description)
+def default_command_parser(parser=None, parents=None):
+    if parser is None and parents is None:
+        parser = argparse.ArgumentParser(description=description)
     else:
-        parser = argparse.ArgumentParser("Accelerate default-config command", description=description)
-
+        default_parser = parser.add_subparsers(title="subcommand {default}", dest="default", description=description)
+        parser = default_parser.add_parser("default", parents=parents)
     parser.add_argument(
         "--config_file",
         default=default_json_config_file,
@@ -39,7 +87,9 @@ def default_command_parser(subparsers=None):
             "such an environment variable, your cache directory ('~/.cache' or the content of `XDG_CACHE_HOME`) suffixed "
             "with 'huggingface'."
         ),
-        dest="save_location",
+        dest="default_args.save_location",
+        metavar="CONFIG_FILE",
+        action=GroupedAction,
     )
 
     parser.add_argument(
@@ -50,14 +100,14 @@ def default_command_parser(subparsers=None):
         "Choose between FP16 and BF16 (bfloat16) training. "
         "BF16 training is only supported on Nvidia Ampere GPUs and PyTorch 1.10 or later.",
         default="no",
+        dest="default_args.mixed_precision",
+        action=GroupedAction,
     )
-
-    if subparsers is not None:
-        parser.set_defaults(func=config_command)
+    parser.set_defaults(func=default_config_command)
     return parser
 
 
-def config_command(args):
+def default_config_command(args):
     args = vars(args)
     args.pop("func", None)
     write_basic_config(**args)
@@ -66,7 +116,7 @@ def config_command(args):
 def main():
     parser = default_command_parser()
     args = parser.parse_args()
-    config_command(args)
+    default_config_command(args)
 
 
 if __name__ == "__main__":

--- a/src/accelerate/commands/config/default.py
+++ b/src/accelerate/commands/config/default.py
@@ -111,13 +111,3 @@ def default_config_command(args):
     args = vars(args)
     args.pop("func", None)
     write_basic_config(**args)
-
-
-def main():
-    parser = default_command_parser()
-    args = parser.parse_args()
-    default_config_command(args)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -14,12 +14,10 @@
 
 import os
 from contextlib import contextmanager
-from pathlib import Path
 
 import torch
 
-from ..commands.config.cluster import ClusterConfig
-from ..commands.config.config_args import default_json_config_file
+from ..commands.config.default import write_basic_config  # noqa: F401
 from ..state import AcceleratorState
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
@@ -113,49 +111,3 @@ def get_pretty_name(obj):
     if hasattr(obj, "__name__"):
         return obj.__name__
     return str(obj)
-
-
-def write_basic_config(mixed_precision="no", save_location: str = default_json_config_file, dynamo_backend="no"):
-    """
-    Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
-    set CPU if it is a CPU-only machine.
-
-    Args:
-        mixed_precision (`str`, *optional*, defaults to "no"):
-            Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
-        save_location (`str`, *optional*, defaults to `default_json_config_file`):
-            Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
-            location is inside the huggingface cache folder (`~/.cache/huggingface`) but can be overriden by setting
-            the `HF_HOME` environmental variable, followed by `accelerate/default_config.yaml`.
-    """
-    path = Path(save_location)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        print(
-            f"Configuration already exists at {save_location}, will not override. Run `accelerate config` manually or pass a different `save_location`."
-        )
-        return
-    mixed_precision = mixed_precision.lower()
-    if mixed_precision not in ["no", "fp16", "bf16"]:
-        raise ValueError(f"`mixed_precision` should be one of 'no', 'fp16', or 'bf16'. Received {mixed_precision}")
-    config = {
-        "compute_environment": "LOCAL_MACHINE",
-        "mixed_precision": mixed_precision,
-        "dynamo_backend": dynamo_backend,
-    }
-    if torch.cuda.is_available():
-        num_gpus = torch.cuda.device_count()
-        config["num_processes"] = num_gpus
-        config["use_cpu"] = False
-        if num_gpus > 1:
-            config["distributed_type"] = "MULTI_GPU"
-        else:
-            config["distributed_type"] = "NO"
-    else:
-        num_gpus = 0
-        config["use_cpu"] = True
-        config["num_processes"] = 1
-        config["distributed_type"] = "NO"
-    if not path.exists():
-        config = ClusterConfig(**config)
-        config.to_json_file(path)


### PR DESCRIPTION
## Motivation

As I'm focusing more on the CLI, eventually we wanted these three commands:

- `accelerate config`
- `accelerate default-config`
- `accelerate update-config` (from https://github.com/huggingface/accelerate/issues/832)

It did not quite make sense to have the CLI in this way, the actions should read start -> end. 

After doing a ton of digging I figured out that there's a neat way to add extra subparsers to existing subparsers by adding them as Argparsers directly. What does this mean? We can now do:

```bash
accelerate config -h
accelerate config default -h
```
And soon:
```bash
accelerate config update -h
```

## How does it work?

This operates by having a single empty parent parser to start. This one has `add_help=False` and doesn't do much explicitly there.

`parent_parser = argparse.ArgumentParser(add_help=False)`

From there we add the main `config` parser like we did before as a subparser of the `parent_parser`.
`config_parser = config_command_parser(subparsers)`

Finally where the real magic happens is the change to the *default_command_parser*. 

Instead of just adding it as a subparser, we instead create a new subparser first that will act as the "help" for the command, and add a full parser to it, linking it to that initial parser through `parents=[parent_parser]`:

```python
default_parser = parser.add_subparsers(title="subcommand {default}", dest="default", description=description)
parser = default_parser.add_parser("default", parents=parents)
```

The `title` here is so that during `accelerate config --help` it will show up as:

```bash
subcommand {default}:
  Create a default config file for Accelerate with only a few flags set.
```

The `dest` is what makes it easy for us to separate what comes from `accelerate config` vs `accelerate config default` etc. 

Lastly there is a `SubcommandHelpFormatter` class. This essentially makes it so that the subcommand is not repeated at the end, and since the user shouldn't be doing something like `accelerate config --config_file {} default` it will remove it from the usage directions.

Here is the full `--help` from `accelerate config`:

```bash
usage: accelerate config [-h] [--config_file CONFIG_FILE] {default} ...

Launches a series of prompts to create and save a `default_config.yaml` configuration file for your training system. Should always be ran first on your machine

optional arguments:
  -h, --help            show this help message and exit
  --config_file CONFIG_FILE
                        The path to use to store the config file. Will default to a file named default_config.yaml in the cache
                        location, which is the content of the environment `HF_HOME` suffixed with 'accelerate', or if you don't have
                        such an environment variable, your cache directory ('~/.cache' or the content of `XDG_CACHE_HOME`) suffixed with
                        'huggingface'.

subcommand {default}:
  Create a default config file for Accelerate with only a few flags set.
```

## Other changes

To avoid a cyclical import error the `write_basic_config` function was moved from `utils` to `commands.config.default`. `from accelerate.utils import write_basic_config` still works however as it's linked. there. After this PR I will be working on the `update` part of this. 