### PR TITLE
Fixing of a bug connected with DeepSpeed

### DIFF
--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -163,9 +163,9 @@ class DeepSpeedEngineWrapper:
     def __init__(self, engine):
         self.engine = engine
 
-    def backward(self, loss):
+    def backward(self, loss, **kwargs):
         # runs backpropagation and handles mixed precision
-        self.engine.backward(loss)
+        self.engine.backward(loss, **kwargs)
 
         # Deepspeed's `engine.step` performs the following operations:
         # - gradient accumulation check


### PR DESCRIPTION
Hello. I tried to use DeepSpeed for my project and met a small bug. The problem was connected with backward function - i had to pass an argument 'retain_graph'. But we lose it by passing to internal DeepSpeed function.
I fixed it and these are my changes.