### PR TITLE
Change CLI help to utilize native argparser

### DIFF
--- a/src/accelerate/commands/args/__init__.py
+++ b/src/accelerate/commands/args/__init__.py
@@ -1,0 +1,2 @@
+from .torchrun import add_arguments as add_torchrun_arguments
+from .xla import add_arguments as add_xla_dist_arguments

--- a/src/accelerate/commands/args/torchrun.py
+++ b/src/accelerate/commands/args/torchrun.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+import torch.distributed.run as distrib_run
+
+
+ignored_params = [
+    "nproc_per_node",
+    "nnodes",
+    "nproc_per_node",
+    "help",
+    "rdzv_endpoint",
+    "training_script",
+    "training_script_args",
+]
+
+changed_name = {
+    "node_rank": "machine_rank",
+}
+
+
+def add_arguments(argument_group: argparse._ArgumentGroup):
+    distrib_parser = distrib_run.get_args_parser()
+    for action in distrib_parser._actions:
+        if action.dest in ignored_params:
+            continue
+        if action.dest in changed_name.keys():
+            action.dest = changed_name[action.dest]
+            action.option_strings = [f"--{action.dest}"]
+        argument_group._add_action(action)
+        action.container = argument_group

--- a/src/accelerate/commands/args/torchrun.py
+++ b/src/accelerate/commands/args/torchrun.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import argparse
 
-import torch.distributed.run as distrib_run
+from torch.distributed.run import get_args_parser
 
 
 ignored_params = [
@@ -34,7 +34,7 @@ changed_name = {
 
 
 def add_arguments(argument_group: argparse._ArgumentGroup):
-    distrib_parser = distrib_run.get_args_parser()
+    distrib_parser = get_args_parser()
     for action in distrib_parser._actions:
         if action.dest in ignored_params:
             continue

--- a/src/accelerate/commands/args/xla.py
+++ b/src/accelerate/commands/args/xla.py
@@ -2,13 +2,13 @@ from ...utils.imports import is_tpu_available
 
 
 if is_tpu_available(False):
-    from torch_xla.distributed import xla_dist
+    from torch_xla.distributed.xla_dist import get_args_parser
 
 ignored_params = ["help", "positional"]
 
 
 def add_arguments(argument_group):
-    distrib_parser = xla_dist.get_args_parser()
+    distrib_parser = get_args_parser()
     for action in distrib_parser._actions:
         if action.dest in ignored_params:
             continue

--- a/src/accelerate/commands/args/xla.py
+++ b/src/accelerate/commands/args/xla.py
@@ -1,0 +1,15 @@
+from ...utils.imports import is_tpu_available
+
+
+if is_tpu_available(False):
+    from torch_xla.distributed import xla_dist
+
+ignored_params = ["help", "positional"]
+
+
+def add_arguments(argument_group):
+    distrib_parser = xla_dist.get_args_parser()
+    for action in distrib_parser._actions:
+        if action.dest in ignored_params:
+            continue
+        argument_group._add_action(action)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -247,7 +247,7 @@ def launch_command_parser(subparsers=None):
         help="The port to use to communicate with the machine of rank 0.",
     )
     # The other torchrun arguments
-    if is_torch_version(">=", "1.9.1"):
+    if is_torch_version(">=", "1.9.1" and torch.distributed.is_available()):
         add_torchrun_arguments(distributed_args)
 
     # TPU arguments

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -247,7 +247,7 @@ def launch_command_parser(subparsers=None):
         help="The port to use to communicate with the machine of rank 0.",
     )
     # The other torchrun arguments
-    if is_torch_version(">=", "1.9.1" and torch.distributed.is_available()):
+    if is_torch_version(">=", "1.9.1") and torch.distributed.is_available():
         add_torchrun_arguments(distributed_args)
 
     # TPU arguments


### PR DESCRIPTION
Rather than having to duplicate all of the options or having to include a catch-all for other args to be passed to `torchrun` and `xla_dist`, this changes the CLI to inherit from the native argparsers they use, rebuild the action, and filter out any arguments we define ourselves that have custom behavior. This keeps the code sustainable and exposes *all the possible options* for torchrun to the user directly.