### PR TITLE
Attempt to fix import error when PyTorch is build without `torch.distributed` module

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -41,6 +41,14 @@ except ImportError:
     _tpu_available = False
 
 
+# Cache this result has it's a C FFI call which can be pretty time-consuming
+_torch_distributed_available = torch.distributed.is_available()
+
+
+def is_torch_distributed_available() -> bool:
+    return _torch_distributed_available
+
+
 def is_ccl_available():
     return (
         importlib.util.find_spec("torch_ccl") is not None

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -224,8 +224,8 @@ def gather(tensor):
     """
     if not is_torch_distributed_available():
         raise ModuleNotFoundError(
-            "torch was compiled without distributed support (torch.distributed.is_available() = False). "
-            "Please use a version which includes distributed support in order to call #gather()"
+            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
+            "Please install a version which includes distributed support in order to call gather."
         )
 
     if PartialState().distributed_type == DistributedType.TPU:
@@ -263,8 +263,8 @@ def gather_object(object: Any):
     """
     if not is_torch_distributed_available():
         raise ModuleNotFoundError(
-            "torch was compiled without distributed support (torch.distributed.is_available() = False). "
-            "Please use a version which includes distributed support in order to call #gather_object()"
+            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
+            "Please install a version which includes distributed support in order to call gather_object."
         )
 
     if PartialState().distributed_type == DistributedType.TPU:
@@ -308,8 +308,8 @@ def broadcast(tensor, from_process: int = 0):
     """
     if not is_torch_distributed_available():
         raise ModuleNotFoundError(
-            "torch was compiled without distributed support (torch.distributed.is_available() = False). "
-            "Please use a version which includes distributed support in order to call #broadcast()"
+            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
+            "Please install a version which includes distributed support in order to call broadcast."
         )
 
     if PartialState().distributed_type == DistributedType.TPU:
@@ -337,8 +337,8 @@ def broadcast_object_list(object_list, from_process: int = 0):
     """
     if not is_torch_distributed_available():
         raise ModuleNotFoundError(
-            "torch was compiled without distributed support (torch.distributed.is_available() = False). "
-            "Please use a version which includes distributed support in order to call #broadcast_object_list()"
+            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
+            "Please install a version which includes distributed support in order to call broadcast_object_list."
         )
 
     if PartialState().distributed_type == DistributedType.TPU:
@@ -455,8 +455,8 @@ def reduce(tensor, reduction="mean"):
     """
     if not is_torch_distributed_available():
         raise ModuleNotFoundError(
-            "torch was compiled without distributed support (torch.distributed.is_available() = False). "
-            "Please use a version which includes distributed support in order to call #reduce()"
+            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
+            "Please install a version which includes distributed support in order to call reduce."
         )
 
     def _reduce_across_processes(tensor, reduction="mean"):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -25,7 +25,7 @@ import torch
 from ..state import PartialState
 from .constants import CUDA_DISTRIBUTED_TYPES
 from .dataclasses import DistributedType, TensorInformation
-from .imports import is_tpu_available, is_torch_distributed_available
+from .imports import is_torch_distributed_available, is_tpu_available
 from .versions import is_torch_version
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -31,6 +31,7 @@ from .versions import is_torch_version
 
 if torch.distributed.is_available():
     from torch.distributed import ReduceOp
+
     TORCH_DISTRIBUTED_AVAILABLE = True
 else:
     TORCH_DISTRIBUTED_AVAILABLE = False

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -222,12 +222,6 @@ def gather(tensor):
     Returns:
         The same data structure as `tensor` with all tensors sent to the proper device.
     """
-    if not is_torch_distributed_available():
-        raise ModuleNotFoundError(
-            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
-            "Please install a version which includes distributed support in order to call gather."
-        )
-
     if PartialState().distributed_type == DistributedType.TPU:
         return _tpu_gather(tensor, name="accelerate.utils.gather")
     elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
@@ -261,12 +255,6 @@ def gather_object(object: Any):
     Returns:
         The same data structure as `object` with all the objects sent to every device.
     """
-    if not is_torch_distributed_available():
-        raise ModuleNotFoundError(
-            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
-            "Please install a version which includes distributed support in order to call gather_object."
-        )
-
     if PartialState().distributed_type == DistributedType.TPU:
         raise NotImplementedError("gather objects in TPU is not supported")
     elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
@@ -306,12 +294,6 @@ def broadcast(tensor, from_process: int = 0):
     Returns:
         The same data structure as `tensor` with all tensors broadcasted to the proper device.
     """
-    if not is_torch_distributed_available():
-        raise ModuleNotFoundError(
-            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
-            "Please install a version which includes distributed support in order to call broadcast."
-        )
-
     if PartialState().distributed_type == DistributedType.TPU:
         return _tpu_broadcast(tensor, src=from_process, name="accelerate.utils.broadcast")
     elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
@@ -335,12 +317,6 @@ def broadcast_object_list(object_list, from_process: int = 0):
     Returns:
         The same list containing the objects from process 0.
     """
-    if not is_torch_distributed_available():
-        raise ModuleNotFoundError(
-            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
-            "Please install a version which includes distributed support in order to call broadcast_object_list."
-        )
-
     if PartialState().distributed_type == DistributedType.TPU:
         for i, obj in enumerate(object_list):
             object_list[i] = xm.mesh_reduce("accelerate.utils.broadcast_object_list", obj, lambda x: x[from_process])
@@ -453,11 +429,6 @@ def reduce(tensor, reduction="mean"):
     Returns:
         The same data structure as `data` with all the tensors reduced.
     """
-    if not is_torch_distributed_available():
-        raise ModuleNotFoundError(
-            "`torch` was compiled without distributed support (`torch.distributed.is_available() == False`). "
-            "Please install a version which includes distributed support in order to call reduce."
-        )
 
     def _reduce_across_processes(tensor, reduction="mean"):
         state = PartialState()

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -25,20 +25,16 @@ import torch
 from ..state import PartialState
 from .constants import CUDA_DISTRIBUTED_TYPES
 from .dataclasses import DistributedType, TensorInformation
-from .imports import is_tpu_available
+from .imports import is_tpu_available, is_torch_distributed_available
 from .versions import is_torch_version
-
-
-if torch.distributed.is_available():
-    from torch.distributed import ReduceOp
-
-    TORCH_DISTRIBUTED_AVAILABLE = True
-else:
-    TORCH_DISTRIBUTED_AVAILABLE = False
 
 
 if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
+
+
+if is_torch_distributed_available():
+    from torch.distributed import ReduceOp
 
 
 def is_torch_tensor(tensor):
@@ -226,7 +222,7 @@ def gather(tensor):
     Returns:
         The same data structure as `tensor` with all tensors sent to the proper device.
     """
-    if not TORCH_DISTRIBUTED_AVAILABLE:
+    if not is_torch_distributed_available():
         raise ModuleNotFoundError(
             "torch was compiled without distributed support (torch.distributed.is_available() = False). "
             "Please use a version which includes distributed support in order to call #gather()"
@@ -265,7 +261,7 @@ def gather_object(object: Any):
     Returns:
         The same data structure as `object` with all the objects sent to every device.
     """
-    if not TORCH_DISTRIBUTED_AVAILABLE:
+    if not is_torch_distributed_available():
         raise ModuleNotFoundError(
             "torch was compiled without distributed support (torch.distributed.is_available() = False). "
             "Please use a version which includes distributed support in order to call #gather_object()"
@@ -310,7 +306,7 @@ def broadcast(tensor, from_process: int = 0):
     Returns:
         The same data structure as `tensor` with all tensors broadcasted to the proper device.
     """
-    if not TORCH_DISTRIBUTED_AVAILABLE:
+    if not is_torch_distributed_available():
         raise ModuleNotFoundError(
             "torch was compiled without distributed support (torch.distributed.is_available() = False). "
             "Please use a version which includes distributed support in order to call #broadcast()"
@@ -339,7 +335,7 @@ def broadcast_object_list(object_list, from_process: int = 0):
     Returns:
         The same list containing the objects from process 0.
     """
-    if not TORCH_DISTRIBUTED_AVAILABLE:
+    if not is_torch_distributed_available():
         raise ModuleNotFoundError(
             "torch was compiled without distributed support (torch.distributed.is_available() = False). "
             "Please use a version which includes distributed support in order to call #broadcast_object_list()"
@@ -457,7 +453,7 @@ def reduce(tensor, reduction="mean"):
     Returns:
         The same data structure as `data` with all the tensors reduced.
     """
-    if not TORCH_DISTRIBUTED_AVAILABLE:
+    if not is_torch_distributed_available():
         raise ModuleNotFoundError(
             "torch was compiled without distributed support (torch.distributed.is_available() = False). "
             "Please use a version which includes distributed support in order to call #reduce()"


### PR DESCRIPTION
When torch is build without distributed support (non pypi release), importing `accelerate` crashs because it tries to import `torch.distributed.ReduceOp`.

This PR attempts to only import when torch has support for distributed setups along with trying to not have too much impact on CCL call performances.

_I'm not quite sure how to test this setup as it, if you have any suggestion ..._

Root error stacktrace:

```python
  File "/usr/local/lib/python3.10/dist-packages/accelerate/utils/operations.py", line 24, in <module>
    from torch.distributed import ReduceOp
ImportError: cannot import name 'ReduceOp' from 'torch.distributed' (/usr/local/lib/python3.10/dist-packages/torch/distributed/__init__.py)
```