### PR TITLE
raise error for duplicate accelerate config  values when using `deepspeed_config_file`

### DIFF
--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -206,7 +206,7 @@ Now that this is done, you can run your script with the following command:
 accelerate launch path_to_script.py --args_for_the_script
 ```
 
-If you stored the config file in a non-default location, you can indicate it to the launcher like his:
+If you stored the config file in a non-default location, you can indicate it to the launcher like this:
 
 ```bash
 accelerate launch --config_file path_to_config.yaml path_to_script.py --args_for_the_script

--- a/docs/source/usage_guides/deepspeed.mdx
+++ b/docs/source/usage_guides/deepspeed.mdx
@@ -397,7 +397,7 @@ Only the `auto` fields specified in above examples are handled by `prepare` meth
 
 **Things to note when using DeepSpeed Config File**
 
-Below is a smaple script using `deepspeed_config_file` in different scenarios.
+Below is a sample script using `deepspeed_config_file` in different scenarios.
 
 Code `test.py`:
 
@@ -417,7 +417,7 @@ if __name__ == "__main__":
 
 **Scenario 1**: Manually tampered accelerate config file having `deepspeed_config_file` along with other entries.
 
-1. `accelerate config`:
+1. Content of the `accelerate` config:
 
 ```yaml
 command_file: null
@@ -508,7 +508,7 @@ How many GPU(s) should be used for distributed training? [1]:4
 accelerate configuration saved at ds_config_sample.yaml
 ```
 
-2. `accelerate config`:
+2. Content of the `accelerate` config:
 
 ```yaml
 compute_environment: LOCAL_MACHINE
@@ -541,9 +541,9 @@ Mixed precision type: bf16
 ds_config: {'bf16': {'enabled': True}, 'zero_optimization': {'stage': 3, 'stage3_gather_16bit_weights_on_model_save': False, 'offload_optimizer': {'device': 'none'}, 'offload_param': {'device': 'none'}}, 'gradient_clipping': 1.0, 'train_batch_size': 'auto', 'train_micro_batch_size_per_gpu': 'auto', 'gradient_accumulation_steps': 10, 'steps_per_print': inf, 'fp16': {'enabled': False}}
 ```
 
