### PR TITLE
Fix slow test by keeping tied weights on the same GPU

### DIFF
--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -318,7 +318,7 @@ class BigModelingTester(unittest.TestCase):
             "transformer.wte": 0,
             "transformer.wpe": 0,
             "transformer.ln_f": 1,
-            "lm_head": 1,
+            "lm_head": 0,
         }
         for i in range(12):
             device_map[f"transformer.h.{i}"] = 0 if i <= 5 else 1


### PR DESCRIPTION
In #1000 we fixed the weight tying in `dispatch_model`, but one of the slow tests relied on the fact it was broken (by mistake) by putting tied weights of GPT-2 on two different devices. This PR fixes that.