### PR TITLE
Fix windows cli selector

### DIFF
--- a/src/accelerate/commands/menu/keymap.py
+++ b/src/accelerate/commands/menu/keymap.py
@@ -17,15 +17,9 @@ Utilities relating to parsing raw characters from the keyboard, based on https:/
 """
 
 
+import os
 import string
 import sys
-import os
-
-if os.name == "nt":
-    import msvcrt
-else:
-    import termios
-    import tty
 
 
 ARROW_KEY_FLAG = 1 << 8
@@ -53,8 +47,13 @@ for i in range(10):
 def get_raw_chars():
     "Gets raw characters from inputs"
     if os.name == "nt":
+        import msvcrt
+
         return msvcrt.getch()
     else:
+        import termios
+        import tty
+
         fd = sys.stdin.fileno()
         old_settings = termios.tcgetattr(fd)
         try:

--- a/src/accelerate/commands/menu/keymap.py
+++ b/src/accelerate/commands/menu/keymap.py
@@ -19,8 +19,13 @@ Utilities relating to parsing raw characters from the keyboard, based on https:/
 
 import string
 import sys
-import termios
-import tty
+import os
+
+if os.name == "nt":
+    import msvcrt
+else:
+    import termios
+    import tty
 
 
 ARROW_KEY_FLAG = 1 << 8
@@ -47,14 +52,17 @@ for i in range(10):
 
 def get_raw_chars():
     "Gets raw characters from inputs"
-    fd = sys.stdin.fileno()
-    old_settings = termios.tcgetattr(fd)
-    try:
-        tty.setraw(fd)
-        ch = sys.stdin.read(1)
-    finally:
-        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-    return ch
+    if os.name == "nt":
+        return msvcrt.getch()
+    else:
+        fd = sys.stdin.fileno()
+        old_settings = termios.tcgetattr(fd)
+        try:
+            tty.setraw(fd)
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+        return ch
 
 
 def get_character():

--- a/src/accelerate/commands/menu/keymap.py
+++ b/src/accelerate/commands/menu/keymap.py
@@ -39,8 +39,6 @@ KEYMAP = {
     "delete": 51,
     "pg_up": 53,
     "pg_down": 54,
-    "home": 72,
-    "end": 70,
 }
 
 KEYMAP["arrow_begin"] = KEYMAP["up"]
@@ -122,14 +120,7 @@ def get_character():
         if ord(combo) == KEYMAP["mod_int"]:
             key = get_raw_chars()
             if ord(key) >= KEYMAP["arrow_begin"] - ARROW_KEY_FLAG and ord(key) <= KEYMAP["arrow_end"] - ARROW_KEY_FLAG:
-                if ord(key) in (KEYMAP["home"] - ARROW_KEY_FLAG, KEYMAP["end"] - ARROW_KEY_FLAG):
-                    return chr(ord(key) + ARROW_KEY_FLAG)
-                else:
-                    trail = get_raw_chars()
-                    if ord(trail) == 126:
-                        return chr(ord(key) + ARROW_KEY_FLAG)
-                    else:
-                        return KEYMAP["undefined"]
+                return chr(ord(key) + ARROW_KEY_FLAG)
             else:
                 return KEYMAP["undefined"]
         else:

--- a/src/accelerate/commands/menu/keymap.py
+++ b/src/accelerate/commands/menu/keymap.py
@@ -39,6 +39,8 @@ KEYMAP = {
     "delete": 51,
     "pg_up": 53,
     "pg_down": 54,
+    "home": 72,
+    "end": 70,
 }
 
 KEYMAP["arrow_begin"] = KEYMAP["up"]
@@ -120,7 +122,14 @@ def get_character():
         if ord(combo) == KEYMAP["mod_int"]:
             key = get_raw_chars()
             if ord(key) >= KEYMAP["arrow_begin"] - ARROW_KEY_FLAG and ord(key) <= KEYMAP["arrow_end"] - ARROW_KEY_FLAG:
-                return chr(ord(key) + ARROW_KEY_FLAG)
+                if ord(key) in (KEYMAP["home"] - ARROW_KEY_FLAG, KEYMAP["end"] - ARROW_KEY_FLAG):
+                    return chr(ord(key) + ARROW_KEY_FLAG)
+                else:
+                    trail = get_raw_chars()
+                    if ord(trail) == 126:
+                        return chr(ord(key) + ARROW_KEY_FLAG)
+                    else:
+                        return KEYMAP["undefined"]
             else:
                 return KEYMAP["undefined"]
         else:

--- a/src/accelerate/commands/menu/selection_menu.py
+++ b/src/accelerate/commands/menu/selection_menu.py
@@ -34,7 +34,9 @@ class BulletMenu:
     def print_choice(self, index: int):
         "Prints the choice at the given index"
         if index == self.position:
-            forceWrite(" ➔  ")
+            forceWrite(" ")
+            forceWrite(u"\u2794")
+            forceWrite("  ")
             writeColor(self.choices[index], 32)
         else:
             forceWrite(f"    {self.choices[index]}")

--- a/src/accelerate/commands/menu/selection_menu.py
+++ b/src/accelerate/commands/menu/selection_menu.py
@@ -15,6 +15,8 @@
 """
 Main driver for the selection menu, based on https://github.com/bchao1/bullet
 """
+import sys
+
 from . import cursor, input
 from .helpers import Direction, clear_line, forceWrite, linebreak, move_cursor, reset_cursor, writeColor
 from .keymap import KEYMAP
@@ -30,14 +32,22 @@ class BulletMenu:
         self.position = 0
         self.choices = choices
         self.prompt = prompt
+        if sys.platform == "win32":
+            self.arrow_char = "*"
+        else:
+            self.arrow_char = "➔ "
+
+    def write_choice(self, index, end: str = ""):
+        if sys.platform != "win32":
+            writeColor(self.choices[index], 32, end)
+        else:
+            forceWrite(self.choices[index], end)
 
     def print_choice(self, index: int):
         "Prints the choice at the given index"
         if index == self.position:
-            forceWrite(" ")
-            forceWrite(u"\u2794")
-            forceWrite("  ")
-            writeColor(self.choices[index], 32)
+            forceWrite(f" {self.arrow_char} ")
+            self.write_choice(index)
         else:
             forceWrite(f"    {self.choices[index]}")
         reset_cursor()
@@ -111,6 +121,5 @@ class BulletMenu:
                     for _ in range(len(self.choices) + 1):
                         move_cursor(1, "UP")
                         clear_line()
-                    forceWrite(" ➔  ")
-                    writeColor(self.choices[choice], 32, "\n")
+                    self.write_choice(choice, "\n")
                     return choice


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/867

Mild fix for right now, need to eventually see why windows just prints the history of arrow keys such as:
```bash
Do you wish to use FP16 or BF16 (mixed precision)?
Please select a choice using the arrow or number keys, and selecting with enter
 * no
    fp16
    bf16
[3A                                                                                                                    [1A                                                                                                                    [1A                                                                                                                    [1A                                                                                                                    [1A                                                                                                                    fp16
```

But the CLI works and the import issue has been resolved with this

Also windows in general doesn't support pretty colors, so adds an option to do `*` if on windows