### PR TITLE
fix batch size in prepare_dataloader for iterable datasets

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -711,7 +711,7 @@ def prepare_data_loader(
     # Need to provide batch_size as batch_sampler is None for Iterable dataset
     if new_batch_sampler is None:
         kwargs["drop_last"] = dataloader.drop_last
-        kwargs["batch_size"] = dataloader.batch_size // num_processes if split_batches else dataloader.batch_size
+        kwargs["batch_size"] = dataloader.batch_size // num_processes if split_batches and not dispatch_batches else dataloader.batch_size
 
     if dispatch_batches:
         kwargs.pop("generator")

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -711,7 +711,9 @@ def prepare_data_loader(
     # Need to provide batch_size as batch_sampler is None for Iterable dataset
     if new_batch_sampler is None:
         kwargs["drop_last"] = dataloader.drop_last
-        kwargs["batch_size"] = dataloader.batch_size // num_processes if split_batches and not dispatch_batches else dataloader.batch_size
+        kwargs["batch_size"] = (
+            dataloader.batch_size // num_processes if split_batches and not dispatch_batches else dataloader.batch_size
+        )
 
     if dispatch_batches:
         kwargs.pop("generator")


### PR DESCRIPTION
There are a lot of cases, so I may be missing something, but I believe this is a bug.
I am setting batch_size=16 with num_processes=2 and using an IterableDataset.
My collator is receiving batches of size 8, and the dataloader is yielding batches of size 4 on each process.

The DataLoaderDispatcher has batch size 8 due to this line, which further gets split later on to 4.
This PR works in my case, but I am not sure it does not break another.
