### PR TITLE
Prefix all accelerate env vars with ACCELERATE

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -119,9 +119,9 @@ class Accelerator:
             in your script multiplied by the number of processes.
         mixed_precision (`str`, *optional*):
             Whether or not to use mixed precision training (fp16 or bfloat16). Choose from 'no','fp16','bf16'. Will
-            default to the value in the environment variable `MIXED_PRECISION`, which will use the default value in the
-            accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp16'
-            requires pytorch 1.6 or higher. 'bf16' requires pytorch 1.10 or higher.
+            default to the value in the environment variable `ACCELERATE_MIXED_PRECISION`, which will use the default
+            value in the accelerate config of the current system or the flag passed with the `accelerate.launch`
+            command. 'fp16' requires pytorch 1.6 or higher. 'bf16' requires pytorch 1.10 or higher.
         gradient_accumulation_steps (`int`, *optional*, default to 1):
             The number of steps that should pass before gradients are accumulated. A number > 1 should be combined with
             `Accelerator.accumulate`.
@@ -231,39 +231,49 @@ class Accelerator:
             dynamo_backend = DynamoBackend(dynamo_backend.upper())
 
         if deepspeed_plugin is None:  # init from env variables
-            deepspeed_plugin = DeepSpeedPlugin() if os.environ.get("USE_DEEPSPEED", "false") == "true" else None
+            deepspeed_plugin = (
+                DeepSpeedPlugin() if os.environ.get("ACCELERATE_USE_DEEPSPEED", "false") == "true" else None
+            )
         else:
             assert isinstance(
                 deepspeed_plugin, DeepSpeedPlugin
             ), "`deepspeed_plugin` must be a DeepSpeedPlugin object."
-            os.environ["USE_DEEPSPEED"] = "true"  # use DeepSpeed if plugin is provided
+            os.environ["ACCELERATE_USE_DEEPSPEED"] = "true"  # use DeepSpeed if plugin is provided
         if deepspeed_plugin:
             if not is_deepspeed_available():
                 raise ImportError("DeepSpeed is not installed => run `pip install deepspeed` or build it from source.")
             if compare_versions("deepspeed", "<", "0.6.5"):
                 raise ImportError("DeepSpeed version must be >= 0.6.5. Please update DeepSpeed.")
 
-            mixed_precision = os.environ.get("MIXED_PRECISION", "no") if mixed_precision is None else mixed_precision
+            mixed_precision = (
+                os.environ.get("ACCELERATE_MIXED_PRECISION", "no") if mixed_precision is None else mixed_precision
+            )
             deepspeed_plugin.set_mixed_precision(mixed_precision)
             deepspeed_plugin.set_deepspeed_weakref()
 
-        if os.environ.get("USE_FSDP", "false") == "true" or isinstance(fsdp_plugin, FullyShardedDataParallelPlugin):
+        if os.environ.get("ACCELERATE_USE_FSDP", "false") == "true" or isinstance(
+            fsdp_plugin, FullyShardedDataParallelPlugin
+        ):
             if is_torch_version("<", "1.12.0"):
                 raise ValueError("FSDP requires PyTorch >= 1.12.0")
 
         if fsdp_plugin is None:  # init from env variables
-            fsdp_plugin = FullyShardedDataParallelPlugin() if os.environ.get("USE_FSDP", "false") == "true" else None
+            fsdp_plugin = (
+                FullyShardedDataParallelPlugin() if os.environ.get("ACCELERATE_USE_FSDP", "false") == "true" else None
+            )
         else:
             if not isinstance(fsdp_plugin, FullyShardedDataParallelPlugin):
                 raise TypeError("`fsdp_plugin` must be a FullyShardedDataParallelPlugin object.")
-            os.environ["USE_FSDP"] = "true"  # use FSDP if plugin is provided
+            os.environ["ACCELERATE_USE_FSDP"] = "true"  # use FSDP if plugin is provided
 
         if megatron_lm_plugin is None:  # init from env variables
-            megatron_lm_plugin = MegatronLMPlugin() if os.environ.get("USE_MEGATRON_LM", "false") == "true" else None
+            megatron_lm_plugin = (
+                MegatronLMPlugin() if os.environ.get("ACCELERATE_USE_MEGATRON_LM", "false") == "true" else None
+            )
         else:
             if not isinstance(megatron_lm_plugin, MegatronLMPlugin):
                 raise TypeError("`megatron_lm_plugin` must be a MegatronLMPlugin object.")
-            os.environ["USE_MEGATRON_LM"] = "true"  # use MegatronLM if plugin is provided
+            os.environ["ACCELERATE_USE_MEGATRON_LM"] = "true"  # use MegatronLM if plugin is provided
 
         if megatron_lm_plugin:
             if not is_megatron_lm_available():
