### PR TITLE
Solve pickling issues

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -933,7 +933,7 @@ class Accelerator:
                 model.forward = torch.autocast(device_type=device_type, dtype=torch.bfloat16)(model.forward)
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
-            model.forward = partial(convert_outputs_to_fp32, model_forward=model.forward)
+            model.forward = convert_outputs_to_fp32(model.forward)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         return model

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -19,7 +19,7 @@ import os
 import sys
 import warnings
 from contextlib import contextmanager
-from functools import partial, wraps
+from functools import wraps
 from typing import List, Optional, Union
 
 import torch

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -933,7 +933,8 @@ class Accelerator:
                 model.forward = torch.autocast(device_type=device_type, dtype=torch.bfloat16)(model.forward)
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
-            model.forward = partial(convert_outputs_to_fp32, model_forward=model.forward)
+            model._original_forward = model.forward
+            model.forward = partial(convert_outputs_to_fp32, model_forward=model._original_forward)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         return model

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -19,7 +19,7 @@ import os
 import sys
 import warnings
 from contextlib import contextmanager
-from functools import wraps
+from functools import partial, wraps
 from typing import List, Optional, Union
 
 import torch
@@ -933,7 +933,7 @@ class Accelerator:
                 model.forward = torch.autocast(device_type=device_type, dtype=torch.bfloat16)(model.forward)
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
-            model.forward = convert_outputs_to_fp32(model.forward)
+            model.forward = partial(convert_outputs_to_fp32, model_forward=model.forward)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         return model

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -926,6 +926,7 @@ class Accelerator:
             kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
             model = torch.nn.parallel.DistributedDataParallel(model, **kwargs)
         if self.native_amp:
+            model._original_forward = model.forward
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
             elif self.mixed_precision == "bf16" and self.distributed_type != DistributedType.TPU:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -933,8 +933,7 @@ class Accelerator:
                 model.forward = torch.autocast(device_type=device_type, dtype=torch.bfloat16)(model.forward)
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
-            model._original_forward = model.forward
-            model.forward = partial(convert_outputs_to_fp32, model_forward=model._original_forward)
+            model.forward = partial(convert_outputs_to_fp32, model_forward=model.forward)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         return model

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -477,6 +477,7 @@ class ConvertOutputsToFp32:
     Args:
         model_forward (`Callable`):
             The function which outputs we want to treat.
+    
     Returns:
         The same function as `model_forward` but with converted outputs.
     """

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -471,14 +471,8 @@ def convert_to_fp32(tensor):
 
 class ConvertOutputsToFp32:
     """
-    Args:
     Decorator to apply to a function outputing tensors (like a model forward pass) that ensures the outputs in FP16
