### PR TITLE
Introduce PartialState

### DIFF
--- a/docs/source/package_reference/state.mdx
+++ b/docs/source/package_reference/state.mdx
@@ -18,6 +18,8 @@ instances share the same state, which is initialized on the first instantiation.
 These classes are immutable and store information about certain configurations or 
 states.
 
+[[autodoc]] state.PartialState
+
 [[autodoc]] state.AcceleratorState
 
 [[autodoc]] state.GradientState

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -15,8 +15,7 @@
 import logging
 import os
 
-from .state import AcceleratorState
-from .utils import DistributedType
+from .state import PartialState
 
 
 class MultiProcessAdapter(logging.LoggerAdapter):
@@ -25,17 +24,15 @@ class MultiProcessAdapter(logging.LoggerAdapter):
 
     `log` takes in an additional `main_process_only` kwarg, which dictates whether it should be called on all processes
     or only the main executed one. Default is `main_process_only=True`.
+
+    Does not require an `Accelerator` object to be created first.
     """
 
     @staticmethod
     def _should_log(main_process_only):
         "Check if log should be performed"
-        state = AcceleratorState()
-        if state.distributed_type != DistributedType.MEGATRON_LM:
-            process_index_flag = state.local_process_index == 0
-        else:
-            process_index_flag = state.process_index == state.num_processes - 1
-        return not main_process_only or (main_process_only and process_index_flag)
+        state = PartialState()
+        return not main_process_only or (main_process_only and state.is_main_process)
 
     def log(self, level, msg, *args, **kwargs):
         """

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -73,6 +73,7 @@ class PartialState:
         self.__dict__ = self._shared_state
         self._check_initialized(cpu)
         if not self.initialized:
