### PR TITLE
Allowing encoded configuration for DeepSpeed

### DIFF
--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import base64
 import io
 import json
-from copy import deepcopy
-import base64
 import os
+from copy import deepcopy
 
 from ..optimizer import AcceleratedOptimizer
 from ..scheduler import AcceleratedScheduler
@@ -50,7 +50,7 @@ class HfDeepSpeedConfig:
                 config = json.load(f)
         else:
             try:
-                config_decoded = base64.urlsafe_b64decode(config_file_or_dict).decode('utf-8')
+                config_decoded = base64.urlsafe_b64decode(config_file_or_dict).decode("utf-8")
                 config = json.loads(config_decoded)
             except (UnicodeDecodeError, AttributeError):
                 raise ValueError(

--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -15,6 +15,8 @@
 import io
 import json
 from copy import deepcopy
+import base64
+import os
 
 from ..optimizer import AcceleratedOptimizer
 from ..scheduler import AcceleratedScheduler
@@ -43,11 +45,18 @@ class HfDeepSpeedConfig:
             # Don't modify user's data should they want to reuse it (e.g. in tests), because once we
             # modified it, it will not be accepted here again, since `auto` values would have been overridden
             config = deepcopy(config_file_or_dict)
-        elif isinstance(config_file_or_dict, str):
+        elif os.path.exists(config_file_or_dict):
             with io.open(config_file_or_dict, "r", encoding="utf-8") as f:
                 config = json.load(f)
         else:
-            raise ValueError("expecting either a path to a DeepSpeed config file or a pre-populated dict")
+            try:
+                config_decoded = base64.urlsafe_b64decode(config_file_or_dict).decode('utf-8')
+                config = json.loads(config_decoded)
+            except (UnicodeDecodeError, AttributeError):
+                raise ValueError(
+                    f"Expected a string path to an existing deepspeed config, or a dictionary, or a base64 encoded string. Received: {config}"
+                )
+
         self.config = config
 
         # zero stage - this is done as early as possible, before model is created, to allow


### PR DESCRIPTION
DeepSpeed now allows deespeed configuration passed in as a base64 encoded string. This PR updates the check in accelerate to accommodate that change.