### PR TITLE
Allow custom SageMaker Estimator arguments

### DIFF
--- a/docs/source/usage_guides/sagemaker.mdx
+++ b/docs/source/usage_guides/sagemaker.mdx
@@ -186,4 +186,4 @@ additional_args:
   max_wait: 86400
 ```
 
-*Note: Spot Instances are subject to be terminated and training to be continued from a checkpoint. This is not handled in 🤗 Accelerate out of the box. Contact us if you would like this feature.
+*Note: Spot Instances are subject to be terminated and training to be continued from a checkpoint. This is not handled in 🤗 Accelerate out of the box. Contact us if you would like this feature.*

--- a/docs/source/usage_guides/sagemaker.mdx
+++ b/docs/source/usage_guides/sagemaker.mdx
@@ -166,4 +166,13 @@ will be installed before your training script is started.
 
 ### Use Spot Instances
 
-*undecided if feature is needed. Contact us if you would like this feature.*
+The configuration allows you to override parameters for the [Estimator](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html).
+
+You can use Spot Instances e.g. using:
+```
+additional_args:
+  use_spot_instances: True
+  max_wait: 86400
+```
+
+*Note: Spot Instances are subject to be terminated and training to be continued from a checkpoint. This is not handled in 🤗 Accelerate out of the box. Contact us if you would like this feature.

--- a/docs/source/usage_guides/sagemaker.mdx
+++ b/docs/source/usage_guides/sagemaker.mdx
@@ -164,11 +164,22 @@ will be installed before your training script is started.
 
 *undecided if feature is needed. Contact us if you would like this feature.*
 
-### Use Spot Instances
+### Advanced configuration
 
 The configuration allows you to override parameters for the [Estimator](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html).
+These settings have to be applied in the config file and are not part of `accelerate config`. You can control many additional aspects of the training job, e.g. use Spot instances, enable network isolation and many more.
 
-You can use Spot Instances e.g. using:
+```
+additional_args:
+  # enable network isolation to restrict internet access for containers
+  enable_network_isolation: True
+```
+
+You can find all available configuration [here](https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html).
+
+### Use Spot Instances
+
+You can use Spot Instances e.g. using (see [Advanced configuration](#advanced-configuration)):
 ```
 additional_args:
   use_spot_instances: True

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -194,3 +194,4 @@ class SageMakerConfig(BaseConfig):
     py_version: str = SAGEMAKER_PYTHON_VERSION
     sagemaker_inputs_file: str = None
     sagemaker_metrics_file: str = None
+    additional_args: dict = None

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1043,23 +1043,28 @@ def sagemaker_launcher(sagemaker_config: SageMakerConfig, args):
 
     # configure session
     print("Creating Estimator")
-    huggingface_estimator = HuggingFace(
-        image_uri=sagemaker_config.image_uri,
-        entry_point=entry_point,
-        source_dir=source_dir,
-        role=sagemaker_config.iam_role_name,
-        transformers_version=sagemaker_config.transformers_version,
-        pytorch_version=sagemaker_config.pytorch_version,
-        py_version=sagemaker_config.py_version,
-        base_job_name=sagemaker_config.base_job_name,
-        instance_count=sagemaker_config.num_machines,
-        instance_type=sagemaker_config.ec2_instance_type,
-        debugger_hook_config=False,
-        distribution=distribution,
-        hyperparameters=hyperparameters,
-        environment=environment,
-        metric_definitions=sagemaker_metrics,
-    )
+    args = {
+        "image_uri": sagemaker_config.image_uri,
+        "entry_point": entry_point,
+        "source_dir": source_dir,
+        "role": sagemaker_config.iam_role_name,
+        "transformers_version": sagemaker_config.transformers_version,
+        "pytorch_version": sagemaker_config.pytorch_version,
+        "py_version": sagemaker_config.py_version,
+        "base_job_name": sagemaker_config.base_job_name,
+        "instance_count": sagemaker_config.num_machines,
+        "instance_type": sagemaker_config.ec2_instance_type,
+        "debugger_hook_config": False,
+        "distribution": distribution,
+        "hyperparameters": hyperparameters,
+        "environment": environment,
+        "metric_definitions": sagemaker_metrics,
+    }
+
+    if sagemaker_config.additional_args is not None:
+        args = {**args, **sagemaker_config.additional_args}
+
+    huggingface_estimator = HuggingFace(**args)
 
     huggingface_estimator.fit(inputs=sagemaker_inputs)
     print(f"You can find your model data at: {huggingface_estimator.model_data}")

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1088,7 +1088,7 @@ def launch_command(args):
         if (
             not args.multi_gpu
             and not args.tpu
-            and not args.tpu_cluster
+            # and not args.tpu_cluster
             and not args.mps
             and not args.use_deepspeed
             and not args.use_fsdp

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1088,7 +1088,7 @@ def launch_command(args):
         if (
             not args.multi_gpu
             and not args.tpu
-            # and not args.tpu_cluster
+            and not args.tpu_cluster
             and not args.mps
             and not args.use_deepspeed
             and not args.use_fsdp
@@ -1097,7 +1097,7 @@ def launch_command(args):
             args.use_deepspeed = defaults.distributed_type == DistributedType.DEEPSPEED
             args.multi_gpu = defaults.distributed_type == DistributedType.MULTI_GPU
             args.tpu = defaults.distributed_type == DistributedType.TPU
-            args.tpu_cluster = defaults.tpu_cluster and args.tpu
+            # args.tpu_cluster = defaults.tpu_cluster and args.tpu
             args.use_fsdp = defaults.distributed_type == DistributedType.FSDP
             args.mps = defaults.distributed_type == DistributedType.MPS
             args.use_megatron_lm = defaults.distributed_type == DistributedType.MEGATRON_LM

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1088,7 +1088,7 @@ def launch_command(args):
         if (
             not args.multi_gpu
             and not args.tpu
-            # and not args.tpu_cluster
+            and not args.tpu_cluster
             and not args.mps
             and not args.use_deepspeed
             and not args.use_fsdp

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1088,7 +1088,7 @@ def launch_command(args):
         if (
             not args.multi_gpu
             and not args.tpu
-            and not args.tpu_cluster
+            # and not args.tpu_cluster
             and not args.mps
             and not args.use_deepspeed
             and not args.use_fsdp
@@ -1097,7 +1097,7 @@ def launch_command(args):
             args.use_deepspeed = defaults.distributed_type == DistributedType.DEEPSPEED
             args.multi_gpu = defaults.distributed_type == DistributedType.MULTI_GPU
             args.tpu = defaults.distributed_type == DistributedType.TPU
-            # args.tpu_cluster = defaults.tpu_cluster and args.tpu
+            args.tpu_cluster = defaults.tpu_cluster and args.tpu
             args.use_fsdp = defaults.distributed_type == DistributedType.FSDP
             args.mps = defaults.distributed_type == DistributedType.MPS
             args.use_megatron_lm = defaults.distributed_type == DistributedType.MEGATRON_LM


### PR DESCRIPTION
The current implementation for SageMaker only allows a limited set of arguments, however the `Estimator` and `HuggingFace` Estimator support many additional arguments. With the current config wizard, this would be very hard to implement, hence I added a new field to `SageMakerConfig` to allow overrides to be set.

This e.g. allows the usage of Spot Instances.