### PR TITLE
Fix process decorators and make them more flexible

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -25,13 +25,12 @@ from typing import Any, Callable, List, Optional, Union
 import torch
 import torch.utils.hooks as hooks
 
-from . import state
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_batches
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
-from .state import AcceleratorState, GradientState, PartialState, parse_flag_from_env
+from .state import AcceleratorState, GradientState, parse_flag_from_env
 from .tracking import LOGGER_TYPE_TO_CLASS, GeneralTracker, filter_trackers
 from .utils import (
     MODEL_NAME,
@@ -67,6 +66,7 @@ from .utils import (
     wait_for_everyone,
 )
 
+from . import state
 
 if is_deepspeed_available():
     import deepspeed
@@ -508,7 +508,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_main_process(function)
+        return state.PartialState().on_main_process(function)
 
     @staticmethod
     def on_local_main_process(function: Callable[..., Any]):
@@ -543,7 +543,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_local_main_process(function)
+        return state.PartialState().on_local_main_process(function)
 
     @staticmethod
     def on_last_process(function: Callable[..., Any]):
@@ -575,7 +575,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_last_process(function)
+        return state.PartialState().on_last_process(function)
 
     @staticmethod
     def on_process(function: Callable[..., Any] = None, process_index: int = None):
@@ -610,7 +610,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_process(function, process_index)
+        return state.PartialState().on_process(function, process_index)
 
     @staticmethod
     def on_local_process(function: Callable[..., Any] = None, local_process_index: int = None):
@@ -648,7 +648,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_local_process(function, local_process_index)
+        return state.PartialState().on_local_process(function, local_process_index)
 
     @staticmethod
     @contextmanager
@@ -676,7 +676,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield PartialState().main_process_first()
+        yield state.PartialState().main_process_first()
 
     @staticmethod
     @contextmanager
@@ -704,7 +704,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield PartialState().local_main_process_first()
+        yield state.PartialState().local_main_process_first()
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -510,8 +510,7 @@ class Accelerator:
             )
         return state.PartialState().on_main_process(function)
 
-    @staticmethod
-    def on_local_main_process(function: Callable[..., Any]):
+    def on_local_main_process(self, function: Callable[..., Any]):
         """
         A decorator that will run the decorated function on the local main process only. Can also be called using the
         `PartialState` class.
@@ -543,10 +542,9 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_local_main_process(function)
+        return self.state.on_local_main_process(function)
 
-    @staticmethod
-    def on_last_process(function: Callable[..., Any]):
+    def on_last_process(self, function: Callable[..., Any]):
         """
         A decorator that will run the decorated function on the last process only. Can also be called using the
         `PartialState` class.
@@ -575,10 +573,9 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_last_process(function)
+        return self.state.on_last_process(function)
 
-    @staticmethod
-    def on_process(function: Callable[..., Any] = None, process_index: int = None):
+    def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
         """
         A decorator that will run the decorated function on a given process index only. Can also be called using the
         `PartialState` class.
@@ -610,10 +607,9 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_process(function, process_index)
+        return self.state.on_process(function, process_index)
 
-    @staticmethod
-    def on_local_process(function: Callable[..., Any] = None, local_process_index: int = None):
+    def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
         """
         A decorator that will run the decorated function on a given local process index only. Can also be called using
         the `PartialState` class.
@@ -648,11 +644,10 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_local_process(function, local_process_index)
+        return self.state.on_local_process(function, local_process_index)
 
-    @staticmethod
     @contextmanager
-    def main_process_first():
+    def main_process_first(self):
         """
         Lets the main process go first inside a with block.
 
@@ -676,11 +671,10 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield state.PartialState().main_process_first()
+        yield self.state.main_process_first()
 
-    @staticmethod
     @contextmanager
-    def local_main_process_first():
+    def local_main_process_first(self):
         """
         Lets the local main process go inside a with block.
 
@@ -704,7 +698,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield state.PartialState().local_main_process_first()
+        yield self.state.local_main_process_first()
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -478,8 +478,8 @@ class Accelerator:
     def mixed_precision(self):
         return self.state.mixed_precision
 
