### PR TITLE
Refactor process executors to be in AcceleratorState

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -770,8 +770,7 @@ class Accelerator:
         >>> accelerator.print("Hello world!")
         ```
         """
-        if self.is_local_main_process:
-            print(*args, **kwargs)
+        self.state.print(*args, **kwargs)
 
     def _prepare_one(self, obj, first_pass=False, device_placement=None):
         # First pass of preparation: DataLoader, model, optimizer

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -558,7 +558,7 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.process_index}")
         ```
         """
-        yield from self.state.main_process_first()
+        yield self.state.main_process_first()
 
     @contextmanager
     def local_main_process_first(self):
@@ -579,7 +579,7 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.local_process_index}")
         ```
         """
-        yield from self.state.local_main_process_first()
+        yield self.state.local_main_process_first()
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -454,18 +454,12 @@ class Accelerator:
     @property
     def is_main_process(self):
         """True for one process only."""
-        return (
-            self.process_index == 0 if self.distributed_type != DistributedType.MEGATRON_LM else self.is_last_process
-        )
+        return self.state.is_main_process
 
     @property
     def is_local_main_process(self):
         """True for one process per server."""
-        return (
-            self.local_process_index == 0
-            if self.distributed_type != DistributedType.MEGATRON_LM
-            else self.is_last_process
-        )
+        return self.state.is_local_main_process
 
     @property
     def use_fp16(self):
@@ -545,15 +539,6 @@ class Accelerator:
 
         return decorator
 
-    def _goes_first(self, is_main):
-        if not is_main:
-            self.wait_for_everyone()
-
-        yield
-
-        if is_main:
-            self.wait_for_everyone()
-
     @contextmanager
     def main_process_first(self):
         """
@@ -573,7 +558,7 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.process_index}")
         ```
         """
-        yield from self._goes_first(self.is_main_process)
+        yield from self.state.main_process_first()
 
     @contextmanager
     def local_main_process_first(self):
@@ -594,7 +579,7 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.local_process_index}")
         ```
         """
-        yield from self._goes_first(self.is_local_main_process)
+        yield from self.state.local_main_process_first()
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -372,6 +372,10 @@ class AcceleratorState:
         """
         yield from self._goes_first(self.is_local_main_process)
 
+    def print(self, *args, **kwargs):
+        if self.is_local_main_process:
+            print(*args, **kwargs)
+
 
 class GradientState:
     """

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -31,6 +31,15 @@ from accelerate.utils import (
 )
 
 
+def process_execution_check():
+    # Test that printing on a single process works
+    accelerator = Accelerator()
+    with accelerator.main_process_first():
+        idx = torch.tensor(accelerator.process_index).to(accelerator.device)
+    idxs = accelerator.gather(idx)
+    assert idxs[0] == 0, "Main process was not first."
+
+
 def init_state_check():
     # Test we can instantiate this twice in a row.
     state = AcceleratorState()
@@ -307,6 +316,9 @@ def main():
     if state.local_process_index == 0:
         print("**Initialization**")
     init_state_check()
+    if state.local_process_index == 0:
+        print("\n**Test process execution**")
+    process_execution_check()
 
     if state.local_process_index == 0:
         print("\n**Test random number generator synchronization**")

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -72,15 +72,7 @@ def wait_for_everyone():
 
     </Tip>
     """
-    if (
-        AcceleratorState().distributed_type == DistributedType.MULTI_GPU
-        or AcceleratorState().distributed_type == DistributedType.MULTI_CPU
-        or AcceleratorState().distributed_type == DistributedType.DEEPSPEED
-        or AcceleratorState().distributed_type == DistributedType.FSDP
-    ):
-        torch.distributed.barrier()
-    elif AcceleratorState().distributed_type == DistributedType.TPU:
-        xm.rendezvous("accelerate.utils.wait_for_everyone")
+    AcceleratorState().wait_for_everyone()
 
 
 def save(obj, f):


### PR DESCRIPTION
Based on conversation in slack, refactors the logic for process executors to be handled in the `AcceleratorState` and delegated to the `Accelerator` instead of in the `Accelerator` itself so that the `State` can be used by individuals that want to do process delegation without needing multiple `Accelerator` objects in their codebase. 

Still TODO is to move the decorators over, but those need some more improvements due to confusions in them and tests so that is a much later to-get-to