### PR TITLE
Add test for ops and fix reduce

### DIFF
--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -16,4 +16,4 @@ from .testing import (
 from .training import RegressionDataset, RegressionModel
 
 
-from .scripts import test_script, test_sync  # isort: skip
+from .scripts import test_script, test_sync, test_ops  # isort: skip

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from accelerate import PartialState
+from accelerate.utils.operations import broadcast, gather, pad_across_processes, reduce
+
+
+state = PartialState()
+
+
+def create_tensor():
+    return (torch.arange(state.num_processes) + 1 + (state.num_processes * state.process_index)).to(state.device)
+
+
+def test_gather():
+    tensor = create_tensor()
+    gathered_tensor = gather(tensor)
+    assert gathered_tensor.shape == torch.Size([state.num_processes**2])
+    assert gathered_tensor.tolist() == list(range(1, state.num_processes**2 + 1))
+
+
+def test_broadcast():
+    tensor = create_tensor()
+    broadcasted_tensor = broadcast(tensor)
+    assert broadcasted_tensor.shape == torch.Size([state.num_processes])
+    assert broadcasted_tensor.tolist() == list(range(1, state.num_processes + 1))
+
+
+def test_pad_across_processes():
+    # We need to pad the tensor with one more element if we are the main process
+    # to ensure that we can pad
+    if state.is_main_process:
+        tensor = torch.arange(state.num_processes + 1).to(state.device)
+    else:
+        tensor = torch.arange(state.num_processes).to(state.device)
+    padded_tensor = pad_across_processes(tensor)
+    assert padded_tensor.shape == torch.Size([state.num_processes + 1])
+    if not state.is_main_process:
+        assert padded_tensor.tolist() == list(range(0, state.num_processes)) + [0]
+
+
+def test_reduce_sum():
+    # For now runs on only two processes
+    if state.num_processes != 2:
+        return
+    tensor = create_tensor()
+    reduced_tensor = reduce(tensor, "sum")
+    truth_tensor = torch.tensor([4.0, 6]).to(state.device)
+    assert torch.allclose(reduced_tensor, truth_tensor), f"{reduced_tensor} != {truth_tensor}"
+
+
+def test_reduce_mean():
+    # For now runs on only two processes
+    if state.num_processes != 2:
+        return
+    tensor = create_tensor()
+    reduced_tensor = reduce(tensor, "mean")
+    truth_tensor = torch.tensor([2.0, 3]).to(state.device)
+    assert torch.allclose(reduced_tensor, truth_tensor), f"{reduced_tensor} != {truth_tensor}"
+
+
+def _mp_fn(index):
+    # For xla_spawn (TPUs)
+    main()
+
+
+def main():
+    state.print("testing gather")
+    test_gather()
+    state.print("testing broadcast")
+    test_broadcast()
+    state.print("testing pad_across_processes")
+    test_pad_across_processes()
+    state.print("testing reduce_sum")
+    test_reduce_sum()
+    state.print("testing reduce_mean")
+    test_reduce_mean()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -30,7 +30,6 @@ def create_tensor():
 def test_gather():
     tensor = create_tensor()
     gathered_tensor = gather(tensor)
-    assert gathered_tensor.shape == torch.Size([state.num_processes**2])
     assert gathered_tensor.tolist() == list(range(1, state.num_processes**2 + 1))
 
 

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -20,9 +20,8 @@ from accelerate import PartialState
 from accelerate.utils.operations import broadcast, gather, pad_across_processes, reduce
 
 
-
 def create_tensor(state):
-    return (torch.arange(state.num_processes) + 1. + (state.num_processes * state.process_index)).to(state.device)
+    return (torch.arange(state.num_processes) + 1.0 + (state.num_processes * state.process_index)).to(state.device)
 
 
 def test_gather(state):

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -22,7 +22,7 @@ from accelerate.utils.operations import broadcast, gather, pad_across_processes,
 
 
 def create_tensor(state):
-    return (torch.arange(state.num_processes) + 1 + (state.num_processes * state.process_index)).to(state.device)
+    return (torch.arange(state.num_processes) + 1. + (state.num_processes * state.process_index)).to(state.device)
 
 
 def test_gather(state):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -232,7 +232,7 @@ def gather(tensor):
 def _gpu_gather_object(object: Any):
     def _gpu_gather_object_one(object: Any):
         output_objects = [None for _ in range(PartialState().num_processes)]
-        torch.distributed.all_gather_object(output_objects, object)
+        torch.distributed.all_gather_object(object, output_objects if PartialState().is_local_main_process else None)
         return output_objects
 
     return recursively_apply(_gpu_gather_object_one, object)
@@ -430,20 +430,20 @@ def reduce(tensor, reduction="mean"):
     def _reduce_across_processes(tensor, reduction="mean"):
         state = PartialState()
         cloned_tensor = tensor.clone()
-        if state.distributed_type == DistributedType.TPU:
-            xm.all_reduce("sum", cloned_tensor)
-            return cloned_tensor
-        elif state.distributed_type.value in CUDA_DISTRIBUTED_TYPES:
-            torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
-            return cloned_tensor
-        elif state.distributed_type == DistributedType.MULTI_CPU:
-            torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
-            return cloned_tensor
-        else:
+        if state.distributed_type == DistributedType.NO:
             if reduction == "sum":
                 return cloned_tensor.sum()
             else:
                 return cloned_tensor.mean()
+        if state.distributed_type == DistributedType.TPU:
+            xm.all_reduce("sum", cloned_tensor)
+        elif state.distributed_type.value in CUDA_DISTRIBUTED_TYPES:
+            torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
+        elif state.distributed_type == DistributedType.MULTI_CPU:
+            torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
+        if reduction == "mean":
+            cloned_tensor /= state.num_processes
+        return cloned_tensor
 
     return recursively_apply(_reduce_across_processes, tensor, error_on_other_type=True, reduction=reduction)
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -232,7 +232,7 @@ def gather(tensor):
 def _gpu_gather_object(object: Any):
     def _gpu_gather_object_one(object: Any):
         output_objects = [None for _ in range(PartialState().num_processes)]
-        torch.distributed.all_gather_object(object, output_objects if PartialState().is_local_main_process else None)
+        torch.distributed.all_gather_object(output_objects, object)
         return output_objects
 
     return recursively_apply(_gpu_gather_object_one, object)

--- a/tests/test_cpu.py
+++ b/tests/test_cpu.py
@@ -15,10 +15,13 @@
 import unittest
 
 from accelerate import debug_launcher
-from accelerate.test_utils import require_cpu, test_script
+from accelerate.test_utils import require_cpu, test_ops, test_script
 
 
 @require_cpu
 class MultiCPUTester(unittest.TestCase):
     def test_cpu(self):
         debug_launcher(test_script.main)
+
+    def test_ops(self):
+        debug_launcher(test_ops.main)

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -31,11 +31,19 @@ class MultiGPUTester(unittest.TestCase):
         self.data_loop_file_path = os.path.sep.join(
             mod_file.split(os.path.sep)[:-1] + ["scripts", "test_distributed_data_loop.py"]
         )
+        self.operation_file_path = os.path.sep.join(mod_file.split(os.path.sep)[:-1] + ["scripts", "test_ops.py"])
 
     @require_multi_gpu
     def test_multi_gpu(self):
         print(f"Found {torch.cuda.device_count()} devices.")
         cmd = get_launch_prefix() + [self.test_file_path]
+        with patch_environment(omp_num_threads=1):
+            execute_subprocess_async(cmd, env=os.environ.copy())
+
+    @require_multi_gpu
+    def test_multi_gpu_ops(self):
+        print(f"Found {torch.cuda.device_count()} devices.")
+        cmd = get_launch_prefix() + [self.operation_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())
 


### PR DESCRIPTION
Closes https://github.com/huggingface/accelerate/issues/1112

Fixes reduce to actually perform the mean operation, and adds a testing suite to the multigpu and cpu testfiles (TPU is a TODO once we have a runner)