-    @staticmethod
-    def on_main_process(function: Callable[..., Any]):
+    @classmethod
+    def on_main_process(cls, function: Callable[..., Any]):
         """
         A decorator that will run the decorated function on the main process only. Can also be called using the
         `PartialState` class.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+from functools import partial
 import math
 import os
 import shutil
@@ -615,6 +616,10 @@ class Accelerator:
                 function = self
             else:
                 raise ValueError("The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object.")
+        
+        if (function is None) and (process_index is not None):
+            return partial(self.on_process, function=function)
+        
         return PartialState().on_process(function, process_index)
 
     def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
@@ -654,6 +659,10 @@ class Accelerator:
                 function = self
             else:
                 raise ValueError("The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object.")
+        
+        if (function is None) and (local_process_index is not None):
+            return partial(self.on_process, function=function)
+        
         return PartialState().on_local_process(function, local_process_index)
 
     @contextmanager

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -31,7 +31,7 @@ from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_b
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
-from .state import AcceleratorState, GradientState, parse_flag_from_env
+from .state import AcceleratorState, GradientState, PartialState, parse_flag_from_env
 from .tracking import LOGGER_TYPE_TO_CLASS, GeneralTracker, filter_trackers
 from .utils import (
     MODEL_NAME,
@@ -508,7 +508,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_main_process(function)
+        return PartialState().on_main_process(function)
 
     @staticmethod
     def on_local_main_process(function: Callable[..., Any]):
@@ -543,7 +543,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_local_main_process(function)
+        return PartialState().on_local_main_process(function)
 
     @staticmethod
     def on_last_process(function: Callable[..., Any]):
@@ -575,7 +575,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_last_process(function)
+        return PartialState().on_last_process(function)
 
     @staticmethod
     def on_process(function: Callable[..., Any] = None, process_index: int = None):
@@ -610,7 +610,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_process(function, process_index)
+        return PartialState().on_process(function, process_index)
 
     @staticmethod
     def on_local_process(function: Callable[..., Any] = None, local_process_index: int = None):
@@ -648,7 +648,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_local_process(function, local_process_index)
+        return PartialState().on_local_process(function, local_process_index)
 
     @staticmethod
     @contextmanager
@@ -676,7 +676,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield state.PartialState().main_process_first()
+        yield PartialState().main_process_first()
 
     @staticmethod
     @contextmanager
@@ -704,7 +704,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield state.PartialState().local_main_process_first()
+        yield PartialState().local_main_process_first()
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -31,7 +31,7 @@ from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_b
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
-from .state import AcceleratorState, GradientState, PartialState, parse_flag_from_env
+from .state import AcceleratorState, GradientState, parse_flag_from_env
 from .tracking import LOGGER_TYPE_TO_CLASS, GeneralTracker, filter_trackers
 from .utils import (
     MODEL_NAME,
@@ -508,7 +508,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_main_process(function)
+        return state.PartialState().on_main_process(function)
 
     @staticmethod
     def on_local_main_process(function: Callable[..., Any]):
@@ -543,7 +543,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_local_main_process(function)
+        return state.PartialState().on_local_main_process(function)
 
     @staticmethod
     def on_last_process(function: Callable[..., Any]):
@@ -575,7 +575,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_last_process(function)
+        return state.PartialState().on_last_process(function)
 
     @staticmethod
     def on_process(function: Callable[..., Any] = None, process_index: int = None):
@@ -610,7 +610,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_process(function, process_index)
+        return state.PartialState().on_process(function, process_index)
 
     @staticmethod
     def on_local_process(function: Callable[..., Any] = None, local_process_index: int = None):
@@ -648,7 +648,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return PartialState().on_local_process(function, local_process_index)
+        return state.PartialState().on_local_process(function, local_process_index)
 
     @staticmethod
     @contextmanager
@@ -676,7 +676,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield PartialState().main_process_first()
+        yield state.PartialState().main_process_first()
 
     @staticmethod
     @contextmanager
@@ -704,7 +704,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        yield PartialState().local_main_process_first()
+        yield state.PartialState().local_main_process_first()
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -31,7 +31,7 @@ from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_b
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
-from .state import AcceleratorState, GradientState, PartialState, parse_flag_from_env
+from .state import AcceleratorState, GradientState, PartialState, is_initialized, parse_flag_from_env
 from .tracking import LOGGER_TYPE_TO_CLASS, GeneralTracker, filter_trackers
 from .utils import (
     MODEL_NAME,
@@ -66,6 +66,7 @@ from .utils import (
     save,
     wait_for_everyone,
 )
+
 
 if is_deepspeed_available():
     import deepspeed
@@ -694,7 +695,8 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.process_index}")
         ```
         """
