### PR TITLE
[`Accelerator`] Fix issue with 8bit models

### DIFF
--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -25,6 +25,8 @@ RUN source activate accelerate && \
     git+https://github.com/huggingface/accelerate#egg=accelerate[testing,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cu113
 
+RUN python3 -m pip install --no-cache-dir bitsandbytes
+
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image
 COPY --from=compile-image /opt/conda /opt/conda

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -6,8 +6,10 @@ from unittest.mock import patch
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
+from accelerate import infer_auto_device_map, init_empty_weights
 from accelerate.accelerator import Accelerator
 from accelerate.state import PartialState
+from accelerate.test_utils import require_multi_gpu, slow
 from accelerate.test_utils.testing import AccelerateTestCase, require_cuda
 from accelerate.utils import patch_environment
 
@@ -160,3 +162,57 @@ class AcceleratorTester(AccelerateTestCase):
 
             # mode.class_name is NOT loaded from config
             self.assertTrue(model.class_name != model.__class__.__name__)
+
+    @slow
+    def test_accelerator_bnb(self):
+        """Tests that the accelerator can be used with the BNB library."""
+        from transformers import AutoModelForCausalLM
+
+        model = AutoModelForCausalLM.from_pretrained(
+            "EleutherAI/gpt-neo-125m",
+            load_in_8bit=True,
+            device_map="auto",
+        )
+        accelerator = Accelerator()
+
+        # This should work
+        model = accelerator.prepare(model)
+
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_pretrained(
+                "EleutherAI/gpt-neo-125m",
+            )
+            device_map = infer_auto_device_map(model)
+            device_map["lm_head"] = "cpu"
+
+        model = AutoModelForCausalLM.from_pretrained(
+            "EleutherAI/gpt-neo-125m", device_map=device_map, load_in_8bit=True, llm_int8_enable_fp32_cpu_offload=True
+        )
+
+        # This should not work and get value error
+        with self.assertRaises(ValueError):
+            model = accelerator.prepare(model)
+
+    @slow
+    @require_multi_gpu
+    def test_accelerator_bnb_multi_gpu(self):
+        """Tests that the accelerator can be used with the BNB library."""
+        from transformers import AutoModelForCausalLM
+
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_pretrained(
+                "EleutherAI/gpt-neo-125m",
+            )
+            device_map = infer_auto_device_map(model)
+            device_map["lm_head"] = 1
+
+        model = AutoModelForCausalLM.from_pretrained(
+            "EleutherAI/gpt-neo-125m",
+            load_in_8bit=True,
+            device_map=device_map,
+        )
+        accelerator = Accelerator()
+
+        # This should not work and get value error
+        with self.assertRaises(ValueError):
+            _ = accelerator.prepare(model)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/accelerate/issues/1147

In theory it is not possible to fine-tune 8-bit models except if you use adapters that can be used only is a `PeftModel` is used for training (I also need to test the snippet below with a `PeftModel` to make sure this is relevant or not)

But in some systems you can use the accelerator to load an 8bit model and use it out of the training scope 

I am not sure if we should support 8-bit models using `Accelerator`, but if so, I propose the following changes in this PR
Happy also to revert the tests / `bnb` dependency 

To reproduce: 
```python
import torch
import torch.nn.functional as F

from transformers import AutoModelForCausalLM
from datasets import load_dataset
from accelerate import Accelerator

model = AutoModelForCausalLM.from_pretrained(
    "EleutherAI/gpt-neo-125m",
    load_in_8bit=True,
    device_map="balanced",
)

accelerator = Accelerator()


model = accelerator.prepare(model)

```

cc @sgugger 

Ran all the slow tests and got errors on DeepSpeed and FSDP tests but not sure if the failing is related to my PR

<img width="1166" alt="Screenshot 2023-03-06 at 18 24 12" src="https://user-images.githubusercontent.com/49240599/223184756-66e6fcbe-4179-444a-b26f-a6a70693cb17.png">