### PR TITLE
Fix CPU error always being raised

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -598,7 +598,7 @@ class AcceleratorState:
         "Checks if a modification is trying to be made and the `AcceleratorState` has already been initialized"
         if self.initialized:
             err = "AcceleratorState has already been initialized and cannot be changed, restart your runtime completely and pass `{flag}` to `Accelerator()`."
-            if cpu != (self.device.type == "cpu"):
+            if cpu and self.device.type != "cpu":
                 raise ValueError(err.format(flag="cpu=True"))
             if (
                 mixed_precision is not None

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -233,10 +233,3 @@ class AcceleratorTester(AccelerateTestCase):
         sgd = torch.optim.SGD(model.parameters(), lr=0.01)
         accelerator = Accelerator(cpu=True)
         _ = accelerator.prepare(sgd)
-
-    @require_cuda
-    def test_accelerator_cpu_flag(self):
-        """Tests that the AcceleratorState will raise the right error when trying to use the cpu flag."""
-        _ = Accelerator(cpu=False)
-        with self.assertRaises(ValueError):
-            _ = Accelerator(cpu=True)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -226,3 +226,17 @@ class AcceleratorTester(AccelerateTestCase):
         # This should not work and get value error
         with self.assertRaises(ValueError):
             _ = accelerator.prepare(model)
+
+    @require_cuda
+    def test_accelerator_cpu_flag_prepare(self):
+        model = torch.nn.Linear(10, 10)
+        sgd = torch.optim.SGD(model.parameters(), lr=0.01)
+        accelerator = Accelerator(cpu=True)
+        _ = accelerator.prepare(sgd)
+
+    # @require_cuda
+    # def test_accelerator_cpu_flag(self):
+    #     """Tests that the AcceleratorState will raise the right error when trying to use the cpu flag."""
+    #     _ = Accelerator(cpu=True)
+    #     with self.assertRaises(AssertionError):
+    #         _ = Accelerator(cpu=False)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -40,7 +40,7 @@ class AcceleratorTester(AccelerateTestCase):
         _ = Accelerator()
         assert PartialState._shared_state["_cpu"] is False
         assert PartialState._shared_state["device"].type == "cuda"
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             _ = Accelerator(cpu=True)
 
     def test_prepared_objects_are_referenced(self):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -234,9 +234,9 @@ class AcceleratorTester(AccelerateTestCase):
         accelerator = Accelerator(cpu=True)
         _ = accelerator.prepare(sgd)
 
-    # @require_cuda
-    # def test_accelerator_cpu_flag(self):
-    #     """Tests that the AcceleratorState will raise the right error when trying to use the cpu flag."""
-    #     _ = Accelerator(cpu=True)
-    #     with self.assertRaises(AssertionError):
-    #         _ = Accelerator(cpu=False)
+    @require_cuda
+    def test_accelerator_cpu_flag(self):
+        """Tests that the AcceleratorState will raise the right error when trying to use the cpu flag."""
+        _ = Accelerator(cpu=False)
+        with self.assertRaises(ValueError):
+            _ = Accelerator(cpu=True)


### PR DESCRIPTION
Turns out I've discovered a neat behavior in the library, that was "broken" with the State rewrite. With how `Accelerate` will work, if the user defines `cpu=False` initially then goes `cpu=True`, then a value error will be raised and the state will be changed. *But* if `cpu=True` is passed first then `cpu=False`, nothing will change and no error will be raised. The reason for this is simply because its the default and its a way for `State` to not override the first choice, so we assume CPU all the time. 

Also brings back the `ACCELERATE_USE_CPU` env flag, as this was removed in the `State` refactor. 

This brings back this behavior and adds a test to the `AcceleratorTester` class. 

Closes https://github.com/huggingface/accelerate/issues/1174