-        if not (PartialState._shared_state != {}):
+        # Check that the state is initialized.
+        if not is_initialized():
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
@@ -721,7 +723,8 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.local_process_index}")
         ```
         """
-        if not (PartialState._shared_state != {}):
+        # Check that the state is initialized.
+        if not is_initialized():
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1857,7 +1857,7 @@ class Accelerator:
         """
         wait_for_everyone()
 
-    # @on_main_process
+    @on_main_process
     def init_trackers(self, project_name: str, config: Optional[dict] = None, init_kwargs: Optional[dict] = {}):
         """
         Initializes a run for all trackers stored in `self.log_with`, potentially with starting configurations
@@ -1905,7 +1905,7 @@ class Accelerator:
             for tracker in self.trackers:
                 tracker.store_init_configuration(config)
 
-    # @on_main_process
+    @on_main_process
     def get_tracker(self, name: str):
         """
         Returns a `tracker` from `self.trackers` based on `name` on the main process only.
@@ -1932,7 +1932,7 @@ class Accelerator:
                 return tracker.tracker
         raise ValueError(f"{name} is not an available tracker stored inside the `Accelerator`.")
 
-    # @on_main_process
+    @on_main_process
     def log(self, values: dict, step: Optional[int] = None, log_kwargs: Optional[dict] = {}):
         """
         Logs `values` to all stored trackers in `self.trackers` on the main process only.
@@ -1962,7 +1962,7 @@ class Accelerator:
         for tracker in self.trackers:
             tracker.log(values, step=step, **log_kwargs.get(tracker.name, {}))
 
-    # @on_main_process
+    @on_main_process
     def end_training(self):
         """
         Runs any special end training behaviors, such as stopping trackers on the main process only. Should always be

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -26,7 +26,6 @@ from typing import Any, Callable, List, Optional, Union
 import torch
 import torch.utils.hooks as hooks
 
-from . import state
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_batches
 from .logging import get_logger
@@ -67,7 +66,6 @@ from .utils import (
     save,
     wait_for_everyone,
 )
-
 
 if is_deepspeed_available():
     import deepspeed
@@ -696,7 +694,7 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.process_index}")
         ```
         """
-        if not state.is_initialized():
+        if not (PartialState._shared_state != {}):
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
@@ -723,7 +721,7 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.local_process_index}")
         ```
         """
-        if not state.is_initialized():
+        if not (PartialState._shared_state != {}):
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1821,7 +1821,7 @@ class Accelerator:
         """
         wait_for_everyone()
 
-    @on_main_process
+    # @on_main_process
     def init_trackers(self, project_name: str, config: Optional[dict] = None, init_kwargs: Optional[dict] = {}):
         """
         Initializes a run for all trackers stored in `self.log_with`, potentially with starting configurations
@@ -1869,7 +1869,7 @@ class Accelerator:
             for tracker in self.trackers:
                 tracker.store_init_configuration(config)
 
-    @on_main_process
+    # @on_main_process
     def get_tracker(self, name: str):
         """
         Returns a `tracker` from `self.trackers` based on `name` on the main process only.
@@ -1896,7 +1896,7 @@ class Accelerator:
                 return tracker.tracker
         raise ValueError(f"{name} is not an available tracker stored inside the `Accelerator`.")
 
-    @on_main_process
+    # @on_main_process
     def log(self, values: dict, step: Optional[int] = None, log_kwargs: Optional[dict] = {}):
         """
         Logs `values` to all stored trackers in `self.trackers` on the main process only.
