### PR TITLE
Remove outdated command directions and use in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Want to learn more? Check out the [documentation](https://huggingface.co/docs/ac
 
 ## Launching script
 
-🤗 Accelerate also provides an optional CLI tool that allows you to quickly configure and test your training environment before launching the scripts. No need to remember how to use `torch.distributed.launch` or to write a specific launcher for TPU training!
+🤗 Accelerate also provides an optional CLI tool that allows you to quickly configure and test your training environment before launching the scripts. No need to remember how to use `torch.distributed.run` or to write a specific launcher for TPU training!
 On your machine(s) just run:
 
 ```bash
@@ -155,7 +155,7 @@ For instance, here is how you would run the GLUE example on the MRPC task (from 
 accelerate launch examples/nlp_example.py
 ```
 
-This CLI tool is **optional**, and you can still use `python my_script.py` or `python -m torch.distributed.launch my_script.py` at your convenance.
+This CLI tool is **optional**, and you can still use `python my_script.py` or `python -m torchrun my_script.py` at your convenance.
 
 ## Launching multi-CPU run using MPI
 

--- a/docs/source/quicktour.mdx
+++ b/docs/source/quicktour.mdx
@@ -164,9 +164,8 @@ should be calculated through the [`~Accelerator.gather_for_metrics`] method to a
 
 ## Launching your distributed script
 
-You can use the regular commands to launch your distributed training (like `torch.distributed.launch` for
-PyTorch), they are fully compatible with 🤗 Accelerate. The only caveat here is that 🤗 Accelerate uses the environment
-to determine all useful information, so `torch.distributed.launch` should be used with the flag `--use_env`.
+You can use the regular commands to launch your distributed training (like `torch.distributed.run` for
+PyTorch), they are fully compatible with 🤗 Accelerate.
 
 🤗 Accelerate also provides a CLI tool that unifies all launchers, so you only have to remember one command. To use it,
 just run:

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,7 @@ To run it in each of these various modes, use the following commands:
         accelerate config  # This will create a config file on your server
         accelerate launch ./nlp_example.py  # This will run the script on your server
         ```
-    * With traditional PyTorch launcher
+    * With traditional PyTorch launcher (`torch.distributed.launch` can be used with older versions of PyTorch)
         ```bash
         python -m torchrun --nproc_per_node 2 --use_env ./nlp_example.py
         ```
@@ -74,7 +74,7 @@ To run it in each of these various modes, use the following commands:
         accelerate config  # This will create a config file on each server
         accelerate launch ./nlp_example.py  # This will run the script on each server
         ```
-    * With PyTorch launcher only
+    * With PyTorch launcher only (`torch.distributed.launch` can be used in older versions of PyTorch)
         ```bash
         python -m torchrun --nproc_per_node 2 \
             --use_env \
@@ -152,7 +152,7 @@ To run it in each of these various modes, use the following commands:
         accelerate config  # This will create a config file on your server
         accelerate launch ./cv_example.py --data_dir path_to_data  # This will run the script on your server
         ```
-    * With traditional PyTorch launcher
+    * With traditional PyTorch launcher (`torch.distributed.launch` can be used with older versions of PyTorch)
         ```bash
         python -m torchrun --nproc_per_node 2 --use_env ./cv_example.py --data_dir path_to_data
         ```
@@ -162,7 +162,7 @@ To run it in each of these various modes, use the following commands:
         accelerate config  # This will create a config file on each server
         accelerate launch ./cv_example.py --data_dir path_to_data  # This will run the script on each server
         ```
-    * With PyTorch launcher only
+    * With PyTorch launcher only (`torch.distributed.launch` can be used with older versions of PyTorch)
         ```bash
         python -m torchrun --nproc_per_node 2 \
             --use_env \

--- a/examples/README.md
+++ b/examples/README.md
@@ -66,7 +66,7 @@ To run it in each of these various modes, use the following commands:
         ```
     * With traditional PyTorch launcher
         ```bash
-        python -m torch.distributed.launch --nproc_per_node 2 --use_env ./nlp_example.py
+        python -m torchrun --nproc_per_node 2 --use_env ./nlp_example.py
         ```
 - multi GPUs, multi node (several machines, using PyTorch distributed mode)
     * With Accelerate config and launcher, on each machine:
@@ -76,12 +76,12 @@ To run it in each of these various modes, use the following commands:
         ```
     * With PyTorch launcher only
         ```bash
-        python -m torch.distributed.launch --nproc_per_node 2 \
+        python -m torchrun --nproc_per_node 2 \
             --use_env \
             --node_rank 0 \
             --master_addr master_node_ip_address \
             ./nlp_example.py  # On the first server
-        python -m torch.distributed.launch --nproc_per_node 2 \
+        python -m torchrun --nproc_per_node 2 \
             --use_env \
             --node_rank 1 \
             --master_addr master_node_ip_address \
@@ -154,7 +154,7 @@ To run it in each of these various modes, use the following commands:
         ```
     * With traditional PyTorch launcher
         ```bash
-        python -m torch.distributed.launch --nproc_per_node 2 --use_env ./cv_example.py --data_dir path_to_data
+        python -m torchrun --nproc_per_node 2 --use_env ./cv_example.py --data_dir path_to_data
         ```
 - multi GPUs, multi node (several machines, using PyTorch distributed mode)
     * With Accelerate config and launcher, on each machine:
@@ -164,12 +164,12 @@ To run it in each of these various modes, use the following commands:
         ```
     * With PyTorch launcher only
         ```bash
-        python -m torch.distributed.launch --nproc_per_node 2 \
+        python -m torchrun --nproc_per_node 2 \
             --use_env \
             --node_rank 0 \
             --master_addr master_node_ip_address \
             ./cv_example.py --data_dir path_to_data  # On the first server
-        python -m torch.distributed.launch --nproc_per_node 2 \
+        python -m torchrun --nproc_per_node 2 \
             --use_env \
             --node_rank 1 \
             --master_addr master_node_ip_address \

--- a/examples/by_feature/README.md
+++ b/examples/by_feature/README.md
@@ -19,7 +19,7 @@ Adjustments to each script from the base `nlp_example.py` file can be found quic
 
 All following scripts also accept these arguments in addition to their added ones.
 
-These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torch.distributed.launch`), such as:
+These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torch.distributed.run`), such as:
 
 ```bash
 accelerate launch ../nlp_example.py --mixed_precision fp16 --cpu 0
@@ -34,7 +34,7 @@ accelerate launch ../nlp_example.py --mixed_precision fp16 --cpu 0
   - `output_dir`, where saved state folders should be saved to, default is current working directory
   - `resume_from_checkpoint`, what checkpoint folder to resume from. ("epoch_0", "step_22", ...)
 
-These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torch.distributed.launch`), such as:
+These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torchrun`), such as:
 
 (Note, `resume_from_checkpoint` assumes that we've ran the script for one epoch with the `--checkpointing_steps epoch` flag)
 
@@ -48,7 +48,7 @@ accelerate launch ./checkpointing.py --checkpointing_steps epoch output_dir "che
 - Arguments available:
   - `num_folds`, the number of folds the training dataset should be split into.
 
-These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torch.distributed.launch`), such as:
+These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torchrun`), such as:
 
 ```bash
 accelerate launch ./cross_validation.py --num_folds 2
