### PR TITLE
devcontainer: "extensions" has been removed and replaced by customizations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,10 +15,14 @@
     "remoteEnv": {
         "PYTHONPATH": "${containerEnv:PATH}:${containerWorkspaceFolder}"
     },
-    "extensions": [
-        // Ensure we have IntelliSense in VSCode when running inside container
-        "ms-python.python"
-    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                // Ensure we have IntelliSense in VSCode when running inside container
+                "ms-python.python"
+            ]
+        }
+    },
     "workspaceFolder": "/workspaces/accelerate",
     // Need git for VSCode to color code modifications. Only runs when building environment.
     "onCreateCommand": "apt-get update && apt-get install -y git && pip install -e '.[dev]'"


### PR DESCRIPTION
"extensions" has been moved to "customizations/vscode"

```
"customizations": {
        "vscode": {
            "extensions": [
                // Ensure we have IntelliSense in VSCode when running inside container
                "ms-python.python"
            ]
        }
    }
```