@@ -1926,7 +1926,7 @@ class Accelerator:
         for tracker in self.trackers:
             tracker.log(values, step=step, **log_kwargs.get(tracker.name, {}))
 
-    @on_main_process
+    # @on_main_process
     def end_training(self):
         """
         Runs any special end training behaviors, such as stopping trackers on the main process only. Should always be

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -478,8 +478,7 @@ class Accelerator:
     def mixed_precision(self):
         return self.state.mixed_precision
 
-    @classmethod
-    def on_main_process(cls, function: Callable[..., Any]):
+    def on_main_process(self, function: Callable[..., Any]):
         """
         A decorator that will run the decorated function on the main process only. Can also be called using the
         `PartialState` class.
@@ -508,7 +507,7 @@ class Accelerator:
             raise ValueError(
                 "The `Accelerator` or `PartialState` object needs to be initialized before using this decorator."
             )
-        return state.PartialState().on_main_process(function)
+        return self.on_main_process(function)
 
     def on_local_main_process(self, function: Callable[..., Any]):
         """

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -15,7 +15,7 @@
 import logging
 import os
 
-from .state import PartialState
+# from .state import PartialState
 
 
 class MultiProcessAdapter(logging.LoggerAdapter):

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -15,7 +15,7 @@
 import logging
 import os
 
-# from .state import PartialState
+from .state import PartialState
 
 
 class MultiProcessAdapter(logging.LoggerAdapter):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -39,12 +39,20 @@ if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
 
-def is_initialized() -> bool:
+def is_initialized(accelerator_state=True) -> bool:
     """
-    Checks if the `AcceleratorState` has been initialized from `Accelerator`. Same as `AcceleratorState.initialized`,
+    Checks if the `AcceleratorState` or `PartialState` has been initialized. Same as `AcceleratorState.initialized`,
     but works as a module method.
+
+    Args:
+        accelerator_state (`bool`, `optional`):
+            Whether or not to check if the `AcceleratorState` has been initialized. If `False`, will check if the
+            `PartialState` has been initialized instead.
     """
-    return AcceleratorState._shared_state != {}
+    if accelerator_state:
+        return AcceleratorState._shared_state != {}
+    else:
+        return PartialState._shared_state != {}
 
 
 # Lambda function that does nothing
@@ -344,7 +352,7 @@ class PartialState:
         """
         yield from self._goes_first(self.is_local_main_process)
 
-    def on_main_process(self, function: Callable[..., Any]=None):
+    def on_main_process(self, function: Callable[..., Any] = None):
         """
         Decorator that only runs the decorated function on the main process.
 
@@ -372,7 +380,7 @@ class PartialState:
             return function
         return do_nothing
 
-    def on_local_main_process(self, function: Callable[..., Any]=None):
+    def on_local_main_process(self, function: Callable[..., Any] = None):
         """
         Decorator that only runs the decorated function on the local main process.
 
@@ -725,7 +733,6 @@ class AcceleratorState:
             function (:obj:`Callable`): The function to decorate.
         """
         return PartialState().on_process(process_index, function)
-        
 
     def on_local_process(self, function=None, process_index: int = None):
         """

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -725,16 +725,26 @@ class AcceleratorState:
             function (:obj:`Callable`): The function to decorate.
         """
         return PartialState().on_process(process_index, function)
+        
 
     def on_local_process(self, function=None, process_index: int = None):
         """
         Decorator that only runs the decorated function on the specified local process.
 
         Args:
-            process_id (:obj:`int`): The id of the process on which to run the function.
-            function (:obj:`Callable`): The function to decorate.
+            process_id (`int`): The id of the process on which to run the function.
+            function (`Callable`): The function to decorate.
         """
         return PartialState().on_local_process(process_index, function)
+
+    def on_last_process(self, function):
+        """
+        Decorator that only runs the decorated function on the last process.
+
+        Args:
+            function (`Callable`): The function to decorate.
+        """
+        return PartialState().on_last_process(function)
 
     def print(self, *args, **kwargs):
         PartialState().print(*args, **kwargs)

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -344,7 +344,7 @@ class PartialState:
         """
         yield from self._goes_first(self.is_local_main_process)
 