-**Scenario 3**: Setting the `accelerate launch` cmd args related to deepspeed as `auto` in  `deepspeed_config_file` and check that things work as expected.
+**Scenario 3**: Setting the `accelerate launch` command arguments related to DeepSpeed as `"auto"` in the DeepSpeed` configuration file and check that things work as expected.
 
-1. New `ds_config.json` with `auto` for the `accelerate launch` deepspeed cmd args:
+1. New `ds_config.json` with `"auto"` for the `accelerate launch` DeepSpeed command arguments:
 
 ```json
 {
@@ -580,7 +580,7 @@ Mixed precision type: fp16
 ds_config: {'bf16': {'enabled': False}, 'zero_optimization': {'stage': 3, 'stage3_gather_16bit_weights_on_model_save': True, 'offload_optimizer': {'device': 'nvme'}, 'offload_param': {'device': 'cpu'}}, 'gradient_clipping': 1.0, 'train_batch_size': 'auto', 'train_micro_batch_size_per_gpu': 'auto', 'gradient_accumulation_steps': 5, 'steps_per_print': inf, 'fp16': {'enabled': True, 'auto_cast': True}}
 ```
 
-**Note**: Remaining `auto` values are handled in `accelerator.prepare()` call as explained in point 2 of 
+**Note**: Remaining `"auto"` values are handled in `accelerator.prepare()` call as explained in point 2 of 
 `Important code changes when using DeepSpeed Config File`.
 
 ## Saving and loading

--- a/docs/source/usage_guides/deepspeed.mdx
+++ b/docs/source/usage_guides/deepspeed.mdx
@@ -494,9 +494,11 @@ It will only ask for the necessary config variables when using `deepspeed_config
 
 ```bash
 $ accelerate config
--------------------------------------------------------------------------------------------------------------------------------In which compute environment are you running?
+-------------------------------------------------------------------------------------------------------------------------------
+In which compute environment are you running?
 This machine                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------Which type of machine are you using?                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+Which type of machine are you using?                                                                                           
 multi-GPU                                                                                                                      
 How many different machines will you use (use more than 1 for multi-node training)? [1]:                                       
 Do you wish to optimize your script with torch dynamo?[yes/NO]:                                                                

--- a/docs/source/usage_guides/deepspeed.mdx
+++ b/docs/source/usage_guides/deepspeed.mdx
@@ -395,6 +395,194 @@ We will look at the changes needed in the code when using these.
 based on model, dataloaders, dummy optimizer and dummy schedulers provided to `prepare` method. 
 Only the `auto` fields specified in above examples are handled by `prepare` method and the rest have to be explicitly specified by the user.
 
+**Things to note when using DeepSpeed Config File**
+
+Below is a smaple script using `deepspeed_config_file` in different scenarios.
+
+Code `test.py`:
+
+```python
+from accelerate import Accelerator
+from accelerate.state import AcceleratorState
+
+
+def main():
+    accelerator = Accelerator()
+    accelerator.print(f"{AcceleratorState()}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+**Scenario 1**: Manually tampered accelerate config file having `deepspeed_config_file` along with other entries.
+
+1. `accelerate config`:
+
+```yaml
+command_file: null
+commands: null
+compute_environment: LOCAL_MACHINE
+deepspeed_config:
+  gradient_accumulation_steps: 1
+  gradient_clipping: 1.0
+  offload_optimizer_device: 'cpu'
+  offload_param_device: 'cpu'
+  zero3_init_flag: true
+  zero3_save_16bit_model: true
+  zero_stage: 3
+  deepspeed_config_file: 'ds_config.json'
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+dynamo_backend: 'NO'
+fsdp_config: {}
+gpu_ids: null
+machine_rank: 0
+main_process_ip: null
+main_process_port: null
+main_training_function: main
+megatron_lm_config: {}
+num_machines: 1
+num_processes: 2
+rdzv_backend: static
+same_network: true
+tpu_name: null
+tpu_zone: null
+use_cpu: false
+```
+
+2. `ds_config.json`:
+
+```json
+{
+    "bf16": {
+        "enabled": true
+    },
+    "zero_optimization": {
+        "stage": 3,
+        "stage3_gather_16bit_weights_on_model_save": false,
+        "offload_optimizer": {
+            "device": "none"
+        },
+        "offload_param": {
+            "device": "none"
+        }
+    },
+    "gradient_clipping": 1.0,
+    "train_batch_size": "auto",
+    "train_micro_batch_size_per_gpu": "auto",
+    "gradient_accumulation_steps": 10,
+    "steps_per_print": 2000000
+}
+```
+
+3. Output of `accelerate launch test.py`:
+
+```bash
+ValueError: When using `deepspeed_config_file`, the following accelerate config variables will be ignored: 
+['gradient_accumulation_steps', 'gradient_clipping', 'zero_stage', 'offload_optimizer_device', 'offload_param_device', 
+'zero3_save_16bit_model', 'mixed_precision'].
+Please specify them appropriately in the DeepSpeed config file.
+If you are using an accelerate config file, remove others config variables mentioned in the above specified list.
+The easiest method is to create a new config following the questionnaire via `accelerate config`.
+It will only ask for the necessary config variables when using `deepspeed_config_file`.
+```
+
+**Scenario 2**: Use the solution of the error to create new accelerate config and check that no ambiguity error is now thrown.
+
+1. Run `accelerate config`:
+
+```bash
+$ accelerate config
+-------------------------------------------------------------------------------------------------------------------------------In which compute environment are you running?
+This machine                                                                                                                   
+-------------------------------------------------------------------------------------------------------------------------------Which type of machine are you using?                                                                                           
+multi-GPU                                                                                                                      
+How many different machines will you use (use more than 1 for multi-node training)? [1]:                                       
+Do you wish to optimize your script with torch dynamo?[yes/NO]:                                                                
+Do you want to use DeepSpeed? [yes/NO]: yes                                                                                    
+Do you want to specify a json file to a DeepSpeed config? [yes/NO]: yes                                                        
+Please enter the path to the json DeepSpeed config file: ds_config.json                                                        
+Do you want to enable `deepspeed.zero.Init` when using ZeRO Stage-3 for constructing massive models? [yes/NO]: yes
+How many GPU(s) should be used for distributed training? [1]:4
+accelerate configuration saved at ds_config_sample.yaml
+```
+
+2. `accelerate config`:
+
+```yaml
+compute_environment: LOCAL_MACHINE
+deepspeed_config:
+  deepspeed_config_file: ds_config.json
+  zero3_init_flag: true
+distributed_type: DEEPSPEED
+downcast_bf16: 'no'
+dynamo_backend: 'NO'
+fsdp_config: {}
+machine_rank: 0
+main_training_function: main
+megatron_lm_config: {}
+num_machines: 1
+num_processes: 4
+rdzv_backend: static
+same_network: true
+use_cpu: false
+```
+
+3. Output of `accelerate launch test.py`:
+
+```bash
+Distributed environment: DEEPSPEED  Backend: nccl
+Num processes: 4
+Process index: 0
+Local process index: 0
+Device: cuda:0
+Mixed precision type: bf16
+ds_config: {'bf16': {'enabled': True}, 'zero_optimization': {'stage': 3, 'stage3_gather_16bit_weights_on_model_save': False, 'offload_optimizer': {'device': 'none'}, 'offload_param': {'device': 'none'}}, 'gradient_clipping': 1.0, 'train_batch_size': 'auto', 'train_micro_batch_size_per_gpu': 'auto', 'gradient_accumulation_steps': 10, 'steps_per_print': inf, 'fp16': {'enabled': False}}
+```
+
+**Scenario 3**: Setting the `accelerate launch` cmd args related to deepspeed as `auto` in  `deepspeed_config_file` and check that things work as expected.
+
+1. New `ds_config.json` with `auto` for the `accelerate launch` deepspeed cmd args:
+
+```json
+{
+    "bf16": {
+        "enabled": "auto"
+    },
+    "zero_optimization": {
+        "stage": "auto",
+        "stage3_gather_16bit_weights_on_model_save": "auto",
+        "offload_optimizer": {
+            "device": "auto"
+        },
+        "offload_param": {
+            "device": "auto"
+        }
+    },
+    "gradient_clipping": "auto",
+    "train_batch_size": "auto",
+    "train_micro_batch_size_per_gpu": "auto",
+    "gradient_accumulation_steps": "auto",
+    "steps_per_print": 2000000
+}
+```
+
+2. Output of `accelerate launch --mixed_precision="fp16" --zero_stage=3 --gradient_accumulation_steps=5 --gradient_clipping=1.0 --offload_param_device="cpu" --offload_optimizer_device="nvme" --zero3_save_16bit_model="true" test.py`:
+
+```bash
+Distributed environment: DEEPSPEED  Backend: nccl
+Num processes: 4
+Process index: 0
+Local process index: 0
+Device: cuda:0
+Mixed precision type: fp16
+ds_config: {'bf16': {'enabled': False}, 'zero_optimization': {'stage': 3, 'stage3_gather_16bit_weights_on_model_save': True, 'offload_optimizer': {'device': 'nvme'}, 'offload_param': {'device': 'cpu'}}, 'gradient_clipping': 1.0, 'train_batch_size': 'auto', 'train_micro_batch_size_per_gpu': 'auto', 'gradient_accumulation_steps': 5, 'steps_per_print': inf, 'fp16': {'enabled': True, 'auto_cast': True}}
+```
+
+**Note**: Remaining `auto` values are handled in `accelerator.prepare()` call as explained in point 2 of 
+`Important code changes when using DeepSpeed Config File`.
+
 ## Saving and loading
 
 1. Saving and loading of models is unchanged for ZeRO Stage-1 and Stage-2.

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -460,7 +460,7 @@ def get_cluster_input():
 
     if distributed_type != DistributedType.TPU:
         if distributed_type == DistributedType.DEEPSPEED and use_deepspeed_config:
-            mixed_precision = "no"
+            mixed_precision = None
         else:
             mixed_precision = _ask_options(
                 "Do you wish to use FP16 or BF16 (mixed precision)?",

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -78,9 +78,7 @@ class BaseConfig:
         for key, value in result.items():
             if isinstance(value, Enum):
                 result[key] = value.value
-            elif value is None:
-                # remove key
-                del result[key]
+        result = {k: v for k, v in result.items() if v is not None}
         return result
 
     @classmethod

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -89,7 +89,7 @@ class BaseConfig:
         if "compute_environment" not in config_dict:
             config_dict["compute_environment"] = ComputeEnvironment.LOCAL_MACHINE
         if "mixed_precision" not in config_dict:
-            config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else "no"
+            config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else None
         if "fp16" in config_dict:  # Convert the config to the new format.
             del config_dict["fp16"]
         if "use_cpu" not in config_dict:
@@ -112,7 +112,7 @@ class BaseConfig:
             config_dict["compute_environment"] = ComputeEnvironment.LOCAL_MACHINE
 
         if "mixed_precision" not in config_dict:
-            config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else "no"
+            config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else None
         if "fp16" in config_dict:  # Convert the config to the new format.
             del config_dict["fp16"]
         if "use_cpu" not in config_dict:

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -78,6 +78,9 @@ class BaseConfig:
         for key, value in result.items():
             if isinstance(value, Enum):
                 result[key] = value.value
+            elif value is None:
+                # remove key
+                del result[key]
         return result
 
     @classmethod

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -979,6 +979,7 @@ def launch_command(args):
 
     defaults = None
     warned = []
+    mp_from_config_flag = False
     # Get the default from the config file.
     if args.config_file is not None or os.path.isfile(default_config_file) and not args.cpu:
         defaults = load_config_from_file(args.config_file)
@@ -1028,7 +1029,6 @@ def launch_command(args):
         if not args.mixed_precision:
             if defaults.mixed_precision is None:
                 args.mixed_precision = "no"
-                mp_from_config_flag = False
             else:
                 args.mixed_precision = defaults.mixed_precision
                 mp_from_config_flag = True
@@ -1075,7 +1075,7 @@ def launch_command(args):
 
     # Use the proper launcher
     if args.use_deepspeed and not args.cpu:
-        args.deepspeed_fields_from_accelerate_config = list(defaults.deepspeed_config.keys())
+        args.deepspeed_fields_from_accelerate_config = list(defaults.deepspeed_config.keys()) if defaults else []
         if mp_from_config_flag:
             args.deepspeed_fields_from_accelerate_config.append("mixed_precision")
         args.deepspeed_fields_from_accelerate_config = ",".join(args.deepspeed_fields_from_accelerate_config)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -309,14 +309,14 @@ def launch_command_parser(subparsers=None):
         default=None,
         type=str,
         help="Decides where (none|cpu|nvme) to offload optimizer states (useful only when `use_deepspeed` flag is passed). "
-        "If unspecified, will default to `none`.",
+        "If unspecified, will default to 'none'.",
     )
     deepspeed_args.add_argument(
         "--offload_param_device",
         default=None,
         type=str,
         help="Decides where (none|cpu|nvme) to offload parameters (useful only when `use_deepspeed` flag is passed). "
-        "If unspecified, will default to `none`.",
+        "If unspecified, will default to 'none'.",
     )
     deepspeed_args.add_argument(
         "--gradient_accumulation_steps",

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -301,45 +301,50 @@ def launch_command_parser(subparsers=None):
         "--zero_stage",
         default=None,
         type=int,
-        help="DeepSpeed's ZeRO optimization stage (useful only when `use_deepspeed` flag is passed).",
+        help="DeepSpeed's ZeRO optimization stage (useful only when `use_deepspeed` flag is passed). "
+        "If unspecified, will default to `2`.",
     )
     deepspeed_args.add_argument(
         "--offload_optimizer_device",
         default=None,
         type=str,
-        help="Decides where (none|cpu|nvme) to offload optimizer states (useful only when `use_deepspeed` flag is passed).",
+        help="Decides where (none|cpu|nvme) to offload optimizer states (useful only when `use_deepspeed` flag is passed). "
+        "If unspecified, will default to `none`.",
     )
     deepspeed_args.add_argument(
         "--offload_param_device",
         default=None,
         type=str,
-        help="Decides where (none|cpu|nvme) to offload parameters (useful only when `use_deepspeed` flag is passed).",
+        help="Decides where (none|cpu|nvme) to offload parameters (useful only when `use_deepspeed` flag is passed). "
+        "If unspecified, will default to `none`.",
     )
     deepspeed_args.add_argument(
         "--gradient_accumulation_steps",
         default=None,
         type=int,
-        help="No of gradient_accumulation_steps used in your training script (useful only when `use_deepspeed` flag is passed).",
+        help="No of gradient_accumulation_steps used in your training script (useful only when `use_deepspeed` flag is passed). "
+        "If unspecified, will default to `1`.",
     )
     deepspeed_args.add_argument(
         "--gradient_clipping",
         default=None,
         type=float,
-        help="gradient clipping value used in your training script (useful only when `use_deepspeed` flag is passed).",
+        help="gradient clipping value used in your training script (useful only when `use_deepspeed` flag is passed). "
+        "If unspecified, will default to `1.0`.",
     )
     deepspeed_args.add_argument(
         "--zero3_init_flag",
-        default="true",
+        default=None,
         type=str,
         help="Decides Whether (true|false) to enable `deepspeed.zero.Init` for constructing massive models. "
-        "Only applicable with DeepSpeed ZeRO Stage-3.",
+        "Only applicable with DeepSpeed ZeRO Stage-3. If unspecified, will default to `true`.",
     )
     deepspeed_args.add_argument(
         "--zero3_save_16bit_model",
-        default="false",
+        default=None,
         type=str,
         help="Decides Whether (true|false) to save 16-bit model weights when using ZeRO Stage-3. "
-        "Only applicable with DeepSpeed ZeRO Stage-3.",
+        "Only applicable with DeepSpeed ZeRO Stage-3. If unspecified, will default to `false`.",
     )
     deepspeed_args.add_argument(
         "--deepspeed_hostfile",
@@ -363,7 +368,7 @@ def launch_command_parser(subparsers=None):
         "--deepspeed_multinode_launcher",
         default=None,
         type=str,
-        help="DeepSpeed multi-node launcher to use.",
+        help="DeepSpeed multi-node launcher to use. If unspecified, will default to `pdsh`.",
     )
 
     # fsdp arguments
@@ -718,13 +723,20 @@ def deepspeed_launcher(args):
     current_env["PYTHONPATH"] = env_var_path_add("PYTHONPATH", os.path.abspath("."))
     current_env["ACCELERATE_MIXED_PRECISION"] = str(mixed_precision)
     current_env["ACCELERATE_USE_DEEPSPEED"] = "true"
-    current_env["ACCELERATE_DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)
-    current_env["ACCELERATE_GRADIENT_ACCUMULATION_STEPS"] = str(args.gradient_accumulation_steps)
-    current_env["ACCELERATE_GRADIENT_CLIPPING"] = str(args.gradient_clipping).lower()
-    current_env["ACCELERATE_DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE"] = str(args.offload_optimizer_device).lower()
-    current_env["ACCELERATE_DEEPSPEED_OFFLOAD_PARAM_DEVICE"] = str(args.offload_param_device).lower()
-    current_env["ACCELERATE_DEEPSPEED_ZERO3_INIT"] = str(args.zero3_init_flag).lower()
-    current_env["ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL"] = str(args.zero3_save_16bit_model).lower()
+    if args.zero_stage is not None:
+        current_env["ACCELERATE_DEEPSPEED_ZERO_STAGE"] = str(args.zero_stage)
+    if args.gradient_accumulation_steps is not None:
+        current_env["ACCELERATE_GRADIENT_ACCUMULATION_STEPS"] = str(args.gradient_accumulation_steps)
+    if args.gradient_clipping is not None:
+        current_env["ACCELERATE_GRADIENT_CLIPPING"] = str(args.gradient_clipping).lower()
+    if args.offload_optimizer_device is not None:
+        current_env["ACCELERATE_DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE"] = str(args.offload_optimizer_device).lower()
+    if args.offload_param_device is not None:
+        current_env["ACCELERATE_DEEPSPEED_OFFLOAD_PARAM_DEVICE"] = str(args.offload_param_device).lower()
+    if args.zero3_init_flag is not None:
+        current_env["ACCELERATE_DEEPSPEED_ZERO3_INIT"] = str(args.zero3_init_flag).lower()
+    if args.zero3_save_16bit_model is not None:
+        current_env["ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL"] = str(args.zero3_save_16bit_model).lower()
     if args.deepspeed_config_file is not None:
         current_env["ACCELERATE_DEEPSPEED_CONFIG_FILE"] = str(args.deepspeed_config_file)
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -574,7 +574,7 @@ class DeepSpeedPlugin:
             env_variable_names_to_ignore = [
                 name.replace("ACCELERATE_", "").lower() for name in env_variable_names_to_ignore
             ]
-            raise warnings.warn(
+            warnings.warn(
                 f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}. "
                 "Please specify them appropriately in the DeepSpeed config file. In accelerate config file, set `mixed_precision=no` and remove others config variables. "
                 "The easiest method is to create new config following the questionnaire via  `accelerate config`. "

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -572,7 +572,8 @@ class DeepSpeedPlugin:
 
         if duplicate_values_flag:
             env_variable_names_to_ignore = [
-                name.replace("ACCELERATE_", "").lower() for name in env_variable_names_to_ignore
+                name.replace("ACCELERATE_", "").replace("DEEPSPEED_", "").lower()
+                for name in env_variable_names_to_ignore
             ]
             raise ValueError(
                 f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}.\n"

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -529,7 +529,7 @@ class DeepSpeedPlugin:
 
         if mixed_precision != "no":
             diff_dtype = "bf16" if mixed_precision == "fp16" else "fp16"
-            if strtobool(str(ds_config.get(diff_dtype, {}).get("enabled", "False"))) == 1:
+            if str(ds_config.get(diff_dtype, {}).get("enabled", "False")).lower() == "true":
                 raise ValueError(
                     f"`--mixed_precision` arg cannot be set to `{mixed_precision}` when `{diff_dtype}` is set in the DeepSpeed config file."
                 )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -553,55 +553,71 @@ class DeepSpeedPlugin:
     def _deepspeed_config_checks(self):
         ds_config = self.hf_ds_config.config
         mismatches = []
-        if os.environ.get("ACCELERATE_GRADIENT_ACCUMULATION_STEPS", None) is not None:
-            if ds_config["gradient_accumulation_steps"] != int(os.environ["ACCELERATE_GRADIENT_ACCUMULATION_STEPS"]):
+
+        accelerate_gradient_accumulation_steps = os.environ.get("ACCELERATE_GRADIENT_ACCUMULATION_STEPS", None)
+        ds_gradient_accumulation_steps = ds_config["gradient_accumulation_steps"]
+        if accelerate_gradient_accumulation_steps is not None:
+            if ds_gradient_accumulation_steps != int(accelerate_gradient_accumulation_steps):
                 mismatches.append(
-                    f"- ds config gradient_accumulation_steps={ds_config['gradient_accumulation_steps']} vs "
-                    f"accelerate config gradient_accumulation_steps={os.environ['ACCELERATE_GRADIENT_ACCUMULATION_STEPS']}"
+                    f"- ds config gradient_accumulation_steps={ds_gradient_accumulation_steps} vs "
+                    f"accelerate config gradient_accumulation_steps={accelerate_gradient_accumulation_steps}"
                 )
 
-        if os.environ.get("ACCELERATE_GRADIENT_CLIPPING", None) is not None:
-            if ds_config["gradient_clipping"] != float(os.environ["ACCELERATE_GRADIENT_CLIPPING"]):
+        accelerate_gradient_clipping = os.environ.get("ACCELERATE_GRADIENT_CLIPPING", None)
+        ds_gradient_clipping = ds_config["gradient_clipping"]
+        if accelerate_gradient_clipping is not None:
+            if ds_gradient_clipping != float(accelerate_gradient_clipping):
                 mismatches.append(
-                    f"- ds config gradient_clipping={ds_config['gradient_clipping']} vs "
-                    f"accelerate config gradient_clipping={os.environ['ACCELERATE_GRADIENT_CLIPPING']}"
+                    f"- ds config gradient_clipping={ds_gradient_clipping} vs "
+                    f"accelerate config gradient_clipping={accelerate_gradient_clipping}"
                 )
 
-        if os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE", None) is not None:
-            if ds_config["zero_optimization"]["stage"] != int(os.environ["ACCELERATE_DEEPSPEED_ZERO_STAGE"]):
+        accelerate_zero_stage = os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE", None)
+        ds_zero_stage = ds_config["zero_optimization"]["stage"]
+        if accelerate_zero_stage is not None:
+            if ds_zero_stage != int(accelerate_zero_stage):
                 mismatches.append(
-                    f"- ds config zero_optimization.stage={ds_config['zero_optimization']['stage']} vs "
-                    f"accelerate config zero_stage={os.environ['ACCELERATE_DEEPSPEED_ZERO_STAGE']}"
+                    f"- ds config zero_optimization.stage={ds_zero_stage} vs "
+                    f"accelerate config zero_stage={accelerate_zero_stage}"
                 )
 
-        if os.environ.get("ACCELERATE_DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE", None) is not None:
-            if (
-                ds_config["zero_optimization"].get("offload_optimizer", {}).get("device", None)
-                != os.environ["ACCELERATE_DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE"]
-            ):
+        accelerate_offload_optimizer = os.environ.get("ACCELERATE_DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE", None)
+        ds_offload_optimizer = ds_config["zero_optimization"].get("offload_optimizer", {}).get("device", None)
+        if accelerate_offload_optimizer is not None:
+            if ds_offload_optimizer != accelerate_offload_optimizer:
                 mismatches.append(
-                    f"- ds config zero_optimization.offload_optimizer.device={ds_config['zero_optimization'].get('offload_optimizer', {}).get('device', None)} vs "
-                    f"accelerate config offload_optimizer_device={os.environ['ACCELERATE_DEEPSPEED_OFFLOAD_OPTIMIZER_DEVICE']}"
+                    f"- ds config zero_optimization.offload_optimizer.device={ds_offload_optimizer} vs "
+                    f"accelerate config offload_optimizer_device={accelerate_offload_optimizer}"
                 )
 
-        if os.environ.get("ACCELERATE_DEEPSPEED_OFFLOAD_PARAM_DEVICE", None) is not None:
-            if (
-                ds_config["zero_optimization"].get("offload_param", {}).get("device", None)
-                != os.environ["ACCELERATE_DEEPSPEED_OFFLOAD_PARAM_DEVICE"]
-            ):
+        accelerate_offload_param = os.environ.get("ACCELERATE_DEEPSPEED_OFFLOAD_PARAM_DEVICE", None)
+        ds_offload_param = ds_config["zero_optimization"].get("offload_param", {}).get("device", None)
+        if accelerate_offload_param is not None:
+            if ds_offload_param != accelerate_offload_param:
                 mismatches.append(
-                    f"- ds config zero_optimization.offload_param.device={ds_config['zero_optimization'].get('offload_param', {}).get('device', None)} vs "
-                    f"accelerate config offload_param_device={os.environ['ACCELERATE_DEEPSPEED_OFFLOAD_PARAM_DEVICE']}"
+                    f"- ds config zero_optimization.offload_param.device={ds_offload_param} vs "
+                    f"accelerate config offload_param_device={accelerate_offload_param}"
                 )
 
-        if os.environ.get("ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL", None) is not None:
-            if ds_config["zero_optimization"].get("stage3_gather_16bit_weights_on_model_save", None) != (
-                os.environ["ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL"] == "true"
-            ):
+        accelerate_zero3_save_16bit_model = os.environ.get("ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL", None)
+        ds_zero3_save_16bit_model = ds_config["zero_optimization"].get(
+            "stage3_gather_16bit_weights_on_model_save", None
+        )
+        if accelerate_zero3_save_16bit_model is not None:
+            accelerate_zero3_save_16bit_model = accelerate_zero3_save_16bit_model == "true"
+            if ds_zero3_save_16bit_model != accelerate_zero3_save_16bit_model:
                 mismatches.append(
-                    f"- ds config zero_optimization.stage3_gather_16bit_weights_on_model_save="
-                    f"{ds_config['zero_optimization'].get('stage3_gather_16bit_weights_on_model_save', None)} vs "
-                    f"accelerate config zero3_save_16bit_model={(os.environ['ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL']=='true')}"
+                    f"- ds config zero_optimization.stage3_gather_16bit_weights_on_model_save={ds_zero3_save_16bit_model} vs "
+                    f"accelerate config zero3_save_16bit_model={accelerate_zero3_save_16bit_model}"
+                )
+
+        accelerate_mixed_precision = os.environ.get("ACCELERATE_MIXED_PRECISION", "no")
+        if accelerate_mixed_precision != "no":
+            if accelerate_mixed_precision not in ds_config:
+                mismatches.append(f"- ds config does not have mixed precision config for {accelerate_mixed_precision}")
+            elif ds_config[accelerate_mixed_precision].get("enabled", None) is None:
+                mismatches.append(
+                    f"- ds config mixed precision config for {accelerate_mixed_precision} is not enabled"
                 )
 
         if len(mismatches) > 0:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -523,14 +523,14 @@ class DeepSpeedPlugin:
         if mixed_precision == "fp16":
             if "fp16" not in ds_config:
                 ds_config.update({"fp16": {"enabled": True, "auto_cast": True}})
-            elif "bf16" in ds_config and strtobool(str(ds_config["bf16"].get("enabled", "False"))) == 1:
+            if "bf16" in ds_config and strtobool(str(ds_config["bf16"].get("enabled", "False"))) == 1:
                 raise ValueError(
                     "`--mixed_precision` arg cannot be set to `fp16` when `bf16` is set in the DeepSpeed config file."
                 )
         elif mixed_precision == "bf16":
             if "bf16" not in ds_config:
                 ds_config.update({"bf16": {"enabled": True}})
-            elif "fp16" in ds_config and strtobool(str(ds_config["fp16"].get("enabled", "False"))) == 1:
+            if "fp16" in ds_config and strtobool(str(ds_config["fp16"].get("enabled", "False"))) == 1:
                 raise ValueError(
                     "`--mixed_precision` arg cannot be set to `bf16` when `fp16` is set in the DeepSpeed config file."
                 )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -579,7 +579,7 @@ class DeepSpeedPlugin:
                 f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}.\n"
                 "Please specify them appropriately in the DeepSpeed config file.\n"
                 "If you are using accelerate config file, set `mixed_precision=no` "
-                "and remove others config variables mentioned in the above specified list;"
+                "and remove others config variables mentioned in the above specified list; "
                 "else don't specify these config variables in `accelerate launch` command. \n"
                 "The easiest method is to create new config following the questionnaire via  `accelerate config`.\n"
                 "It will only ask for the necessary config variables when using `deepspeed_config_file`."

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -577,8 +577,10 @@ class DeepSpeedPlugin:
             ]
             raise ValueError(
                 f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}.\n"
-                "Please specify them appropriately in the DeepSpeed config file. In accelerate config file, set `mixed_precision=no` "
-                "and remove others config variables mentioned in the above specified list.\n"
+                "Please specify them appropriately in the DeepSpeed config file.\n"
+                "If you are using accelerate config file, set `mixed_precision=no` "
+                "and remove others config variables mentioned in the above specified list;"
+                "else don't specify these config variables in `accelerate launch` command. \n"
                 "The easiest method is to create new config following the questionnaire via  `accelerate config`.\n"
                 "It will only ask for the necessary config variables when using `deepspeed_config_file`."
             )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -578,9 +578,9 @@ class DeepSpeedPlugin:
             raise ValueError(
                 f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}.\n"
                 "Please specify them appropriately in the DeepSpeed config file.\n"
-                "If you are using accelerate config file, set `mixed_precision=no` "
+                "If you are using an accelerate config file, set `mixed_precision=no` "
                 "and remove others config variables mentioned in the above specified list; "
-                "else don't specify these config variables in `accelerate launch` command. \n"
+                "and make sure to not specify these config variables in `accelerate launch` command. \n"
                 "The easiest method is to create new config following the questionnaire via  `accelerate config`.\n"
                 "It will only ask for the necessary config variables when using `deepspeed_config_file`."
             )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -615,7 +615,7 @@ class DeepSpeedPlugin:
         if accelerate_mixed_precision != "no":
             if accelerate_mixed_precision not in ds_config:
                 mismatches.append(f"- ds config does not have mixed precision config for {accelerate_mixed_precision}")
