### PR TITLE
Add new release_memory util

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import contextlib
-import gc
 import math
 import os
 import shutil
@@ -60,6 +59,7 @@ from .utils import (
     pad_across_processes,
     recursively_apply,
     reduce,
+    release_memory,
     save,
     wait_for_everyone,
 )
@@ -1785,8 +1785,7 @@ class Accelerator:
         self._models = []
         self._dataloaders = []
         self.deepspeed_engine_wrapped = None
-        gc.collect()
-        torch.cuda.empty_cache()
+        release_memory()
 
     def clear(self):
         """

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -119,7 +119,7 @@ from .megatron_lm import prepare_data_loader as megatron_lm_prepare_data_loader
 from .megatron_lm import prepare_model as megatron_lm_prepare_model
 from .megatron_lm import prepare_optimizer as megatron_lm_prepare_optimizer
 from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
-from .memory import find_executable_batch_size
+from .memory import find_executable_batch_size, release_memory
 from .other import (
     extract_model_from_parallel,
     get_pretty_name,

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -24,6 +24,37 @@ import inspect
 import torch
 
 
+def release_memory(*objects):
+    """
+    Releases memory from `objects` by setting them to `None` and calls `gc.collect()` and `torch.cuda.empty_cache()`.
+    Returned objects should be reassigned to the same variables.
+
+    Args:
+        objects (`Iterable`):
+            An iterable of objects
+    Returns:
+        A list of `None` objects to replace `objects`
+
+    Example:
+
+        ```python
+        >>> import torch
+        >>> from accelerate.utils import release_memory
+
+        >>> a = torch.ones(1000, 1000).cuda()
+        >>> b = torch.ones(1000, 1000).cuda()
+        >>> a, b = release_memory(a, b)
+        ```
+    """
+    if not isinstance(objects, list):
+        objects = list(objects)
+    for i in range(len(objects)):
+        objects[i] = None
+    gc.collect()
+    torch.cuda.empty_cache()
+    return objects
+
+
 def should_reduce_batch_size(exception: Exception) -> bool:
     """
     Checks if `exception` relates to CUDA out-of-memory, CUDNN not supported, or CPU out-of-memory

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -17,6 +17,7 @@ import unittest
 import torch
 from torch import nn
 
+from accelerate.test_utils import require_cuda
 from accelerate.utils.memory import find_executable_batch_size, release_memory
 
 
@@ -104,6 +105,7 @@ class MemoryTest(unittest.TestCase):
             mock_training_loop_function()
             self.assertIn("Oops, we had an error!", cm.exception.args[0])
 
+    @require_cuda
     def test_release_memory(self):
         self.assertEqual(torch.cuda.memory_allocated(), 0)
         model = ModelForTest()


### PR DESCRIPTION
Helps https://github.com/huggingface/transformers/issues/21094 by introducing a lower-level convenience API for releasing memory. It's quite similar to `Accelerator.free_memory` but let's the user pass in a list of objects to remove.

Example usage:

```python
        >>> import torch
        >>> from accelerate.utils import release_memory

        >>> a = torch.ones(1000, 1000).cuda()
        >>> b = torch.ones(1000, 1000).cuda()
        >>> a, b = release_memory(a, b)
```

Extracting it outside into a new util let's it be used by more usecases, such as big model inference