### PR TITLE
Add error when trying to load non-existant config.yaml

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -41,8 +41,16 @@ else:
 
 
 def load_config_from_file(config_file):
-    config_file_exists = config_file is not None and os.path.isfile(config_file)
-    config_file = config_file if config_file_exists else default_config_file
+    if config_file is not None:
+        if not os.path.isfile(config_file):
+            raise FileNotFoundError(
+                f"The passed configuration file `{config_file}` does not exist. "
+                "Please pass an existing file to `accelerate launch`, or use the the default one "
+                "created through `accelerate config` and run `accelerate launch` "
+                "without the `--config_file` argument."
+            )
+    else:
+        config_file = default_config_file
     with open(config_file, "r", encoding="utf-8") as f:
         if config_file.endswith(".json"):
             if (


### PR DESCRIPTION
As noted in https://github.com/huggingface/accelerate/issues/1073, the user tried to perform `accelerate launch --config_file MY_CONFIG.yaml ...` and if the file does not exist then a non-intuitive trace is given:
```python
FileNotFoundError: [Errno 2] No such file or directory: '/root/.cache/huggingface/accelerate/default_config.yaml'
```
Even though the user specified their own custom configuration.

This PR introduces a guard now instead of a magic-always-passing dropback when using `accelerate launch` that originally would then check if the default configuration could be used instead. 

New error message:
```python
(accelerate) zach@workstation:~/accelerate/accelerate$ accelerate launch --config_file "config.yml" test.py
Traceback (most recent call last):
  File "/home/zach/miniconda3/envs/accelerate/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/home/zach/accelerate/accelerate/src/accelerate/commands/accelerate_cli.py", line 45, in main
    args.func(args)
  File "/home/zach/accelerate/accelerate/src/accelerate/commands/launch.py", line 1082, in launch_command
    defaults = load_config_from_file(args.config_file)
  File "/home/zach/accelerate/accelerate/src/accelerate/commands/config/config_args.py", line 46, in load_config_from_file
    raise FileNotFoundError(
FileNotFoundError: The passed configuration file `config.yml` does not exist. Please pass an existing file to `accelerate launch`, or use the the default one created through `accelerate config` and run `accelerate launch` without the `--config_file` argument.
```