### PR TITLE
Support bfloat16 in load_offloaded_weight

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -21,7 +21,6 @@ import tempfile
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple, Union
 
-import numpy as np
 import torch
 import torch.nn as nn
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -25,7 +25,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from .offload import offload_weight, save_offload_index
+from .offload import load_offloaded_weight, offload_weight, save_offload_index
 
 
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
@@ -324,9 +324,8 @@ def load_offloaded_weights(model, index, offload_folder):
 
     for param_name, metadata in index.items():
         tensor_file = os.path.join(offload_folder, f"{param_name}.dat")
-        shape = tuple(metadata["shape"])
-        weight = np.memmap(tensor_file, dtype=metadata["dtype"], mode="r", shape=shape)
-        set_module_tensor_to_device(model, param_name, "cpu", value=torch.tensor(weight))
+        weight = load_offloaded_weight(tensor_file, metadata)
+        set_module_tensor_to_device(model, param_name, "cpu", value=weight)
 
 
 def get_balanced_memory(


### PR DESCRIPTION
Currently loading offloaded weights via `load_offloaded_weights` (as is done in Transformers in `from_pretrained` with `offload_state_dict=True`) does not work in bfloat16 because Numpy does not support that floating type.

This PR addresses that by reusing the function `load_offloaded_weight` which has the logic.