@@ -339,7 +349,7 @@ class Accelerator:
         err = "{mode} mixed precision requires {requirement}"
         if self.state.mixed_precision == "fp16" and self.distributed_type != DistributedType.MEGATRON_LM:
             self.native_amp = True
-            if not torch.cuda.is_available() and not parse_flag_from_env("USE_MPS_DEVICE"):
+            if not torch.cuda.is_available() and not parse_flag_from_env("ACCELERATE_USE_MPS_DEVICE"):
                 raise ValueError(err.format(mode="fp16", requirement="a GPU"))
             kwargs = self.scaler_handler.to_kwargs() if self.scaler_handler is not None else {}
             if self.distributed_type == DistributedType.FSDP:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -518,14 +518,14 @@ def simple_launcher(args):
     cmd.extend(args.training_script_args)
 
     current_env = os.environ.copy()
-    current_env["USE_CPU"] = str(args.cpu or args.use_cpu)
+    current_env["ACCELERATE_USE_CPU"] = str(args.cpu or args.use_cpu)
     if args.use_mps_device:
         warnings.warn(
             '`use_mps_device` flag is deprecated and will be removed in version 0.15.0 of 🤗 Accelerate. Use "--mps" instead.',
             FutureWarning,
         )
         args.mps = True
-    current_env["USE_MPS_DEVICE"] = str(args.mps)
+    current_env["ACCELERATE_USE_MPS_DEVICE"] = str(args.mps)
     if args.mps:
         current_env["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
     elif args.gpu_ids != "all" and args.gpu_ids is not None:
@@ -551,13 +551,13 @@ def simple_launcher(args):
         )
         mixed_precision = "fp16"
 
-    current_env["MIXED_PRECISION"] = str(mixed_precision)
+    current_env["ACCELERATE_MIXED_PRECISION"] = str(mixed_precision)
 
     try:
         dynamo_backend = DynamoBackend(args.dynamo_backend.upper())
     except ValueError:
         raise ValueError(f"Unknown dynamo backend: {args.dynamo_backend.upper()}. Choose between {DYNAMO_BACKENDS}.")
-    current_env["DYNAMO_BACKEND"] = dynamo_backend.value
+    current_env["ACCELERATE_DYNAMO_BACKEND"] = dynamo_backend.value
 
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
 
@@ -612,16 +612,16 @@ def multi_gpu_launcher(args):
         )
         mixed_precision = "fp16"
 
-    current_env["MIXED_PRECISION"] = str(mixed_precision)
+    current_env["ACCELERATE_MIXED_PRECISION"] = str(mixed_precision)
 
     try:
         dynamo_backend = DynamoBackend(args.dynamo_backend.upper())
     except ValueError:
         raise ValueError(f"Unknown dynamo backend: {args.dynamo_backend.upper()}. Choose between {DYNAMO_BACKENDS}.")
-    current_env["DYNAMO_BACKEND"] = dynamo_backend.value
+    current_env["ACCELERATE_DYNAMO_BACKEND"] = dynamo_backend.value
 
     if args.use_fsdp:
-        current_env["USE_FSDP"] = "true"
+        current_env["ACCELERATE_USE_FSDP"] = "true"
         current_env["FSDP_SHARDING_STRATEGY"] = str(args.fsdp_sharding_strategy)
         current_env["FSDP_OFFLOAD_PARAMS"] = str(args.fsdp_offload_params).lower()
         current_env["FSDP_MIN_NUM_PARAMS"] = str(args.fsdp_min_num_params)
@@ -636,7 +636,7 @@ def multi_gpu_launcher(args):
 
     if args.use_megatron_lm:
         prefix = "MEGATRON_LM_"
-        current_env["USE_MEGATRON_LM"] = "true"
+        current_env["ACCELERATE_USE_MEGATRON_LM"] = "true"
         current_env[prefix + "TP_DEGREE"] = str(args.megatron_lm_tp_degree)
         current_env[prefix + "PP_DEGREE"] = str(args.megatron_lm_pp_degree)
         current_env[prefix + "GRADIENT_CLIPPING"] = str(args.megatron_lm_gradient_clipping)
@@ -748,8 +748,8 @@ def deepspeed_launcher(args):
         mixed_precision = "fp16"
 
     current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath("."))
