### PR TITLE
Adds a utility function to install correct version of torch XLA

### DIFF
--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -93,3 +93,10 @@ These utilities relate to setting and synchronizing of all the random states.
 [[autodoc]] utils.synchronize_rng_state
 
 [[autodoc]] utils.synchronize_rng_states
+
+
+## PyTorch XLA
+
+These include utilities that are useful while using PyTorch with XLA.
+
+[[autodoc]] utils.install_xla

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -99,7 +99,6 @@ if is_deepspeed_available():
         HfDeepSpeedConfig,
     )
 
-from .torch_xla import install_xla
 from .launch import PrepareForLaunch, _filter_args, get_launch_prefix
 from .megatron_lm import (
     AbstractTrainStep,
@@ -129,4 +128,5 @@ from .other import (
     write_basic_config,
 )
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
+from .torch_xla import install_xla
 from .tqdm import tqdm

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -99,6 +99,7 @@ if is_deepspeed_available():
         HfDeepSpeedConfig,
     )
 
+from .torch_xla import install_xla
 from .launch import PrepareForLaunch, _filter_args, get_launch_prefix
 from .megatron_lm import (
     AbstractTrainStep,

--- a/src/accelerate/utils/torch_xla.py
+++ b/src/accelerate/utils/torch_xla.py
@@ -35,7 +35,7 @@ def install_xla(upgrade: bool = False):
             subprocess.run(torch_install_cmd, check=True)
         # get the current version of torch
         torch_version = pkg_resources.get_distribution("torch").version
-        torch_version_trunc = torch_version[:torch_version.rindex(".")]
+        torch_version_trunc = torch_version[: torch_version.rindex(".")]
         xla_wheel = f"https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-{torch_version_trunc}-cp37-cp37m-linux_x86_64.whl"
         xla_install_cmd = ["pip", "install", xla_wheel]
         subprocess.run(xla_install_cmd, check=True)

--- a/src/accelerate/utils/torch_xla.py
+++ b/src/accelerate/utils/torch_xla.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import subprocess
+import sys
+
 import pkg_resources
 
 

--- a/src/accelerate/utils/torch_xla.py
+++ b/src/accelerate/utils/torch_xla.py
@@ -1,0 +1,43 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import subprocess
+import pkg_resources
+
+
+def install_xla(upgrade: bool = False):
+    """
+    Helper function to install appropriate xla wheels based on the `torch` version.
+
+    Args:
+        upgrade (`bool`, *optional*, defaults to `False`):
+            Whether to upgrade `torch` and install the latest `torch_xla` wheels.
+    """
+    in_colab = False
+    if "IPython" in sys.modules:
+        in_colab = "google.colab" in str(sys.modules["IPython"].get_ipython())
+
+    if in_colab:
+        if upgrade:
+            torch_install_cmd = ["pip", "install", "-U", "torch"]
+            subprocess.run(torch_install_cmd, check=True)
+        # get the current version of torch
+        torch_version = pkg_resources.get_distribution("torch").version
+        torch_version_trunc = torch_version[:torch_version.rindex(".")]
+        xla_wheel = f"https://storage.googleapis.com/tpu-pytorch/wheels/colab/torch_xla-{torch_version_trunc}-cp37-cp37m-linux_x86_64.whl"
+        xla_install_cmd = ["pip", "install", xla_wheel]
+        subprocess.run(xla_install_cmd, check=True)
+    else:
+        raise RuntimeError("`install_xla` utility works only on google colab.")


### PR DESCRIPTION
The PR adds a function ```install_xla``` to install the correct version of XLA wheels based on the version of torch installed on the system. The function also takes in a boolean argument ```upgrade``` which allow the user to install the latest available version of torch and XLA.

Closes #586 