### PR TITLE
Fix test introduced in PR and introduce AcceleratorTestCase

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -223,6 +223,19 @@ class TempDirTestCase(unittest.TestCase):
                     shutil.rmtree(path)
 
 
+class AccelerateTestCase(unittest.TestCase):
+    """
+    A TestCase class that will reset the accelerator state at the end of every test. Every test that checks or utilizes
+    the `AcceleratorState` class should inherit from this to avoid silent failures due to state being shared between
+    tests.
+    """
+
+    def tearDown(self):
+        super().tearDown()
+        # Reset the state of the AcceleratorState singleton.
+        AcceleratorState._reset_state()
+
+
 class MockingTestCase(unittest.TestCase):
     """
     A TestCase class designed to dynamically add various mockers that should be used in every test, mimicking the

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -18,7 +18,6 @@ import itertools
 import json
 import os
 import tempfile
-import unittest
 from copy import deepcopy
 from pathlib import Path
 
@@ -30,6 +29,7 @@ from accelerate.accelerator import Accelerator
 from accelerate.scheduler import AcceleratedScheduler
 from accelerate.state import AcceleratorState
 from accelerate.test_utils.testing import (
+    AccelerateTestCase,
     TempDirTestCase,
     execute_subprocess_async,
     require_cuda,
@@ -94,7 +94,7 @@ optim_scheduler_params = list(itertools.product(optims, schedulers))
 
 @require_deepspeed
 @require_cuda
-class DeepSpeedConfigIntegration(unittest.TestCase):
+class DeepSpeedConfigIntegration(AccelerateTestCase):
     def setUp(self):
         super().setUp()
 
@@ -126,10 +126,6 @@ class DeepSpeedConfigIntegration(unittest.TestCase):
             LOCAL_RANK="0",
             WORLD_SIZE="1",
         )
-
-    def tearDown(self):
-        super().tearDown()
-        AcceleratorState._reset_state()
 
     def get_config_dict(self, stage):
         # As some tests modify the dict, always make a copy

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -15,7 +15,6 @@
 
 import inspect
 import os
-import unittest
 
 import torch
 
@@ -23,6 +22,7 @@ import accelerate
 from accelerate.accelerator import Accelerator
 from accelerate.state import AcceleratorState
 from accelerate.test_utils.testing import (
+    AccelerateTestCase,
     TempDirTestCase,
     execute_subprocess_async,
     require_cuda,
@@ -53,7 +53,7 @@ dtypes = [FP16, BF16]
 
 @require_fsdp
 @require_cuda
-class FSDPPluginIntegration(unittest.TestCase):
+class FSDPPluginIntegration(AccelerateTestCase):
     def setUp(self):
         super().setUp()
 
@@ -65,10 +65,6 @@ class FSDPPluginIntegration(unittest.TestCase):
             LOCAL_RANK="0",
             WORLD_SIZE="1",
         )
-
-    def tearDown(self):
-        super().tearDown()
-        AcceleratorState._reset_state()
 
     def test_sharding_strategy(self):
         from torch.distributed.fsdp.fully_sharded_data_parallel import ShardingStrategy

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -30,6 +30,10 @@ def load_random_weights(model):
 
 
 class AcceleratorTester(unittest.TestCase):
+    def tearDown(self):
+        # Reset the state of the AcceleratorState singleton.
+        AcceleratorState._reset_state()
+
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()
@@ -47,7 +51,6 @@ class AcceleratorTester(unittest.TestCase):
         self.assertTrue(prepared_scheduler in accelerator._schedulers)
         self.assertTrue(prepared_train_dl in accelerator._dataloaders)
         self.assertTrue(prepared_valid_dl in accelerator._dataloaders)
-        AcceleratorState._reset_state()
 
     def test_free_memory_dereferences_prepared_components(self):
         accelerator = Accelerator()
@@ -59,7 +62,6 @@ class AcceleratorTester(unittest.TestCase):
         self.assertTrue(len(accelerator._optimizers) == 0)
         self.assertTrue(len(accelerator._schedulers) == 0)
         self.assertTrue(len(accelerator._dataloaders) == 0)
-        AcceleratorState._reset_state()
 
     def test_save_load_model(self):
         accelerator = Accelerator()
@@ -78,7 +80,6 @@ class AcceleratorTester(unittest.TestCase):
             # make sure loaded weights match
             accelerator.load_state(tmpdirname)
             self.assertTrue(abs(model_signature - get_signature(model)) < 1e-3)
-        AcceleratorState._reset_state()
 
     def test_save_load_model_with_hooks(self):
         accelerator = Accelerator()
@@ -141,4 +142,3 @@ class AcceleratorTester(unittest.TestCase):
 
             # mode.class_name is NOT loaded from config
             self.assertTrue(model.class_name != model.__class__.__name__)
-        AcceleratorState._reset_state()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -53,7 +53,6 @@ class AcceleratorTester(unittest.TestCase):
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()
         accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
-
         accelerator.free_memory()
 
         self.assertTrue(len(accelerator._models) == 0)
@@ -79,6 +78,7 @@ class AcceleratorTester(unittest.TestCase):
             # make sure loaded weights match
             accelerator.load_state(tmpdirname)
             self.assertTrue(abs(model_signature - get_signature(model)) < 1e-3)
+        AcceleratorState._reset_state()
 
     def test_save_load_model_with_hooks(self):
         accelerator = Accelerator()
@@ -141,3 +141,4 @@ class AcceleratorTester(unittest.TestCase):
 
             # mode.class_name is NOT loaded from config
             self.assertTrue(model.class_name != model.__class__.__name__)
+        AcceleratorState._reset_state()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1,13 +1,12 @@
 import json
 import os
 import tempfile
-import unittest
 
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate.accelerator import Accelerator
-from accelerate.state import AcceleratorState
+from accelerate.test_utils.testing import AccelerateTestCase
 
 
 def create_components():
@@ -29,11 +28,7 @@ def load_random_weights(model):
     model.load_state_dict(state)
 
 
-class AcceleratorTester(unittest.TestCase):
-    def tearDown(self):
-        # Reset the state of the AcceleratorState singleton.
-        AcceleratorState._reset_state()
-
+class AcceleratorTester(AccelerateTestCase):
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()


### PR DESCRIPTION
Fixes test introduced in https://github.com/huggingface/accelerate/pull/991

It needed another call to `AcceleratorState._reset_state()` so I just moved it to the `tearDown` since every test in it reset the state. 

Also introduces an `AcceleratorTestCase` class to handle the `_reset_state()` for users since it's very easy to forget it happens and then a cryptic stack trace follows