### PR TITLE
fixing lr_scheduler prepare issue when using pytorch nightly

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -95,6 +95,12 @@ if is_torch_version(">", "1.10.0"):
 if is_tpu_available(check_device=False):
     import torch_xla.distributed.xla_multiprocessing as xmp
 
+
+if is_torch_version("<=", "1.13.5"):
+    from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
+else:
+    from torch.optim.lr_scheduler import LRScheduler as LRScheduler
+
 logger = get_logger(__name__)
 
 
@@ -725,7 +731,7 @@ class Accelerator:
                 optimizer = self.prepare_optimizer(obj, device_placement=device_placement)
                 return optimizer
         # Second pass of preparation: LR scheduler (which need the full list of optimizers)
-        elif isinstance(obj, torch.optim.lr_scheduler._LRScheduler):
+        elif isinstance(obj, LRScheduler):
             scheduler = self.prepare_scheduler(obj)
             return scheduler
         # Return the unprocessed object if previous criteria was not met


### PR DESCRIPTION
### What does this PR do?
1. In torch 1.14.0.dev, LR Scheduler never gets prepared. PyTorch PR that will be impacting the LR schedulers: [#61232](https://github.com/pytorch/pytorch/commit/0a69c50a46d50ae265e2d1d826d0b4b69d4351fd) (2 weeks ago change)
2. This PR fixes the above issue