### PR TITLE
Fix offload when weights are on the GPU

### DIFF
--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -34,7 +34,7 @@ def offload_weight(weight, weight_name, offload_folder, index=None):
         # Need to reinterpret the underlined data as int16 since NumPy does not handle bfloat16s.
         weight = weight.view(torch.int16)
         dtype = "bfloat16"
-    array = weight.numpy()
+    array = weight.cpu().numpy()
     tensor_file = os.path.join(offload_folder, f"{weight_name}.dat")
     if index is not None:
         if dtype is None:


### PR DESCRIPTION
This was reported in #938 and is a very small and easy fix: some checkpoints may have weights on the GPU and if the user does not pass along `map_location="cpu"` (which also our `load_checkpoint` function does not) we end with an error at this line.