### PR TITLE
Allow the torch device to be set with an env var

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -92,6 +92,8 @@ class AcceleratorState:
             env_device = os.environ.get("ACCELERATE_TORCH_DEVICE", None)
             if env_device:
                 self.device = torch.device(env_device)
+            else:
+                self.device = None
             self.dynamo_backend = DynamoBackend(dynamo_backend.upper())
             if not _from_accelerator:
                 raise ValueError(
@@ -113,7 +115,7 @@ class AcceleratorState:
                     self.num_processes = torch.distributed.get_world_size()
                     self.process_index = torch.distributed.get_rank()
                     self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                    if not env_device:
+                    if not self.device:
                         self.device = torch.device("cuda", self.local_process_index)
                     torch.cuda.set_device(self.device)
                     self._mixed_precision = mixed_precision
@@ -152,7 +154,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                if not env_device:
+                if not self.device:
                     self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = "no"  # deepspeed handles mixed_precision using deepspeed_config
@@ -165,7 +167,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                if not env_device:
+                if not self.device:
                     self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = mixed_precision
@@ -217,7 +219,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = local_rank
-                if not env_device:
+                if not self.device:
                     self.device = torch.device("cpu")
                 self._mixed_precision = mixed_precision
             else:
@@ -247,9 +249,9 @@ class AcceleratorState:
                                 "It has major fixes related to model correctness and performance improvements for transformer based models. "
                                 "Please refer to https://github.com/pytorch/pytorch/issues/82707 for more details."
                             )
-                        if not env_device:
+                        if not self.device:
                             self.device = torch.device("mps")
-                elif not env_device:
+                elif not self.device:
                     if cpu or not torch.cuda.is_available():
                         self.device = torch.device("cpu")
                     else:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -90,10 +90,7 @@ class AcceleratorState:
                 parse_choice_from_env("ACCELERATE_DYNAMO_BACKEND", "no") if dynamo_backend is None else dynamo_backend
             )
             env_device = os.environ.get("ACCELERATE_TORCH_DEVICE", None)
-            if env_device:
-                self.device = torch.device(env_device)
-            else:
-                self.device = None
+            self.device = torch.device(env_device) if env_device is not None else None
             self.dynamo_backend = DynamoBackend(dynamo_backend.upper())
             if not _from_accelerator:
                 raise ValueError(
@@ -115,7 +112,7 @@ class AcceleratorState:
                     self.num_processes = torch.distributed.get_world_size()
                     self.process_index = torch.distributed.get_rank()
                     self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                    if not self.device:
+                    if self.device is None:
                         self.device = torch.device("cuda", self.local_process_index)
                     torch.cuda.set_device(self.device)
                     self._mixed_precision = mixed_precision
@@ -154,7 +151,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                if not self.device:
+                if self.device is None:
                     self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = "no"  # deepspeed handles mixed_precision using deepspeed_config
@@ -167,7 +164,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                if not self.device:
+                if self.device is None:
                     self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = mixed_precision
@@ -219,7 +216,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = local_rank
-                if not self.device:
+                if self.device is None:
                     self.device = torch.device("cpu")
                 self._mixed_precision = mixed_precision
             else:
@@ -249,9 +246,9 @@ class AcceleratorState:
                                 "It has major fixes related to model correctness and performance improvements for transformer based models. "
                                 "Please refer to https://github.com/pytorch/pytorch/issues/82707 for more details."
                             )
-                        if not self.device:
+                        if self.device is None:
                             self.device = torch.device("mps")
-                elif not self.device:
+                elif self.device is None:
                     if cpu or not torch.cuda.is_available():
                         self.device = torch.device("cpu")
                     else:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -110,7 +110,9 @@ class AcceleratorState:
                     self.num_processes = torch.distributed.get_world_size()
                     self.process_index = torch.distributed.get_rank()
                     self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                    self.device = torch.device("cuda", self.local_process_index)
+                    self.device = torch.device(
+                        "cuda", os.environ.get("ACCELERATE_TORCH_DEVICE", self.local_process_index)
+                    )
                     torch.cuda.set_device(self.device)
                     self._mixed_precision = mixed_precision
             elif is_tpu_available() and not cpu:
@@ -148,7 +150,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                self.device = torch.device("cuda", self.local_process_index)
+                self.device = torch.device("cuda", os.environ.get("ACCELERATE_TORCH_DEVICE", self.local_process_index))
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = "no"  # deepspeed handles mixed_precision using deepspeed_config
                 self.deepspeed_plugin = deepspeed_plugin
@@ -160,7 +162,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))
-                self.device = torch.device("cuda", self.local_process_index)
+                self.device = torch.device("cuda", os.environ.get("ACCELERATE_TORCH_DEVICE", self.local_process_index))
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = mixed_precision
                 if os.environ.get("ACCELERATE_USE_FSDP", "false") == "true":
@@ -211,7 +213,7 @@ class AcceleratorState:
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = local_rank
-                self.device = torch.device("cpu")
+                self.device = torch.device(os.environ.get("ACCELERATE_TORCH_DEVICE", "cpu"))
                 self._mixed_precision = mixed_precision
             else:
                 self.distributed_type = DistributedType.NO
