### PR TITLE
Efficiently skip batches in a dataloader

### DIFF
--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -203,13 +203,12 @@ def training_function(config, args):
     # Now we train the model
     for epoch in range(starting_epoch, num_epochs):
         model.train()
-        for step, batch in enumerate(train_dataloader):
-            # New Code #
-            # We need to skip steps until we reach the resumed step during the first epoch
-            if args.resume_from_checkpoint and epoch == starting_epoch:
-                if resume_step is not None and step < resume_step:
-                    overall_step += 1
-                    continue
+        # New Code #
+        if args.resume_from_checkpoint and epoch == starting_epoch:
+            # We need to skip steps until we reach the resumed step
+            train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
+            overall_step += resume_step
+        for batch in train_dataloader:
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
             outputs = model(**batch)

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -206,7 +206,7 @@ def training_function(config, args):
         # New Code #
         if args.resume_from_checkpoint and epoch == starting_epoch:
             # We need to skip steps until we reach the resumed step
-            train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
+            train_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
             overall_step += resume_step
         for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -208,7 +208,7 @@ def training_function(config, args):
             # We need to skip steps until we reach the resumed step
             train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
             overall_step += resume_step
-        for batch in train_dataloader:
+        for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
             outputs = model(**batch)

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -204,7 +204,7 @@ def training_function(config, args):
     for epoch in range(starting_epoch, num_epochs):
         model.train()
         # New Code #
-        if args.resume_from_checkpoint and epoch == starting_epoch:
+        if args.resume_from_checkpoint and epoch == starting_epoch and resume_step is not None:
             # We need to skip steps until we reach the resumed step
             train_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
             overall_step += resume_step

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -207,7 +207,7 @@ def training_function(config, args):
             # We need to skip steps until we reach the resumed step
             train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
             overall_step += resume_step
-        for step, batch in enumerate(train_dataloader):
+        for batch in train_dataloader:
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch = {k: v.to(accelerator.device) for k, v in batch.items()}
             inputs = (batch["image"] - mean) / std

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -205,7 +205,7 @@ def training_function(config, args):
             total_loss = 0
         if args.resume_from_checkpoint and epoch == starting_epoch:
             # We need to skip steps until we reach the resumed step
-            train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
+            train_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
             overall_step += resume_step
         for batch in train_dataloader:
             # We could avoid this line since we set the accelerator with `device_placement=True`.

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -203,7 +203,7 @@ def training_function(config, args):
         model.train()
         if args.with_tracking:
             total_loss = 0
-        if args.resume_from_checkpoint and epoch == starting_epoch:
+        if args.resume_from_checkpoint and epoch == starting_epoch and resume_step is not None:
             # We need to skip steps until we reach the resumed step
             train_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
             overall_step += resume_step

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -203,12 +203,11 @@ def training_function(config, args):
         model.train()
         if args.with_tracking:
             total_loss = 0
-        for step, batch in enumerate(train_dataloader):
+        if args.resume_from_checkpoint and epoch == starting_epoch:
             # We need to skip steps until we reach the resumed step
-            if args.resume_from_checkpoint and epoch == starting_epoch:
-                if resume_step is not None and step < resume_step:
-                    overall_step += 1
-                    continue
+            train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
+            overall_step += resume_step
+        for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch = {k: v.to(accelerator.device) for k, v in batch.items()}
             inputs = (batch["image"] - mean) / std

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -180,7 +180,7 @@ def training_function(config, args):
         model.train()
         if args.with_tracking:
             total_loss = 0
-        if args.resume_from_checkpoint and epoch == starting_epoch:
+        if args.resume_from_checkpoint and epoch == starting_epoch and resume_step is not None:
             # We need to skip steps until we reach the resumed step
             train_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
             overall_step += resume_step

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -182,7 +182,7 @@ def training_function(config, args):
             total_loss = 0
         if args.resume_from_checkpoint and epoch == starting_epoch:
             # We need to skip steps until we reach the resumed step
-            train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
+            train_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
             overall_step += resume_step
         for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -184,7 +184,7 @@ def training_function(config, args):
             # We need to skip steps until we reach the resumed step
             train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
             overall_step += resume_step
-        for batch in train_dataloader:
+        for step, batch in enumerate(train_dataloader):
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
             outputs = model(**batch)

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -180,12 +180,11 @@ def training_function(config, args):
         model.train()
         if args.with_tracking:
             total_loss = 0
-        for step, batch in enumerate(train_dataloader):
+        if args.resume_from_checkpoint and epoch == starting_epoch:
             # We need to skip steps until we reach the resumed step
