### PR TITLE
Fix tied parameters test in big model inference

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -509,7 +509,9 @@ def infer_auto_device_map(
             )
         # Assess size needed
         module_size = module_sizes[name]
-        tied_params = [v for k, v in tied_parameters.items() if name in k]
+        # We keep relevant tied parameters only: once of the tied parameters is inside the current module and the other
+        # is not.
+        tied_params = [v for k, v in tied_parameters.items() if name in k and name not in v]
         # We ignore parameters that are tied when they're tied to > 1 one
         tied_param = tied_params[0] if len(tied_params) == 1 else None
 


### PR DESCRIPTION
This PR fixes the test to determine tied parameters in `infer_auto_device_map`. The problem was discovered while investigating #958. When the module to treat contains both tied parameters (in the case of the issue, the module treated is `transformers` and the tied parameters are `'transformer.shared.weight'` and `'transformer.decoder.embed_tokens.weight'`) and it can fit on the current device, we get to an index error when the module treated is removed from the list of modules_to_treat.

The fix is to just ignore tied parameters in this case: this is only done to make sure they end up on the same device, but if we treat a module containing the tied parameters together, they will be put on the same device.

Fixes #958