### PR TITLE
Switch default log to warn

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -78,7 +78,7 @@ def get_logger(name: str, log_level: str = None):
     ```
     """
     if log_level is None:
-        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "WARN")
+        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "WARNING")
     logger = logging.getLogger(name)
     logging.basicConfig(level=log_level.upper())
     return MultiProcessAdapter(logger, {})

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -78,7 +78,7 @@ def get_logger(name: str, log_level: str = None):
     ```
     """
     if log_level is None:
-        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "INFO")
+        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "WARN")
     logger = logging.getLogger(name)
     logging.basicConfig(level=log_level.upper())
     return MultiProcessAdapter(logger, {})


### PR DESCRIPTION
Was noticing a bit more logs than expected post the log change, this is because by default the logging library uses WARN, not INFO (as stated down here: https://docs.python.org/3/howto/logging.html#when-to-use-logging)