### PR TITLE
Add is_initialized method and refactor

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -300,7 +300,7 @@ class AcceleratorState:
 
     def _check_initialized(self, mixed_precision=None, cpu=None):
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"
-        if not self.initialized:
+        if self.initialized:
             err = "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `{flag}` to `Accelerate()`."
             if cpu and self.device.type != "cpu":
                 raise ValueError(err.format(flag="cpu=True"))

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -35,6 +35,14 @@ if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
 
+def is_initialized() -> bool:
+    """
+    Checks if the `AcceleratorState` has been initialized from `Accelerator`. Same as `AcceleratorState.initialized`,
+    but works as a module method.
+    """
+    return AcceleratorState._shared_state != {}
+
+
 # Inspired by Alex Martelli's 'Borg'.
 class AcceleratorState:
     """
@@ -51,11 +59,6 @@ class AcceleratorState:
           of mixed precision being performed.
         - **num_processes** (`int`) -- The number of processes currently launched in parallel.
         - **process_index** (`int`) -- The index of the current process.
-
-    **Available methods:**
-
-        - **is_initialized** -- Whether or not the `AcceleratorState` has been initialized from `Accelerator` as a
-          staticmethod.
     """
 
     _shared_state = {}
@@ -292,11 +295,6 @@ class AcceleratorState:
     @property
     def initialized(self) -> bool:
         "Returns whether the `AcceleratorState` has been initialized"
-        return AcceleratorState._shared_state != {}
-
-    @staticmethod
-    def is_initialized() -> bool:
-        "Same as `AcceleratorState.initialized`, but works as a static method"
         return AcceleratorState._shared_state != {}
 
     def _check_initialized(self, mixed_precision=None, cpu=None):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -79,7 +79,7 @@ class AcceleratorState:
             cpu = True
         self._check_initialized(mixed_precision, cpu)
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
-        if not getattr(self, "initialized", False):
+        if not self.initialized:
             self.backend = None
             self.deepspeed_plugin = None
             mixed_precision = (
@@ -322,11 +322,15 @@ class GradientState:
 
     def __init__(self):
         self.__dict__ = self._shared_state
-        if not getattr(self, "initialized", False):
+        if not self.initialized:
             self.sync_gradients = True
             self.end_of_dataloader = False
             self.remainder = -1
-        self.initialized = True
+
+    @property
+    def initialized(self) -> bool:
+        "Returns whether the `GradientState` has been initialized"
+        return GradientState._shared_state != {}
 
     def __repr__(self):
         return (


### PR DESCRIPTION
# Add a static `is_initialized` method and refactor existing logic for initialization check

## What does this add?

This PR introduces a static `is_initialized` method which will check  if the state's dictionary is empty or not. It also refactors current methods to have `initialized` be a `@property` check of the same to increase code clarity towards what is happening under the hood.

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/933

## Why is it needed?

The feature request asked for a similar API to what `torch` uses for `cuda`, i.e. `torch.cuda.is_initialized()` for `Accelerate`, so a user can do `import accelerate; accelerate.state.is_initialized()`

## What parts of the API does this impact?

### User-facing:

A new `is_initialized` method was added to the `accelerate.state` module

### Internal structure:

`initialized` was changed to be a dictionary check to mimic how the new `is_initialized()` function operates

## Basic Usage Example(s):

```python
# One way:
import accelerate
accelerate.state.is_initialized()

# Or:
from accelerate import Accelerator
accelerator = Accelerator()
accelerator.state.initialized
```

## When would I use it, and when wouldn't I?

When a static method is needed to check if the `AcceleratorState` has been initialized without doing a `getattr`, or a cleaner interface to present to the user