### PR TITLE
Expand warning and grab all GPUs available by default

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -815,7 +815,8 @@ def _validate_launch_command(args):
             warned.append(f"\t`--num_processes` was set to a value of `{args.num_processes}`")
             if torch.cuda.device_count() > 1 and not args.multi_gpu:
                 warned.append(
-                    "\tMore than one GPU was found, enabling multi-GPU training. If this was unintended please pass in `--num_processes=1`."
+                    "\t\tMore than one GPU was found, enabling multi-GPU training.\n"
+                    "\t\tIf this was unintended please pass in `--num_processes=1`."
                 )
                 args.multi_gpu = True
         if args.num_machines is None:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -811,8 +811,13 @@ def _validate_launch_command(args):
             args.dynamo_backend = "no"
     else:
         if args.num_processes is None:
-            args.num_processes = torch.cuda.device_count() if args.multi_gpu else 1
+            args.num_processes = torch.cuda.device_count()
             warned.append(f"\t`--num_processes` was set to a value of `{args.num_processes}`")
+            if torch.cuda.device_count() > 1 and not args.multi_gpu:
+                warned.append(
+                    "\tMore than one GPU was found, enabling multi-GPU training. If this was unintended please pass in `--num_processes=1`."
+                )
+                args.multi_gpu = True
         if args.num_machines is None:
             warned.append("\t`--num_machines` was set to a value of `1`")
             args.num_machines = 1


### PR DESCRIPTION
Modifies the default for `launch` to grab all of the GPUs available if called without specifying anything. Will then also set `multi_gpu` to `True`. 