### PR TITLE
Introduce `project_dir` and limit the number of saved checkpoints

### DIFF
--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -24,7 +24,7 @@ These are basic dataclasses used throughout 🤗 Accelerate and they can be pass
 
 [[autodoc]] utils.PrecisionType
 
-[[autodoc]] utils.SaveConfiguration
+[[autodoc]] utils.ProjectConfiguration
 
 ## Data Manipulation and Operations
 

--- a/docs/source/package_reference/utilities.mdx
+++ b/docs/source/package_reference/utilities.mdx
@@ -24,6 +24,8 @@ These are basic dataclasses used throughout 🤗 Accelerate and they can be pass
 
 [[autodoc]] utils.PrecisionType
 
+[[autodoc]] utils.SaveConfiguration
+
 ## Data Manipulation and Operations
 
 These include data operations that mimic the same `torch` ops but can be used on distributed processes.

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -370,7 +370,8 @@ Note that since all the model parameters are references to tensors, this will lo
 ## Saving/loading entire states
 
 When training your model, you may want to save the current state of the model, optimizer, random generators, and potentially LR schedulers to be restored in the _same script_.
-You can use [`~Accelerator.save_state`] and [`~Accelerator.load_state`] respectively to do so, just by simply passing in a save location. 
+You can use [`~Accelerator.save_state`] and [`~Accelerator.load_state`] respectively to do so, just by simply passing in a project directory to [`Accelerator.init`]. Each saved 
+checkpoints will be located then at `Accelerator.project_dir/checkpoints/checkpoint_{checkpoint_number}`
 If you have registered any other stateful items to be stored through [`~Accelerator.register_for_checkpointing`] they will also be saved and/or loaded.
 
 <Tip>

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -372,7 +372,7 @@ Note that since all the model parameters are references to tensors, this will lo
 When training your model, you may want to save the current state of the model, optimizer, random generators, and potentially LR schedulers to be restored in the _same script_.
 You can use [`~Accelerator.save_state`] and [`~Accelerator.load_state`] respectively to do so.
 
-To further customize where and how states saved through [`~Accelerator.save_state`] the [`~utils.SaveConfiguration`] class can be used. For example 
+To further customize where and how states saved through [`~Accelerator.save_state`] the [`~utils.ProjectConfiguration`] class can be used. For example 
 if `automatic_checkpoint_naming` is enabled each saved checkpoint will be located then at `Accelerator.project_dir/checkpoints/checkpoint_{checkpoint_number}`.
 
 If you have registered any other stateful items to be stored through [`~Accelerator.register_for_checkpointing`] they will also be saved and/or loaded.

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -370,8 +370,11 @@ Note that since all the model parameters are references to tensors, this will lo
 ## Saving/loading entire states
 
 When training your model, you may want to save the current state of the model, optimizer, random generators, and potentially LR schedulers to be restored in the _same script_.
-You can use [`~Accelerator.save_state`] and [`~Accelerator.load_state`] respectively to do so, just by simply passing in a project directory to [`Accelerator.init`]. Each saved 
-checkpoints will be located then at `Accelerator.project_dir/checkpoints/checkpoint_{checkpoint_number}`
+You can use [`~Accelerator.save_state`] and [`~Accelerator.load_state`] respectively to do so.
+
+To further customize where and how states saved through [`~Accelerator.save_state`] the [`~utils.SaveConfiguration`] class can be used. For example 
+if `automatic_checkpoint_naming` is enabled each saved checkpoint will be located then at `Accelerator.project_dir/checkpoints/checkpoint_{checkpoint_number}`.
+
 If you have registered any other stateful items to be stored through [`~Accelerator.register_for_checkpointing`] they will also be saved and/or loaded.
 
 <Tip>

--- a/docs/source/usage_guides/checkpoint.mdx
+++ b/docs/source/usage_guides/checkpoint.mdx
@@ -14,8 +14,11 @@ specific language governing permissions and limitations under the License.
 
 When training a PyTorch model with 🤗 Accelerate, you may often want to save and continue a state of training. Doing so requires
 saving and loading the model, optimizer, RNG generators, and the GradScaler. Inside 🤗 Accelerate are two convenience functions to achieve this quickly:
-- Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location passed to [`~Accelerator.init`]
+- Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location
 - Use [`~Accelerator.load_state`] for loading everything stored from an earlier `save_state`
+
+To further customize where and how states saved through [`~Accelerator.save_state`] the [`~utils.SaveConfiguration`] class can be used. For example 
+if `automatic_checkpoint_naming` is enabled each saved checkpoint will be located then at `Accelerator.project_dir/checkpoints/checkpoint_{checkpoint_number}`.
 
 It should be noted that the expectation is that those states come from the same training script, they should not be from two separate scripts.
 

--- a/docs/source/usage_guides/checkpoint.mdx
+++ b/docs/source/usage_guides/checkpoint.mdx
@@ -17,7 +17,7 @@ saving and loading the model, optimizer, RNG generators, and the GradScaler. Ins
 - Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location
 - Use [`~Accelerator.load_state`] for loading everything stored from an earlier `save_state`
 
-To further customize where and how states saved through [`~Accelerator.save_state`] the [`~utils.SaveConfiguration`] class can be used. For example 
+To further customize where and how states saved through [`~Accelerator.save_state`] the [`~utils.ProjectConfiguration`] class can be used. For example 
 if `automatic_checkpoint_naming` is enabled each saved checkpoint will be located then at `Accelerator.project_dir/checkpoints/checkpoint_{checkpoint_number}`.
 
 It should be noted that the expectation is that those states come from the same training script, they should not be from two separate scripts.

--- a/docs/source/usage_guides/checkpoint.mdx
+++ b/docs/source/usage_guides/checkpoint.mdx
@@ -14,7 +14,7 @@ specific language governing permissions and limitations under the License.
 
 When training a PyTorch model with 🤗 Accelerate, you may often want to save and continue a state of training. Doing so requires
 saving and loading the model, optimizer, RNG generators, and the GradScaler. Inside 🤗 Accelerate are two convenience functions to achieve this quickly:
-- Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location
+- Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location passed to [`~Accelerator.init`]
 - Use [`~Accelerator.load_state`] for loading everything stored from an earlier `save_state`
 
 It should be noted that the expectation is that those states come from the same training script, they should not be from two separate scripts.
@@ -28,7 +28,7 @@ Below is a brief example using checkpointing to save and reload a state during t
 from accelerate import Accelerator
 import torch
 
-accelerator = Accelerator()
+accelerator = Accelerator(project_dir="my/save/path")
 
 my_scheduler = torch.optim.lr_scheduler.StepLR(my_optimizer, step_size=1, gamma=0.99)
 my_model, my_optimizer, my_training_dataloader = accelerator.prepare(my_model, my_optimizer, my_training_dataloader)
@@ -37,7 +37,7 @@ my_model, my_optimizer, my_training_dataloader = accelerator.prepare(my_model, m
 accelerator.register_for_checkpointing(my_scheduler)
 
 # Save the starting state
-accelerator.save_state("my/save/path")
+accelerator.save_state()
 
 device = accelerator.device
 my_model.to(device)
@@ -56,5 +56,5 @@ for epoch in range(num_epochs):
     my_scheduler.step()
 
 # Restore previous state
-accelerator.load_state("my/save/path")
+accelerator.load_state("my/save/path/checkpointing/checkpoint_0")
 ```

--- a/docs/source/usage_guides/tracking.mdx
+++ b/docs/source/usage_guides/tracking.mdx
@@ -96,7 +96,7 @@ To implement a new tracker to be used in `Accelerator`, a new one can be made th
 Every tracker must implement three functions and have three properties:
   - `__init__`: 
     - Should store a `run_name` and initialize the tracker API of the integrated library. 
-    - If a tracker stores their data locally (such as TensorBoard), a `project_dir` parameter can be added.
+    - If a tracker stores their data locally (such as TensorBoard), a `logging_dir` parameter can be added.
   - `store_init_configuration`: 
     - Should take in a `values` dictionary and store them as a one-time experiment configuration
   - `log`: 

--- a/docs/source/usage_guides/tracking.mdx
+++ b/docs/source/usage_guides/tracking.mdx
@@ -84,7 +84,7 @@ accelerator.end_training()
 ```
 
 If a tracker requires a directory to save data to such as `TensorBoard` then a `logging_dir` or `project_dir` can be passed in. `project_dir` is useful 
-for if there are other further configurations such as those which can be combined with the [`~utils.SaveConfiguration`] dataclass.
+for if there are other further configurations such as those which can be combined with the [`~utils.ProjectConfiguration`] dataclass.
 
 ```python
 accelerator = Accelerator(log_with="tensorboard", logging_dir=".")

--- a/docs/source/usage_guides/tracking.mdx
+++ b/docs/source/usage_guides/tracking.mdx
@@ -90,7 +90,7 @@ To implement a new tracker to be used in `Accelerator`, a new one can be made th
 Every tracker must implement three functions and have three properties:
   - `__init__`: 
     - Should store a `run_name` and initialize the tracker API of the integrated library. 
-    - If a tracker stores their data locally (such as TensorBoard), a `logging_dir` parameter can be added.
+    - If a tracker stores their data locally (such as TensorBoard), a `project_dir` parameter can be added.
   - `store_init_configuration`: 
     - Should take in a `values` dictionary and store them as a one-time experiment configuration
   - `log`: 
@@ -99,8 +99,8 @@ Every tracker must implement three functions and have three properties:
   - `name` (`str`):
     - A unique string name for the tracker, such as `"wandb"` for the wandb tracker. 
     - This will be used for interacting with this tracker specifically
-  - `requires_logging_directory` (`bool`):
-    - Whether a `logging_dir` is needed for this particular tracker and if it uses one.
+  - `requires_project_directory` (`bool`):
+    - Whether a `project_dir` is needed for this particular tracker and if it uses one.
   - `tracker`: 
     - This should be implemented as a `@property` function 
     - Should return the internal tracking mechanism the library uses, such as the `run` object for `wandb`.
@@ -115,7 +115,7 @@ import wandb
 
 class MyCustomTracker(GeneralTracker):
     name = "wandb"
-    requires_logging_directory = False
+    requires_project_directory = False
 
     def __init__(self, run_name: str):
         self.run_name = run_name

--- a/docs/source/usage_guides/tracking.mdx
+++ b/docs/source/usage_guides/tracking.mdx
@@ -84,7 +84,7 @@ accelerator.end_training()
 ```
 
 If a tracker requires a directory to save data to such as `TensorBoard` then a `logging_dir` or `project_dir` can be passed in. `project_dir` is useful 
-for if there are other further configurations such as those which can be combined with the [`~utils.ProjectConfiguration`] dataclass.
+if there are other further configurations such as those which can be combined with the [`~utils.ProjectConfiguration`] dataclass.
 
 ```python
 accelerator = Accelerator(log_with="tensorboard", logging_dir=".")

--- a/docs/source/usage_guides/tracking.mdx
+++ b/docs/source/usage_guides/tracking.mdx
@@ -83,6 +83,12 @@ for iteration in config["num_iterations"]:
 accelerator.end_training()
 ```
 
+If a tracker requires a directory to save data to such as `TensorBoard` then a `logging_dir` or `project_dir` can be passed in. `project_dir` is useful 
+for if there are other further configurations such as those which can be combined with the [`~utils.SaveConfiguration`] dataclass.
+
+```python
+accelerator = Accelerator(log_with="tensorboard", logging_dir=".")
+```
 
 ## Implementing Custom Trackers
 
@@ -99,8 +105,8 @@ Every tracker must implement three functions and have three properties:
   - `name` (`str`):
     - A unique string name for the tracker, such as `"wandb"` for the wandb tracker. 
     - This will be used for interacting with this tracker specifically
-  - `requires_project_directory` (`bool`):
-    - Whether a `project_dir` is needed for this particular tracker and if it uses one.
+  - `requires_logging_directory` (`bool`):
+    - Whether a `logging_dir` is needed for this particular tracker and if it uses one.
   - `tracker`: 
     - This should be implemented as a `@property` function 
     - Should return the internal tracking mechanism the library uses, such as the `run` object for `wandb`.
@@ -115,7 +121,7 @@ import wandb
 
 class MyCustomTracker(GeneralTracker):
     name = "wandb"
-    requires_project_directory = False
+    requires_logging_directory = False
 
     def __init__(self, run_name: str):
         self.run_name = run_name

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -214,7 +214,7 @@ class Accelerator:
         rng_types: Optional[List[Union[str, RNGType]]] = None,
         log_with: Optional[List[Union[str, LoggerType, GeneralTracker]]] = None,
         project_dir: Optional[Union[str, os.PathLike]] = None,
-        save_configuration: Optional[SaveConfiguration] = None,
+        save_config: Optional[SaveConfiguration] = None,
         logging_dir: Optional[Union[str, os.PathLike]] = None,
         dispatch_batches: Optional[bool] = None,
         even_batches: bool = True,
@@ -222,8 +222,8 @@ class Accelerator:
         kwargs_handlers: Optional[List[KwargsHandler]] = None,
         dynamo_backend: Union[DynamoBackend, str] = None,
     ):