-            elif ds_config[accelerate_mixed_precision].get("enabled", None) is None:
+            elif ds_config[accelerate_mixed_precision].get("enabled", None) != "true":
                 mismatches.append(
                     f"- ds config mixed precision config for {accelerate_mixed_precision} is not enabled"
                 )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -465,8 +465,8 @@ class DeepSpeedPlugin:
         self.deepspeed_config = self.hf_ds_config.config
         self.deepspeed_config["steps_per_print"] = float("inf")  # this will stop deepspeed from logging @ stdout
         if self.zero3_init_flag is None:
-            self.zero3_init_flag = strtobool(
-                os.environ.get("ACCELERATE_DEEPSPEED_ZERO3_INIT", str(self.hf_ds_config.is_zero3()))
+            self.zero3_init_flag = (
+                strtobool(os.environ.get("ACCELERATE_DEEPSPEED_ZERO3_INIT", str(self.hf_ds_config.is_zero3()))) == 1
             )
         if self.zero3_init_flag and not self.hf_ds_config.is_zero3():
             warnings.warn("DeepSpeed Zero3 Init flag is only applicable for ZeRO Stage 3. Setting it to False.")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -523,14 +523,14 @@ class DeepSpeedPlugin:
         if mixed_precision == "fp16":
             if "fp16" not in ds_config:
                 ds_config.update({"fp16": {"enabled": True, "auto_cast": True}})
-            elif "bf16" in ds_config and ds_config["bf16"].get("enabled", False) == True:
+            elif "bf16" in ds_config and strtobool(str(ds_config["bf16"].get("enabled", "False"))) == 1:
                 raise ValueError(
                     "`--mixed_precision` arg cannot be set to `fp16` when `bf16` is set in the DeepSpeed config file."
                 )
         elif mixed_precision == "bf16":
             if "bf16" not in ds_config:
                 ds_config.update({"bf16": {"enabled": True}})
-            elif "fp16" in ds_config and ds_config["fp16"].get("enabled", False) == True:
+            elif "fp16" in ds_config and strtobool(str(ds_config["fp16"].get("enabled", "False"))) == 1:
                 raise ValueError(
                     "`--mixed_precision` arg cannot be set to `bf16` when `fp16` is set in the DeepSpeed config file."
                 )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -563,9 +563,9 @@ class DeepSpeedPlugin:
         ]
         duplicate_values_flag = False
         for name in env_variable_names_to_ignore:
