### PR TITLE
First get decorator working

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -234,6 +234,13 @@ class PartialState:
         return self._shared_state != {}
 
     @property
+    def use_distributed(self):
+        """
+        Whether the Accelerator is configured for distributed training
+        """
+        return self.distributed_type != DistributedType.NO and self.num_processes > 1
+
+    @property
     def is_last_process(self) -> bool:
         "Returns whether the current process is the last one"
         return self.process_index == self.num_processes - 1
@@ -434,6 +441,13 @@ class AcceleratorState:
         AcceleratorState._shared_state = {}
         if reset_partial_state:
             PartialState._reset_state()
+
+    @property
+    def use_distributed(self):
+        """
+        Whether the Accelerator is configured for distributed training
+        """
+        return PartialState().use_distributed
 
     @property
     def is_last_process(self) -> bool:

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+import io
+
 import torch
 from torch.utils.data import DataLoader
 
@@ -31,13 +34,68 @@ from accelerate.utils import (
 )
 
 
+def print_main(state):
+    print(f"Printing from the main process {state.process_index}")
+
+
+def print_local_main(state):
+    print(f"Printing from the local main process {state.local_process_index}")
+
+
+def print_last(state):
+    print(f"Printing from the last process {state.process_index}")
+
+
+def print_on(state, process_idx):
+    print(f"Printing from process {process_idx}: {state.process_index}")
+
+
 def process_execution_check():
-    # Test that printing on a single process works
     accelerator = Accelerator()
+    num_processes = accelerator.num_processes
     with accelerator.main_process_first():
         idx = torch.tensor(accelerator.process_index).to(accelerator.device)
     idxs = accelerator.gather(idx)
     assert idxs[0] == 0, "Main process was not first."
+
+    # Test the decorators
+    f = io.StringIO()
+    with contextlib.redirect_stdout(f):
+        accelerator.on_main_process(print_main)(accelerator.state)
+    if accelerator.is_main_process:
+        assert f.getvalue().rstrip() == "Printing from the main process 0"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    with contextlib.redirect_stdout(f):
+        accelerator.on_local_main_process(print_local_main)(accelerator.state)
+    if accelerator.is_local_main_process:
+        assert f.getvalue().rstrip() == "Printing from the local main process 0"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    with contextlib.redirect_stdout(f):
+        accelerator.on_last_process(print_last)(accelerator.state)
+    if accelerator.is_last_process:
+        assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    for process_idx in range(num_processes):
+        with contextlib.redirect_stdout(f):
+            accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
+        if accelerator.process_index == process_idx:
+            assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
+        else:
+            assert f.getvalue().rstrip() == ""
+        f.truncate(0)
+        f.seek(0)
 
 
 def init_state_check():

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -71,6 +71,7 @@ class AcceleratorTester(AccelerateTestCase):
 
     def test_env_var_device(self):
         """Tests that setting the torch device with ACCELERATE_TORCH_DEVICE overrides default device."""
+        PartialState._reset_state()
 
         # Mock torch.cuda.set_device to avoid an exception as the device doesn't exist
         def noop(*args, **kwargs):


### PR DESCRIPTION
# Fix process decorators and make them more flexible

## What does this add?

This PR completely refactors/reworks the decorator methodology introduced in https://github.com/huggingface/accelerate/pull/488 into something that fully completes the proposed API

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/923

## Why is it needed?

The decorators that were introduced did not work as intended, and only worked to have the `Accelerator` object itself actually use it. To use it outside the `Accelerator` was impossible. As a result, this PR completely reworks how the existing decorators were designed by making them utilize the `state` instead, and ensures that a special internal use case is added when using the decorators back on the `Accelerator` class itself, with a raised error if a user tries to do the same. 

## What parts of the API does this impact?

### User-facing:

A user can now actually perform `@accelerator.on_main_process` as a decorator, along with the rest of the existing ones.
The `AcceleratorState` also now stores the `use_distributed` value originally in the `Accelerator` object

### Internal structure:

The existing implementation in `Accelerator` was gutted, and reworked into a usable fashion.

Specifically, this logic has now been added to the decorators:
```python
    def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
        ...
        if function is None:
            if "Accelerator." in self.__qualname__:
                function = self
            else:
                raise ValueError(
                    "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                )
```
This check is to ensure if `self` is a function *from* the `Accelerator` itself, or the behavior that occurs when performing:

```python
# Inside the Accelerator object definition
    @on_main_process
    def log(self, ...)
        ...
```
Instead of requiring complex workarounds. As you can see in the above, a proper error will also be raised if a user breaks this "magic" with a clear description of what is happening.

Inside the `on_process*` functions there also exists this snippet:

```python
    def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
        # Initial construction of the decorator.
        if (self is not None) and (process_index is not None) and (function is None):
            return partial(self.on_process, process_index=process_index)
```
This is to check if an overloaded decorator was used, potentially again on the `Accelerator` class, before moving on to the proper constructor. 

## Basic Usage Example(s):

```python
from accelerate import Accelerator
accelerator = Accelerator()
@accelerator.on_local_main_process
def print_local_main():
    print(f"Printing from the local main process {state.local_process_index}")
print_local_main()
```