@@ -61,7 +61,7 @@ accelerate launch ./cross_validation.py --num_folds 2
 - Arguments available:
   - `with_tracking`, whether to load in all available experiment trackers from the environment.
 
-These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torch.distributed.launch`), such as:
+These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torchrun`), such as:
 
 ```bash
 accelerate launch ./tracking.py --with_tracking
@@ -73,7 +73,7 @@ accelerate launch ./tracking.py --with_tracking
 - Arguments available:
   - `gradient_accumulation_steps`, the number of steps to perform before the gradients are accumulated and the optimizer and scheduler are stepped + zero_grad
 
-These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torch.distributed.launch`), such as:
+These arguments should be added at the end of any method for starting the python script (such as `python`, `accelerate launch`, `python -m torchrun`), such as:
 
 ```bash
 accelerate launch ./gradient_accumulation.py --gradient_accumulation_steps 5

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -14,7 +14,6 @@
 
 import inspect
 import os
-import sys
 import unittest
 from dataclasses import dataclass
 
@@ -23,7 +22,7 @@ import torch
 from accelerate import Accelerator, DistributedDataParallelKwargs, GradScalerKwargs
 from accelerate.state import AcceleratorState
 from accelerate.test_utils import execute_subprocess_async, require_cuda, require_multi_gpu
-from accelerate.utils import KwargsHandler
+from accelerate.utils import KwargsHandler, get_launch_prefix
 
 
 @dataclass
@@ -61,13 +60,8 @@ class DataLoaderTester(unittest.TestCase):
 
     @require_multi_gpu
     def test_ddp_kwargs(self):
-        distributed_args = f"""
-            -m torch.distributed.run
-            --nproc_per_node={torch.cuda.device_count()}
-            --use_env
-            {inspect.getfile(self.__class__)}
-        """.split()
-        cmd = [sys.executable] + distributed_args
+        cmd = get_launch_prefix()
+        cmd += [f"--nproc_per_node={torch.cuda.device_count()}", inspect.getfile(self.__class__)]
         execute_subprocess_async(cmd, env=os.environ.copy())
 
 

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -62,7 +62,7 @@ class DataLoaderTester(unittest.TestCase):
     @require_multi_gpu
     def test_ddp_kwargs(self):
         distributed_args = f"""
-            -m torch.distributed.launch
+            -m torch.distributed.run
             --nproc_per_node={torch.cuda.device_count()}
             --use_env
             {inspect.getfile(self.__class__)}


### PR DESCRIPTION
Since `torch.distributed.launch` is deprecated, finds all cases of `launch` and replaces with `run`/`torchrun`