-            if name == "ACCELERATE_MIXED_PRECISION" and os.environ.get(name, "no") != "no":
+            if name != "ACCELERATE_MIXED_PRECISION" and os.environ.get(name, None) is not None:
                 duplicate_values_flag = True
-            elif os.environ.get(name, None) is not None:
+            elif name == "ACCELERATE_MIXED_PRECISION" and os.environ.get(name, "no") != "no":
                 duplicate_values_flag = True
             if duplicate_values_flag:
                 break
@@ -574,10 +574,11 @@ class DeepSpeedPlugin:
             env_variable_names_to_ignore = [
                 name.replace("ACCELERATE_", "").lower() for name in env_variable_names_to_ignore
             ]
-            warnings.warn(
-                f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}. "
-                "Please specify them appropriately in the DeepSpeed config file. In accelerate config file, set `mixed_precision=no` and remove others config variables. "
-                "The easiest method is to create new config following the questionnaire via  `accelerate config`. "
+            raise ValueError(
+                f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}.\n"
+                "Please specify them appropriately in the DeepSpeed config file. In accelerate config file, set `mixed_precision=no` "
+                "and remove others config variables mentioned in the above specified list.\n"
+                "The easiest method is to create new config following the questionnaire via  `accelerate config`.\n"
                 "It will only ask for the necessary config variables when using `deepspeed_config_file`."
             )
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -616,9 +616,7 @@ class DeepSpeedPlugin:
             if accelerate_mixed_precision not in ds_config:
                 mismatches.append(f"- ds config does not have mixed precision config for {accelerate_mixed_precision}")
             elif ds_config[accelerate_mixed_precision].get("enabled", None) != "true":
