### PR TITLE
Fix import of LrScheduler

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -101,9 +101,9 @@ if is_tpu_available(check_device=False):
     import torch_xla.distributed.xla_multiprocessing as xmp
 
 
-if is_torch_version("<=", "1.13.5"):
+try:
     from torch.optim.lr_scheduler import _LRScheduler as LRScheduler
-else:
+except ImportError:
     from torch.optim.lr_scheduler import LRScheduler as LRScheduler
 
 logger = get_logger(__name__)


### PR DESCRIPTION
As mentioned in #878 the current version of Accelerate breaks with the latest Nvidia PyTorch docker image (22.12) which doesn't have the change of class names for `LrScheduler`. Therefore, I switched the test to be replaced with a try except.

Fixes #1019