+            self.backend = None
             env_device = os.environ.get("ACCELERATE_TORCH_DEVICE", None)
             self.device = torch.device(env_device) if env_device is not None else None
             if (

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -74,8 +74,9 @@ class PartialState:
         # Raise an error if the user tries to reinitialize on a different device setup in the same launch
         if self.initialized and (self._cpu != cpu):
             raise AssertionError(
-                "You cannot reinitialize the state with a different device setup in the same script,"
-                "please launch the script again using the desired device setup."
+                "The current device and desired device are not the same. If the `PartialState` was generated "
+                "before the `AcceleratorState` has been made, ensure the `cpu` flag is the same for both. In this case, "
+                f"the `PartialState` has {self._cpu} and the desired device is {cpu}. Please use `cpu={self._cpu}`."
             )
         if not self.initialized:
             self._cpu = cpu

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -75,7 +75,7 @@ class PartialState:
         if self.initialized and (self._cpu != cpu):
             raise AssertionError(
                 "The current device and desired device are not the same. If the `PartialState` was generated "
-                "before the `AcceleratorState` has been made, ensure the `cpu` flag is the same for both. In this case, "
+                "before the `Accelerator` has been instantiated, ensure the `cpu` flag is the same for both. In this case, "
                 f"the `PartialState` has {self._cpu} and the desired device is {cpu}. Please use `cpu={self._cpu}`."
             )
         if not self.initialized:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -46,59 +46,35 @@ def is_initialized() -> bool:
 
 
 # Inspired by Alex Martelli's 'Borg'.
-class AcceleratorState:
+class PartialState:
     """
-    Singleton class that has information about the current training environment.
+    Singleton class that has information about the current training environment and functions to help with process
+    control. Designed to be used when only process control and device execution states are needed. Does *not* need to
+    be initialized from `Accelerator`.
 
     **Available attributes:**
 
         - **device** (`torch.device`) -- The device to use.
         - **distributed_type** ([`~accelerate.state.DistributedType`]) -- The type of distributed environment currently
           in use.
-        - **initialized** (`bool`) -- Whether or not the `AcceleratorState` has been initialized from `Accelerator`.
         - **local_process_index** (`int`) -- The index of the current process on the current server.
         - **mixed_precision** (`str`) -- Whether or not the current script will use mixed precision, and if so the type
           of mixed precision being performed.
         - **num_processes** (`int`) -- The number of processes currently launched in parallel.
         - **process_index** (`int`) -- The index of the current process.
+        - **is_last_process** (`bool`) -- Whether or not the current process is the last one.
+        - **is_main_process** (`bool`) -- Whether or not the current process is the main one.
+        - **is_local_main_process** (`bool`) -- Whether or not the current process is the main one on the local node.
     """
 
     _shared_state = {}
 
-    def __init__(
-        self,
-        mixed_precision: str = None,
-        cpu: bool = False,
-        dynamo_backend=None,
-        deepspeed_plugin=None,
-        fsdp_plugin=None,
-        megatron_lm_plugin=None,
-        _from_accelerator: bool = False,
-        **kwargs,
-    ):
+    def __init__(self, cpu: bool = False, **kwargs):
         self.__dict__ = self._shared_state
-        if parse_flag_from_env("ACCELERATE_USE_CPU"):
-            cpu = True
-        self._check_initialized(mixed_precision, cpu)
+        self._check_initialized(cpu)
         if not self.initialized:
-            self.backend = None
-            self.deepspeed_plugin = None
-            mixed_precision = (
-                parse_choice_from_env("ACCELERATE_MIXED_PRECISION", "no")
-                if mixed_precision is None
-                else mixed_precision.lower()
-            )
-            dynamo_backend = (
-                parse_choice_from_env("ACCELERATE_DYNAMO_BACKEND", "no") if dynamo_backend is None else dynamo_backend
-            )
             env_device = os.environ.get("ACCELERATE_TORCH_DEVICE", None)
-            self.device = torch.device(env_device) if env_device is not None else None
-            self.dynamo_backend = DynamoBackend(dynamo_backend.upper())
-            if not _from_accelerator:
-                raise ValueError(
-                    "Please make sure to properly initialize your accelerator via `accelerator = Accelerator()` "
-                    "before using any functionality from the `accelerate` library."
-                )
+            self.deivce = torch.device(env_device) if env_device is not None else None
             if (
                 os.environ.get("ACCELERATE_USE_SAGEMAKER", "false") == "true"
                 and os.environ.get("ACCELERATE_SAGEMAKER_DISTRIBUTED_TYPE") != SageMakerDistributedType.NO
@@ -117,23 +93,12 @@ class AcceleratorState:
                     if self.device is None:
                         self.device = torch.device("cuda", self.local_process_index)
                     torch.cuda.set_device(self.device)
-                    self._mixed_precision = mixed_precision
             elif is_tpu_available() and not cpu:
                 self.distributed_type = DistributedType.TPU
                 self.num_processes = xm.xrt_world_size()
                 self.process_index = xm.get_ordinal()
                 self.local_process_index = xm.get_local_ordinal()
                 self.device = xm.xla_device()
-                if mixed_precision == "bf16":
-                    if os.environ.get("ACCELERATE_DOWNCAST_BF16"):
-                        os.environ["XLA_USE_BF16"] = str(0)
-                        os.environ["XLA_DOWNCAST_BF16"] = str(1)
-                        self.downcast_bfloat = True
-                    else:
-                        os.environ["XLA_USE_BF16"] = str(1)
-                        os.environ["XLA_DOWNCAST_BF16"] = str(0)
-                        self.downcast_bfloat = False
-                self._mixed_precision = mixed_precision
             elif os.environ.get("ACCELERATE_USE_DEEPSPEED", "false") == "true" and not cpu:
                 assert (
                     is_deepspeed_available()
@@ -157,7 +122,6 @@ class AcceleratorState:
                     self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
                 self._mixed_precision = "no"  # deepspeed handles mixed_precision using deepspeed_config
-                self.deepspeed_plugin = deepspeed_plugin
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
@@ -169,16 +133,6 @@ class AcceleratorState:
                 if self.device is None:
                     self.device = torch.device("cuda", self.local_process_index)
                 torch.cuda.set_device(self.device)
-                self._mixed_precision = mixed_precision
-                if os.environ.get("ACCELERATE_USE_FSDP", "false") == "true":
-                    self.distributed_type = DistributedType.FSDP
-                    if self._mixed_precision != "no":
-                        fsdp_plugin.set_mixed_precision(self._mixed_precision)
-                    self.fsdp_plugin = fsdp_plugin
-                if os.environ.get("ACCELERATE_USE_MEGATRON_LM", "false") == "true":
-                    self.distributed_type = DistributedType.MEGATRON_LM
-                    megatron_lm_plugin.set_mixed_precision(self._mixed_precision)
-                    self.megatron_lm_plugin = megatron_lm_plugin
             elif get_int_from_env(["PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "WORLD_SIZE"], 1) > 1:
                 self.distributed_type = DistributedType.MULTI_CPU
                 if is_ccl_available() and get_int_from_env(["CCL_WORKER_COUNT"], 0) > 0:
@@ -220,7 +174,6 @@ class AcceleratorState:
                 self.local_process_index = local_rank
                 if self.device is None:
                     self.device = torch.device("cpu")
-                self._mixed_precision = mixed_precision
             else:
                 self.distributed_type = DistributedType.NO
                 self.num_processes = 1
@@ -251,71 +204,37 @@ class AcceleratorState:
                         self.device = torch.device("mps")
                     else:
                         self.device = torch.device("cuda")
-                self._mixed_precision = mixed_precision
-
-            if (
-                self.dynamo_backend != DynamoBackend.NO
-                and self._mixed_precision == "no"
-                and self.device.type == "cuda"
-            ):
-                torch.backends.cuda.matmul.allow_tf32 = True
-
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
-    def __repr__(self):
-        repr = (
+    def __repr__(self) -> str:
+        return (
             f"Distributed environment: {self.distributed_type}{('  Backend: ' + self.backend) if self.backend else ''}\n"
             f"Num processes: {self.num_processes}\n"
             f"Process index: {self.process_index}\n"
             f"Local process index: {self.local_process_index}\n"
             f"Device: {self.device}\n"
-            f"Mixed precision type: {self.mixed_precision}\n"
         )
-        if self.distributed_type == DistributedType.DEEPSPEED:
-            repr += f"ds_config: {self.deepspeed_plugin.deepspeed_config}\n"
-        return repr
-
-    # For backward compatibility
-    @property
-    def use_fp16(self):
-        return self._mixed_precision != "no"
-
-    @property
-    def mixed_precision(self):
-        if self.distributed_type == DistributedType.DEEPSPEED:
-            config = self.deepspeed_plugin.deepspeed_config
-            if config.get("fp16", {}).get("enabled", False):
-                mixed_precision = "fp16"
-            elif config.get("bf16", {}).get("enabled", False):
-                mixed_precision = "bf16"
-            else:
-                mixed_precision = "no"
-        else:
-            mixed_precision = self._mixed_precision
-        return mixed_precision
 
     @staticmethod
     def _reset_state():
         "Resets `_shared_state`, is used internally and should not be called"
-        AcceleratorState._shared_state = {}
+        PartialState._shared_state = {}
 
     @property
     def initialized(self) -> bool:
-        "Returns whether the `AcceleratorState` has been initialized"
+        "Returns whether the `PartialState` has been initialized"
         return self._shared_state != {}
 
-    def _check_initialized(self, mixed_precision=None, cpu=None):
-        "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"
+    def _check_initialized(self, cpu=None):
+        "Checks if a modification is trying to be made and the `PartialState` has already been initialized"
         if self.initialized:
-            err = "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `{flag}` to `Accelerate()`."
+            err = "PartialState has already been initialized and cannot be changed, restart your runtime completely and pass `{flag}` to `PartialState()`."
             if cpu and self.device.type != "cpu":
                 raise ValueError(err.format(flag="cpu=True"))
-            if mixed_precision is not None and mixed_precision != self._mixed_precision:
-                raise ValueError(err.format(flag=f"mixed_precision='{mixed_precision}'"))
 
     @property
     def is_last_process(self) -> bool:
-        "Returns whether the current process is the last process"
+        "Returns whether the current process is the last one"
         return self.process_index == self.num_processes - 1
 
     @property
@@ -375,6 +294,129 @@ class AcceleratorState:
     def print(self, *args, **kwargs):
         if self.is_local_main_process:
             print(*args, **kwargs)
+
+
+class AcceleratorState(PartialState):
+    """
+    Singleton class that has information about the current training environment.
+
+    **Available attributes:**
+
+        - **device** (`torch.device`) -- The device to use.
+        - **distributed_type** ([`~accelerate.state.DistributedType`]) -- The type of distributed environment currently
+          in use.
+        - **initialized** (`bool`) -- Whether or not the `AcceleratorState` has been initialized from `Accelerator`.
+        - **local_process_index** (`int`) -- The index of the current process on the current server.
+        - **mixed_precision** (`str`) -- Whether or not the current script will use mixed precision, and if so the type
+          of mixed precision being performed.
+        - **num_processes** (`int`) -- The number of processes currently launched in parallel.
+        - **process_index** (`int`) -- The index of the current process.
+        - **is_last_process** (`bool`) -- Whether or not the current process is the last one.
+        - **is_main_process** (`bool`) -- Whether or not the current process is the main one.
+        - **is_local_main_process** (`bool`) -- Whether or not the current process is the main one on the local node.
+    """
+
+    def __init__(
+        self,
+        mixed_precision: str = None,
+        cpu: bool = False,
+        dynamo_backend=None,
+        deepspeed_plugin=None,
+        fsdp_plugin=None,
+        megatron_lm_plugin=None,
+        _from_accelerator: bool = False,
+        **kwargs,
+    ):
+        super().__init__(cpu, **kwargs)
+        self._check_initialized(mixed_precision, cpu)
+        if not self.initialized:
+            self.backend = None
+            self.deepspeed_plugin = None
+            mixed_precision = (
+                parse_choice_from_env("ACCELERATE_MIXED_PRECISION", "no")
+                if mixed_precision is None
+                else mixed_precision.lower()
+            )
+            dynamo_backend = (
+                parse_choice_from_env("ACCELERATE_DYNAMO_BACKEND", "no") if dynamo_backend is None else dynamo_backend
+            )
+            self.dynamo_backend = DynamoBackend(dynamo_backend.upper())
+            if not _from_accelerator:
+                raise ValueError(
+                    "Please make sure to properly initialize your accelerator via `accelerator = Accelerator()` "
+                    "before using any functionality from the `accelerate` library."
+                )
+            # deepspeed handles mixed_precision using deepspeed_config
+            self._mixed_precision = "no" if self.distributed_type == DistributedType.DEEPSPEED else mixed_precision
+            if self.distributed_type == DistributedType.TPU:
+                if mixed_precision == "bf16":
+                    if os.environ.get("ACCELERATE_DOWNCAST_BF16"):
+                        os.environ["XLA_USE_BF16"] = str(0)
+                        os.environ["XLA_DOWNCAST_BF16"] = str(1)
+                        self.downcast_bfloat = True
+                    else:
+                        os.environ["XLA_USE_BF16"] = str(1)
+                        os.environ["XLA_DOWNCAST_BF16"] = str(0)
+                        self.downcast_bfloat = False
+            elif self.distributed_type == DistributedType.DEEPSPEED:
+                self.deepspeed_plugin = deepspeed_plugin
+            elif self.distributed_type == DistributedType.MULTI_GPU:
+                if os.environ.get("ACCELERATE_USE_FSDP", "false") == "true":
+                    self.distributed_type = DistributedType.FSDP
+                    if self._mixed_precision != "no":
+                        fsdp_plugin.set_mixed_precision(self._mixed_precision)
+                    self.fsdp_plugin = fsdp_plugin
+                if os.environ.get("ACCELERATE_USE_MEGATRON_LM", "false") == "true":
+                    self.distributed_type = DistributedType.MEGATRON_LM
+                    megatron_lm_plugin.set_mixed_precision(self._mixed_precision)
+                    self.megatron_lm_plugin = megatron_lm_plugin
+            if (
+                self.dynamo_backend != DynamoBackend.NO
+                and self._mixed_precision == "no"
+                and self.device.type == "cuda"
+            ):
+                torch.backends.cuda.matmul.allow_tf32 = True
+
+    @property
+    def initialized(self) -> bool:
+        return super().initialized and getattr(self, "_mixed_precision", None) is not None
+
+    def __repr__(self):
+        repr = (super().__repr__(), f"Mixed precision type: {self.mixed_precision}\n")
+        if self.distributed_type == DistributedType.DEEPSPEED:
+            repr += f"ds_config: {self.deepspeed_plugin.deepspeed_config}\n"
+        return repr
+
+    def _check_initialized(self, mixed_precision=None, cpu=None):
+        "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"
+        if self.initialized:
+            err = "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `{flag}` to `Accelerator()`."
+            if mixed_precision is not None and mixed_precision != self._mixed_precision:
+                raise ValueError(err.format(flag=f"mixed_precision='{mixed_precision}'"))
+
+    # For backward compatibility
+    @property
+    def use_fp16(self):
+        return self._mixed_precision != "no"
+
+    @property
+    def mixed_precision(self):
+        if self.distributed_type == DistributedType.DEEPSPEED:
+            config = self.deepspeed_plugin.deepspeed_config
+            if config.get("fp16", {}).get("enabled", False):
+                mixed_precision = "fp16"
+            elif config.get("bf16", {}).get("enabled", False):
+                mixed_precision = "bf16"
+            else:
+                mixed_precision = "no"
+        else:
+            mixed_precision = self._mixed_precision
+        return mixed_precision
+
+    @staticmethod
+    def _reset_state():
+        "Resets `_shared_state`, is used internally and should not be called"
+        AcceleratorState._shared_state = {}
 
 
 class GradientState:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -420,10 +420,9 @@ class AcceleratorState:
         return mixed_precision
 
     @staticmethod
-    def _reset_state():
+    def _reset_state(with_partial=True):
         "Resets `_shared_state`, is used internally and should not be called"
         AcceleratorState._shared_state = {}
-        PartialState._shared_state = {}
 
     @property
     def is_last_process(self) -> bool:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -219,7 +219,7 @@ class PartialState:
     def _reset_state():
         "Resets `_shared_state`, is used internally and should not be called"
         PartialState._shared_state = {}
-    # This is a test commit
+
     @property
     def initialized(self) -> bool:
         "Returns whether the `PartialState` has been initialized"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -71,10 +71,12 @@ class PartialState:
 
     def __init__(self, cpu: bool = False, **kwargs):
         self.__dict__ = self._shared_state
-        # Override the existing intialization if the user chooses a different CPU setting.
+        # Raise an error if the user tries to reinitialize on a different device setup in the same launch
         if self.initialized and (self._cpu != cpu):
-            # Needs to happen in this object, can't be done via staticmethod
-            self._shared_state = {}
+            raise AssertionError(
+                "You cannot reinitialize the state with a different device setup in the same script,"
+                "please launch the script again using the desired device setup."
+            )
         if not self.initialized:
             self._cpu = cpu
             self.backend = None

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -219,7 +219,7 @@ class PartialState:
     def _reset_state():
         "Resets `_shared_state`, is used internally and should not be called"
         PartialState._shared_state = {}
-
+    # This is a test commit
     @property
     def initialized(self) -> bool:
         "Returns whether the `PartialState` has been initialized"

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import os
 from copy import deepcopy
 
 import datasets
@@ -26,6 +27,9 @@ from transformers import AutoModelForSequenceClassification, AutoTokenizer
 from accelerate import Accelerator
 from accelerate.test_utils import RegressionDataset, RegressionModel
 from accelerate.utils import is_tpu_available, set_seed
+
+
+os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "true"
 
 
 def get_basic_setup(accelerator, num_samples=82, batch_size=16):

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -19,7 +19,7 @@ from torch.utils.data import DataLoader
 
 from accelerate import Accelerator
 from accelerate.data_loader import prepare_data_loader
-from accelerate.state import AcceleratorState, PartialState
+from accelerate.state import AcceleratorState
 from accelerate.test_utils import RegressionDataset, RegressionModel, are_the_same_tensors
 from accelerate.utils import (
     DistributedType,
@@ -33,20 +33,11 @@ from accelerate.utils import (
 
 def process_execution_check():
     # Test that printing on a single process works
-    # First from the `PartialState`
-    partial_state = PartialState()
-    with partial_state.main_process_first():
-        idx = torch.tensor(partial_state.process_index).to(partial_state.device)
-    idxs = gather(idx)
-    assert idxs[0] == 0, "Main process was not first when using `PartialState`."
-    partial_state._reset_state()
-
-    # Then on the `AcceleratorState`
     accelerator = Accelerator()
     with accelerator.main_process_first():
         idx = torch.tensor(accelerator.process_index).to(accelerator.device)
     idxs = accelerator.gather(idx)
-    assert idxs[0] == 0, "Main process was not first when using `AcceleratorState`."
+    assert idxs[0] == 0, "Main process was not first."
 
 
 def init_state_check():

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -27,7 +27,7 @@ from unittest import mock
 
 import torch
 
-from ..state import AcceleratorState
+from ..state import AcceleratorState, PartialState
 from ..utils import (
     gather,
     is_comet_ml_available,
@@ -243,6 +243,7 @@ class AccelerateTestCase(unittest.TestCase):
         super().tearDown()
         # Reset the state of the AcceleratorState singleton.
         AcceleratorState._reset_state()
+        PartialState._reset_state()
 
 
 class MockingTestCase(unittest.TestCase):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -7,7 +7,8 @@ import torch
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate.accelerator import Accelerator
-from accelerate.test_utils.testing import AccelerateTestCase
+from accelerate.state import PartialState
+from accelerate.test_utils.testing import AccelerateTestCase, require_cuda
 from accelerate.utils import patch_environment
 
 
@@ -31,6 +32,15 @@ def load_random_weights(model):
 
 
 class AcceleratorTester(AccelerateTestCase):
+    @require_cuda
+    def test_accelerator_can_be_reinstantiated(self):
+        _ = Accelerator()
+        assert PartialState._shared_state["_cpu"] is False
+        assert PartialState._shared_state["device"].type == "cuda"
+        _ = Accelerator(cpu=True)
+        assert PartialState._shared_state["_cpu"] is True
+        assert PartialState._shared_state["device"].type == "cpu"
+
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -37,9 +37,8 @@ class AcceleratorTester(AccelerateTestCase):
         _ = Accelerator()
         assert PartialState._shared_state["_cpu"] is False
         assert PartialState._shared_state["device"].type == "cuda"
-        _ = Accelerator(cpu=True)
-        assert PartialState._shared_state["_cpu"] is True
-        assert PartialState._shared_state["device"].type == "cpu"
+        with self.assertRaises(AssertionError):
+            _ = Accelerator(cpu=True)
 
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -18,6 +18,7 @@ from functools import partial
 import torch
 
 from accelerate import Accelerator, debug_launcher
+from accelerate.state import AcceleratorState
 from accelerate.test_utils import require_cpu
 
 
@@ -82,15 +83,19 @@ class SchedulerTester(unittest.TestCase):
         debug_launcher(partial(one_cycle_test, num_processes=1, step_scheduler_with_optimizer=False), num_processes=1)
 
     def test_lambda_scheduler_steps_with_optimizer_multiprocess(self):
+        AcceleratorState._reset_state(True)
         debug_launcher(lambda_test)
         debug_launcher(partial(lambda_test, num_processes=1, split_batches=True), num_processes=1)
 
     def test_one_cycle_scheduler_steps_with_optimizer_multiprocess(self):
+        AcceleratorState._reset_state(True)
         debug_launcher(one_cycle_test)
         debug_launcher(partial(one_cycle_test, num_processes=1, split_batches=True), num_processes=1)
 
     def test_lambda_scheduler_not_step_with_optimizer_multiprocess(self):
+        AcceleratorState._reset_state(True)
         debug_launcher(partial(lambda_test, step_scheduler_with_optimizer=False))
 
     def test_one_cycle_scheduler_not_step_with_optimizer_multiprocess(self):
+        AcceleratorState._reset_state(True)
         debug_launcher(partial(one_cycle_test, step_scheduler_with_optimizer=False))


### PR DESCRIPTION
This PR introduces a `PartialState` class, which allows for process control while being *fully disconnected* from the `Accelerator` class. This allows users to utilize `print`, `on_main_process`, and more on their library integrations without needing to create an `Accelerator` object, and leave that to the user to create themselves. 

The `AcceleratorState` class does not inherit from this class, as otherwise the `__dict__`'s would be the same for `PartialState` and `AcceleratorState`, which we don't want. So it's referenced instead without explicit inheritance with passthroughs. 