### PR TITLE
Fix env var for MPS device on notebook_launcher

### DIFF
--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -123,7 +123,7 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
                 print("Launching training on one GPU.")
             else:
                 print("Launching training on CPU.")
-            with patch_environment(use_mps_device=use_mps_device):
+            with patch_environment(accelerate_use_mps_device=use_mps_device):
                 function(*args)
 
 


### PR DESCRIPTION
When adding the `ACCELERATE` prefix in https://github.com/huggingface/accelerate/pull/890, the `notebook_launcher` needs to check `ACCELERATE_USE_MPS_DEVICE`

Closes https://github.com/huggingface/accelerate/issues/1022