### PR TITLE
ds zero-3 init context manager

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -23,6 +23,7 @@ import functools
 import os
 import typing
 import warnings
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
 from distutils.util import strtobool
@@ -528,6 +529,23 @@ class DeepSpeedPlugin:
             from transformers.deepspeed import HfDeepSpeedConfig
 
             self.dschf = HfDeepSpeedConfig(ds_config)  # keep this object alive # noqa
+
+    def is_zero3_init_enabled(self):
+        return self.zero3_init_flag
+
+    @contextmanager
+    def set_zero3_init(self, enable=False):
+        old = self.zero3_init_flag
+        if old == enable:
+            yield
+            return
+        self.zero3_init_flag = enable
+        self.dschf = None
+        self.set_deepspeed_weakref()
+        yield
+        self.zero3_init_flag = old
+        self.dschf = None
+        self.set_deepspeed_weakref()
 
 
 @dataclass

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -534,7 +534,7 @@ class DeepSpeedPlugin:
         return self.zero3_init_flag
 
     @contextmanager
-    def set_zero3_init(self, enable=False):
+    def zero3_init_context_manager(self, enable=False):
         old = self.zero3_init_flag
         if old == enable:
             yield

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -538,14 +538,14 @@ class DeepSpeedPlugin:
         old = self.zero3_init_flag
         if old == enable:
             yield
-            return
-        self.zero3_init_flag = enable
-        self.dschf = None
-        self.set_deepspeed_weakref()
-        yield
-        self.zero3_init_flag = old
-        self.dschf = None
-        self.set_deepspeed_weakref()
+        else:
+            self.zero3_init_flag = enable
+            self.dschf = None
+            self.set_deepspeed_weakref()
+            yield
+            self.zero3_init_flag = old
+            self.dschf = None
+            self.set_deepspeed_weakref()
 
 
 @dataclass


### PR DESCRIPTION
### What doe this PR do?
1. Adds DeepSpeed ZeRO-3 init context manager

### What is added?
1. context manager to enabled/disable `zero.Init`
2. util function to check if `zero.Init` is enabled

### An example showcasing the usage

Sample accelerate config `ds_zero3.yaml` :
```yaml
command_file: null
commands: null
compute_environment: LOCAL_MACHINE
deepspeed_config:
  gradient_accumulation_steps: 1
  gradient_clipping: 1.0
  offload_optimizer_device: 'cpu'
  offload_param_device: 'cpu'
  zero3_init_flag: true
  zero3_save_16bit_model: true
  zero_stage: 3
distributed_type: DEEPSPEED
downcast_bf16: 'no'
dynamo_backend: 'NO'
fsdp_config: {}
gpu_ids: null
machine_rank: 0
main_process_ip: null
main_process_port: null
main_training_function: main
megatron_lm_config: {}
mixed_precision: 'no'
num_machines: 1
num_processes: 2
rdzv_backend: static
same_network: true
tpu_name: null
tpu_zone: null
use_cpu: false
```

Code `ds_zero3_init_cm_test.py`:
```python
from accelerate import Accelerator

from transformers import AutoConfig, AutoModel
from transformers.deepspeed import is_deepspeed_zero3_enabled

vision_model_name = "google/vit-base-patch16-224-in21k"

def main():
    accelerator = Accelerator()
    
    deepspeed_plugin = accelerator.state.deepspeed_plugin
    zero_init_enabled = deepspeed_plugin.is_zero3_init_enabled()
    accelerator.print(f"{zero_init_enabled=}")
    
    if zero_init_enabled:
        with deepspeed_plugin.set_zero3_init(enable=False):
            vision_model = AutoModel.from_pretrained(vision_model_name)
            accelerator.print(f"{vision_model.pooler.dense.weight.shape=}")
            assert is_deepspeed_zero3_enabled()==False, "Assertion Error"
            accelerator.print(f"within context manager: {is_deepspeed_zero3_enabled()=}\n\n")
            
        vision_model = AutoModel.from_pretrained(vision_model_name)
        accelerator.print(f"{vision_model.pooler.dense.weight.shape=}")
        assert is_deepspeed_zero3_enabled()==True, "Assertion Error"
        accelerator.print(f"outside context manager: {is_deepspeed_zero3_enabled()=}")

if __name__ == "__main__":
    main()
```

command to run and output:
```bash
$ accelerate launch --config_file ds_zero3.yaml temp/ds_zero3_init_cm_test.py 
[07:17:47] WARNING                                                                                                   run.py:663
                    *****************************************                                                                  
                    Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your            
                    system being overloaded, please further tune the variable for optimal performance in your                  
                    application as needed.                                                                                     
                    *****************************************                                                                  
[2022-12-20 07:17:49,625] [INFO] [comm.py:423:init_distributed] Initializing TorchBackend in DeepSpeed with backend nccl
zero_init_enabled=True
vision_model.pooler.dense.weight.shape=torch.Size([768, 768])
within context manager: is_deepspeed_zero3_enabled()=False


[2022-12-20 07:17:53,699] [INFO] [partition_parameters.py:437:__exit__] finished initializing model with 0.09B parameters
vision_model.pooler.dense.weight.shape=torch.Size([0])
outside context manager: is_deepspeed_zero3_enabled()=True
```