@@ -240,11 +242,11 @@ class AcceleratorState:
                                 "It has major fixes related to model correctness and performance improvements for transformer based models. "
                                 "Please refer to https://github.com/pytorch/pytorch/issues/82707 for more details."
                             )
-                        self.device = torch.device("mps")
+                        self.device = torch.device(os.environ.get("ACCELERATE_TORCH_DEVICE", "mps"))
                 elif cpu or not torch.cuda.is_available():
-                    self.device = torch.device("cpu")
+                    self.device = torch.device(os.environ.get("ACCELERATE_TORCH_DEVICE", "cpu"))
                 else:
-                    self.device = torch.device("cuda")
+                    self.device = torch.device(os.environ.get("ACCELERATE_TORCH_DEVICE", "cuda"))
                 self._mixed_precision = mixed_precision
 
             if (

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -60,6 +60,6 @@ class AcceleratorTester(unittest.TestCase):
         def noop(*args, **kwargs):
             pass
 
-        with patch("torch.cuda.set_device", noop), patch_environment(ACCELERATE_TORCH_DEVICE="privateuseone"):
+        with patch("torch.cuda.set_device", noop), patch_environment(ACCELERATE_TORCH_DEVICE="cuda:1234"):
             accelerator = Accelerator()
-            self.assertEqual(str(accelerator.state.device), "privateuseone")
+            self.assertEqual(str(accelerator.state.device), "cuda:1234")

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -20,6 +20,9 @@ def create_components():
 
 
 class AcceleratorTester(unittest.TestCase):
+    def tearDown(self) -> None:
+        AcceleratorState._reset_state()
+
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()
@@ -37,7 +40,6 @@ class AcceleratorTester(unittest.TestCase):
         self.assertTrue(prepared_scheduler in accelerator._schedulers)
         self.assertTrue(prepared_train_dl in accelerator._dataloaders)
         self.assertTrue(prepared_valid_dl in accelerator._dataloaders)
-        AcceleratorState._reset_state()
 
     def test_free_memory_dereferences_prepared_components(self):
         accelerator = Accelerator()
@@ -50,7 +52,6 @@ class AcceleratorTester(unittest.TestCase):
         self.assertTrue(len(accelerator._optimizers) == 0)
         self.assertTrue(len(accelerator._schedulers) == 0)
         self.assertTrue(len(accelerator._dataloaders) == 0)
-        AcceleratorState._reset_state()
 
     def test_env_var_device(self):
         """Tests that setting the torch device with ACCELERATE_TORCH_DEVICE overrides default device."""
@@ -61,4 +62,4 @@ class AcceleratorTester(unittest.TestCase):
 
         with patch("torch.cuda.set_device", noop), patch_environment(ACCELERATE_TORCH_DEVICE="privateuseone"):
             accelerator = Accelerator()
-            assert str(accelerator.device) == "privateuseone"
+            self.assertEqual(str(accelerator.state.device), "privateuseone")

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -56,10 +56,10 @@ class AcceleratorTester(unittest.TestCase):
     def test_env_var_device(self):
         """Tests that setting the torch device with ACCELERATE_TORCH_DEVICE overrides default device."""
 
-        # Mock torch.cuda.set_device to avoid an exception as the device test doesn't exist
+        # Mock torch.cuda.set_device to avoid an exception as the device doesn't exist
         def noop(*args, **kwargs):
             pass
 
-        with patch("torch.cuda.set_device", noop), patch_environment(ACCELERATE_TORCH_DEVICE="cuda:1234"):
+        with patch("torch.cuda.set_device", noop), patch_environment(ACCELERATE_TORCH_DEVICE="cuda:64"):
             accelerator = Accelerator()
-            self.assertEqual(str(accelerator.state.device), "cuda:1234")
+            self.assertEqual(str(accelerator.state.device), "cuda:64")

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -56,7 +56,7 @@ class AcceleratorTester(unittest.TestCase):
     def test_env_var_device(self):
         """Tests that setting the torch device with ACCELERATE_TORCH_DEVICE overrides default device."""
 
-        # Set torch.cuda.set_device to avoid an exception as the device test doesn't exist
+        # Mock torch.cuda.set_device to avoid an exception as the device test doesn't exist
         def noop(*args, **kwargs):
             pass
 


### PR DESCRIPTION
Signed-off-by: Antoni Baum <antoni.baum@protonmail.com>

# Why

Currently, `AccelerateState` will always use the Torch device corresponding to the local rank. This is fine in most cases, but may be limiting for advanced uses (eg. fractional GPUs) or compatibility with other libraries which manage resources themselves like Ray Train.

# How

This PR adds logic to first derive the device from `ACCELERATE_TORCH_DEVICE` env var and falling back to local rank if that env var is not set. As this is an advanced use case, no documentation changes are introduced and there is no expectation that most users will make use of it.

# Notes

I wasn't sure if this required tests and if so, what file they should be put into. Would appreciate some pointers here :)

This would make usage of Accelerate on Ray Train less error-prone.