-    def on_main_process(self, function: Callable[..., Any]):
+    def on_main_process(self, function: Callable[..., Any]=None):
         """
         Decorator that only runs the decorated function on the main process.
 
@@ -372,7 +372,7 @@ class PartialState:
             return function
         return do_nothing
 
-    def on_local_main_process(self, function: Callable[..., Any]):
+    def on_local_main_process(self, function: Callable[..., Any]=None):
         """
         Decorator that only runs the decorated function on the local main process.
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -376,6 +376,8 @@ class PartialState:
         "This will be printed by process 0 only"
         ```
         """
+        if not self.initialized:
+            raise ValueError("The `PartialState` or `Accelerator` must be initialized before calling this function.")
         if self.is_main_process or not self.use_distributed:
             return function
         return do_nothing
@@ -729,8 +731,8 @@ class AcceleratorState:
         Decorator that only runs the decorated function on the specified process.
 
         Args:
-            process_id (:obj:`int`): The id of the process on which to run the function.
-            function (:obj:`Callable`): The function to decorate.
+            process_id (`int`): The id of the process on which to run the function.
+            function (`Callable`): The function to decorate.
         """
         return PartialState().on_process(process_index, function)
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -15,6 +15,8 @@
 import os
 import warnings
 from contextlib import contextmanager
+from functools import partial
+from typing import Any, Callable
 
 import torch
 
@@ -43,6 +45,11 @@ def is_initialized() -> bool:
     but works as a module method.
     """
     return AcceleratorState._shared_state != {}
+
+
+# Lambda function that does nothing
+def do_nothing(*args, **kwargs):
+    return None
 
 
 # Inspired by Alex Martelli's 'Borg'.
@@ -255,6 +262,27 @@ class PartialState:
         )
 
     def wait_for_everyone(self):
+        """
+        Will stop the execution of the current process until every other process has reached that point (so this does
+        nothing when the script is only run in one process). Useful to do before saving a model.
+
+        Example:
+
+        ```python
+        >>> # Assuming two GPU processes
+        >>> import time
+        >>> from accelerate.state import PartialState
+
+        >>> state = PartialState()
+        >>> if state.is_main_process:
+        ...     time.sleep(2)
+        >>> else:
+        ...     print("I'm waiting for the main process to finish its sleep...")
+        >>> state.wait_for_everyone()
+        >>> # Should print on every process at the same time
+        >>> print("Everyone is here")
+        ```
+        """
         if self.distributed_type in (
             DistributedType.MULTI_GPU,
             DistributedType.MULTI_CPU,
@@ -280,6 +308,18 @@ class PartialState:
         Lets the main process go first inside a with block.
 
         The other processes will enter the with block after the main process exits.
+
+        Example:
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator()
+        >>> with accelerator.main_process_first():
+        ...     # This will be printed first by process 0 then in a seemingly
+        ...     # random order by the other processes.
+        ...     print(f"This will be printed by process {accelerator.process_index}")
+        ```
         """
         yield from self._goes_first(self.is_main_process)
 
@@ -289,10 +329,197 @@ class PartialState:
         Lets the local main process go inside a with block.
 
         The other processes will enter the with block after the main process exits.
+
+        Example:
+
+        ```python
+        >>> from accelerate.state import PartialState
+
+        >>> state = PartialState()
+        >>> with state.local_main_process_first():
+        ...     # This will be printed first by local process 0 then in a seemingly
+        ...     # random order by the other processes.
+        ...     print(f"This will be printed by process {state.local_process_index}")
+        ```
         """
         yield from self._goes_first(self.is_local_main_process)
 
