### PR TITLE
Discussion: unwrap tracker

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1936,7 +1936,7 @@ class Accelerator:
         if len(getattr(self, "trackers", [])) > 0:
             for tracker in self.trackers:
                 if tracker.name == name:
-                    return tracker
+                    return tracker.tracker if unwrap else tracker
             raise ValueError(f"{name} is not an available tracker stored inside the `Accelerator`.")
         # Handle tracker only made on main process
         return GeneralTracker(_blank=True)


### PR DESCRIPTION
Just opening this PR for discussion, related to the changes in https://github.com/huggingface/accelerate/commit/38fd30e764ea87ef86e7d69fcba559c3605925b1

Observations:
- According to https://github.com/huggingface/accelerate/blob/38fd30e764ea87ef86e7d69fcba559c3605925b1/docs/source/usage_guides/tracking.mdx#accessing-the-internal-tracker, getting the tracker should expose that tracker's methods. In the example, the user is able to invoke `log_artifact`, which is specific to the `wandb` tracker. However, the same appears not to be working for us with the `tensorboard` tracker when we attempt to invoke `add_images`: https://github.com/huggingface/diffusers/issues/2468.
- The `unwrap` argument to `get_tracker()` appears not to be in use.

My question is, is the user expected to pass `unwrap=True` (and, therefore, there's a slight API change here), or is this being caused by some other issue? How is `unwrap` meant to work? The change in this PR makes it work for me, but I'm not sure if this is the intended way. Happy to dig into this further once the expectations have been clarified :)