### PR TITLE
Remove mixed precision hook as part of the unwrap_model

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1464,16 +1464,16 @@ class Accelerator:
         """
         return pad_across_processes(tensor, dim=dim, pad_index=pad_index, pad_first=pad_first)
 
-    def unwrap_model(self, model):
+    def unwrap_model(self, model, remove_fp32_hook: bool = False):
         """
         Unwraps the `model` from the additional layer possible added by [`~Accelerator.prepare`]. Useful before saving
-        the model.
+        the model. Will also optionally remove the mixed precision hook if it was added.
 
         Args:
             model (`torch.nn.Module`):
                 The model to unwrap.
         """
-        return extract_model_from_parallel(model)
+        return extract_model_from_parallel(model, remove_fp32_hook)
 
     def wait_for_everyone(self):
         """

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1467,7 +1467,7 @@ class Accelerator:
     def unwrap_model(self, model, keep_fp32_wrapper: bool = False):
         """
         Unwraps the `model` from the additional layer possible added by [`~Accelerator.prepare`]. Useful before saving
-        the model. Will also remove the mixed precision hook if it was added by default.
+        the model.
 
         Args:
             model (`torch.nn.Module`):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1472,6 +1472,8 @@ class Accelerator:
         Args:
             model (`torch.nn.Module`):
                 The model to unwrap.
+            keep_fp32_wrapper (`bool`, *optional*, defaults to `False`):
+                Whether to not remove the mixed precision hook if it was added.
         """
         return extract_model_from_parallel(model, keep_fp32_wrapper)
 
@@ -1760,7 +1762,7 @@ class Accelerator:
         Args:
             model (`torch.nn.Module`):
                 A PyTorch model sent through [`Accelerator.prepare`]
-            unwrap (`bool`, *optional*, defaults to True):
+            unwrap (`bool`, *optional*, defaults to `True`):
                 Whether to return the original underlying state_dict of `model` or to return the wrapped state_dict
         """
         is_zero_3 = False

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1464,16 +1464,16 @@ class Accelerator:
         """
         return pad_across_processes(tensor, dim=dim, pad_index=pad_index, pad_first=pad_first)
 
-    def unwrap_model(self, model, remove_fp32_hook: bool = False):
+    def unwrap_model(self, model, keep_fp32_wrapper: bool = False):
         """
         Unwraps the `model` from the additional layer possible added by [`~Accelerator.prepare`]. Useful before saving
-        the model. Will also optionally remove the mixed precision hook if it was added.
+        the model. Will also remove the mixed precision hook if it was added by default.
 
         Args:
             model (`torch.nn.Module`):
                 The model to unwrap.
         """
-        return extract_model_from_parallel(model, remove_fp32_hook)
+        return extract_model_from_parallel(model, keep_fp32_wrapper)
 
     def wait_for_everyone(self):
         """

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -31,14 +31,14 @@ if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
 
-def extract_model_from_parallel(model, remove_fp32_hook: bool = False):
+def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
     """
     Extract a model from its distributed containers.
 
     Args:
         model (`torch.nn.Module`):
             The model to extract.
-        remove_fp32_hook (`bool`, *optional*):
+        keep_fp32_wrapper (`bool`, *optional*):
             Whether to remove mixed precision hooks from the model.
 
     Returns:
@@ -51,7 +51,7 @@ def extract_model_from_parallel(model, remove_fp32_hook: bool = False):
     while isinstance(model, options):
         model = model.module
 
-    if remove_fp32_hook:
+    if not keep_fp32_wrapper:
         forward = getattr(model, "forward")
         if isinstance(forward, ConvertOutputsToFp32):
             setattr(model, "forward", forward.model_forward)


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/858

Adds a new `remove_fp32_hook` param to `extract_model_from_parallel` and `unwrap_model` that will check to see if the forward pass is an instance of `ConvertOutputsToFp32` and if so then sets the forward pass back to the original forward pass