### PR TITLE
Raise minimum version for distrib launch

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -555,8 +555,10 @@ def simple_launcher(args):
 
 
 def multi_gpu_launcher(args):
-    if is_torch_version(">=", "1.9.0"):
+    if is_torch_version(">=", "1.9.1"):
         import torch.distributed.run as distrib_run
+    else:
+        raise NotImplementedError("Native multi-GPU training requires pytorch>=1.9.1")
     num_processes = getattr(args, "num_processes")
     num_machines = getattr(args, "num_machines")
     main_process_ip = getattr(args, "main_process_ip")
@@ -630,8 +632,6 @@ def multi_gpu_launcher(args):
             current_env[prefix + "USE_DISTRIBUTED_OPTIMIZER"] = str(args.megatron_lm_use_distributed_optimizer)
 
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
-    if is_torch_version("<", "1.9.0"):
-        raise NotImplementedError("Multi-node training requires pytorch>=1.9.0")
 
     debug = getattr(args, "debug", False)
     args = _filter_args(args)
@@ -646,7 +646,7 @@ def multi_gpu_launcher(args):
 
 
 def deepspeed_launcher(args):
-    if is_torch_version(">=", "1.9.0"):
+    if is_torch_version(">=", "1.9.1"):
         import torch.distributed.run as distrib_run
     if not is_deepspeed_available():
         raise ImportError("DeepSpeed is not installed => run `pip3 install deepspeed` or build it from source.")
@@ -756,8 +756,8 @@ def deepspeed_launcher(args):
             else:
                 sys.exit(1)
     else:
-        if is_torch_version("<", "1.9.0"):
-            raise NotImplementedError("Multi-node training requires pytorch>=1.9.0")
+        if is_torch_version("<", "1.9.1"):
+            raise NotImplementedError("Multi-node training requires pytorch>=1.9.1")
 
         debug = getattr(args, "debug", False)
         args = _filter_args(args)

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -39,7 +39,7 @@ def _filter_args(args):
     """
     Filters out all `accelerate` specific args
     """
-    if is_torch_version(">=", "1.9.0"):
+    if is_torch_version(">=", "1.9.1"):
         import torch.distributed.run as distrib_run
     distrib_args = distrib_run.get_args_parser()
     new_args, _ = distrib_args.parse_known_args()


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/847

TL;DR there was a neat bug in torch 1.9.0 where `torchrun` wouldn't always *actually run*. This PR changes the flag for checking to be 1.9.1, which I found *did* work after successfully recreating the 1.9.0 issue. 

It also modifies the `if/else` flag as it was always going to raise if the value was `<` 1.9.0 but gives it a much more clear answer as to what is truly happening here. 