### PR TITLE
Fix notebook_launcher

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -511,10 +511,10 @@ class Accelerator:
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
 
-        def inner(function):
-            return PartialState().on_main_process(function)
+        def _inner(*args, **kwargs):
+            return PartialState().on_main_process(function)(*args, **kwargs)
 
-        return partial(inner, function=function)
+        return _inner
 
     def on_local_main_process(self, function: Callable[..., Any] = None):
         """
@@ -553,10 +553,10 @@ class Accelerator:
                     "The `on_local_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
 
-        def inner(function):
-            return PartialState().on_local_main_process(function)
+        def _inner(*args, **kwargs):
+            return PartialState().on_local_main_process(function)(*args, **kwargs)
 
-        return partial(inner, function=function)
+        return _inner
 
     def on_last_process(self, function: Callable[..., Any]):
         """
@@ -592,10 +592,10 @@ class Accelerator:
                     "The `on_last_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
 
-        def inner(function):
-            return PartialState().on_last_process(function)
+        def _inner(*args, **kwargs):
+            return PartialState().on_last_process(function)(*args, **kwargs)
 
-        return partial(inner, function=function)
+        return _inner
 
     def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
         """
@@ -637,10 +637,10 @@ class Accelerator:
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
 
-        def inner(function, process_index):
-            return PartialState().on_process(function, process_index)
+        def _inner(*args, **kwargs):
+            return PartialState().on_process(function, process_index)(*args, **kwargs)
 
-        return partial(inner, function=function, process_index=process_index)
+        return _inner
 
     def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
         """
@@ -685,10 +685,10 @@ class Accelerator:
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
 
-        def inner(function, local_process_index):
-            return PartialState().on_local_process(function, local_process_index)
+        def _inner(*args, **kwargs):
+            return PartialState().on_local_process(function, local_process_index)(*args, **kwargs)
 
-        return partial(inner, function=function, local_process_index=local_process_index)
+        return _inner
 
     @contextmanager
     def main_process_first(self):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -510,7 +510,11 @@ class Accelerator:
                 raise ValueError(
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        return PartialState().on_main_process(function)
+
+        def inner(function):
+            return PartialState().on_main_process(function)
+
+        return partial(inner, function=function)
 
     def on_local_main_process(self, function: Callable[..., Any] = None):
         """
@@ -548,7 +552,11 @@ class Accelerator:
                 raise ValueError(
                     "The `on_local_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        return PartialState().on_local_main_process(function)
+
+        def inner(function):
+            return PartialState().on_local_main_process(function)
+
+        return partial(inner, function=function)
 
     def on_last_process(self, function: Callable[..., Any]):
         """
@@ -583,7 +591,11 @@ class Accelerator:
                 raise ValueError(
                     "The `on_last_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        return PartialState().on_last_process(function)
+
+        def inner(function):
+            return PartialState().on_last_process(function)
+
+        return partial(inner, function=function)
 
     def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
         """
@@ -624,7 +636,11 @@ class Accelerator:
                 raise ValueError(
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        return PartialState().on_process(function, process_index)
+
+        def inner(function, process_index):
+            return PartialState().on_process(function, process_index)
+
+        return partial(inner, function=function, process_index=process_index)
 
     def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
         """
@@ -668,7 +684,11 @@ class Accelerator:
                 raise ValueError(
                     "The `on_main_process` decorator must be called with a function on an instantiated `Accelerator` object."
                 )
-        return PartialState().on_local_process(function, local_process_index)
+
+        def inner(function, local_process_index):
+            return PartialState().on_local_process(function, local_process_index)
+
+        return partial(inner, function=function, local_process_index=local_process_index)
 
     @contextmanager
     def main_process_first(self):

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -28,6 +28,7 @@ from accelerate.utils import (
     DistributedType,
     gather,
     is_bf16_available,
+    is_torch_version,
     set_seed,
     synchronize_rng_states,
 )

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -371,30 +371,30 @@ def training_check():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
     if state.local_process_index == 0:
         print("\n**Test process execution**")
     process_execution_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    if state.local_process_index == 0:
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-    #     central_dl_preparation_check()
+    if state.local_process_index == 0:
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+        central_dl_preparation_check()
 
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check()
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check()
 
 
 def _mp_fn(index):

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -28,7 +28,6 @@ from accelerate.utils import (
     DistributedType,
     gather,
     is_bf16_available,
-    is_torch_version,
     set_seed,
     synchronize_rng_states,
 )
@@ -62,10 +61,11 @@ def process_execution_check():
     f = io.StringIO()
     with contextlib.redirect_stdout(f):
         accelerator.on_main_process(print_main)(accelerator.state)
+    result = f.getvalue().rstrip()
     if accelerator.is_main_process:
-        assert f.getvalue().rstrip() == "Printing from the main process 0"
+        assert result == "Printing from the main process 0", f"{result} != Printing from the main process 0"
     else:
-        assert f.getvalue().rstrip() == ""
+        assert f.getvalue().rstrip() == "", f'{result} != ""'
     f.truncate(0)
     f.seek(0)
 
@@ -371,30 +371,30 @@ def training_check():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
     if state.local_process_index == 0:
         print("\n**Test process execution**")
     process_execution_check()
 
-    if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-        central_dl_preparation_check()
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+    #     central_dl_preparation_check()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check()
 
 
 def _mp_fn(index):


### PR DESCRIPTION
The decorators in the Accelerator object still were initialing the Accelerator on import, leading to issues when using the `notebook_launcher` (as seen in https://github.com/huggingface/accelerate/issues/1119). This PR fixes https://github.com/huggingface/accelerate/issues/1119 by rewriting the decorators again to follow the `_inner` pattern. Note that this is only needed on the `Accelerator`, for the self-decorators. This isn't needed for the `PartialState` elsewhere. 

(And this problem is mostly apparent on `notebook_launcher`, which takes a fork of the current process)