### PR TITLE
Fix for BLOOM models which has slightly different model structure

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -111,7 +111,7 @@ def set_module_tensor_to_device(
         for split in splits[:-1]:
             if hasattr(module, split):
                 new_module = getattr(module, split)
-            elif hasattr(module, "transformer"): # Hack for BLOOM models
+            elif hasattr(module, "transformer"):  # Hack for BLOOM models
                 new_module = getattr(module.transformer, split, None)
             if new_module is None:
                 raise ValueError(f"{module} has no attribute {split}.")

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -109,7 +109,10 @@ def set_module_tensor_to_device(
     if "." in tensor_name:
         splits = tensor_name.split(".")
         for split in splits[:-1]:
-            new_module = getattr(module, split)
+            if hasattr(module, split):
+                new_module = getattr(module, split)
+            elif hasattr(module, "transformer"): # Hack for BLOOM models
+                new_module = getattr(module.transformer, split, None)
             if new_module is None:
                 raise ValueError(f"{module} has no attribute {split}.")
             module = new_module


### PR DESCRIPTION
Without this fix, there will be exceptions like
```
AttributeError: 'BloomForCausalLM' object has no attribute 'word_embeddings'
```
raised from /data/accelerate/src/accelerate/utils/modeling.py:112

This fix is to handle for the special case of BloomForCausalLM where there is a ".transformer" indirection.