-                mismatches.append(
-                    f"- ds config mixed precision config for {accelerate_mixed_precision} is not enabled"
-                )
+                mismatches.append(f"- ds config mixed precision for {accelerate_mixed_precision} is not enabled")
 
         if len(mismatches) > 0:
             mismatches_msg = "\n".join(mismatches)

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -465,7 +465,9 @@ class DeepSpeedPlugin:
         self.deepspeed_config = self.hf_ds_config.config
         self.deepspeed_config["steps_per_print"] = float("inf")  # this will stop deepspeed from logging @ stdout
         if self.zero3_init_flag is None:
-            self.zero3_init_flag = os.environ.get("ACCELERATE_DEEPSPEED_ZERO3_INIT", "true") == "true"
+            self.zero3_init_flag = strtobool(
+                os.environ.get("ACCELERATE_DEEPSPEED_ZERO3_INIT", str(self.hf_ds_config.is_zero3()))
+            )
         if self.zero3_init_flag and not self.hf_ds_config.is_zero3():
             warnings.warn("DeepSpeed Zero3 Init flag is only applicable for ZeRO Stage 3. Setting it to False.")
             self.zero3_init_flag = False

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -578,10 +578,9 @@ class DeepSpeedPlugin:
             raise ValueError(
                 f"When using `deepspeed_config_file`, the following accelerate config variables will be ignored: {env_variable_names_to_ignore}.\n"
                 "Please specify them appropriately in the DeepSpeed config file.\n"
-                "If you are using an accelerate config file, set `mixed_precision=no` "
-                "and remove others config variables mentioned in the above specified list; "
+                "If you are using an accelerate config file, remove others config variables mentioned in the above specified list; "
                 "and make sure to not specify these config variables in `accelerate launch` command. \n"
-                "The easiest method is to create new config following the questionnaire via  `accelerate config`.\n"
+                "The easiest method is to create new config following the questionnaire via `accelerate config`.\n"
                 "It will only ask for the necessary config variables when using `deepspeed_config_file`."
             )
 

