### PR TITLE
fix partial state

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -542,7 +542,7 @@ class AcceleratorState:
         self.__dict__ = self._shared_state
         if PartialState._shared_state == {} or (cpu != PartialState._shared_state.get("_cpu", False)):
             PartialState(cpu, **kwargs)
-            self.__dict__.update(PartialState._shared_state)
+        self.__dict__.update(PartialState._shared_state)
         self._check_initialized(mixed_precision)
         if not self.initialized:
             self.backend = None

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -542,7 +542,7 @@ class AcceleratorState:
         self.__dict__ = self._shared_state
         if PartialState._shared_state == {} or (cpu != PartialState._shared_state.get("_cpu", False)):
             PartialState(cpu, **kwargs)
-        self.__dict__.update(PartialState._shared_state)
+            self.__dict__.update(PartialState._shared_state)
         self._check_initialized(mixed_precision)
         if not self.initialized:
             self.backend = None
@@ -591,6 +591,7 @@ class AcceleratorState:
                 and self.device.type == "cuda"
             ):
                 torch.backends.cuda.matmul.allow_tf32 = True
+            PartialState._shared_state["distributed_type"] = self.distributed_type
 
     @property
     def initialized(self) -> bool:


### PR DESCRIPTION
### What does this PR do?
1. FSDP and Megatron-LM integrations are broken since the introduction of `PartialState` #1055. In prepare_data_loader , state obj is created again via `state = AcceleratorState()` . Now, it causes everything to go haywire, `self.__dict__.update(PartialState._shared_state)`  reverts FSDP  in AcceleratorState to `MULTI_GPU`  present in PartialState. This PR fixes it.










