### PR TITLE
Allow safetensors offload

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -34,6 +34,7 @@ from .imports import (
     is_megatron_lm_available,
     is_mlflow_available,
     is_rich_available,
+    is_safetensors_available,
     is_sagemaker_available,
     is_tensorboard_available,
     is_tpu_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -101,6 +101,10 @@ def is_megatron_lm_available():
     return False
 
 
+def is_safetensors_available():
+    return importlib.util.find_spec("safetensors") is not None
+
+
 def is_transformers_available():
     return importlib.util.find_spec("transformers") is not None
 

--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -20,6 +20,12 @@ from typing import Dict, List, Optional, Union
 import numpy as np
 import torch
 
+from ..logging import get_logger
+from .imports import is_safetensors_available
+
+
+logger = get_logger(__name__)
+
 
 def offload_weight(weight, weight_name, offload_folder, index=None):
     dtype = None
@@ -161,6 +167,13 @@ class OffloadedWeightsLoader(Mapping):
             return self.state_dict[key]
         weight_info = self.index[key]
         if weight_info.get("safetensors_file") is not None:
+            if not is_safetensors_available():
+                raise ImportError("These offloaded weights require the use of safetensors: `pip install safetensors`.")
+
+            if not "SAFETENSORS_FAST_GPU" in os.environ:
+                logger.info("Enabling fast loading with safetensors by setting `SAFETENSORS_FAST_GPU` to 1.")
+                os.environ["SAFETENSORS_FAST_GPU"] = "1"
+
             from safetensors import safe_open
 
             device = "cpu" if self.device is None else self.device

--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -170,7 +170,7 @@ class OffloadedWeightsLoader(Mapping):
             if not is_safetensors_available():
                 raise ImportError("These offloaded weights require the use of safetensors: `pip install safetensors`.")
 
-            if not "SAFETENSORS_FAST_GPU" in os.environ:
+            if "SAFETENSORS_FAST_GPU" not in os.environ:
                 logger.info("Enabling fast loading with safetensors by setting `SAFETENSORS_FAST_GPU` to 1.")
                 os.environ["SAFETENSORS_FAST_GPU"] = "1"
 


### PR DESCRIPTION
This PR reworks a bit the internals of the offload hooks to allow for the case where the checkpoint is saved with `safetensors`. In this case, there is no need to have a separate save of the weight as a Numpy memory-mapped array, as we can directly access the weight using `safe_open`.

Goes along with https://github.com/huggingface/transformers/pull/20321