### PR TITLE
Load tensors directly on device

### DIFF
--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -6,6 +6,7 @@ from .testing import (
     require_huggingface_suite,
     require_mps,
     require_multi_gpu,
+    require_safetensors,
     require_single_gpu,
     require_torch_min_version,
     require_tpu,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -33,6 +33,7 @@ from ..utils import (
     is_comet_ml_available,
     is_datasets_available,
     is_deepspeed_available,
+    is_safetensors_available,
     is_tensorboard_available,
     is_torch_version,
     is_tpu_available,
@@ -126,6 +127,14 @@ def require_multi_gpu(test_case):
     GPUs.
     """
     return unittest.skipUnless(torch.cuda.device_count() > 1, "test requires multiple GPUs")(test_case)
+
+
+def require_safetensors(test_case):
+    """
+    Decorator marking a test that requires safetensors installed. These tests are skipped when safetensors isn't
+    installed
+    """
+    return unittest.skipUnless(is_safetensors_available(), "test requires safetensors")(test_case)
 
 
 def require_deepspeed(test_case):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -51,6 +51,7 @@ from .modeling import (
     infer_auto_device_map,
     load_checkpoint_in_model,
     load_offloaded_weights,
+    load_state_dict,
     named_module_tensors,
     retie_parameters,
     set_module_tensor_to_device,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -662,7 +662,7 @@ def load_state_dict(checkpoint_file, device_map=None):
     if checkpoint_file.endswith(".safetensors"):
         if not is_safetensors_available():
             raise ImportError(
-                f"To load {checkpoint_file}, the `safetensors` library is necessary `pip install safetensors`>"
+                f"To load {checkpoint_file}, the `safetensors` library is necessary `pip install safetensors`."
             )
         with safe_open(checkpoint_file, framework="pt") as f:
             metadata = f.metadata()


### PR DESCRIPTION
This PR refines `load_checkpoint_in_model` to directly load weights on the GPUs when the checkpoint file is a safetensors file, since `safetensors` can load very fast directly there. It also introduces a new `load_state_dict` function to do this loading.

@patrickvonplaten is this enough for your use case in `diffusers`?