### PR TITLE
Change default for keep_fp32_wrapper

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1513,7 +1513,7 @@ class Accelerator:
         """
         return pad_across_processes(tensor, dim=dim, pad_index=pad_index, pad_first=pad_first)
 
-    def unwrap_model(self, model, keep_fp32_wrapper: bool = False):
+    def unwrap_model(self, model, keep_fp32_wrapper: bool = True):
         """
         Unwraps the `model` from the additional layer possible added by [`~Accelerator.prepare`]. Useful before saving
         the model.
@@ -1521,7 +1521,7 @@ class Accelerator:
         Args:
             model (`torch.nn.Module`):
                 The model to unwrap.
-            keep_fp32_wrapper (`bool`, *optional*, defaults to `False`):
+            keep_fp32_wrapper (`bool`, *optional*, defaults to `True`):
                 Whether to not remove the mixed precision hook if it was added.
         """
         return extract_model_from_parallel(model, keep_fp32_wrapper)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -30,7 +30,7 @@ if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
 
-def extract_model_from_parallel(model, keep_fp32_wrapper: bool = False):
+def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True):
     """
     Extract a model from its distributed containers.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,7 +85,7 @@ class UtilsTester(unittest.TestCase):
         model = RegressionModel()
         model._original_forward = model.forward
         model.forward = convert_outputs_to_fp32(model.forward)
-        model = extract_model_from_parallel(model)
+        model = extract_model_from_parallel(model, keep_fp32_wrapper=False)
         _ = pickle.dumps(model)
 
     @require_cuda
@@ -94,7 +94,7 @@ class UtilsTester(unittest.TestCase):
         model._original_forward = model.forward
         model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
         model.forward = convert_outputs_to_fp32(model.forward)
-        model = extract_model_from_parallel(model)
+        model = extract_model_from_parallel(model, keep_fp32_wrapper=False)
         _ = pickle.dumps(model)
 
     def test_find_device(self):


### PR DESCRIPTION
> If a user does an evaluation loop at the end of each epoch, then they have to use unwrap_model with the keep_wrapper at True for FP16 integration. We made a breaking change with that when introducing the arg.
> For instance the no trainer translation and summarization scripts have stopped working with FP16.

Switches regression and makes the default `True`