### PR TITLE
Fix typo in launch.py tpu_pod_launcher

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -707,7 +707,7 @@ def tpu_pod_launcher(args):
         str(1),
         "--mixed_precision",
         "no",
-        "--dynmo_backend",
+        "--dynamo_backend",
         "no",
         "--num_processes",
         str(args.num_processes),


### PR DESCRIPTION
Fixed typo in tpu_pod_launcher src/accelerate/commands/launch.py that caused accelerate launch to crash on TPU pods by not reading config properly. Replaced  "--dynmo_backend" with  "--dynamo_backend",