### PR TITLE
Swap utils over to use PartialState

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -23,7 +23,7 @@ from typing import Any, Mapping
 import torch
 from torch.distributed import ReduceOp
 
-from ..state import AcceleratorState
+from ..state import PartialState
 from .constants import CUDA_DISTRIBUTED_TYPES
 from .dataclasses import DistributedType, TensorInformation
 from .imports import is_tpu_available
@@ -219,11 +219,11 @@ def gather(tensor):
     Returns:
         The same data structure as `tensor` with all tensors sent to the proper device.
     """
-    if AcceleratorState().distributed_type == DistributedType.TPU:
+    if PartialState().distributed_type == DistributedType.TPU:
         return _tpu_gather(tensor, name="accelerate.utils.gather")
-    elif AcceleratorState().distributed_type in CUDA_DISTRIBUTED_TYPES:
+    elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
         return _gpu_gather(tensor)
-    elif AcceleratorState().distributed_type == DistributedType.MULTI_CPU:
+    elif PartialState().distributed_type == DistributedType.MULTI_CPU:
         return _cpu_gather(tensor)
     else:
         return tensor
@@ -231,7 +231,7 @@ def gather(tensor):
 
 def _gpu_gather_object(object: Any):
     def _gpu_gather_object_one(object: Any):
-        output_objects = [None for _ in range(AcceleratorState().num_processes)]
+        output_objects = [None for _ in range(PartialState().num_processes)]
         torch.distributed.all_gather_object(output_objects, object)
         return output_objects
 
@@ -252,11 +252,11 @@ def gather_object(object: Any):
     Returns:
         The same data structure as `object` with all the objects sent to every device.
     """
-    if AcceleratorState().distributed_type == DistributedType.TPU:
+    if PartialState().distributed_type == DistributedType.TPU:
         raise NotImplementedError("gather objects in TPU is not supported")
-    elif AcceleratorState().distributed_type in CUDA_DISTRIBUTED_TYPES:
+    elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
         return _gpu_gather_object(object)
-    elif AcceleratorState().distributed_type == DistributedType.MULTI_CPU:
+    elif PartialState().distributed_type == DistributedType.MULTI_CPU:
         return _cpu_gather_object(object)
     else:
         return object
@@ -291,11 +291,11 @@ def broadcast(tensor, from_process: int = 0):
     Returns:
         The same data structure as `tensor` with all tensors broadcasted to the proper device.
     """
-    if AcceleratorState().distributed_type == DistributedType.TPU:
+    if PartialState().distributed_type == DistributedType.TPU:
         return _tpu_broadcast(tensor, src=from_process, name="accelerate.utils.broadcast")
-    elif AcceleratorState().distributed_type in CUDA_DISTRIBUTED_TYPES:
+    elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
         return _gpu_broadcast(tensor, src=from_process)
-    elif AcceleratorState().distributed_type == DistributedType.MULTI_CPU:
+    elif PartialState().distributed_type == DistributedType.MULTI_CPU:
         return _gpu_broadcast(tensor, src=from_process)
     else:
         return tensor
@@ -314,12 +314,12 @@ def broadcast_object_list(object_list, from_process: int = 0):
     Returns:
         The same list containing the objects from process 0.
     """
-    if AcceleratorState().distributed_type == DistributedType.TPU:
+    if PartialState().distributed_type == DistributedType.TPU:
         for i, obj in enumerate(object_list):
             object_list[i] = xm.mesh_reduce("accelerate.utils.broadcast_object_list", obj, lambda x: x[from_process])
-    elif AcceleratorState().distributed_type in CUDA_DISTRIBUTED_TYPES:
+    elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
         torch.distributed.broadcast_object_list(object_list, src=from_process)
-    elif AcceleratorState().distributed_type == DistributedType.MULTI_CPU:
+    elif PartialState().distributed_type == DistributedType.MULTI_CPU:
         torch.distributed.broadcast_object_list(object_list, src=from_process)
     return object_list
 
@@ -428,7 +428,7 @@ def reduce(tensor, reduction="mean"):
     """
 
     def _reduce_across_processes(tensor, reduction="mean"):
-        state = AcceleratorState()
+        state = PartialState()
         cloned_tensor = tensor.clone()
         if state.distributed_type == DistributedType.TPU:
             xm.all_reduce("sum", cloned_tensor)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -18,7 +18,7 @@ from contextlib import contextmanager
 import torch
 
 from ..commands.config.default import write_basic_config  # noqa: F401
-from ..state import AcceleratorState
+from ..state import PartialState
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
 
@@ -72,7 +72,7 @@ def wait_for_everyone():
 
     </Tip>
     """
-    AcceleratorState().wait_for_everyone()
+    PartialState().wait_for_everyone()
 
 
 def save(obj, f):
@@ -83,9 +83,9 @@ def save(obj, f):
         obj: The data to save
         f: The file (or file-like object) to use to save the data
     """
-    if AcceleratorState().distributed_type == DistributedType.TPU:
+    if PartialState().distributed_type == DistributedType.TPU:
         xm.save(obj, f)
-    elif AcceleratorState().local_process_index == 0:
+    elif PartialState().local_process_index == 0:
         torch.save(obj, f)
 
 

--- a/src/accelerate/utils/tqdm.py
+++ b/src/accelerate/utils/tqdm.py
@@ -18,7 +18,7 @@ from .imports import is_tqdm_available
 if is_tqdm_available():
     import tqdm.auto as _tqdm
 
-from ..state import AcceleratorState
+from ..state import PartialState
 
 
 def tqdm(main_process_only: bool = True, *args, **kwargs):
@@ -33,5 +33,5 @@ def tqdm(main_process_only: bool = True, *args, **kwargs):
         raise ImportError("Accelerate's `tqdm` module requires `tqdm` to be installed. Please run `pip install tqdm`.")
     disable = False
     if main_process_only:
-        disable = AcceleratorState().local_process_index == 0
+        disable = PartialState().local_process_index == 0
     return _tqdm(*args, **kwargs, disable=disable)


### PR DESCRIPTION
Swaps over any utils that do not directly relate to the `Accelerator` object to use the `PartialState` instead (so utils on the optimizer, dataloader, etc all remain the same because they directly work with `accelerator.prepare`)