### PR TITLE
Adds missing "lfs" in instructions for using git-lfs

### DIFF
--- a/docs/source/usage_guides/big_modeling.mdx
+++ b/docs/source/usage_guides/big_modeling.mdx
@@ -102,7 +102,7 @@ Here is how we can use this to load the [GPT-J-6B](https://huggingface.co/Eleuth
 git clone https://huggingface.co/sgugger/sharded-gpt-j-6B
 cd sharded-gpt-j-6B
 git-lfs install
-git pull
+git lfs pull
 ```
 
 then we can initialize the model with


### PR DESCRIPTION
The instructions suggested to use `git pull`, but the command to get the actual files from git-lfs is `git lfs pull`.