### PR TITLE
Fix DeepSpeed tests

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -243,8 +243,7 @@ class DeepSpeedConfigIntegration(unittest.TestCase):
 
     @parameterized.expand([FP16, BF16], name_func=parameterized_custom_name_func)
     def test_accelerate_state_deepspeed(self, dtype):
-        if AcceleratorState().initialized:
-            AcceleratorState._reset_state()
+        AcceleratorState._reset_state()
         deepspeed_plugin = DeepSpeedPlugin(
             gradient_accumulation_steps=1,
             gradient_clipping=1.0,

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -243,10 +243,6 @@ class DeepSpeedConfigIntegration(unittest.TestCase):
 
     @parameterized.expand([FP16, BF16], name_func=parameterized_custom_name_func)
     def test_accelerate_state_deepspeed(self, dtype):
-        state = AcceleratorState(_from_accelerator=True)
-        if state.initialized:
-            state.initialized = False
-
         deepspeed_plugin = DeepSpeedPlugin(
             gradient_accumulation_steps=1,
             gradient_clipping=1.0,
@@ -259,7 +255,6 @@ class DeepSpeedConfigIntegration(unittest.TestCase):
         with mockenv_context(**self.dist_env):
             state = Accelerator(mixed_precision=dtype, deepspeed_plugin=deepspeed_plugin).state
             self.assertTrue(state.deepspeed_plugin.deepspeed_config[dtype]["enabled"])
-            state.initialized = False
 
     def test_init_zero3(self):
         deepspeed_plugin = DeepSpeedPlugin(

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -243,6 +243,8 @@ class DeepSpeedConfigIntegration(unittest.TestCase):
 
     @parameterized.expand([FP16, BF16], name_func=parameterized_custom_name_func)
     def test_accelerate_state_deepspeed(self, dtype):
+        if AcceleratorState().initialized:
+            AcceleratorState._reset_state()
         deepspeed_plugin = DeepSpeedPlugin(
             gradient_accumulation_steps=1,
             gradient_clipping=1.0,


### PR DESCRIPTION
The `DeepSpeed` tests manually set `AcceleratorState.initialized` when trying to test the mixed precision types when it should use `_reset_state()`, leading to a failure on the recent API change introduced in #949.

IIUC this should be the proper fix, let me know if there was a specific reason for this particular setup @pacman100 when testing and I can modify this fix differently.

Proof tests pass can be seen here: https://github.com/huggingface/accelerate/actions/runs/3830884007