### PR TITLE
Specify inference on Big Modeling

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -28,7 +28,7 @@
   - local: usage_guides/tracking
     title: Using experiment trackers
   - local: usage_guides/big_modeling
-    title: How to use large models with small resources
+    title: How perform inference on large models with small resources
   - local: usage_guides/memory
     title: How to avoid CUDA Out-of-Memory
   - local: usage_guides/sagemaker

--- a/docs/source/usage_guides/big_modeling.mdx
+++ b/docs/source/usage_guides/big_modeling.mdx
@@ -10,7 +10,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 -->
 
-# Handling big models
+# Handling big models for inference
 
 When loading a pretrained model in PyTorch, the usual workflow looks like this:
 


### PR DESCRIPTION
Users are very *very* confused as to why they can't combine Big Model Inference capability with the training capability of the library, and don't understand that they're two completely different sublibraries and that the current functionality to combine both does not exist (but actively being looked at). This PR adjusts the titles slightly so that it can be a bit more transparent, but also open to other ideas. 