### PR TITLE
do not scale gradient in bf16 mode

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -392,11 +392,6 @@ class Accelerator:
             if mixed_precision == "bf16" and not self.native_amp and not is_tpu_available():
                 raise ValueError(err.format(mode="bf16", requirement="PyTorch >= 1.10 and a supported device."))
 
-            # Only on the GPU do we care about scaling the gradients
-            if torch.cuda.is_available() and self.device.type != "cpu":
-                kwargs = self.scaler_handler.to_kwargs() if self.scaler_handler is not None else {}
-                self.scaler = torch.cuda.amp.GradScaler(**kwargs)
-
         # Start of internal step tracking
         self.step = 0
         self.gradient_state = GradientState()


### PR DESCRIPTION
`GradScaler` only makes sense in float16 mode and not for bf16 on the GPU. Removed block of code which did this for bf16.