-        if save_configuration is not None:
-            self.save_configuration = save_configuration
+        if save_config is not None:
+            self.save_configuration = save_config
         else:
             self.save_configuration = SaveConfiguration(project_dir=project_dir)
         if self.project_dir is not None and logging_dir is None:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1631,9 +1631,9 @@ class Accelerator:
         """
         Saves the current states of the model, optimizer, scaler, RNG generators, and registered objects to a folder.
 
-        If a `ProjectConfiguration` was passed to the `Accelerator` object with `automatic_checkpoint_naming` enabled then
-        checkpoints will be saved to `self.project_dir/checkpoints`. If the number of current saves is greater than
-        `total_limit` then the oldest save is deleted. Each checkpoint is saved in seperate folders named
+        If a `ProjectConfiguration` was passed to the `Accelerator` object with `automatic_checkpoint_naming` enabled
+        then checkpoints will be saved to `self.project_dir/checkpoints`. If the number of current saves is greater
+        than `total_limit` then the oldest save is deleted. Each checkpoint is saved in seperate folders named
         `checkpoint_<iteration>`.
 
         Otherwise they are just saved to `output_dir`.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1632,8 +1632,10 @@ class Accelerator:
                 f"`output_dir='{output_dir}'` is deprecated and will be removed in version 0.17.0 of 🤗 Accelerate. Please use `Accelerator(project_dir=output_dir)` instead.",
                 FutureWarning,
             )
+            old_version = True
         else:
             output_dir = os.path.join(self.project_dir, "checkpoints")
+            old_version = False
         os.makedirs(output_dir, exist_ok=True)
         folders = [os.path.join(output_dir, folder) for folder in os.listdir(output_dir)]
         if self.save_total_limit is not None and (len(folders) + 1 > self.save_total_limit):
@@ -1643,13 +1645,14 @@ class Accelerator:
             )
             for folder in folders[: len(folders) + 1 - self.save_total_limit]:
                 shutil.rmtree(folder)
-        output_dir = os.path.join(output_dir, f"checkpoint_{self.save_iteration}")
-        if os.path.exists(output_dir):
-            raise ValueError(
-                f"Checkpoint directory {output_dir} ({self.save_iteration}) already exists. Please manually override `self.save_iteration` with what iteration to start with."
-            )
-        os.makedirs(output_dir, exist_ok=True)
-        logger.info(f"Saving current state to {output_dir}")
+        if not old_version:
+            save_location = os.path.join(output_dir, f"checkpoint_{self.save_iteration}")
+            if os.path.exists(output_dir):
+                raise ValueError(
+                    f"Checkpoint directory {output_dir} ({self.save_iteration}) already exists. Please manually override `self.save_iteration` with what iteration to start with."
+                )
+        os.makedirs(save_location, exist_ok=True)
+        logger.info(f"Saving current state to {save_location}")
 
         # Save the models taking care of FSDP and DeepSpeed nuances
         weights = []

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1555,7 +1555,7 @@ class Accelerator:
                 self.trackers.append(tracker)
             else:
                 tracker_init = LOGGER_TYPE_TO_CLASS[str(tracker)]
-                if getattr(tracker_init, "requires_logger_directory"):
+                if getattr(tracker_init, "requires_logging_directory"):
                     # We can skip this check since it was done in `__init__`
                     self.trackers.append(
                         tracker_init(project_name, self.logging_dir, **init_kwargs.get(str(tracker), {}))

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -222,7 +222,7 @@ class Accelerator:
         if project_config is not None:
             self.project_configuration = project_config
         else:
-            self.project_configuration = ProjectConfiguration()
+            self.project_configuration = ProjectConfiguration(project_dir=project_dir)
 
         if logging_dir is not None:
             warnings.warn(

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -159,9 +159,6 @@ class Accelerator:
             - `"comet_ml"`
             If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can
             also accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
-        logging_dir (`str`, `os.PathLike`, *optional*):
-            A path to a directory for storing logs of locally-compatible loggers. If not passed will save in
-            `project_dir` by default.
         save_config (`SaveConfiguration`, *optional*):
             A configuration for how saving the state can be handled.
         project_dir (`str`, `os.PathLike`, *optional*):
@@ -226,11 +223,15 @@ class Accelerator:
             self.save_configuration = save_config
         else:
             self.save_configuration = SaveConfiguration()
+
+        if logging_dir is not None:
+            warnings.warn(
+                "`logging_dir` is deprecated and will be removed in version 0.18.0 of 🤗 Accelerate. Use `project_dir` instead.",
+                FutureWarning,
+            )
+            self.save_configuration.logging_dir = logging_dir
         if project_dir is not None and self.project_dir is None:
             self.save_configuration.project_dir = project_dir
-        if self.project_dir is not None and logging_dir is None:
-            logging_dir = self.project_dir
-        self.logging_dir = logging_dir
         if mixed_precision is not None:
             mixed_precision = str(mixed_precision)
             if mixed_precision not in PrecisionType:
@@ -441,6 +442,10 @@ class Accelerator:
     @property
     def project_dir(self):
         return self.save_configuration.project_dir
+
+    @property
+    def logging_dir(self):
+        return self.save_configuration.logging_dir
 
     @property
     def save_iteration(self):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1631,7 +1631,7 @@ class Accelerator:
         """
         Saves the current states of the model, optimizer, scaler, RNG generators, and registered objects to a folder.
 
