### PR TITLE
Let GradientState know active dataloaders and reset the remainder

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -368,7 +368,6 @@ class DataLoaderShard(DataLoader):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.synchronized_generator)
         self.gradient_state._add_dataloader(self)
-        self.gradient_state._set_end_of_dataloader(False)
         # We can safely pass because the default is -1
         with suppress(Exception):
             length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
@@ -392,7 +391,6 @@ class DataLoaderShard(DataLoader):
                 batch_index += 1
                 current_batch = next_batch
             except StopIteration:
-                self.gradient_state._set_end_of_dataloader(True)
                 self.gradient_state._remove_dataloader(self)
                 if batch_index >= self.skip_batches:
                     yield current_batch
@@ -505,7 +503,6 @@ class DataLoaderDispatcher(DataLoader):
 
     def __iter__(self):
         self.gradient_state._add_dataloader(self)
-        self.gradient_state._set_end_of_dataloader(False)
         main_iterator = None
         if self.state.process_index == 0:
             # We only iterate through the DataLoader on process 0.
@@ -552,7 +549,6 @@ class DataLoaderDispatcher(DataLoader):
 
             if stop_iteration:
                 self.gradient_state._set_remainder(observed_batch_size)
-                self.gradient_state._set_end_of_dataloader(True)
                 self.gradient_state._remove_dataloader(self)
             if batch_index >= self.skip_batches:
                 yield batch

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -548,8 +548,8 @@ class DataLoaderDispatcher(DataLoader):
             batch = slice_tensors(batch, data_slice)
 
             if stop_iteration:
-                self.gradient_state._set_remainder(observed_batch_size)
                 self.gradient_state._remove_dataloader(self)
+                self.gradient_state._set_remainder(observed_batch_size)
             if batch_index >= self.skip_batches:
                 yield batch
             batch_index += 1

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -713,7 +713,6 @@ class GradientState:
             self.remainder = -1
             self.active_dataloader = None
             self.dataloader_references = [None]
-            self.remainder_references = [-1]
 
     @property
     def initialized(self) -> bool:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -17,7 +17,6 @@ import warnings
 from contextlib import contextmanager
 from functools import partial
 from typing import Any, Callable
-import weakref
 
 import torch
 
@@ -744,11 +743,13 @@ class GradientState:
         "Private function that adds a dataloader to `self.dataloader_references` and sets `in_dataloader` to `True`. Users should not have to call this."
         self.active_dataloader = dataloader
         self.dataloader_references.append(self.active_dataloader)
+        self._set_end_of_dataloader(False)
 
     def _remove_dataloader(self, dataloader):
         "Private function that removes a dataloader from `self.dataloader_references` and sets `in_dataloader` to `False` if there are no more dataloaders. Users should not have to call this."
         self.dataloader_references.remove(dataloader)
         self.active_dataloader = self.dataloader_references[-1]
+        self._set_end_of_dataloader(True)
 
     @property
     def in_dataloader(self) -> bool:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -713,6 +713,7 @@ class GradientState:
             self.remainder = -1
             self.active_dataloader = None
             self.dataloader_references = [None]
+            self.remainder_references = [-1]
 
     @property
     def initialized(self) -> bool:
@@ -733,7 +734,6 @@ class GradientState:
     def _set_end_of_dataloader(self, end_of_dataloader):
         "Private function that sets whether the end of the current dataloader has been reached. Users should not have to call this."
         self.end_of_dataloader = end_of_dataloader
-        self.remainder = -1
 
     def _set_remainder(self, remainder):
         "Private function that sets the number of remaining samples at the end of the dataloader. Users should not have to call this."

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -260,7 +260,6 @@ def main():
     if state.local_process_index == 0:
         print("**Test `accumulate` gradient accumulation with dataloader break**")
     test_dataloader_break()
-    accelerator.gradient_state._shared_state = {}
     if state.distributed_type == DistributedType.NO:
         if state.local_process_index == 0:
             print("**Test NOOP `no_sync` context manager**")

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -260,6 +260,7 @@ def main():
     if state.local_process_index == 0:
         print("**Test `accumulate` gradient accumulation with dataloader break**")
     test_dataloader_break()
+    accelerator.gradient_state._shared_state = {}
     if state.distributed_type == DistributedType.NO:
         if state.local_process_index == 0:
             print("**Test NOOP `no_sync` context manager**")

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -243,11 +243,17 @@ def test_dataloader_break():
             if iteration == 1:
                 for batch_num, _ in enumerate(second_dataloader):
                     if batch_num < len(second_dataloader) - 1:
-                        assert id(accelerator.gradient_state.active_dataloader) == id(second_dataloader), f"First dataloader: {id(first_dataloader)}\nSecond dataloader: {id(second_dataloader)}\nActive dataloader: {id(accelerator.gradient_state.active_dataloader)}\n"
+                        assert id(accelerator.gradient_state.active_dataloader) == id(
+                            second_dataloader
+                        ), f"First dataloader: {id(first_dataloader)}\nSecond dataloader: {id(second_dataloader)}\nActive dataloader: {id(accelerator.gradient_state.active_dataloader)}\n"
                     else:
-                        assert id(accelerator.gradient_state.active_dataloader) == id(first_dataloader), f"First dataloader: {id(first_dataloader)}\nSecond dataloader: {id(second_dataloader)}\nActive dataloader: {id(accelerator.gradient_state.active_dataloader)}\n"
+                        assert id(accelerator.gradient_state.active_dataloader) == id(
+                            first_dataloader
+                        ), f"First dataloader: {id(first_dataloader)}\nSecond dataloader: {id(second_dataloader)}\nActive dataloader: {id(accelerator.gradient_state.active_dataloader)}\n"
         else:
