### PR TITLE
Add in code exploration tool to docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -17,6 +17,8 @@
     title: Launching distributed training from Jupyter Notebooks
   title: Tutorials
 - sections:
+  - local: usage_guides/explore
+    title: Start Here!
   - local: usage_guides/training_zoo
     title: Example Zoo
   - local: usage_guides/big_modeling

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -55,7 +55,7 @@ accelerate launch {my_script.py}
       ><div class="w-full text-center bg-gradient-to-br from-blue-400 to-blue-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">Tutorials</div>
       <p class="text-gray-700">Learn the basics and become familiar with using 🤗 Accelerate. Start here if you are using 🤗 Accelerate for the first time!</p>
     </a>
-    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./usage_guides/gradient_accumulation"
+    <a class="!no-underline border dark:border-gray-700 p-5 rounded-lg shadow hover:shadow-lg" href="./usage_guides/explore"
       ><div class="w-full text-center bg-gradient-to-br from-indigo-400 to-indigo-500 rounded-lg py-1.5 font-semibold mb-5 text-white text-lg leading-relaxed">How-to guides</div>
       <p class="text-gray-700">Practical guides to help you achieve a specific goal. Take a look at these guides to learn how to use 🤗 Accelerate to solve real-world problems.</p>
     </a>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -35,5 +35,5 @@ for batch in dataloader:
 <iframe 
     src="https://muellerzr-accelerate-examples.hf.space"
     width="850"
-    height="1550"
+    height="1600"
 ></iframe>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -1,0 +1,26 @@
+<!--Copyright 2022 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Learning how to incorporate 🤗 Accelerate features quickly!
+
+Please use the interactive tool below to help you get started with learning about a particular 
+feature of 🤗 Accelerate and how to utilize it! It will provide you with a code diff, an explaination
+towards what is going on, as well as provide you with some useful links to explore more within
+the documentation!
+
+
+<iframe
+	src="https://muellerzr-accelerate-examples.hf.space"
+	frameborder="0"
+	width="850"
+	height="450"
+></iframe>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -18,16 +18,8 @@ towards what is going on, as well as provide you with some useful links to explo
 the documentation!
 
 
-<!-- {/* <iframe 
+<iframe 
     src="https://muellerzr-accelerate-examples.hf.space"
     width="850"
     height="750"
-></iframe> */} -->
-<svelte:head>
-  <script 
-    type="module"
-    src="https://gradio.s3-us-west-2.amazonaws.com/3.14.0/gradio.js">
-  </script>
-</svelte:head>
-
-<gradio-app src="https://muellerzr-accelerate-examples.hf.space"></gradio-app>
+></iframe>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -35,5 +35,5 @@ for batch in dataloader:
 <iframe 
     src="https://muellerzr-accelerate-examples.hf.space"
     width="850"
-    height="750"
+    height="1550"
 ></iframe>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -18,9 +18,9 @@ towards what is going on, as well as provide you with some useful links to explo
 the documentation!
 
 
-<iframe
-	src="https://muellerzr-accelerate-examples.hf.space"
-	frameborder="0"
-	width="850"
-	height="100%"
+<iframe 
+    src="https://muellerzr-accelerate-examples.hf.space"
+    width="850"
+    height="750"
+    onload='javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+"px";}(this));' 
 ></iframe>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -22,5 +22,9 @@ the documentation!
     src="https://muellerzr-accelerate-examples.hf.space"
     width="850"
     height="750"
-    onload='javascript:(function(o){o.style.height=o.contentWindow.document.body.scrollHeight+"px";}(this));' 
 ></iframe>
+<!-- {/* <script 
+    type="module"
+    src="https://gradio.s3-us-west-2.amazonaws.com/3.14.0/gradio.js">
+</script>
+<gradio-app src="https://muellerzr-accelerate-examples.hf.space"></gradio-app> */} -->

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -17,6 +17,20 @@ feature of 🤗 Accelerate and how to utilize it! It will provide you with a cod
 towards what is going on, as well as provide you with some useful links to explore more within
 the documentation!
 
+Most code examples start from the following python code before integrating 🤗 Accelerate in some way:
+
+```python
+for batch in dataloader:
+    optimizer.zero_grad()
+    inputs, targets = batch
+    inputs = inputs.to(device)
+    targets = targets.to(device)
+    outputs = model(inputs)
+    loss = loss_function(outputs, targets)
+    loss.backward()
+    optimizer.step()
+    scheduler.step()
+```
 
 <iframe 
     src="https://muellerzr-accelerate-examples.hf.space"

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -18,11 +18,11 @@ towards what is going on, as well as provide you with some useful links to explo
 the documentation!
 
 
-<iframe 
+<!-- {/* <iframe 
     src="https://muellerzr-accelerate-examples.hf.space"
     width="850"
     height="750"
-></iframe>
+></iframe> */} -->
 <svelte:head>
   <script 
     type="module"

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -23,8 +23,11 @@ the documentation!
     width="850"
     height="750"
 ></iframe>
-<!-- {/* <script 
+<svelte:head>
+  <script 
     type="module"
     src="https://gradio.s3-us-west-2.amazonaws.com/3.14.0/gradio.js">
-</script>
-<gradio-app src="https://muellerzr-accelerate-examples.hf.space"></gradio-app> */} -->
+  </script>
+</svelte:head>
+
+<gradio-app src="https://muellerzr-accelerate-examples.hf.space"></gradio-app>

--- a/docs/source/usage_guides/explore.mdx
+++ b/docs/source/usage_guides/explore.mdx
@@ -22,5 +22,5 @@ the documentation!
 	src="https://muellerzr-accelerate-examples.hf.space"
 	frameborder="0"
 	width="850"
-	height="450"
+	height="100%"
 ></iframe>


### PR DESCRIPTION
This PR introduces an interactive feature integrator tool into the Accelerate documentation. The space itself is hosted [here](https://huggingface.co/spaces/muellerzr/accelerate_examples). It operates by first having the user select a feature:

![image](https://user-images.githubusercontent.com/7831895/214885513-a7282034-c596-4181-b6d3-07d97062413d.png)

Then it will provide them with the code diff, an explanation, and a link to the docs for more information:

![image](https://user-images.githubusercontent.com/7831895/214885671-df8454ca-52f3-4277-ba8c-2c69c094d3da.png)

Ideally we use this for all of the items that exist in "Usage Guides" as fast visual tutorials, before linking to others. In the future this would include having an option to view CLI options as well as Big Model Inference, and other items with higher complexity's/diffs in a seperate interface category users can use (like select "Accelerator" vs "CLI" vs "Big Model Inference")

To add a new tutorial, please see the [README](https://huggingface.co/spaces/muellerzr/accelerate_examples/blob/main/README.md) on the space, or request I make one for you 😉 

Preview on the docs at: https://moon-ci-docs.huggingface.co/docs/accelerate/pr_1014/en/usage_guides/explore