-    current_env["MIXED_PRECISION"] = str(mixed_precision)
-    current_env["USE_DEEPSPEED"] = "true"
+    current_env["ACCELERATE_MIXED_PRECISION"] = str(mixed_precision)
+    current_env["ACCELERATE_USE_DEEPSPEED"] = "true"
     current_env["DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)
     current_env["GRADIENT_ACCUMULATION_STEPS"] = str(args.gradient_accumulation_steps)
     current_env["GRADIENT_CLIPPING"] = str(args.gradient_clipping).lower()
@@ -924,10 +924,10 @@ def sagemaker_launcher(sagemaker_config: SageMakerConfig, args):
 
     # Environment variables to be set for use during training job
     environment = {
-        "USE_SAGEMAKER": "true",
-        "MIXED_PRECISION": str(mixed_precision),
-        "DYNAMO_BACKEND": dynamo_backend.value,
-        "SAGEMAKER_DISTRIBUTED_TYPE": sagemaker_config.distributed_type.value,
+        "ACCELERATE_USE_SAGEMAKER": "true",
+        "ACCELERATE_MIXED_PRECISION": str(mixed_precision),
+        "ACCELERATE_DYNAMO_BACKEND": dynamo_backend.value,
+        "ACCELERATE_SAGEMAKER_DISTRIBUTED_TYPE": sagemaker_config.distributed_type.value,
     }
     # configure distribution set up
     distribution = None

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -163,9 +163,9 @@ def debug_launcher(function, args=(), num_processes=2):
             world_size=num_processes,
             master_addr="127.0.01",
             master_port="29500",
-            mixed_precision="no",
+            accelerate_mixed_precision="no",
             accelerate_debug_rdv_file=tmp_file.name,
-            use_cpu="yes",
+            accelerate_use_cpu="yes",
         ):
             launcher = PrepareForLaunch(function, debug=True)
             start_processes(launcher, args=args, nprocs=num_processes, start_method="fork")

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -69,7 +69,7 @@ class AcceleratorState:
         if parse_flag_from_env("ACCELERATE_USE_CPU"):
             cpu = True
         self._check_initialized(mixed_precision, cpu)
-        self.fork_launched = parse_flag_from_env("ACCELERATE_FORK_LAUNCHED", 0)
+        self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
         if not getattr(self, "initialized", False):
             self.backend = None
             self.deepspeed_plugin = None

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -93,7 +93,7 @@ def is_bf16_available(ignore_tpu=False):
 
 
 def is_megatron_lm_available():
-    if strtobool(os.environ.get("USE_MEGATRON_LM", "False")) == 1:
+    if strtobool(os.environ.get("ACCELERATE_USE_MEGATRON_LM", "False")) == 1:
         package_exists = importlib.util.find_spec("megatron") is not None
         if package_exists:
             megatron_version = parse(importlib_metadata.version("megatron-lm"))

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -130,7 +130,7 @@ def is_boto3_available():
 
 
 def is_rich_available():
-    return (importlib.util.find_spec("rich") is not None) and (not parse_flag_from_env("DISABLE_RICH"))
+    return (importlib.util.find_spec("rich") is not None) and (not parse_flag_from_env("ACCELERATE_DISABLE_RICH"))
 
 
 def is_sagemaker_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -15,6 +15,7 @@
 import importlib
 import os
 import sys
+import warnings
 from distutils.util import strtobool
 from functools import lru_cache
 
@@ -130,7 +131,15 @@ def is_boto3_available():
 
 
 def is_rich_available():
-    return (importlib.util.find_spec("rich") is not None) and (not parse_flag_from_env("ACCELERATE_DISABLE_RICH"))
+    if importlib.util.find_spec("rich") is not None:
+        if parse_flag_from_env("DISABLE_RICH"):
+            warnings.warn(
+                "The `DISABLE_RICH` flag is deprecated and will be removed in version 0.17.0 of 🤗 Accelerate. Use `ACCELERATE_DISABLE_RICH` instead.",
+                FutureWarning,
+            )
+            return not parse_flag_from_env("DISABLE_RICH")
+        return not parse_flag_from_env("ACCELERATE_DISABLE_RICH")
+    return False
 
 
 def is_sagemaker_available():

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -93,5 +93,5 @@ class PrepareForLaunch:
             os.environ["LOCAL_RANK"] = str(index)
             os.environ["RANK"] = str(index)
 
-        os.environ["ACCELERATE_FORK_LAUNCHED"] = str(1)
+        os.environ["FORK_LAUNCHED"] = str(1)
         self.launcher(*args)

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -93,5 +93,5 @@ class PrepareForLaunch:
             os.environ["LOCAL_RANK"] = str(index)
             os.environ["RANK"] = str(index)
 
-        os.environ["FORK_LAUNCHED"] = str(1)
+        os.environ["ACCELERATE_FORK_LAUNCHED"] = str(1)
         self.launcher(*args)


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/888 and follows the current pattern for `LOG_LEVEL` by prefixing all env variables Accelerate uses with `ACCELERATOR`