+    def on_main_process(self, function: Callable[..., Any]):
+        """
+        Decorator that only runs the decorated function on the main process.
+
+        Args:
+            function (`Callable`): The function to decorate.
+
+        Example:
+
+        ```python
+        >>> from accelerate.state import PartialState
+
+        >>> state = PartialState()
+
+
+        >>> @state.on_main_process
+        ... def print_something():
+        ...     print("This will be printed by process 0 only.")
+
+
+        >>> print_something()
+        "This will be printed by process 0 only"
+        ```
+        """
+        if self.is_main_process or not self.use_distributed:
+            return function
+        return do_nothing
+
+    def on_local_main_process(self, function: Callable[..., Any]):
+        """
+        Decorator that only runs the decorated function on the local main process.
+
+        Args:
+            function (`Callable`): The function to decorate.
+
+        Example:
+        ```python
+        # Assume we have 2 servers with 4 processes each.
+        from accelerate.state import PartialState
+
+        state = PartialState()
+
+
+        @state.on_local_main_process
+        def print_something():
+            print("This will be printed by process 0 only on each server.")
+
+
+        print_something()
+        # On server 1:
+        "This will be printed by process 0 only"
+        # On server 2:
+        "This will be printed by process 0 only"
+        ```
+        """
+        if self.is_local_main_process or not self.use_distributed:
+            return function
+        return do_nothing
+
+    def on_last_process(self, function: Callable[..., Any]):
+        """
+        Decorator that only runs the decorated function on the last process.
+
+        Args:
+            function (`Callable`): The function to decorate.
+
+        Example:
+        ```python
+        # Assume we have 4 processes.
+        from accelerate.state import PartialState
+
+        state = PartialState()
+
+
+        @state.on_last_process
+        def print_something():
+            print(f"Printed on process {state.process_index}")
+
+
+        print_something()
+        "Printed on process 3"
+        ```
+        """
+        if self.is_last_process or not self.use_distributed:
+            return function
+        return do_nothing
+
+    def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
+        """
+        Decorator that only runs the decorated function on the process with the given index.
+
+        Args:
+            function (`Callable`, `optional`):
+                The function to decorate.
+            process_index (`int`, `optional`):
+                The index of the process on which to run the function.
+
+        Example:
+        ```python
+        # Assume we have 4 processes.
+        from accelerate.state import PartialState
+
+        state = PartialState()
+
+
+        @state.on_process(process_index=2)
+        def print_something():
+            print(f"Printed on process {state.process_index}")
+
+
+        print_something()
+        "Printed on process 2"
+        ```
+        """
+        if function is None:
+            return partial(self.on_process, process_index=process_index)
+        if (self.process_index == process_index) or (not self.use_distributed):
+            return function
+        return do_nothing
+
+    def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
+        """
+        Decorator that only runs the decorated function on the process with the given index on the current node.
+
+        Args:
+            function (`Callable`, *optional*):
+                The function to decorate.
+            local_process_index (`int`, *optional*):
+                The index of the local process on which to run the function.
+
+        Example:
+        ```python
+        # Assume we have 2 servers with 4 processes each.
+        from accelerate import Accelerator
+
+        accelerator = Accelerator()
+
+
+        @accelerator.on_local_process(local_process_index=2)
+        def print_something():
+            print(f"Printed on process {accelerator.local_process_index}")
+
+
+        print_something()
+        # On server 1:
+        "Printed on process 2"
+        # On server 2:
+        "Printed on process 2"
+        ```
+        """
+        if function is None:
+            return partial(self.on_local_process, local_process_index=local_process_index)
+        if (self.local_process_index == local_process_index) or (not self.use_distributed):
+            return function
+        return do_nothing
+
+    @property
+    def use_distributed(self):
+        """
+        Whether the Accelerator is configured for distributed training
+        """
+        return self.distributed_type != DistributedType.NO and self.num_processes > 1
+
     def print(self, *args, **kwargs):
+        """
+        Drop in replacement of `print()` to only print once per server.
+
+        Example:
+
+        ```python
+        >>> from accelerate.state import PartialState
+
+        >>> state = PartialState()
+        >>> state.print("Hello world!")
+        ```
+        """
         if self.is_local_main_process:
             print(*args, **kwargs)
 
