### PR TITLE
fix issue that amp bf16 does not work for cpu in env with cuda.

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1089,7 +1089,7 @@ def launch_command(args):
                 ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
             )
             threads_per_process = int(psutil.cpu_count(logical=False) / local_size)
-            if args.num_cpu_threads_per_process > 1:
+            if threads_per_process > 1:
                 args.num_cpu_threads_per_process = threads_per_process
                 warned.append(
                     f"\t`--num_cpu_threads_per_process` was set to `{args.num_cpu_threads_per_process}` to improve out-of-box performance when training on CPUs"


### PR DESCRIPTION
and num_cpu_threads_per_process is not reset for better performance in cpu only case

Signed-off-by: Wang, Yi A <yi.a.wang@intel.com>