-            assert accelerator.gradient_state.active_dataloader == None
+            assert accelerator.gradient_state.active_dataloader is None
+
+
 def main():
     accelerator = Accelerator()
     state = accelerator.state

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -257,6 +257,9 @@ def test_dataloader_break():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
+    if state.local_process_index == 0:
+        print("**Test `accumulate` gradient accumulation with dataloader break**")
+    test_dataloader_break()
     if state.distributed_type == DistributedType.NO:
         if state.local_process_index == 0:
             print("**Test NOOP `no_sync` context manager**")
@@ -291,9 +294,6 @@ def main():
                         f"`split_batches={split_batch}` and `dispatch_batches={dispatch_batches}`**",
                     )
                 test_gradient_accumulation_with_opt_and_scheduler(split_batch, dispatch_batches)
-    if state.local_process_index == 0:
-        print("**Test `accumulate` gradient accumulation with dataloader break**")
-    test_dataloader_break()
 
 
 def _mp_fn(index):

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -22,7 +22,7 @@ from torch.utils.data import DataLoader
 
 from accelerate.accelerator import Accelerator
 from accelerate.test_utils import RegressionDataset, RegressionModel
-from accelerate.utils import set_seed
+from accelerate.utils import DistributedType, set_seed
 
 
 def check_model_parameters(model_a, model_b, did_step, iteration):
@@ -257,40 +257,40 @@ def test_dataloader_break():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.distributed_type == DistributedType.NO:
-    #     if state.local_process_index == 0:
-    #         print("**Test NOOP `no_sync` context manager**")
-    #     test_noop_sync(accelerator)
-    # if state.distributed_type in (DistributedType.MULTI_GPU, DistributedType.MULTI_CPU):
-    #     if state.local_process_index == 0:
-    #         print("**Test Distributed `no_sync` context manager**")
-    #     test_distributed_sync(accelerator)
-    # if state.distributed_type == DistributedType.MULTI_GPU:
-    #     for split_batch in [True, False]:
-    #         for dispatch_batches in [True, False]:
-    #             if state.local_process_index == 0:
-    #                 print(
-    #                     "**Test `accumulate` gradient accumulation, ",
-    #                     f"`split_batches={split_batch}` and `dispatch_batches={dispatch_batches}`**",
-    #                 )
-    #             test_gradient_accumulation(split_batch, dispatch_batches)
-    # if state.local_process_index == 0:
-    #     print(
-    #         "**Test `accumulate` gradient accumulation with optimizer and scheduler, ",
-    #         "`split_batches=False`, `dispatch_batches=False`**",
-    #     )
-    # test_gradient_accumulation_with_opt_and_scheduler()
-    # if state.distributed_type == DistributedType.MULTI_GPU:
-    #     for split_batch in [True, False]:
-    #         for dispatch_batches in [True, False]:
-    #             if not split_batch and not dispatch_batches:
-    #                 continue
-    #             if state.local_process_index == 0:
-    #                 print(
-    #                     "**Test `accumulate` gradient accumulation with optimizer and scheduler, ",
-    #                     f"`split_batches={split_batch}` and `dispatch_batches={dispatch_batches}`**",
-    #                 )
-    #             test_gradient_accumulation_with_opt_and_scheduler(split_batch, dispatch_batches)
+    if state.distributed_type == DistributedType.NO:
+        if state.local_process_index == 0:
+            print("**Test NOOP `no_sync` context manager**")
+        test_noop_sync(accelerator)
+    if state.distributed_type in (DistributedType.MULTI_GPU, DistributedType.MULTI_CPU):
+        if state.local_process_index == 0:
+            print("**Test Distributed `no_sync` context manager**")
+        test_distributed_sync(accelerator)
+    if state.distributed_type == DistributedType.MULTI_GPU:
+        for split_batch in [True, False]:
+            for dispatch_batches in [True, False]:
+                if state.local_process_index == 0:
+                    print(
+                        "**Test `accumulate` gradient accumulation, ",
+                        f"`split_batches={split_batch}` and `dispatch_batches={dispatch_batches}`**",
+                    )
+                test_gradient_accumulation(split_batch, dispatch_batches)
+    if state.local_process_index == 0:
+        print(
+            "**Test `accumulate` gradient accumulation with optimizer and scheduler, ",
+            "`split_batches=False`, `dispatch_batches=False`**",
+        )
+    test_gradient_accumulation_with_opt_and_scheduler()
+    if state.distributed_type == DistributedType.MULTI_GPU:
+        for split_batch in [True, False]:
+            for dispatch_batches in [True, False]:
+                if not split_batch and not dispatch_batches:
+                    continue
+                if state.local_process_index == 0:
+                    print(
+                        "**Test `accumulate` gradient accumulation with optimizer and scheduler, ",
+                        f"`split_batches={split_batch}` and `dispatch_batches={dispatch_batches}`**",
+                    )
+                test_gradient_accumulation_with_opt_and_scheduler(split_batch, dispatch_batches)
     if state.local_process_index == 0:
         print("**Test `accumulate` gradient accumulation with dataloader break**")
     test_dataloader_break()


### PR DESCRIPTION
Adjusts the `GradientState` so it can know:
- What dataloader is entered/exited on `__iter__`
- The total dataloader list that we are currently iterating over
- Changes the logic for setting the end of the dataloader to exist in `GradientState._add_dataloader` and `GradientState._remove_dataloader`

Solves https://github.com/huggingface/accelerate/issues/960 and https://github.com/huggingface/accelerate/issues/1050