### PR TITLE
Fix args failure by adding in the defaults

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -672,7 +672,11 @@ def multi_gpu_launcher(args):
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
 
     debug = getattr(args, "debug", False)
-    args = _filter_args(args, distrib_run.get_args_parser())
+    args = _filter_args(
+        args,
+        distrib_run.get_args_parser(),
+        ["--training_script", args.training_script, "--training_script_args", args.training_script_args],
+    )
     with patch_environment(**current_env):
         try:
             distrib_run.run(args)
@@ -798,7 +802,11 @@ def deepspeed_launcher(args):
             raise NotImplementedError("Multi-node training requires pytorch>=1.9.1")
 
         debug = getattr(args, "debug", False)
-        args = _filter_args(args, distrib_run.get_args_parser())
+        args = _filter_args(
+            args,
+            distrib_run.get_args_parser(),
+            ["--training_script", args.training_script, "--training_script_args", args.training_script_args],
+        )
         with patch_environment(**current_env):
             try:
                 distrib_run.run(args)

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -40,7 +40,6 @@ def _filter_args(args, parser, default_args=[]):
     Filters out all `accelerate` specific args
     """
     new_args, _ = parser.parse_known_args(default_args)
-
     for key, value in vars(args).items():
         if key in vars(new_args).keys():
             setattr(new_args, key, value)


### PR DESCRIPTION
The post-filtered GPU params to `launch` need to maintain the script and arg parameters. This PR adds them in. 

Running on the nightly-ci to be sure before merging