@@ -470,6 +697,44 @@ class AcceleratorState:
         The other processes will enter the with block after the main process exits.
         """
         yield PartialState().local_main_process_first()
+
+    def on_main_process(self, function):
+        """
+        Decorator that only runs the decorated function on the main process.
+
+        Args:
+            function (:obj:`Callable`): The function to decorate.
+        """
+        return PartialState().on_main_process(function)
+
+    def on_local_main_process(self, function):
+        """
+        Decorator that only runs the decorated function on the local main process.
+
+        Args:
+            function (:obj:`Callable`): The function to decorate.
+        """
+        return PartialState().on_local_main_process(function)
+
+    def on_process(self, function=None, process_index: int = None):
+        """
+        Decorator that only runs the decorated function on the specified process.
+
+        Args:
+            process_id (:obj:`int`): The id of the process on which to run the function.
+            function (:obj:`Callable`): The function to decorate.
+        """
+        return PartialState().on_process(process_index, function)
+
+    def on_local_process(self, function=None, process_index: int = None):
+        """
+        Decorator that only runs the decorated function on the specified local process.
+
+        Args:
+            process_id (:obj:`int`): The id of the process on which to run the function.
+            function (:obj:`Callable`): The function to decorate.
+        """
+        return PartialState().on_local_process(process_index, function)
 
     def print(self, *args, **kwargs):
         PartialState().print(*args, **kwargs)

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -371,9 +371,9 @@ def training_check():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
     if state.local_process_index == 0:
         print("\n**Test process execution**")
     process_execution_check()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+import io
+
 import torch
 from torch.utils.data import DataLoader
 
@@ -31,13 +34,68 @@ from accelerate.utils import (
 )
 
 
+def print_main(state):
+    print(f"Printing from the main process {state.process_index}")
+
+
+def print_local_main(state):
+    print(f"Printing from the local main process {state.local_process_index}")
+
+
+def print_last(state):
+    print(f"Printing from the last process {state.process_index}")
+
+
+def print_on(state, process_idx):
+    print(f"Printing from process {process_idx}: {state.process_index}")
+
+
 def process_execution_check():
-    # Test that printing on a single process works
     accelerator = Accelerator()
+    num_processes = accelerator.num_processes
     with accelerator.main_process_first():
         idx = torch.tensor(accelerator.process_index).to(accelerator.device)
     idxs = accelerator.gather(idx)
     assert idxs[0] == 0, "Main process was not first."
+
+    # Test the decorators
+    f = io.StringIO()
+    with contextlib.redirect_stdout(f):
+        accelerator.on_main_process(print_main)(accelerator.state)
+    if accelerator.is_main_process:
+        assert f.getvalue().rstrip() == "Printing from the main process 0"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    with contextlib.redirect_stdout(f):
+        accelerator.on_local_main_process(print_local_main)(accelerator.state)
+    if accelerator.is_local_main_process:
+        assert f.getvalue().rstrip() == "Printing from the local main process 0"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    with contextlib.redirect_stdout(f):
+        accelerator.on_last_process(print_last)(accelerator.state)
+    if accelerator.is_last_process:
+        assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    for process_idx in range(num_processes):
+        with contextlib.redirect_stdout(f):
+            accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
+        if accelerator.process_index == process_idx:
+            assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
+        else:
+            assert f.getvalue().rstrip() == ""
+        f.truncate(0)
+        f.seek(0)
 
 
 def init_state_check():
@@ -313,9 +371,9 @@ def training_check():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
     if state.local_process_index == 0:
         print("\n**Test process execution**")
     process_execution_check()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -71,6 +71,8 @@ class AcceleratorTester(AccelerateTestCase):
 
     def test_env_var_device(self):
         """Tests that setting the torch device with ACCELERATE_TORCH_DEVICE overrides default device."""
+        # Manually reset the state since we're turning it into "CUDA"
+        PartialState._reset_state()
 
         # Mock torch.cuda.set_device to avoid an exception as the device doesn't exist
         def noop(*args, **kwargs):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -12,22 +12,6 @@ from accelerate.test_utils.testing import AccelerateTestCase, require_cuda
 from accelerate.utils import patch_environment
 
 
-def print_main(state):
-    print(f"Printing from the main process {state.process_index}")
-
-
-def print_local_main(state):
-    print(f"Printing from the local main process {state.local_process_index}")
-
-
-def print_last(state):
-    print(f"Printing from the last process {state.process_index}")
-
-
-def print_on(state, process_idx):
-    print(f"Printing from process {process_idx}: {state.process_index}")
-
-
 def create_components():
     model = torch.nn.Linear(2, 4)
     optimizer = torch.optim.AdamW(model.parameters(), lr=1.0)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1,5 +1,3 @@
-import contextlib
-import io
 import json
 import os
 import tempfile
@@ -177,43 +175,3 @@ class AcceleratorTester(AccelerateTestCase):
 
             # mode.class_name is NOT loaded from config
             self.assertTrue(model.class_name != model.__class__.__name__)
-
-    def test_accelerator_state_printing(self):
-        accelerator = Accelerator()
-        f = io.StringIO()
-        with contextlib.redirect_stdout(f):
-            accelerator.on_main_process(print_main)(accelerator.state)
-        if accelerator.is_main_process:
-            assert f.getvalue().rstrip() == "Printing from the main process 0"
-        else:
-            assert f.getvalue().rstrip() == ""
-        f.truncate(0)
-        f.seek(0)
-
-        with contextlib.redirect_stdout(f):
-            accelerator.on_local_main_process(print_local_main)(accelerator.state)
-        if accelerator.is_local_main_process:
-            assert f.getvalue().rstrip() == "Printing from the local main process 0"
-        else:
-            assert f.getvalue().rstrip() == ""
-        f.truncate(0)
-        f.seek(0)
-
-        with contextlib.redirect_stdout(f):
-            accelerator.on_last_process(print_last)(accelerator.state)
-        if accelerator.is_last_process:
-            assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
-        else:
-            assert f.getvalue().rstrip() == ""
-        f.truncate(0)
-        f.seek(0)
-
-        for process_idx in range(accelerator.num_processes):
-            with contextlib.redirect_stdout(f):
-                accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
-            if accelerator.process_index == process_idx:
-                assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
-            else:
-                assert f.getvalue().rstrip() == ""
-            f.truncate(0)
-            f.seek(0)


### PR DESCRIPTION
# Fix process decorators and make them more flexible

## What does this add?

This PR brings in the context management roles for process delegation from the `Accelerator` class into the `PartialState` class, and completely refactors/reworks the decorator methodology introduced in https://github.com/huggingface/accelerate/pull/488 into something that fully completes the proposed API

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/923

## Why is it needed?

The decorators that were introduced did not work as intended, and only worked to have the `Accelerator` object itself actually use it. To use it outside the `Accelerator` was impossible. As a result, this PR completely reworks how the existing decorators were designed by making them utilize the `state` instead, and ensures that a special internal use case is added when using the decorators back on the `Accelerator` class itself, with a raised error if a user tries to do the same. 

## What parts of the API does this impact?

### User-facing:

A user can now actually perform `@accelerator.on_main_process` or `PartialState().on_main_process` as decorators, along with the rest of the existing ones.

Along with this, `PartialState` now includes all of the `on_*_process` functionality. 

### Internal structure:

The existing implementation in `Accelerator` was gutted, delegated to the `PartialState` since it's the main process controller and as a result should control this behavior natively, and the `Accelerator` utilizes this. 

Specifically, this logic has now been added to the decorators:
```python
    def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
        ...
        if function is None:
            if "Accelerator." in self.__qualname__:
                function = self
            else:
                raise ValueError(
                    "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                )
```
This check is to ensure if `self` is a function *from* the `Accelerator` itself, or the behavior that occurs when performing:

```python
# Inside the Accelerator object definition
    @on_main_process
    def log(self, ...)
        ...
```
Instead of requiring complex workarounds. As you can see in the above, a proper error will also be raised if a user breaks this "magic" with a clear description of what is happening.

Inside the `on_process*` functions there also exists this snippet:

```python
    def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
        # Initial construction of the decorator.
        if (self is not None) and (process_index is not None) and (function is None):
            return partial(self.on_process, process_index=process_index)
```
This is to check if an overloaded decorator was used, potentially again on the `Accelerator` class, before moving on to the proper constructor. 

## Basic Usage Example(s):
Note that `accelerator` can be replaced with `PartialState` here as well

```python
from accelerate import Accelerator
accelerator = Accelerator()
@accelerator.on_local_main_process
def print_local_main():
    print(f"Printing from the local main process {state.local_process_index}")
print_local_main()
```