-            if args.resume_from_checkpoint and epoch == starting_epoch:
-                if resume_step is not None and step < resume_step:
-                    overall_step += 1
-                    continue
+            train_dataloader = accelerator.skip_batches(train_dataloader, resume_step)
+            overall_step += resume_step
+        for batch in train_dataloader:
             # We could avoid this line since we set the accelerator with `device_placement=True`.
             batch.to(accelerator.device)
             outputs = model(**batch)

--- a/src/accelerate/__init__.py
+++ b/src/accelerate/__init__.py
@@ -13,6 +13,7 @@ from .big_modeling import (
     init_on_device,
     load_checkpoint_and_dispatch,
 )
+from .data_loader import skip_first_batches
 from .launchers import debug_launcher, notebook_launcher
 from .utils import (
     DeepSpeedPlugin,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -25,7 +25,7 @@ from typing import List, Optional, Union
 import torch
 
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
-from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_batches
+from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_batches
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
@@ -1919,7 +1919,7 @@ class Accelerator:
                 return True
         return False
 
-    def skip_batches(self, dataloader, num_batches: int = 0):
+    def skip_first_batches(self, dataloader, num_batches: int = 0):
         """
         Creates a new `torch.utils.data.DataLoader` that will efficiently skip the first `num_batches`.
 
@@ -1927,4 +1927,4 @@ class Accelerator:
             dataloader (`torch.utils.data.DataLoader`): The data loader in which to skip batches.
             num_batches (`int`, *optional*, defaults to 0): The number of batches to skip
         """
-        return skip_batches(dataloader, num_batches=num_batches)
+        return skip_first_batches(dataloader, num_batches=num_batches)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -25,7 +25,7 @@ from typing import List, Optional, Union
 import torch
 
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
-from .data_loader import DataLoaderDispatcher, prepare_data_loader
+from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_batches
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
@@ -1918,3 +1918,13 @@ class Accelerator:
             if optimizer.step_was_skipped:
                 return True
         return False
+
+    def skip_batches(self, dataloader, num_batches: int = 0):
+        """
+        Creates a new `torch.utils.data.DataLoader` that will efficiently skip the first `num_batches`.
+
+        Args:
+            dataloader (`torch.utils.data.DataLoader`): The data loader in which to skip batches.
+            num_batches (`int`, *optional*, defaults to 0): The number of batches to skip
+        """
+        return skip_batches(dataloader, num_batches=num_batches)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -427,7 +427,7 @@ class DataLoaderDispatcher(DataLoader):
             `dataloader` multiplied by `num_processes` otherwise. Setting this option to `True` requires that the batch
             size of the `dataloader` is a round multiple of `batch_size`.
         skip_batches (`int`, *optional*, defaults to 0):
-            The number of batches to skip at the beginning.
+            The number of batches to skip at the beginning of an iteration.
 
     **Available attributes:**
 
@@ -766,7 +766,7 @@ def prepare_data_loader(
 
 class SkipBatchSampler(BatchSampler):
     """
-    A `torch.utils.data.BatchSampler` that skips the first batches of another `torch.utils.data.BatchSampler`.
+    A `torch.utils.data.BatchSampler` that skips the first `n` batches of another `torch.utils.data.BatchSampler`.
     """
 
     def __init__(self, batch_sampler, skip_batches=0):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -865,7 +865,6 @@ def skip_first_batches(dataloader, num_batches=0):
         dataloader = DataLoaderShard(
             dataset,
             device=dataloader.device,
-            split_batches=dataloader.split_batches,
             rng_types=dataloader.rng_types,
             synchronized_generator=dataloader.synchronized_generator,
             **kwargs,

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -809,7 +809,7 @@ class SkipDataLoader(DataLoader):
                 yield batch
 
 
-def skip_batches(dataloader, num_batches=0):
+def skip_first_batches(dataloader, num_batches=0):
     """
     Creates a `torch.utils.data.DataLoader` that will efficiently skip the first `num_batches`.
     """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -804,7 +804,7 @@ class SkipDataLoader(DataLoader):
         self.skip_batches = skip_batches
 
     def __iter__(self):
-        for index, batch in enumerate(self):
+        for index, batch in enumerate(super().__iter__()):
             if index >= self.skip_batches:
                 yield batch
 


### PR DESCRIPTION
This PR adds a new function to efficiently skip batches in a given DataLoader when the underlying dataset is not an `IterableDataset`. It works by replacing the `batch_sampler` with one that skips the first n batches, since iterating though the batch sampler is fast.

Missing tests and examples for now.