-        If a `SaveConfiguration` was passed to the `Accelerator` object with `automatic_checkpoint_naming` enabled then
+        If a `ProjectConfiguration` was passed to the `Accelerator` object with `automatic_checkpoint_naming` enabled then
         checkpoints will be saved to `self.project_dir/checkpoints`. If the number of current saves is greater than
         `total_limit` then the oldest save is deleted. Each checkpoint is saved in seperate folders named
         `checkpoint_<iteration>`.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -83,7 +83,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         pass
 
     @abstractproperty
-    def requires_logging_directory(self):
+    def requires_logger_directory(self):
         """
         Whether the logger requires a directory to store their logs. Should either return `True` or `False`.
         """
@@ -145,7 +145,7 @@ class TensorBoardTracker(GeneralTracker):
     """
 
     name = "tensorboard"
-    requires_logging_directory = True
+    requires_logger_directory = True
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = None, **kwargs):
         self.run_name = run_name
@@ -227,7 +227,7 @@ class WandBTracker(GeneralTracker):
     """
 
     name = "wandb"
-    requires_logging_directory = False
+    requires_logger_directory = False
 
     def __init__(self, run_name: str, **kwargs):
         self.run_name = run_name
@@ -291,7 +291,7 @@ class CometMLTracker(GeneralTracker):
     """
 
     name = "comet_ml"
-    requires_logging_directory = False
+    requires_logger_directory = False
 
     def __init__(self, run_name: str, **kwargs):
         self.run_name = run_name
@@ -362,7 +362,7 @@ class AimTracker(GeneralTracker):
     """
 
     name = "aim"
-    requires_logging_directory = True
+    requires_logger_directory = True
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
         self.run_name = run_name
@@ -439,7 +439,7 @@ class MLflowTracker(GeneralTracker):
     """
 
     name = "mlflow"
-    requires_logging_directory = True
+    requires_logger_directory = True
 
     def __init__(
         self,
@@ -589,7 +589,7 @@ def filter_trackers(
                     if log_type not in loggers:
                         if log_type in get_available_trackers():
                             tracker_init = LOGGER_TYPE_TO_CLASS[str(log_type)]
-                            if getattr(tracker_init, "requires_logging_directory"):
+                            if getattr(tracker_init, "requires_logger_directory"):
                                 if logging_dir is None:
                                     raise ValueError(
                                         f"Logging with `{log_type}` requires a `logging_dir` to be passed in."

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -83,7 +83,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         pass
 
     @abstractproperty
-    def requires_logger_directory(self):
+    def requires_logging_directory(self):
         """
         Whether the logger requires a directory to store their logs. Should either return `True` or `False`.
         """
@@ -145,7 +145,7 @@ class TensorBoardTracker(GeneralTracker):
     """
 
     name = "tensorboard"
-    requires_logger_directory = True
+    requires_logging_directory = True
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = None, **kwargs):
         self.run_name = run_name
@@ -227,7 +227,7 @@ class WandBTracker(GeneralTracker):
     """
 
     name = "wandb"
-    requires_logger_directory = False
+    requires_logging_directory = False
 
     def __init__(self, run_name: str, **kwargs):
         self.run_name = run_name
@@ -291,7 +291,7 @@ class CometMLTracker(GeneralTracker):
     """
 
     name = "comet_ml"
-    requires_logger_directory = False
+    requires_logging_directory = False
 
     def __init__(self, run_name: str, **kwargs):
         self.run_name = run_name
@@ -362,7 +362,7 @@ class AimTracker(GeneralTracker):
     """
 
     name = "aim"
-    requires_logger_directory = True
+    requires_logging_directory = True
 
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
         self.run_name = run_name
@@ -439,7 +439,7 @@ class MLflowTracker(GeneralTracker):
     """
 
     name = "mlflow"