--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -50,6 +50,9 @@ class HfDeepSpeedConfig:
             raise ValueError("expecting either a path to a DeepSpeed config file or a pre-populated dict")
         self.config = config
 
+        self.set_stage_and_offload()
+
+    def set_stage_and_offload(self):
         # zero stage - this is done as early as possible, before model is created, to allow
         # ``is_deepspeed_zero3_enabled`` query and getting to the early deepspeed config object
         # during ``zero.Init()`` which needs to know the dtype, and some other hparams.


### PR DESCRIPTION
### What dos this PR do?
1. Fixes: #936 

Example:
1. accelerate config manually tweaked to have both `deepspeed_config_file` and other ds config entries that are available in the json config file:
```yaml
command_file: null
commands: null
compute_environment: LOCAL_MACHINE
deepspeed_config:
  gradient_accumulation_steps: 1
  gradient_clipping: 1.0
  offload_optimizer_device: 'cpu'
  offload_param_device: 'cpu'
  zero3_init_flag: true
  zero3_save_16bit_model: true
  zero_stage: 3
  deepspeed_config_file: 'ds_config.json'
distributed_type: DEEPSPEED
downcast_bf16: 'no'
dynamo_backend: 'NO'
fsdp_config: {}
gpu_ids: null
machine_rank: 0
main_process_ip: null
main_process_port: null
main_training_function: main
megatron_lm_config: {}
mixed_precision: 'bf16'
num_machines: 1
num_processes: 2
rdzv_backend: static
same_network: true
tpu_name: null
tpu_zone: null
use_cpu: false
```

