### PR TITLE
Fix test for converting tensor to proper dtype

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -127,7 +127,7 @@ def set_module_tensor_to_device(
         if dtype is None:
             # For compatibility with PyTorch load_state_dict which converts state dict dtype to existing dtype in model
             value = value.to(old_value.dtype)
-        elif str(value.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):
+        elif not str(value.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):
             value = value.to(dtype)
 
     with torch.no_grad():

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -126,6 +126,11 @@ class ModelingUtilsTester(unittest.TestCase):
         model = ModelForTest().to(0)
         self.check_set_module_tensor_for_device(model, 0, 1)
 
+    def test_set_module_tensor_sets_dtype(self):
+        model = ModelForTest()
+        set_module_tensor_to_device(model, "linear1.weight", "cpu", value=model.linear1.weight, dtype=torch.float16)
+        self.assertEqual(model.linear1.weight.dtype, torch.float16)
+
     def test_named_tensors(self):
         model = nn.BatchNorm1d(4)
         named_tensors = named_module_tensors(model)


### PR DESCRIPTION
I made a typo in #920 and forgot a `not` while copy-pasting some code :grimacing: 
This PR fixes that.