-    requires_logger_directory = True
+    requires_logging_directory = True
 
     def __init__(
         self,
@@ -589,7 +589,7 @@ def filter_trackers(
                     if log_type not in loggers:
                         if log_type in get_available_trackers():
                             tracker_init = LOGGER_TYPE_TO_CLASS[str(log_type)]
-                            if getattr(tracker_init, "requires_logger_directory"):
+                            if getattr(tracker_init, "requires_logging_directory"):
                                 if logging_dir is None:
                                     raise ValueError(
                                         f"Logging with `{log_type}` requires a `logging_dir` to be passed in."

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 # Expectation:
-# Provide a project dir name, then each type of logger gets stored in project/{`logging_dir`}
+# Provide a project dir name, then each type of logger gets stored in project/{`project_dir`}
 
 import json
 import os
 import time
+import warnings
 from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import Any, Dict, List, Optional, Union
 
@@ -83,7 +84,7 @@ class GeneralTracker(object, metaclass=ABCMeta):
         pass
 
     @abstractproperty
-    def requires_logging_directory(self):
+    def requires_project_directory(self):
         """
         Whether the logger requires a directory to store their logs. Should either return `True` or `False`.
         """
@@ -138,20 +139,26 @@ class TensorBoardTracker(GeneralTracker):
     Args:
         run_name (`str`):
             The name of the experiment run
-        logging_dir (`str`, `os.PathLike`):
+        project_dir (`str`, `os.PathLike`):
             Location for TensorBoard logs to be stored.
         kwargs:
             Additional key word arguments passed along to the `tensorboard.SummaryWriter.__init__` method.
     """
 
     name = "tensorboard"
-    requires_logging_directory = True
+    requires_project_directory = True
 
-    def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]], **kwargs):
+    def __init__(self, run_name: str, project_dir: Optional[Union[str, os.PathLike]] = None, **kwargs):
+        if "logging_dir" in kwargs.keys():
+            project_dir = kwargs.pop("logging_dir")
+            warnings.warn(
+                f"`logging_dir='{project_dir}'` is deprecated and will be removed in version 0.17.0 of 🤗 Accelerate. Please use `project_dir={project_dir}` instead.",
+                FutureWarning,
+            )
         self.run_name = run_name
-        self.logging_dir = os.path.join(logging_dir, run_name)
-        self.writer = tensorboard.SummaryWriter(self.logging_dir, **kwargs)
-        logger.debug(f"Initialized TensorBoard project {self.run_name} logging to {self.logging_dir}")
+        self.project_dir = os.path.join(project_dir, run_name)
+        self.writer = tensorboard.SummaryWriter(self.project_dir, **kwargs)
+        logger.debug(f"Initialized TensorBoard project {self.run_name} logging to {self.project_dir}")
         logger.debug(
             "Make sure to log any initial configurations with `self.store_init_configuration` before training!"
         )
@@ -173,7 +180,7 @@ class TensorBoardTracker(GeneralTracker):
         self.writer.add_hparams(values, metric_dict={})
         self.writer.flush()
         project_run_name = time.time()
-        dir_name = os.path.join(self.logging_dir, str(project_run_name))
+        dir_name = os.path.join(self.project_dir, str(project_run_name))
         os.makedirs(dir_name, exist_ok=True)
         with open(os.path.join(dir_name, "hparams.yml"), "w") as outfile:
             try:
@@ -227,7 +234,7 @@ class WandBTracker(GeneralTracker):
     """
 
     name = "wandb"
-    requires_logging_directory = False
+    requires_project_directory = False
 
     def __init__(self, run_name: str, **kwargs):
         self.run_name = run_name
@@ -291,7 +298,7 @@ class CometMLTracker(GeneralTracker):
     """
 
     name = "comet_ml"
-    requires_logging_directory = False
+    requires_project_directory = False
 
     def __init__(self, run_name: str, **kwargs):
         self.run_name = run_name
@@ -362,11 +369,17 @@ class AimTracker(GeneralTracker):
     """
 
     name = "aim"
-    requires_logging_directory = True
+    requires_project_directory = True
 
-    def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
+    def __init__(self, run_name: str, project_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
+        if "logging_dir" in kwargs.keys():
+            project_dir = kwargs.pop("logging_dir")
+            warnings.warn(
+                f"`logging_dir='{project_dir}'` is deprecated and will be removed in version 0.17.0 of 🤗 Accelerate. Please use `project_dir={project_dir}` instead.",
+                FutureWarning,
+            )
         self.run_name = run_name
-        self.writer = Run(repo=logging_dir, **kwargs)
+        self.writer = Run(repo=project_dir, **kwargs)
         self.writer.name = self.run_name
         logger.debug(f"Initialized Aim project {self.run_name}")
         logger.debug(
@@ -417,7 +430,7 @@ class MLflowTracker(GeneralTracker):
     Args:
         experiment_name (`str`, *optional*):
             Name of the experiment. Environment variable MLFLOW_EXPERIMENT_NAME has priority over this argument.
-        logging_dir (`str` or `os.PathLike`, defaults to `"."`):
+        project_dir (`str` or `os.PathLike`, defaults to `"."`):
             Location for mlflow logs to be stored.
         run_id (`str`, *optional*):
             If specified, get the run with the specified UUID and log parameters and metrics under that run. The run’s
@@ -439,19 +452,25 @@ class MLflowTracker(GeneralTracker):
     """
 
     name = "mlflow"
-    requires_logging_directory = True
+    requires_project_directory = True
 
     def __init__(
         self,
         experiment_name: str = None,
-        logging_dir: Optional[Union[str, os.PathLike]] = ".",
+        project_dir: Optional[Union[str, os.PathLike]] = ".",
         run_id: Optional[str] = None,
         tags: Optional[Union[Dict[str, Any], str]] = None,
         nested_run: Optional[bool] = False,
         run_name: Optional[str] = None,
         description: Optional[str] = None,
+        logging_dir: Optional[Union[str, os.PathLike]] = None,
     ):
-
+        if logging_dir is not None:
+            project_dir = logging_dir
+            warnings.warn(
+                f"`logging_dir='{project_dir}'` is deprecated and will be removed in version 0.17.0 of 🤗 Accelerate. Please use `project_dir={project_dir}` instead.",
+                FutureWarning,
+            )
         experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME", experiment_name)
         run_id = os.getenv("MLFLOW_RUN_ID", run_id)
         tags = os.getenv("MLFLOW_TAGS", tags)
@@ -462,7 +481,7 @@ class MLflowTracker(GeneralTracker):
 
         experiment_id = mlflow.create_experiment(
             name=experiment_name,
-            artifact_location=logging_dir,
+            artifact_location=project_dir,
             tags=tags,
         )
 
@@ -550,14 +569,14 @@ LOGGER_TYPE_TO_CLASS = {
 
 
 def filter_trackers(
-    log_with: List[Union[str, LoggerType, GeneralTracker]], logging_dir: Union[str, os.PathLike] = None
+    log_with: List[Union[str, LoggerType, GeneralTracker]], project_dir: Union[str, os.PathLike] = None
 ):
     """
     Takes in a list of potential tracker types and checks that:
         - The tracker wanted is available in that environment
         - Filters out repeats of tracker types
         - If `all` is in `log_with`, will return all trackers in the environment
-        - If a tracker requires a `logging_dir`, ensures that `logging_dir` is not `None`
+        - If a tracker requires a `project_dir`, ensures that `project_dir` is not `None`
 
     Args:
         log_with (list of `str`, [`~utils.LoggerType`] or [`~tracking.GeneralTracker`], *optional*):
@@ -570,7 +589,7 @@ def filter_trackers(
             - `"mlflow"`
             If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can
             also accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
-        logging_dir (`str`, `os.PathLike`, *optional*):
+        project_dir (`str`, `os.PathLike`, *optional*):
             A path to a directory for storing logs of locally-compatible loggers.
     """
     loggers = []
@@ -590,10 +609,10 @@ def filter_trackers(
                     if log_type not in loggers:
                         if log_type in get_available_trackers():
                             tracker_init = LOGGER_TYPE_TO_CLASS[str(log_type)]
-                            if getattr(tracker_init, "requires_logging_directory"):
-                                if logging_dir is None:
+                            if getattr(tracker_init, "requires_project_directory"):
+                                if project_dir is None:
                                     raise ValueError(
-                                        f"Logging with `{log_type}` requires a `logging_dir` to be passed in."
+                                        f"Logging with `{log_type}` requires a `project_dir` to be passed in."
                                     )
                             loggers.append(log_type)
                         else:

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -16,9 +16,9 @@ from .dataclasses import (
     LoggerType,
     MegatronLMPlugin,
     PrecisionType,
+    ProjectConfiguration,
     RNGType,
     SageMakerDistributedType,
-    SaveConfiguration,
     TensorInformation,
 )
 from .environment import get_int_from_env, parse_choice_from_env, parse_flag_from_env

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -18,6 +18,7 @@ from .dataclasses import (
     PrecisionType,
     RNGType,
     SageMakerDistributedType,
+    SaveConfiguration,
     TensorInformation,
 )
 from .environment import get_int_from_env, parse_choice_from_env, parse_flag_from_env

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -314,12 +314,18 @@ class TensorInformation:
 
 
 @dataclass
-class SaveConfiguration:
+class ProjectConfiguration:
     """
     Configuration for the Accelerator object based on inner-project needs.
     """
 
     project_dir: str = field(default=None, metadata={"help": "A path to a directory for storing data."})
+    logging_dir: str = field(
+        default=None,
+        metadata={
+            "help": "A path to a directory for storing logs of locally-compatible loggers. If None, defaults to `project_dir`."
+        },
+    )
     automatic_checkpoint_naming: bool = field(
         default=False,
         metadata={"help": "Whether saved states should be automatically iteratively named."},
@@ -334,6 +340,10 @@ class SaveConfiguration:
         default=0,
         metadata={"help": "The current save iteration."},
     )
+
+    def __post_init__(self):
+        if self.logging_dir is None:
+            self.logging_dir = self.project_dir
 
 
 @dataclass

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -314,6 +314,29 @@ class TensorInformation:
 
 
 @dataclass
+class SaveConfiguration:
+    """
+    Configuration for the Accelerator object based on inner-project needs.
+    """
+
+    project_dir: str = field(default=None, metadata={"help": "A path to a directory for storing data."})
+    automatic_checkpoint_naming: bool = field(
+        default=False,
+        metadata={"help": "Whether saved states should be automatically iteratively named."},
+    )
+
+    save_total_limit: int = field(
+        default=None,
+        metadata={"help": "The maximum number of total saved states to keep."},
+    )
+
+    save_iteration: int = field(
+        default=0,
+        metadata={"help": "The current save iteration."},
+    )
+
+
+@dataclass
 class DeepSpeedPlugin:
     """
     This plugin is used to integrate DeepSpeed.

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -325,12 +325,12 @@ class SaveConfiguration:
         metadata={"help": "Whether saved states should be automatically iteratively named."},
     )
 
-    save_total_limit: int = field(
+    total_limit: int = field(
         default=None,
         metadata={"help": "The maximum number of total saved states to keep."},
     )
 
-    save_iteration: int = field(
+    iteration: int = field(
         default=0,
         metadata={"help": "The current save iteration."},
     )

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -93,7 +93,7 @@ class CheckpointTest(unittest.TestCase):
             # Save second state
             print("Saving second time")
             accelerator.save_state()
-            self.assertEqual(len(os.listdir(accelerator.save_dir)), 1)
+            self.assertEqual(len(os.listdir(accelerator.project_dir)), 1)
 
     def test_can_resume_training(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -102,7 +102,7 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(save_dir=tmpdir)
+            accelerator = Accelerator(project_dir=tmpdir)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -23,7 +23,7 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.utils import set_seed
+from accelerate.utils import SaveConfiguration, set_seed
 
 
 logger = logging.getLogger(__name__)
@@ -81,8 +81,9 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
+            save_config = SaveConfiguration(save_total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
             # Train baseline
-            accelerator = Accelerator(save_total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
+            accelerator = Accelerator(save_config=save_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -151,8 +152,10 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
+            save_config = SaveConfiguration(automatic_checkpoint_naming=True)
+
             # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir, automatic_checkpoint_naming=True)
+            accelerator = Accelerator(project_dir=tmpdir, save_config=save_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -216,8 +219,9 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.99)
             train_dataloader, valid_dataloader = dummy_dataloaders()
+            save_config = SaveConfiguration(automatic_checkpoint_naming=True)
             # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir, automatic_checkpoint_naming=True)
+            accelerator = Accelerator(project_dir=tmpdir, save_config=save_config)
             model, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader, scheduler
             )

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -23,7 +23,7 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.utils import SaveConfiguration, set_seed
+from accelerate.utils import ProjectConfiguration, set_seed
 
 
 logger = logging.getLogger(__name__)
@@ -81,9 +81,9 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            save_config = SaveConfiguration(total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
+            project_config = ProjectConfiguration(total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
             # Train baseline
-            accelerator = Accelerator(save_config=save_config)
+            accelerator = Accelerator(project_config=project_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -151,10 +151,10 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            save_config = SaveConfiguration(automatic_checkpoint_naming=True)
+            project_config = ProjectConfiguration(automatic_checkpoint_naming=True)
 
             # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir, save_config=save_config)
+            accelerator = Accelerator(project_dir=tmpdir, project_config=project_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -171,8 +171,8 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            save_config = SaveConfiguration(iteration=1, automatic_checkpoint_naming=True)
-            accelerator = Accelerator(project_dir=tmpdir, save_config=save_config)
+            project_config = ProjectConfiguration(iteration=1, automatic_checkpoint_naming=True)
+            accelerator = Accelerator(project_dir=tmpdir, project_config=project_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -218,9 +218,9 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.99)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            save_config = SaveConfiguration(automatic_checkpoint_naming=True)
+            project_config = ProjectConfiguration(automatic_checkpoint_naming=True)
             # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir, save_config=save_config)
+            accelerator = Accelerator(project_dir=tmpdir, project_config=project_config)
             model, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader, scheduler
             )

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -82,16 +82,14 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(save_total_limit=1, project_dir=tmpdir)
+            accelerator = Accelerator(save_total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
             # Save initial
-            print("Saving first time")
             accelerator.save_state()
 
             # Save second state
-            print("Saving second time")
             accelerator.save_state()
             self.assertEqual(len(os.listdir(accelerator.project_dir)), 1)
 
@@ -154,7 +152,7 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir)
+            accelerator = Accelerator(project_dir=tmpdir, automatic_checkpoint_naming=True)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -171,7 +169,7 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            accelerator = Accelerator(project_dir=tmpdir)
+            accelerator = Accelerator(project_dir=tmpdir, automatic_checkpoint_naming=True)
             accelerator.save_iteration = 1
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -82,14 +82,16 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(save_total_limit=1, save_dir=os.path.join(tmpdir, "checkpoints"))
+            accelerator = Accelerator(save_total_limit=1, project_dir=tmpdir)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
             # Save initial
+            print("Saving first time")
             accelerator.save_state()
 
             # Save second state
+            print("Saving second time")
             accelerator.save_state()
             self.assertEqual(len(os.listdir(accelerator.save_dir)), 1)
 
@@ -100,7 +102,7 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(save_dir=os.path.join(tmpdir, "checkpoints"))
+            accelerator = Accelerator(save_dir=tmpdir)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -117,7 +119,8 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            accelerator = Accelerator()
+            accelerator = Accelerator(project_dir=tmpdir)
+            accelerator.save_iteration = 1
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -133,7 +136,7 @@ class CheckpointTest(unittest.TestCase):
             accelerator.save_state()
 
             # Load everything back in and make sure all states work
-            accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"))
+            accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_1"))
             test_rands += train(1, model, train_dataloader, optimizer, accelerator)
             (a3, b3) = model.a.item(), model.b.item()
             opt_state3 = optimizer.state_dict()
@@ -164,7 +167,7 @@ class CheckpointTest(unittest.TestCase):
             scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.99)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(save_dir=os.path.join(tmpdir, "checkpoints"))
+            accelerator = Accelerator(project_dir=tmpdir)
             model, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader, scheduler
             )

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -217,7 +217,7 @@ class CheckpointTest(unittest.TestCase):
             scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.99)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir)
+            accelerator = Accelerator(project_dir=tmpdir, automatic_checkpoint_naming=True)
             model, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader, scheduler
             )

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -81,7 +81,7 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            save_config = SaveConfiguration(save_total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
+            save_config = SaveConfiguration(total_limit=1, project_dir=tmpdir, automatic_checkpoint_naming=True)
             # Train baseline
             accelerator = Accelerator(save_config=save_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
@@ -120,7 +120,6 @@ class CheckpointTest(unittest.TestCase):
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
             accelerator = Accelerator()
-            accelerator.save_iteration = 1
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )
@@ -172,8 +171,8 @@ class CheckpointTest(unittest.TestCase):
             model = DummyModel()
             optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
             train_dataloader, valid_dataloader = dummy_dataloaders()
-            accelerator = Accelerator(project_dir=tmpdir, automatic_checkpoint_naming=True)
-            accelerator.save_iteration = 1
+            save_config = SaveConfiguration(iteration=1, automatic_checkpoint_naming=True)
+            accelerator = Accelerator(project_dir=tmpdir, save_config=save_config)
             model, optimizer, train_dataloader, valid_dataloader = accelerator.prepare(
                 model, optimizer, train_dataloader, valid_dataloader
             )

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -222,7 +222,7 @@ class MyCustomTracker(GeneralTracker):
     ]
 
     name = "my_custom_tracker"
-    requires_logging_directory = False
+    requires_logger_directory = False
 
     def __init__(self, dir: str):
         self.f = open(f"{dir}/log.csv", "w+")

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -49,7 +49,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
     def test_init_trackers(self):
         project_name = "test_project_with_config"
         with tempfile.TemporaryDirectory() as dirpath:
-            accelerator = Accelerator(log_with="tensorboard", logging_dir=dirpath)
+            accelerator = Accelerator(log_with="tensorboard", project_dir=dirpath)
             config = {"num_iterations": 12, "learning_rate": 1e-2, "some_boolean": False, "some_string": "some_value"}
             accelerator.init_trackers(project_name, config)
             accelerator.end_training()
@@ -60,7 +60,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
     def test_log(self):
         project_name = "test_project_with_log"
         with tempfile.TemporaryDirectory() as dirpath:
-            accelerator = Accelerator(log_with="tensorboard", logging_dir=dirpath)
+            accelerator = Accelerator(log_with="tensorboard", project_dir=dirpath)
             accelerator.init_trackers(project_name)
             values = {"total_loss": 0.1, "iteration": 1, "my_text": "some_value"}
             accelerator.log(values, step=0)
@@ -70,11 +70,11 @@ class TensorBoardTrackingTest(unittest.TestCase):
             log = list(filter(lambda x: x.is_file(), Path(f"{dirpath}/{project_name}").iterdir()))[0]
             self.assertNotEqual(str(log), "")
 
-    def test_logging_dir(self):
-        with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `logging_dir`"):
+    def test_project_dir(self):
+        with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `project_dir`"):
             _ = Accelerator(log_with="tensorboard")
         with tempfile.TemporaryDirectory() as dirpath:
-            _ = Accelerator(log_with="tensorboard", logging_dir=dirpath)
+            _ = Accelerator(log_with="tensorboard", project_dir=dirpath)
 
 
 @require_wandb

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -222,7 +222,7 @@ class MyCustomTracker(GeneralTracker):
     ]
 
     name = "my_custom_tracker"
-    requires_logger_directory = False
+    requires_logging_directory = False
 
     def __init__(self, dir: str):
         self.f = open(f"{dir}/log.csv", "w+")

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -220,7 +220,7 @@ class MyCustomTracker(GeneralTracker):
     ]
 
     name = "my_custom_tracker"
-    requires_logging_directory = False
+    requires_project_directory = False
 
     def __init__(self, dir: str):
         self.f = open(f"{dir}/log.csv", "w+")

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -49,7 +49,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
     def test_init_trackers(self):
         project_name = "test_project_with_config"
         with tempfile.TemporaryDirectory() as dirpath:
-            accelerator = Accelerator(log_with="tensorboard", project_dir=dirpath)
+            accelerator = Accelerator(log_with="tensorboard", logging_dir=dirpath)
             config = {"num_iterations": 12, "learning_rate": 1e-2, "some_boolean": False, "some_string": "some_value"}
             accelerator.init_trackers(project_name, config)
             accelerator.end_training()
@@ -60,7 +60,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
     def test_log(self):
         project_name = "test_project_with_log"
         with tempfile.TemporaryDirectory() as dirpath:
-            accelerator = Accelerator(log_with="tensorboard", project_dir=dirpath)
+            accelerator = Accelerator(log_with="tensorboard", logging_dir=dirpath)
             accelerator.init_trackers(project_name)
             values = {"total_loss": 0.1, "iteration": 1, "my_text": "some_value"}
             accelerator.log(values, step=0)
@@ -71,10 +71,12 @@ class TensorBoardTrackingTest(unittest.TestCase):
             self.assertNotEqual(str(log), "")
 
     def test_project_dir(self):
-        with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `project_dir`"):
+        with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `logging_dir`"):
             _ = Accelerator(log_with="tensorboard")
         with tempfile.TemporaryDirectory() as dirpath:
             _ = Accelerator(log_with="tensorboard", project_dir=dirpath)
+        with tempfile.TemporaryDirectory() as dirpath:
+            _ = Accelerator(log_with="tensorboard", logging_dir=dirpath)
 
 
 @require_wandb
@@ -220,7 +222,7 @@ class MyCustomTracker(GeneralTracker):
     ]
 
     name = "my_custom_tracker"
-    requires_project_directory = False
+    requires_logging_directory = False
 
     def __init__(self, dir: str):
         self.f = open(f"{dir}/log.csv", "w+")


### PR DESCRIPTION
# Introduce `project_dir` and limit the number of saved checkpoints

## What does this add?

- Makes `logging_dir` optional and centralizes anything written to be saved to a `project_dir`
- Allows for a set limit to the number of saved checkpoints
- Introduces a `checkpoints` folder when saving with `Accelerator.save_state`

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/914

## Why is it needed?

As more needs to customize directories with Accelerate arises, rather than having 2+ different folders a user can save things into it would be better to have a centralized "Project Directory" to work out of instead where the users checkpoints will always save to and loggers that require a directory will point to. 

## What parts of the API does this impact?

### User-facing:

- A `SaveConfiguration` dataclass has been made which will store customizations when saving states through `Accelerator.save_state`
- `save_state` will no longer require a `save_path`, instead a `project_dir` can passed into the `Accelerator` object and it uses this.
- If combined with `automatic_checkpoint_naming=True` checkpoints are saved to `save_path/checkpoint_{number}` instead 
- `logging_dir` and `project_dir` when it comes to tracking will act the same if a `logging_dir` was not passed in
- A limit to the number of saved checkpoints can be performed and the oldest version (by name) will be removed through `Accelerator(save_total_limit={n})`

### Internal structure:

- `project_dir` when calling `save_state` will be used to create a new directory called `checkpoints` that checkpoints will be saved to. If a `project_dir` was not passed and instead `save_state` got a directory it will save to that new directory / `checkpoint_{n}`.
- The current number of checkpoints is saved in the `Accelerator` object. We could potentially save this in `AcceleratorState` instead, let me know if that is of interest.


## Basic Usage Example(s):

To fully utilize the new behavior: 

```diff
  accelerator = Accelerator(
-   logging_dir="some_dir",
+   project_dir="some_dir",
+   save_total_limit=3,
  )
```

## When would I use it, and when wouldn't I?

The limitation of `save_state` should be used when lots of checkpoints are being performed and a limit should be set on just how many should be saved.
