### PR TITLE
Add `cpu_offload_with_hook`

### DIFF
--- a/src/accelerate/__init__.py
+++ b/src/accelerate/__init__.py
@@ -7,6 +7,7 @@ __version__ = "0.17.0.dev0"
 from .accelerator import Accelerator
 from .big_modeling import (
     cpu_offload,
+    cpu_offload_with_hook,
     disk_offload,
     dispatch_model,
     init_empty_weights,

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -19,7 +19,14 @@ from typing import Dict, List, Optional, Union
 import torch
 import torch.nn as nn
 
-from .hooks import AlignDevicesHook, add_hook_to_module, attach_align_device_hook, attach_align_device_hook_on_blocks, CpuOffload, UserCpuOffloadHook
+from .hooks import (
+    AlignDevicesHook,
+    CpuOffload,
+    UserCpuOffloadHook,
+    add_hook_to_module,
+    attach_align_device_hook,
+    attach_align_device_hook_on_blocks,
+)
 from .utils import (
     OffloadedWeightsLoader,
     check_device_map,

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Union
 import torch
 import torch.nn as nn
 
-from .hooks import AlignDevicesHook, add_hook_to_module, attach_align_device_hook, attach_align_device_hook_on_blocks
+from .hooks import AlignDevicesHook, add_hook_to_module, attach_align_device_hook, attach_align_device_hook_on_blocks, CpuOffload, UserCpuOffloadHook
 from .utils import (
     OffloadedWeightsLoader,
     check_device_map,
@@ -182,6 +182,13 @@ def cpu_offload(
     )
 
     return model
+
+
+def cpu_offload_with_hook(model, execution_device=None):
+    hook = CpuOffload(execution_device=execution_device)
+    add_hook_to_module(model, hook, append=True)
+    user_hook = UserCpuOffloadHook(model, hook)
+    return model, user_hook
 
 
 def disk_offload(

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -191,7 +191,44 @@ def cpu_offload(
     return model
 
 
-def cpu_offload_with_hook(model, execution_device=None, user_hook=None):
+def cpu_offload_with_hook(
+    model: torch.nn.Module,
+    execution_device: Optional[Union[int, str, torch.device]] = None,
+    user_hook: Optional[UserCpuOffloadHook] = None,
+):
+    """
+    Offloads a model on the CPU and puts it back to an execution device when executed. The difference with
+    [`cpu_offload`] is that the model stays on the execution device after the forward and is only offloaded again when
+    the `offload` method of the returned `hook` is called. Useful for pipelines running a model in a loop.
+
+    Args:
+        model (`torch.nn.Module`):
+            The model to offload.
+        execution_device(`str`, `int` or `torch.device`, *optional*):
+            The device on which the model should be executed. Will default to the MPS device if it's available, then
+            GPU 0 if there is a GPU, and finally to the CPU.
+        prev_module_hook (`UserCpuOffloadHook`, *optional*):
+            The hook sent back by this function for a previous model in the pipeline you are running. If passed, its
+            offload method will be called just before the forward of the model to which this hook is attached.
+
+    Example:
+
+    ```py
+    hook_1 = cpu_offload_with_hook(model_1, cuda_device)
+    hook_2 = cpu_offload_with_hook(model_2, cuda_device, user_hook=hook_1)
+    hook_3 = cpu_offload_with_hook(model_3, cuda_device, user_hook=hook_2)
+
+    hid_1 = model_1(input)
+    for i in range(50):
+        # model1 is offloaded on the CPU at the first iteration, model 2 stays on the GPU for this whole loop.
+        hid_2 = model_2(hid_1)
+    # model2 is offloaded to the CPU just before this forward.
+    hid_3 = model_3(hid_3)
+
+    # For model3, you need to manually call the hook offload method.
+    hook_3.offload()
+    ```
+    """
     hook = CpuOffload(execution_device=execution_device, user_hook=user_hook)
     add_hook_to_module(model, hook, append=True)
     user_hook = UserCpuOffloadHook(model, hook)

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -194,7 +194,7 @@ def cpu_offload(
 def cpu_offload_with_hook(
     model: torch.nn.Module,
     execution_device: Optional[Union[int, str, torch.device]] = None,
-    user_hook: Optional[UserCpuOffloadHook] = None,
+    prev_module_hook: Optional[UserCpuOffloadHook] = None,
 ):
     """
     Offloads a model on the CPU and puts it back to an execution device when executed. The difference with
@@ -215,8 +215,8 @@ def cpu_offload_with_hook(
 
     ```py
     hook_1 = cpu_offload_with_hook(model_1, cuda_device)
-    hook_2 = cpu_offload_with_hook(model_2, cuda_device, user_hook=hook_1)
-    hook_3 = cpu_offload_with_hook(model_3, cuda_device, user_hook=hook_2)
+    hook_2 = cpu_offload_with_hook(model_2, cuda_device, prev_module_hook=hook_1)
+    hook_3 = cpu_offload_with_hook(model_3, cuda_device, prev_module_hook=hook_2)
 
     hid_1 = model_1(input)
     for i in range(50):
@@ -229,7 +229,7 @@ def cpu_offload_with_hook(
     hook_3.offload()
     ```
     """
-    hook = CpuOffload(execution_device=execution_device, user_hook=user_hook)
+    hook = CpuOffload(execution_device=execution_device, prev_module_hook=prev_module_hook)
     add_hook_to_module(model, hook, append=True)
     user_hook = UserCpuOffloadHook(model, hook)
     return model, user_hook

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -191,8 +191,8 @@ def cpu_offload(
     return model
 
 
-def cpu_offload_with_hook(model, execution_device=None):
-    hook = CpuOffload(execution_device=execution_device)
+def cpu_offload_with_hook(model, execution_device=None, user_hook=None):
+    hook = CpuOffload(execution_device=execution_device, user_hook=user_hook)
     add_hook_to_module(model, hook, append=True)
     user_hook = UserCpuOffloadHook(model, hook)
     return model, user_hook

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -504,7 +504,9 @@ def attach_align_device_hook_on_blocks(
 
 
 class CpuOffload(ModelHook):
-    def __init__(self, execution_device=None):
+    def __init__(self, execution_device=None, prev_module_hook: Optional[UserCpuOffloadHook] = None):
+        self.prev_model_hook = prev_module_hook
+        
         if execution_device is not None:
             self.execution_device = execution_device
         elif is_mps_available():
@@ -519,6 +521,8 @@ class CpuOffload(ModelHook):
 
     def pre_forward(self, module, *args, **kwargs):
         module.to(self.execution_device)
+        if self.prev_module_hook is not None:
+            prev_module_hook.offload()
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -18,7 +18,14 @@ from typing import Dict, List, Mapping, Optional, Union
 import torch
 import torch.nn as nn
 
-from .utils import PrefixedDataset, find_device, named_module_tensors, send_to_device, set_module_tensor_to_device, is_mps_available
+from .utils import (
+    PrefixedDataset,
+    find_device,
+    is_mps_available,
+    named_module_tensors,
+    send_to_device,
+    set_module_tensor_to_device,
+)
 
 
 class ModelHook:
@@ -506,10 +513,10 @@ class CpuOffload(ModelHook):
             self.execution_device = torch.device(0)
         else:
             self.execution_device = torch.device("cpu")
-    
+
     def init_hook(self, module):
         return module.to("cpu")
-    
+
     def pre_forward(self, module, *args, **kwargs):
         module.to(self.execution_device)
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
@@ -519,9 +526,9 @@ class UserCpuOffloadHook:
     def __init__(self, model, hook):
         self.model = model
         self.hook = hook
-    
+
     def offload(self):
         self.hook.init_hook(self.model)
-    
+
     def remove(self):
         remove_hook_from_module(self.model)

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -523,7 +523,7 @@ class CpuOffload(ModelHook):
         execution_device: Optional[Union[str, int, torch.device]] = None,
         prev_module_hook: Optional["UserCpuOffloadHook"] = None,
     ):
-        self.prev_model_hook = prev_module_hook
+        self.prev_module_hook = prev_module_hook
 
         if execution_device is not None:
             self.execution_device = execution_device


### PR DESCRIPTION
This is a feature request for Diffusers. This PR adds a new `cpu_offload_with_hook` function that will offload the model to CPU, then put it back on the GPU once executed, but without offloading it just after the forward like `cpu_offload` does. Instead, it's up to the user to call the `hook.offload()` to offload it again.

Example:
```py
import torch
form accelerate import cpu_offload_with_hook

model = nn.Linear(4, 5)
model, hook = cpu_offload_with_hook(model)
print(model.weight.device) # Always cpu

outputs = model(inputs)
print(outputs.device) # Outputs are on GPU, execution was done on GPU
print(model.weight.device) # Stays on the GPU until hook.offload() is called

hook.offload()
print(model.weight.device) # Back to cpu
```

cc @pcuenca @patrickvonplaten 
