### PR TITLE
TensorBoardTracker: wrong arg def

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -183,7 +183,7 @@ class TensorBoardTracker(GeneralTracker):
     requires_logging_directory = True
 
     @on_main_process
-    def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = None, **kwargs):
+    def __init__(self, run_name: str, logging_dir: Union[str, os.PathLike], **kwargs):
         super().__init__()
         self.run_name = run_name
         self.logging_dir = os.path.join(logging_dir, run_name)


### PR DESCRIPTION
there is a small bug here:
```
$ python -c "import accelerate.tracking; x = accelerate.tracking.TensorBoardTracker('1')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/nvme0/code/huggingface/accelerate-master/src/accelerate/tracking.py", line 155, in __init__
    self.logging_dir = os.path.join(logging_dir, run_name)
  File "/home/stas/anaconda3/envs/py38-pt113/lib/python3.8/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

So the `logging_dir` arg can't be Optional, which this PR fixes, with it:

```
$ python -c "import accelerate.tracking; x = accelerate.tracking.TensorBoardTracker('1')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/mnt/nvme0/code/huggingface/accelerate-master/src/accelerate/tracking.py", line 83, in execute_on_main_process
    return PartialState().on_main_process(function)(self, *args, **kwargs)
TypeError: __init__() missing 1 required positional argument: 'logging_dir'
```