### PR TITLE
Flag to silence subprocess.CalledProcessError in launch

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -137,6 +137,9 @@ def launch_command_parser(subparsers=None):
     parser.add_argument(
         "--config_file", default=None, help="The config file to use for the default values in the launching script."
     )
+    parser.add_argument(
+        "--quiet", "-q", action="store_true", help="Don't print an error message if an error return code is returned from launch."
+    )
     # Hardware selection arguments
     hardware_args = parser.add_argument_group(
         "Hardware Selection Arguments", "Arguments for selecting the hardware to be used."
@@ -564,7 +567,10 @@ def simple_launcher(args):
     process = subprocess.Popen(cmd, env=current_env)
     process.wait()
     if process.returncode != 0:
-        raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
+        if not args.quiet:
+            raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
+        else:
+            sys.exit(1)
 
 
 def multi_gpu_launcher(args):
@@ -770,7 +776,10 @@ def deepspeed_launcher(args):
         process = subprocess.Popen(cmd, env=current_env)
         process.wait()
         if process.returncode != 0:
-            raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
+            if not args.quiet:
+                raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
+            else:
+                sys.exit(1)
     else:
         if is_torch_version("<", "1.9.0"):
             raise NotImplementedError("Multi-node training requires pytorch>=1.9.0")


### PR DESCRIPTION
Raising an internal Python error is ugly. Here's an option to silence it.

Instead of:
```bash
$ accelerate launch jk13klj123
/usr/bin/python3: can't open file '/mnt/remote/infra/infra/jk13klj123': [Errno 2] No such file or directory
Traceback (most recent call last):
  File "/home/dpanzer/.local/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/home/dpanzer/.local/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 45, in main
    args.func(args)
  File "/home/dpanzer/.local/lib/python3.10/site-packages/accelerate/commands/launch.py", line 1069, in launch_command
    simple_launcher(args)
  File "/home/dpanzer/.local/lib/python3.10/site-packages/accelerate/commands/launch.py", line 551, in simple_launcher
    raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
subprocess.CalledProcessError: Command '['/usr/bin/python3', 'jk13klj123']' returned non-zero exit status 2.
```

You'll get:
```bash
$ accelerate launch -q jk13klj123
/usr/bin/python3: can't open file 'jk13klj123': [Errno 2] No such file or directory
```

When running with `-q` or `--quiet` the process will exit with `sys.exit(1)`.