### PR TITLE
Use create_task when calling `_read_stream` during test_utils

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -338,8 +338,8 @@ async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=Fals
     # XXX: the timeout doesn't seem to make any difference here
     await asyncio.wait(
         [
-            _read_stream(p.stdout, lambda l: tee(l, out, sys.stdout, label="stdout:")),
-            _read_stream(p.stderr, lambda l: tee(l, err, sys.stderr, label="stderr:")),
+            asyncio.create_task(_read_stream(p.stdout, lambda l: tee(l, out, sys.stdout, label="stdout:"))),
+            asyncio.create_task(_read_stream(p.stderr, lambda l: tee(l, err, sys.stderr, label="stderr:"))),
         ],
         timeout=timeout,
     )


### PR DESCRIPTION
Gets rid of:

```
================================================================ warnings summary =================================================================
tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility
tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility
tests/test_cli.py::AccelerateLauncherTester::test_config_compatibility
tests/test_cli.py::AccelerateLauncherTester::test_no_config
  /home/zach/accelerate/accelerate/src/accelerate/test_utils/testing.py:339: DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.
    await asyncio.wait(
```
when running tests on py 3.9