-    precision will be convert back to FP32. Use a class instead of a decorator because otherwise, the prepared model
-    can no longer be pickled (issue #273).
-        model_forward (`Callable`):
-            The function which outputs we want to treat.
-    Returns:
-        The same function as `model_forward` but with converted outputs.
+    precision will be convert back to FP32.
     """
 
     def __init__(self, model_forward):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -490,7 +490,7 @@ class ConvertOutputsToFp32:
 
     def __getstate__(self):
         raise pickle.PicklingError(
-            "Cannot pickle a prepared model, please unwrap the model with `Accelerator.unwrap_model(model)` before pickling it."
+            "Cannot pickle a prepared model with automatic mixed precision, please unwrap the model with `Accelerator.unwrap_model(model)` before pickling it."
         )
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -468,7 +468,7 @@ def convert_to_fp32(tensor):
     return recursively_apply(_convert_to_fp32, tensor, test_type=_is_fp16_bf16_tensor)
 
 
-def convert_outputs_to_fp32(model_forward):
+def convert_outputs_to_fp32(model_forward, *args, **kwargs):
     """
     Decorator to apply to a function outputing tensors (like a model forward pass) that ensures the outputs in FP16
     precision will be convert back to FP32.
@@ -481,12 +481,7 @@ def convert_outputs_to_fp32(model_forward):
         The same function as `model_forward` but with converted outputs.
     """
 
-    @wraps
-    def wrapped(*args, **kwargs):
-        outputs = model_forward(*args, **kwargs)
-        return convert_to_fp32(outputs)
-
-    return wrapped
+    return convert_to_fp32(model_forward(*args, **kwargs))
 
 
 def find_device(data):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -468,7 +468,7 @@ def convert_to_fp32(tensor):
     return recursively_apply(_convert_to_fp32, tensor, test_type=_is_fp16_bf16_tensor)
 
 
-def convert_outputs_to_fp32(model_forward, *args, **kwargs):
+def convert_outputs_to_fp32(model_forward):
     """
     Decorator to apply to a function outputing tensors (like a model forward pass) that ensures the outputs in FP16
     precision will be convert back to FP32.
@@ -480,8 +480,11 @@ def convert_outputs_to_fp32(model_forward, *args, **kwargs):
     Returns:
         The same function as `model_forward` but with converted outputs.
     """
-
-    return convert_to_fp32(model_forward(*args, **kwargs))
+    @wraps(model_forward)
+    def inner(*args, **kwargs):
+        outputs = model_forward(*args, **kwargs)
+        return convert_to_fp32(outputs)
+    return inner
 
 
 def find_device(data):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -477,7 +477,7 @@ class ConvertOutputsToFp32:
     Args:
         model_forward (`Callable`):
             The function which outputs we want to treat.
-    
+
     Returns:
         The same function as `model_forward` but with converted outputs.
     """

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -473,6 +473,12 @@ class ConvertOutputsToFp32:
     """
     Decorator to apply to a function outputing tensors (like a model forward pass) that ensures the outputs in FP16
     precision will be convert back to FP32.
+
+    Args:
+        model_forward (`Callable`):
+            The function which outputs we want to treat.
+    Returns:
+        The same function as `model_forward` but with converted outputs.
     """
 
     def __init__(self, model_forward):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -17,7 +17,7 @@ A set of basic tensor ops compatible with tpu, gpu, and multigpu
 """
 
 
-from functools import update_wrapper, wraps
+from functools import wraps
 from typing import Any, Mapping
 
 import torch
@@ -480,10 +480,12 @@ def convert_outputs_to_fp32(model_forward):
     Returns:
         The same function as `model_forward` but with converted outputs.
     """
+
     @wraps(model_forward)
     def inner(*args, **kwargs):
         outputs = model_forward(*args, **kwargs)
         return convert_to_fp32(outputs)
+
     return inner
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -52,8 +52,11 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
 
     if not keep_fp32_wrapper:
         forward = getattr(model, "forward")
+        original_forward = model.__dict__.pop("_original_forward")
         while hasattr(forward, "__wrapped__"):
             forward = forward.__wrapped__
+            if forward == original_forward:
+                break
         model.forward = forward
     return model
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -52,12 +52,13 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
 
     if not keep_fp32_wrapper:
         forward = getattr(model, "forward")
-        original_forward = model.__dict__.pop("_original_forward")
-        while hasattr(forward, "__wrapped__"):
-            forward = forward.__wrapped__
-            if forward == original_forward:
-                break
-        model.forward = forward
+        original_forward = model.__dict__.pop("_original_forward", None)
+        if original_forward is not None:
+            while hasattr(forward, "__wrapped__"):
+                forward = forward.__wrapped__
+                if forward == original_forward:
+                    break
+            model.forward = forward
     return model
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -21,7 +21,7 @@ from ..commands.config.default import write_basic_config  # noqa: F401
 from ..state import AcceleratorState
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
-from .operations import ConvertOutputsToFp32
+from .operations import convert_outputs_to_fp32
 
 
 if is_deepspeed_available():
@@ -53,7 +53,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
 
     if not keep_fp32_wrapper:
         forward = getattr(model, "forward")
-        if isinstance(forward, ConvertOutputsToFp32):
+        if isinstance(forward, convert_outputs_to_fp32):
             setattr(model, "forward", forward.model_forward)
     return model
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -55,7 +55,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
         forward = getattr(model, "forward")
         while hasattr(forward, "__wrapped__"):
             forward = forward.__wrapped__
-        setattr(model, "forward", forward)
+        model.forward = forward
     return model
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -21,7 +21,6 @@ from ..commands.config.default import write_basic_config  # noqa: F401
 from ..state import AcceleratorState
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
-from .operations import convert_outputs_to_fp32
 
 
 if is_deepspeed_available():

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -53,8 +53,9 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
 
     if not keep_fp32_wrapper:
         forward = getattr(model, "forward")
-        if isinstance(forward, convert_outputs_to_fp32):
-            setattr(model, "forward", forward.model_forward)
+        while hasattr(forward, "__wrapped__"):
+            forward = forward.__wrapped__
+        setattr(model, "forward", forward)
     return model
 
 


### PR DESCRIPTION
Fixes https://github.com/huggingface/accelerate/issues/866

## Proposal:

In order to fully unwrap the amount of chaining done in https://github.com/huggingface/accelerate/blob/main/src/accelerate/accelerator.py#L928-L936 and support pickling we have to explore each and every single `__wrapped__` that exists inside `model.forward` until we get back to the original forward implementation and present that. 

To know just when we've hit the original version, the model should store the original function somewhere so a `==` check works and we don't just remove all of the decorators in existence (say if someone wrapped `torch.no_grad` on the forward func)

This then lets you perform:

```python
torch.save(accelerator.unwrap_model(model))
```

Also changes the `test_pickle` because technically that test always failed since it was testing the wrong thing. I'll be adding a test to check that we can unwrap fp16 as well

