### PR TITLE
Make sure direct parameters are properly set on device

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -303,6 +303,7 @@ def dispatch_model(
     execution_device = {
         name: main_device if device in ["cpu", "disk"] else device for name, device in device_map.items()
     }
+    execution_device[""] = main_device
     offloaded_devices = ["disk"] if main_device == "cpu" else ["cpu", "disk"]
     offload = {name: device in offloaded_devices for name, device in device_map.items()}
     save_folder = offload_dir if len(disk_modules) > 0 else None

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -454,7 +454,7 @@ def attach_align_device_hook_on_blocks(
     if not isinstance(offload, Mapping):
         offload = {key: offload for key in execution_device.keys()}
 
-    if module_name in execution_device and not offload[module_name]:
+    if module_name in execution_device and module_name in offload and not offload[module_name]:
         hook = AlignDevicesHook(
             execution_device=execution_device[module_name],
             offload_buffers=offload_buffers,
@@ -463,7 +463,7 @@ def attach_align_device_hook_on_blocks(
         )
         add_hook_to_module(module, hook)
         attach_execution_device_hook(module, execution_device[module_name])
-    elif module_name in execution_device:
+    elif module_name in execution_device and module_name in offload:
         attach_align_device_hook(
             module,
             execution_device=execution_device[module_name],
@@ -480,7 +480,7 @@ def attach_align_device_hook_on_blocks(
             module, execution_device[module_name], preload_module_classes=preload_module_classes
         )
     elif module_name == "":
-        hook = AlignDevicesHook(io_same_device=True)
+        hook = AlignDevicesHook(execution_device=execution_device.get(""), io_same_device=True)
         add_hook_to_module(module, hook)
 
     for child_name, child in module.named_children():


### PR DESCRIPTION
As pointed out in #1041, one dispatching a model that has direct parameters, there is a device mismatch. This PR should fix it by adding the main execution device to the hook attached to whole model.

Fixes #1041