### PR TITLE
Refactor state and make `PartialState` first class citizen 

### DIFF
--- a/src/accelerate/__init__.py
+++ b/src/accelerate/__init__.py
@@ -12,6 +12,7 @@ from .big_modeling import (
 )
 from .data_loader import skip_first_batches
 from .launchers import debug_launcher, notebook_launcher
+from .state import PartialState
 from .utils import (
     DeepSpeedPlugin,
     DistributedDataParallelKwargs,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -109,10 +109,6 @@ except ImportError:
 logger = get_logger(__name__)
 
 
-def do_nothing(*args, **kwargs):
-    return None
-
-
 class Accelerator:
     """
     Creates an instance of an accelerator for distributed training (on multi-GPU, TPU) or mixed precision training.
@@ -515,12 +511,7 @@ class Accelerator:
                 raise ValueError(
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        if PartialState().process_index == 0 or not (
-            PartialState().distributed_type != DistributedType.NO and PartialState().num_processes > 1
-        ):
-            return function
-        else:
-            return do_nothing
+        return PartialState().on_main_process(function)
 
     def on_local_main_process(self, function: Callable[..., Any] = None):
         """
@@ -556,12 +547,9 @@ class Accelerator:
                 function = self
             else:
                 raise ValueError(
-                    "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
+                    "The `on_local_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        if PartialState().is_local_main_process or not PartialState().use_distributed:
-            return function
-        else:
-            return do_nothing
+        return PartialState().on_local_main_process(function)
 
     def on_last_process(self, function: Callable[..., Any]):
         """
@@ -594,12 +582,9 @@ class Accelerator:
                 function = self
             else:
                 raise ValueError(
-                    "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
+                    "The `on_last_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        if PartialState().is_last_process or not PartialState().use_distributed:
-            return function
-        else:
-            return do_nothing
+        return PartialState().on_last_process(function)
 
     def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
         """
@@ -640,10 +625,7 @@ class Accelerator:
                 raise ValueError(
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        if PartialState().process_index == process_index or not PartialState().use_distributed:
-            return function
-        else:
-            return do_nothing
+        return PartialState().on_process(function, process_index)
 
     def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
         """
@@ -687,11 +669,7 @@ class Accelerator:
                 raise ValueError(
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-
-        if PartialState().local_process_index == local_process_index or not PartialState().use_distributed:
-            return function
-        else:
-            return do_nothing
+        return PartialState().on_local_process(function, local_process_index)
 
     @contextmanager
     def main_process_first(self):


### PR DESCRIPTION
Refactors the `PartialState` and `Accelerator` to have the core decorator process-logic happen inside `PartialState` and then upstreams it to `AcceleratorState` and `Accelerator`, as `PartialState` should act as the main processes controller for users if they choose not to use the `Accelerator`. As a result, `PartialState` has complete docs for the functions while the `AcceleratorState` does not. I can also make a note on the version in `AcceleratorState` to point this out to users potentially. 