### PR TITLE
[Safetensors] Relax missing metadata constraint

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -674,7 +674,8 @@ def load_state_dict(checkpoint_file, device_map=None):
 
         if metadata is None:
             logger.warn(
-                f"The safetensors archive passed at {checkpoint_file} does not contain metadata. Make sure to save your model with the `save_pretrained` method. Defaulting to 'pt' metadata."
+                f"The safetensors archive passed at {checkpoint_file} does not contain metadata. "
+                "Make sure to save your model with the `save_pretrained` method. Defaulting to 'pt' metadata."
             )
             metadata = {"format": "pt"}
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -14,6 +14,7 @@
 
 import gc
 import json
+import logging
 import os
 import re
 import shutil
@@ -33,6 +34,9 @@ if is_safetensors_available():
     from safetensors.torch import load_file as safe_load_file
 
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
+
+
+logger = logging.getLogger(__name__)
 
 
 def convert_file_size_to_int(size: Union[int, str]):
@@ -667,6 +671,13 @@ def load_state_dict(checkpoint_file, device_map=None):
         with safe_open(checkpoint_file, framework="pt") as f:
             metadata = f.metadata()
             weight_names = f.keys()
+
+        if "format" not in metadata:
+            logger.warn(
+                f"The safetensors archive passed at {checkpoint_file} does not contain metadata. Make sure to save your model with the `save_pretrained` method. Defaulting to 'pt' metadata."
+            )
+            metadata["format"] = "pt"
+
         if metadata.get("format") not in ["pt", "tf", "flax"]:
             raise OSError(
                 f"The safetensors archive passed at {checkpoint_file} does not contain the valid metadata. Make sure "

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -672,11 +672,11 @@ def load_state_dict(checkpoint_file, device_map=None):
             metadata = f.metadata()
             weight_names = f.keys()
 
-        if "format" not in metadata:
+        if metadata is None:
             logger.warn(
                 f"The safetensors archive passed at {checkpoint_file} does not contain metadata. Make sure to save your model with the `save_pretrained` method. Defaulting to 'pt' metadata."
             )
-            metadata["format"] = "pt"
+            metadata = {"format": "pt"}
 
         if metadata.get("format") not in ["pt", "tf", "flax"]:
             raise OSError(


### PR DESCRIPTION
Many diffusers checkpoint are sadly saved without `metadata["format"] = "pt"` which then creates the following issues: https://github.com/huggingface/diffusers/issues/2445

@sgugger could we maybe relax the constraint here a bit that if the metadata is missing we assume it's PT (also since accelerate is only made for PT)