### PR TITLE
Fix failed deepspeed tests with proper reset of state

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -238,7 +238,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 
     @parameterized.expand([FP16, BF16], name_func=parameterized_custom_name_func)
     def test_accelerate_state_deepspeed(self, dtype):
-        AcceleratorState._reset_state()
+        AcceleratorState._reset_state(True)
         deepspeed_plugin = DeepSpeedPlugin(
             gradient_accumulation_steps=1,
             gradient_clipping=1.0,
@@ -622,7 +622,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             )
             self.assertTrue(deepspeed_plugin.deepspeed_config[dtype]["enabled"])
 
-        AcceleratorState._reset_state()
+        AcceleratorState._reset_state(True)
         diff_dtype = "bf16" if dtype == "fp16" else "fp16"
         with mockenv_context(**self.dist_env):
             with self.assertRaises(ValueError) as cm:

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -156,7 +156,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
                     self.assertTrue(isinstance(accelerator.scaler, ShardedGradScaler))
                 elif mp_dtype == BF16:
                     self.assertIsNone(accelerator.scaler)
-                AcceleratorState._reset_state()
+                AcceleratorState._reset_state(True)
 
     def test_cpu_offload(self):
         from torch.distributed.fsdp.fully_sharded_data_parallel import CPUOffload


### PR DESCRIPTION
Same comment as before, `reset_state` needs `True` to reset the `PartialState` for these tests. Ran locally on two GPUs to prove it fixes the failures. 