### PR TITLE
Ensure that last batch doesn't get dropped if perfectly even in gather_for_metrics

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1455,7 +1455,7 @@ class Accelerator:
                 return tensor
             try:
                 # Then see if we're on the last batch of our eval dataloader
-                if self.gradient_state.end_of_dataloader:
+                if self.gradient_state.end_of_dataloader and self.gradient_state.remainder > 0:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
                         return tensor[: self.gradient_state.remainder]

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -91,7 +91,9 @@ def generate_predictions(model, dataloader, accelerator):
     return logits, targs
 
 
-def test_torch_metrics(accelerator: Accelerator, num_samples=82, dispatch_batches=False, split_batches=False, batch_size=16):
+def test_torch_metrics(
+    accelerator: Accelerator, num_samples=82, dispatch_batches=False, split_batches=False, batch_size=16
+):
     model, ddp_model, dataloader = get_basic_setup(accelerator, num_samples, batch_size)
     logits, targs = generate_predictions(ddp_model, dataloader, accelerator)
     assert (
@@ -130,6 +132,7 @@ def test_mrpc(dispatch_batches: bool = False, split_batches: bool = False):
         assert math.isclose(
             baseline[key], distributed[key]
         ), f"Baseline and Distributed are not the same for key {key}:\n\tBaseline: {baseline[key]}\n\tDistributed: {distributed[key]}\n"
+
 
 def main():
     accelerator = Accelerator(split_batches=False, dispatch_batches=False)


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/952 

TL;DR in a perfectly distributed batch setup (say dset 512, bs of 16), we need to ensure not to drop any samples and delegate to the `else` statement. Added a test to ensure this can get caught as well. 