### PR TITLE
[Big model loading] Correct GPU only loading

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -678,10 +678,10 @@ def load_state_dict(checkpoint_file, device_map=None):
             return safe_load_file(checkpoint_file)
         else:
             devices = [device for device in device_map.values() if device not in ["disk"]]
-            
+
             # if we only have one device we can load everything directly
             if len(devices) == 1:
-                return safe_load_file(checkpoint_file, device=devices[0]) 
+                return safe_load_file(checkpoint_file, device=devices[0])
             # cpu device should always exist as fallback option
             devices = set(devices + ["cpu"])
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -678,6 +678,10 @@ def load_state_dict(checkpoint_file, device_map=None):
             return safe_load_file(checkpoint_file)
         else:
             devices = [device for device in device_map.values() if device not in ["disk"]]
+            
+            # if we only have one device we can load everything directly
+            if len(devices) == 1:
+                return safe_load_file(checkpoint_file, device=devices[0]) 
             # cpu device should always exist as fallback option
             devices = set(devices + ["cpu"])
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -682,6 +682,7 @@ def load_state_dict(checkpoint_file, device_map=None):
             # if we only have one device we can load everything directly
             if len(devices) == 1:
                 return safe_load_file(checkpoint_file, device=devices[0])
+                
             # cpu device should always exist as fallback option
             devices = set(devices + ["cpu"])
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -684,7 +684,8 @@ def load_state_dict(checkpoint_file, device_map=None):
                 return safe_load_file(checkpoint_file, device=devices[0])
 
             # cpu device should always exist as fallback option
-            devices = set(devices + ["cpu"])
+            if "cpu" not in devices:
+                devices.append("cpu")
 
             # For each device, get the weights that go there
             device_weights = {device: [] for device in devices}
@@ -692,7 +693,7 @@ def load_state_dict(checkpoint_file, device_map=None):
                 if device in devices:
                     device_weights[device].extend([k for k in weight_names if k.startswith(module_name)])
 
-            # all weights that haven't defined a device sholud be loaded on CPU
+            # all weights that haven't defined a device should be loaded on CPU
             device_weights["cpu"].extend([k for k in weight_names if k not in sum(device_weights.values(), [])])
             tensors = {}
             for device in devices:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -682,7 +682,7 @@ def load_state_dict(checkpoint_file, device_map=None):
             # if we only have one device we can load everything directly
             if len(devices) == 1:
                 return safe_load_file(checkpoint_file, device=devices[0])
-                
+
             # cpu device should always exist as fallback option
             devices = set(devices + ["cpu"])
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -430,6 +430,6 @@ class ModelingUtilsTester(unittest.TestCase):
 
                 loaded_state_dict = load_state_dict(checkpoint_file, device_map=device_map)
 
-            for k, v in device_map.items():
-                v = v if v != "disk" else "cpu"
-                self.assertEqual(loaded_state_dict[k].device, torch.device(v))
+            for param, device in device_map.items():
+                device = device if device != "disk" else "cpu"
+                self.assertEqual(loaded_state_dict[param].device, torch.device(device))

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -421,13 +421,15 @@ class ModelingUtilsTester(unittest.TestCase):
         from safetensors.torch import save_file
 
         state_dict = {k: torch.randn(4, 5) for k in ["a", "b", "c"]}
-        device_map = {"a": "cpu", "b": 0, "c": "disk"}
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            checkpoint_file = os.path.join(tmp_dir, "model.safetensors")
-            save_file(state_dict, checkpoint_file, metadata={"format": "pt"})
+        device_maps = [{"a": "cpu", "b": 0, "c": "disk"}, {"a": 0, "b": 0, "c": "disk"}, {"a": 0, "b": 0, "c": 0}]
 
-            loaded_state_dict = load_state_dict(checkpoint_file, device_map=device_map)
+        for device_map in device_maps:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                checkpoint_file = os.path.join(tmp_dir, "model.safetensors")
+                save_file(state_dict, checkpoint_file, metadata={"format": "pt"})
 
-        self.assertEqual(loaded_state_dict["a"].device, torch.device("cpu"))
-        self.assertEqual(loaded_state_dict["b"].device, torch.device(0))
-        self.assertEqual(loaded_state_dict["c"].device, torch.device("cpu"))
+                loaded_state_dict = load_state_dict(checkpoint_file, device_map=device_map)
+
+            for k, v in device_map.items():
+                v = v if v != "disk" else "cpu"
+                self.assertEqual(loaded_state_dict[k].device, torch.device(v))


### PR DESCRIPTION
There was a bug when loading safetensors directly on GPU via `device_map="auto"` in `diffusers`.

The test shows the failure case.