2. ds_config.json:
```json
{
    "fp16": {
        "enabled": true
    },
    "zero_optimization": {
        "stage": 3,
        "stage3_gather_16bit_weights_on_model_save": false,
        "offload_optimizer": {
            "device": "none"
        },
        "offload_param": {
            "device": "none"
        }
    },
    "gradient_clipping": 1.0,
    "train_batch_size": "auto",
    "train_micro_batch_size_per_gpu": "auto",
    "gradient_accumulation_steps": 10,
    "steps_per_print": 2000000
}
```

3. Code:
```python
from accelerate import Accelerator

def main():
    accelerator = Accelerator()

if __name__ == "__main__":
    main()
```

4. output:
```bash
ValueError: When using `deepspeed_config_file`, the following accelerate config variables will be 
ignored: ['gradient_accumulation_steps', 'gradient_clipping', 'zero_stage', 
'offload_optimizer_device', 'offload_param_device', 'zero3_save_16bit_model', 'mixed_precision'].
Please specify them appropriately in the DeepSpeed config file.
If you are using accelerate config file, set `mixed_precision=no` and remove others config variables
mentioned in the above specified list; else don't specify these config variables in `accelerate 
launch` command. 
The easiest method is to create new config following the questionnaire via  `accelerate config`.
It will only ask for the necessary config variables when using `deepspeed_config_file`.
```