### PR TITLE
[`Accelerator`] We should not call `to` on modules that wraps `accelerate` loaded models

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1137,6 +1137,14 @@ class Accelerator:
             device_placement = self.device_placement and self.distributed_type != DistributedType.FSDP
         self._models.append(model)
         # We check only for models loaded with `accelerate`
+
+        # recursively check for the attribute - some models wraps models that are loaded with `accelerate`.
+        has_hf_device_map = False
+        for m in model.modules():
+            if hasattr(m, "hf_device_map"):
+                has_hf_device_map = True
+                break
+
         if getattr(model, "is_loaded_in_8bit", False) and getattr(model, "hf_device_map", False):
             model_devices = set(model.hf_device_map.values())
             if len(model_devices) > 1:
@@ -1157,7 +1165,7 @@ class Accelerator:
                 raise ValueError(
                     "You can't train a model that has been loaded in 8-bit precision with CPU or disk offload."
                 )
-        elif device_placement:
+        elif device_placement and not has_hf_device_map:
             model = model.to(self.device)
 
         if self.distributed_type == DistributedType.MULTI_GPU:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1138,7 +1138,7 @@ class Accelerator:
         self._models.append(model)
         # We check only for models loaded with `accelerate`
 
-        # recursively check for the attribute - some models wraps models that are loaded with `accelerate`.
+        # Checks if any of the child module has the attribute `hf_device_map`.
         has_hf_device_map = False
         for m in model.modules():
             if hasattr(m, "hf_device_map"):


### PR DESCRIPTION
# What does this PR do?

In some training setups such as in `trl`: https://github.com/lvwerra/trl sometimes users create a new module that wraps modules that are loaded with `accelerate`. Check for example [this class](https://github.com/lvwerra/trl/blob/ddb6df367da4a7374287f35ae37d092f7c32a815/trl/models/modeling_value_head.py#L57)
I propose a simple fix in the accelerator to check if there is any immediate child module that has the `hf_device_map` attribute

cc @sgugger 

I can confirm all slow tests pass except the similar ones as in https://github.com/huggingface/accelerate/pull/1155 - which I believe are related to the way I am creating my env