### PR TITLE
enabling `mps` device by default and removing related config

### DIFF
--- a/docs/source/usage_guides/mps.mdx
+++ b/docs/source/usage_guides/mps.mdx
@@ -31,41 +31,10 @@ please follow this nice medium article [GPU-Acceleration Comes to PyTorch on M1 
 
 
 ## How it works out of the box
+It is enabled by default on MacOs machines with MPS enabled Apple Silicon GPUs.
+To disable it, pass `--cpu` flag to `accelerate launch` command or answer the corresponding question when answering the `accelerate config` questionnaire.
 
-On your machine(s) just run:
-
-```bash
-accelerate config
-```
-
-and answer the questions asked, specifically choose `MPS` for the query:
-
-```
- Which type of machine are you using?. 
- ```
-
-This will generate a config file that will be used automatically to properly set 
-the default options when doing `accelerate launch`, such as the one shown below:
-
-```bash
-compute_environment: LOCAL_MACHINE
-deepspeed_config: {}
-distributed_type: MPS
-downcast_bf16: 'no'
-fsdp_config: {}
-machine_rank: 0
-main_process_ip: null
-main_process_port: null
-main_training_function: main
-mixed_precision: 'no'
-num_machines: 1
-num_processes: 1
-use_cpu: false
-```
-
-After this configuration has been made, here is how you run the CV example 
-(from the root of the repo) with MPS enabled:
-
+You can directly run the following script to test it out on MPS enabled Apple Silicon machines:
 ```bash
 accelerate launch /examples/cv_example.py --data_dir images
 ```

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -21,6 +21,7 @@ from ...utils import (
     DistributedType,
     DynamoBackend,
     is_deepspeed_available,
+    is_mps_available,
     is_transformers_available,
 )
 from ...utils.constants import (
@@ -129,14 +130,7 @@ def get_cluster_input():
     else:
         dynamo_backend = DynamoBackend.NO
 
-    use_mps = False
-    if distributed_type == DistributedType.NO:
-        use_mps = _ask_field(
-            "Do you want to use Apple Silicon GPUs via `mps` device backend? [yes/NO]:",
-            _convert_yes_no_to_bool,
-            default=False,
-            error_message="Please enter yes or no.",
-        )
+    use_mps = not use_cpu and is_mps_available()
     deepspeed_config = {}
     if distributed_type in [DistributedType.MULTI_GPU, DistributedType.NO] and not use_mps:
         use_deepspeed = _ask_field(

--- a/src/accelerate/commands/config/config_utils.py
+++ b/src/accelerate/commands/config/config_utils.py
@@ -66,7 +66,7 @@ def _convert_compute_environment(value):
 
 def _convert_distributed_mode(value):
     value = int(value)
-    return DistributedType(["NO", "MULTI_CPU", "MULTI_GPU", "TPU", "MPS"][value])
+    return DistributedType(["NO", "MULTI_CPU", "MULTI_GPU", "TPU"][value])
 
 
 def _convert_dynamo_backend(value):

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import sys
+import warnings
 from ast import literal_eval
 from pathlib import Path
 from typing import Dict, List
@@ -152,7 +153,8 @@ def launch_command_parser(subparsers=None):
         "--mps",
         default=False,
         action="store_true",
-        help="Whether or not this should use MPS-enabled GPU device on MacOS machines.",
+        help="This argument is deprecated. MPS device will be enabled by default when available and can be disabled via `--cpu`."
+        " Whether or not this should use MPS-enabled GPU device on MacOS machines.",
     )
     hardware_args.add_argument(
         "--multi_gpu",
@@ -518,7 +520,11 @@ def simple_launcher(args):
     current_env["ACCELERATE_USE_CPU"] = str(args.cpu or args.use_cpu)
     current_env["ACCELERATE_USE_MPS_DEVICE"] = str(args.mps)
     if args.mps:
-        current_env["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+        warnings.warn(
+            "`mps` is deprecated and will be removed in version 0.18.0 of 🤗 Accelerate."
+            " MPS device will be enabled by default when available and can be disabled via `--cpu`.",
+            FutureWarning,
+        )
     elif args.gpu_ids != "all" and args.gpu_ids is not None:
         current_env["CUDA_VISIBLE_DEVICES"] = args.gpu_ids
     if args.num_machines > 1:

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -19,7 +19,7 @@ import tempfile
 import torch
 
 from .state import AcceleratorState
-from .utils import PrecisionType, PrepareForLaunch, patch_environment
+from .utils import PrecisionType, PrepareForLaunch, is_mps_available, patch_environment
 
 
 def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no", use_port="29500"):
@@ -115,7 +115,7 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
 
         else:
             # No need for a distributed launch otherwise as it's either CPU, GPU or MPS.
-            if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+            if is_mps_available():
                 os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
                 print("Launching training on MPS.")
             elif torch.cuda.is_available():

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -115,16 +115,14 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
 
         else:
             # No need for a distributed launch otherwise as it's either CPU, GPU or MPS.
-            use_mps_device = "false"
-            if torch.backends.mps.is_available():
+            if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+                os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
                 print("Launching training on MPS.")
-                use_mps_device = "true"
             elif torch.cuda.is_available():
                 print("Launching training on one GPU.")
             else:
                 print("Launching training on CPU.")
-            with patch_environment(accelerate_use_mps_device=use_mps_device):
-                function(*args)
+            function(*args)
 
 
 def debug_launcher(function, args=(), num_processes=2):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -24,6 +24,7 @@ from .utils import (
     get_int_from_env,
     is_ccl_available,
     is_deepspeed_available,
+    is_mps_available,
     is_tpu_available,
     parse_choice_from_env,
     parse_flag_from_env,
@@ -228,7 +229,7 @@ class AcceleratorState:
                 if parse_flag_from_env("ACCELERATE_USE_MPS_DEVICE") and not cpu:
                     from .utils import is_torch_version
 
-                    if torch.backends.mps.is_available() and torch.backends.mps.is_built():
+                    if is_mps_available():
                         if not is_torch_version(">", "1.12.0"):
                             warnings.warn(
                                 "We strongly recommend to install PyTorch >= 1.13 for transformer based models."
@@ -242,13 +243,9 @@ class AcceleratorState:
                         )
 
                 if self.device is None:
-                    if (
-                        cpu
-                        or not torch.cuda.is_available()
-                        or not (torch.backends.mps.is_available() and torch.backends.mps.is_built())
-                    ):
+                    if cpu or not (torch.cuda.is_available() or is_mps_available()):
                         self.device = torch.device("cpu")
-                    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+                    elif is_mps_available():
                         os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
                         self.device = torch.device("mps")
                     else:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -223,34 +223,34 @@ class AcceleratorState:
                 self.distributed_type = DistributedType.NO
                 self.num_processes = 1
                 self.process_index = self.local_process_index = 0
-                if parse_flag_from_env("ACCELERATE_USE_MPS_DEVICE") and not cpu:
-                    if not torch.backends.mps.is_available():
-                        if not torch.backends.mps.is_built():
-                            raise AssertionError(
-                                "MPS not available because the current PyTorch install was not "
-                                "built with MPS enabled. Please install torch version >=1.12.0 on "
-                                "your Apple silicon Mac running macOS 12.3 or later with a native "
-                                "version (arm64) of Python"
-                            )
-                        else:
-                            raise AssertionError(
-                                "MPS not available because the current MacOS version is not 12.3+ "
-                                "and/or you do not have an MPS-enabled device on this machine."
-                            )
-                    else:
-                        from .utils import is_torch_version
 
+                # the below block using env variable for `mps` will be removed in version 0.18.0
+                if parse_flag_from_env("ACCELERATE_USE_MPS_DEVICE") and not cpu:
+                    from .utils import is_torch_version
+
+                    if torch.backends.mps.is_available() and torch.backends.mps.is_built():
                         if not is_torch_version(">", "1.12.0"):
                             warnings.warn(
-                                "We strongly recommend to install PyTorch >= 1.13 (nightly version at the time of writing) on your MacOS machine. "
-                                "It has major fixes related to model correctness and performance improvements for transformer based models. "
-                                "Please refer to https://github.com/pytorch/pytorch/issues/82707 for more details."
+                                "We strongly recommend to install PyTorch >= 1.13 for transformer based models."
                             )
-                        if self.device is None:
-                            self.device = torch.device("mps")
-                elif self.device is None:
-                    if cpu or not torch.cuda.is_available():
+                        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+                        self.device = torch.device("mps")
+                    else:
+                        raise AssertionError(
+                            "MPS not available because PyTorch version is < 1.12.0 or MacOS version is < 12.3 "
+                            "and/or you do not have an MPS-enabled device on this machine."
+                        )
+
+                if self.device is None:
+                    if (
+                        cpu
+                        or not torch.cuda.is_available()
+                        or not (torch.backends.mps.is_available() and torch.backends.mps.is_built())
+                    ):
                         self.device = torch.device("cpu")
+                    elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+                        os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"
+                        self.device = torch.device("mps")
                     else:
                         self.device = torch.device("cuda")
                 self._mixed_precision = mixed_precision

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -34,6 +34,7 @@ from .imports import (
     is_deepspeed_available,
     is_megatron_lm_available,
     is_mlflow_available,
+    is_mps_available,
     is_rich_available,
     is_safetensors_available,
     is_sagemaker_available,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -161,7 +161,7 @@ class DistributedType(str, enum.Enum):
     DEEPSPEED = "DEEPSPEED"
     FSDP = "FSDP"
     TPU = "TPU"
-    MPS = "MPS"
+    MPS = "MPS"  # here for backward compatibility. Remove in v0.18.0
     MEGATRON_LM = "MEGATRON_LM"
 
 

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -159,4 +159,4 @@ def is_mlflow_available():
 
 
 def is_mps_available():
-    return torch.backends.mps.is_available() and torch.backends.mps.is_built()
+    return is_torch_version(">=", "1.12") and torch.backends.mps.is_available() and torch.backends.mps.is_built()

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -156,3 +156,7 @@ def is_tqdm_available():
 
 def is_mlflow_available():
     return importlib.util.find_spec("mlflow") is not None
+
+
+def is_mps_available():
+    return torch.backends.mps.is_available() and torch.backends.mps.is_built()


### PR DESCRIPTION
### What does this PR do?
1. As `mps` and `cuda` won't be concurrently available/set, we can remove the `mps` config and have it enabled by default when it is available. To disable it use `--cpu` arg. This PR does that.
2. Supports backward compatibility till version 0.18.0. Post that `mps` related config will be removed.

 