### PR TITLE
update fsdp docs and removing deepspeed version pinning

### DIFF
--- a/docs/source/usage_guides/fsdp.mdx
+++ b/docs/source/usage_guides/fsdp.mdx
@@ -79,11 +79,11 @@ Currently, `Accelerate` supports the following config through the CLI:
   Below is an example:
 
 ```diff
-unwrapped_model.save_pretrained(
-    args.output_dir,
-    is_main_process=accelerator.is_main_process,
-    save_function=accelerator.save,
-+   state_dict=accelerator.get_state_dict(model),
+  unwrapped_model.save_pretrained(
+      args.output_dir,
+      is_main_process=accelerator.is_main_process,
+      save_function=accelerator.save,
++     state_dict=accelerator.get_state_dict(model),
 )
 ```
 

--- a/docs/source/usage_guides/fsdp.mdx
+++ b/docs/source/usage_guides/fsdp.mdx
@@ -73,6 +73,20 @@ Currently, `Accelerate` supports the following config through the CLI:
 `State Dict Type`: [1] FULL_STATE_DICT, [2] LOCAL_STATE_DICT, [3] SHARDED_STATE_DICT  
 ```
 
+## Saving and loading
+
+1. When using transformers `save_pretrained`, pass `state_dict=accelerator.get_state_dict(model)` to save the model state dict. 
+  Below is an example:
+
+```diff
+unwrapped_model.save_pretrained(
+    args.output_dir,
+    is_main_process=accelerator.is_main_process,
+    save_function=accelerator.save,
++   state_dict=accelerator.get_state_dict(model),
+)
+```
+
 ## A few caveats to be aware of
 
 - PyTorch FSDP auto wraps sub-modules, flattens the parameters and shards the parameters in place.

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras = {}
 extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
-extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed<0.7.0", "tqdm"]
+extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm"]
 extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["rich"] = ["rich"]
 


### PR DESCRIPTION
### What does this PR do?
1. Adds docs on correct way to save FSDP models as per the resolution of issue #1054 
2. Removes deepspeed version pinning