### PR TITLE
Don't automatically offload buffers when loading checkpoints

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -404,6 +404,7 @@ def load_checkpoint_and_dispatch(
         offload_folder=offload_folder,
         dtype=dtype,
         offload_state_dict=offload_state_dict,
+        offload_buffers=offload_buffers,
     )
     if device_map is None:
         return model

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -607,6 +607,7 @@ def load_checkpoint_in_model(
     offload_folder: Optional[Union[str, os.PathLike]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     offload_state_dict: bool = False,
+    offload_buffers: bool = False,
 ):
     """
     Loads a (potentially sharded) checkpoint inside a model, potentially sending weights to a given device as they are
@@ -636,6 +637,8 @@ def load_checkpoint_in_model(
         offload_state_dict (`bool`, *optional*, defaults to `False`):
             If `True`, will temporarily offload the CPU state dict on the hard drive to avoid getting out of CPU RAM if
             the weight of the CPU state dict + the biggest shard does not fit.
+        offload_buffers (`bool`, *optional*, defaults to `False):
+            Whether or not to include the buffers in the weights offloaded to disk.
     """
     if offload_folder is None and device_map is not None and "disk" in device_map.values():
         raise ValueError(
@@ -687,6 +690,8 @@ def load_checkpoint_in_model(
         state_dict_folder = tempfile.mkdtemp()
         state_dict_index = {}
 
+    buffer_names = [name for name, _ in model.named_buffers()]
+
     for checkpoint_file in checkpoint_files:
         checkpoint = torch.load(checkpoint_file)
         if device_map is None:
@@ -703,7 +708,8 @@ def load_checkpoint_in_model(
                 param_device = device_map[module_name]
 
                 if param_device == "disk":
-                    set_module_tensor_to_device(model, param_name, "meta")
+                    if offload_buffers or param_name not in buffer_names:
+                        set_module_tensor_to_device(model, param_name, "meta")
                     offload_weight(param, param_name, offload_folder, index=offload_index)
                 elif param_device == "cpu" and offload_state_dict:
                     set_module_tensor_to_device(model, param_name, "meta")


### PR DESCRIPTION
This PR fixes an issue uncovered with the bug reported in #938. When loading a checkpoint with Accelerate big model inference, each weight is put on the device set in the `device_map`. In particular, all weights in the `state_dict` that should be offloaded to the disk according to the `device_map` are set on the meta device by `load_checkpoint_in_model`.

On the other hand, the hooks set by `dispatch_model` will by default no offload buffers on the disk (since they are usually small) and during their `init`, they move them to the execution `device`.

So the weights in the state dict that are buffers and inside modules offloaded to the disk end up on the meta device and are then moved to the execution device (which is GPU 0 usually). This crashes with the error reported in #938.

The fix is quite simple, just add an `offload_buffers` new arguments to `load_checkpoint_in_model` with a default consistent with `dispatch_model`.

Fixes #938