### PR TITLE
Flag use_fp16 for deprecation in 1.0

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -463,6 +463,11 @@ class Accelerator:
 
     @property
     def use_fp16(self):
+        warnings.warn(
+            "The `use_fp16` property is deprecated and will be removed in version 1.0 of Accelerate use "
+            "`Accelerator.mixed_precision == 'fp16'` instead.",
+            FutureWarning,
+        )
         return self.mixed_precision != "no"
 
     @property
@@ -1447,7 +1452,7 @@ class Accelerator:
         >>> accelerator.unscale_gradients(optimizer=optimizer)
         ```
         """
-        if self.use_fp16 and self.native_amp:
+        if self.native_amp and self.mixed_precision == "fp16":
             if optimizer is None:
                 # TODO: this unscales all optimizers where we should only unscale the one where parameters are.
                 optimizer = self._optimizers

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -278,6 +278,11 @@ class AcceleratorState:
     # For backward compatibility
     @property
     def use_fp16(self):
+        warnings.warn(
+            "The `use_fp16` property is deprecated and will be removed in version 1.0 of Accelerate use "
+            "`AcceleratorState.mixed_precision == 'fp16'` instead.",
+            FutureWarning,
+        )
         return self._mixed_precision != "no"
 
     @property


### PR DESCRIPTION
As discussed in https://huggingface.slack.com/archives/C01Q6JPP6NA/p1676299264125009, flags `use_fp16` for deprecation once v1.0.0 of Accelerate is released. 