### PR TITLE
Even more log level refined, leave alone if not explicitly set

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -78,7 +78,8 @@ def get_logger(name: str, log_level: str = None):
     ```
     """
     if log_level is None:
-        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "WARNING")
+        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", None)
     logger = logging.getLogger(name)
-    logger.setLevel(log_level)
+    if log_level is not None:
+        logger.setLevel(log_level.upper())
     return MultiProcessAdapter(logger, {})

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -78,9 +78,7 @@ def get_logger(name: str, log_level: str = None):
     ```
     """
     if log_level is None:
-        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", None)
-    if hasattr(log_level, "upper"):
-        log_level = log_level.upper()
+        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "WARNING")
     logger = logging.getLogger(name)
-    logging.basicConfig(level=log_level)
+    logger.setLevel(log_level)
     return MultiProcessAdapter(logger, {})

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -78,7 +78,9 @@ def get_logger(name: str, log_level: str = None):
     ```
     """
     if log_level is None:
-        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", "WARNING")
+        log_level = os.environ.get("ACCELERATE_LOG_LEVEL", None)
+    if hasattr(log_level, "upper"):
+        log_level = log_level.upper()
     logger = logging.getLogger(name)
-    logging.basicConfig(level=log_level.upper())
+    logging.basicConfig(level=log_level)
     return MultiProcessAdapter(logger, {})


### PR DESCRIPTION
Still not quite pleased with this implementation, learning more about the logging library + good practices. For example the transformers tests the output of `accelerator.state()` won't actually be logged unless the env var is set currently. 

So this PR makes us take a different approach of only filter *if we explicitly choose to filter* otherwise do nothing. This also limits it to the logger for the module, before it was setting the global log level which was leading to bloated traces