### PR TITLE
Make the Scheduler adjust the steps taken relative to the gradient accumulation steps

### DIFF
--- a/docs/source/usage_guides/gradient_accumulation.mdx
+++ b/docs/source/usage_guides/gradient_accumulation.mdx
@@ -111,6 +111,11 @@ You can remove all the special checks for the step number and the loss adjustmen
 
 As you can see the [`Accelerator`] is able to keep track of the batch number you are on and it will automatically know whether to step through the prepared optimizer and how to adjust the loss. 
 
+<Tip>
+  Typically with gradient accumulation, you would need to adjust the number of steps to reflect the change in total batches you are 
+  training on. 🤗 Accelerate will automatically do this for you, so long as you pass `adjust_scheduler_to_accumulation` to the [`Accelerator`] object's `__init__`.
+</Tip>
+
 ## The finished code
 
 Below is the finished implementation for performing gradient accumulation with 🤗 Accelerate

--- a/docs/source/usage_guides/gradient_accumulation.mdx
+++ b/docs/source/usage_guides/gradient_accumulation.mdx
@@ -112,8 +112,10 @@ You can remove all the special checks for the step number and the loss adjustmen
 As you can see the [`Accelerator`] is able to keep track of the batch number you are on and it will automatically know whether to step through the prepared optimizer and how to adjust the loss. 
 
 <Tip>
-  Typically with gradient accumulation, you would need to adjust the number of steps to reflect the change in total batches you are 
-  training on. 🤗 Accelerate will automatically do this for you, so long as you pass `adjust_scheduler_to_accumulation` to the [`Accelerator`] object's `__init__`.
+
+Typically with gradient accumulation, you would need to adjust the number of steps to reflect the change in total batches you are 
+training on. 🤗 Accelerate will automatically do this for you, so long as you pass `adjust_scheduler_to_accumulation` to the [`Accelerator`] object's `__init__`.
+
 </Tip>
 
 ## The finished code

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -27,6 +27,8 @@ from typing import Any, Callable, List, Optional, Union
 import torch
 import torch.utils.hooks as hooks
 
+from accelerate.utils.environment import parse_choice_from_env
+
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_batches
 from .logging import get_logger
@@ -308,6 +310,10 @@ class Accelerator:
         if megatron_lm_plugin:
             if not is_megatron_lm_available():
                 raise ImportError("Megatron is not installed. please build it from source.")
+
+        gradient_accumulation_steps = int(
+            parse_choice_from_env("ACCELERATE_GRADIENT_ACCUMULATION_STEPS", gradient_accumulation_steps)
+        )
 
         if gradient_accumulation_plugin is not None:
             if gradient_accumulation_steps != 1:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -217,7 +217,6 @@ class Accelerator:
         split_batches: bool = False,
         mixed_precision: Union[PrecisionType, str] = None,
         gradient_accumulation_steps: int = None,
-        adjust_scheduler_to_accumulation: bool = False,
         cpu: bool = False,
         deepspeed_plugin: DeepSpeedPlugin = None,
         fsdp_plugin: FullyShardedDataParallelPlugin = None,
@@ -373,7 +372,6 @@ class Accelerator:
         ):
             raise ValueError("Can only use `downcast_bf16` when using `mixed_precision='bf16'` and on a TPU")
 
-        self.adjust_scheduler_to_accumulation = adjust_scheduler_to_accumulation
         self.device_placement = device_placement
         self.split_batches = split_batches
         self.dispatch_batches = dispatch_batches
@@ -830,7 +828,7 @@ class Accelerator:
         >>> from accelerate import Accelerator
         >>> from accelerate.utils import GradientAccumulationPlugin
 
-        >>> plugin = GradientAccumulationPlugin(gradient_accumulation_steps=2)
+        >>> plugin = GradientAccumulationPlugin(num_steps=2)
         >>> accelerator = Accelerator(gradient_accumulation_plugin=plugin)
         >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
 
@@ -1632,7 +1630,7 @@ class Accelerator:
         >>> from accelerate import Accelerator
         >>> from accelerate.utils import GradientAccumulationPlugin
 
-        >>> plugin = GradientAccumulationPlugin(gradient_accumulation_steps=2)
+        >>> plugin = GradientAccumulationPlugin(num_steps=2)
         >>> accelerator = Accelerator(gradient_accumulation_plugin=plugin)
         >>> outputs = model(inputs)
         >>> loss = loss_fn(outputs, labels)
@@ -1697,8 +1695,10 @@ class Accelerator:
 
         ```python
         >>> from accelerate import Accelerator
+        >>> from accelerate.utils import GradientAccumulationPlugin
 
-        >>> accelerator = Accelerator(gradient_accumulation_steps=2)
+        >>> plugin = GradientAccumulationPlugin(num_steps=2)
+        >>> accelerator = Accelerator(gradient_accumulation_plugin=plugin)
         >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
 
         >>> for input, target in dataloader:
@@ -1732,8 +1732,10 @@ class Accelerator:
 
         ```python
         >>> from accelerate import Accelerator
+        >>> from accelerate.utils import GradientAccumulationPlugin
 
-        >>> accelerator = Accelerator(gradient_accumulation_steps=2)
+        >>> plugin = GradientAccumulationPlugin(num_steps=2)
+        >>> accelerator = Accelerator(gradient_accumulation_plugin=plugin)
         >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
 
         >>> for input, target in dataloader:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -811,6 +811,10 @@ class Accelerator:
     def sync_gradients(self):
         return self.gradient_state.sync_gradients
 
+    @property
+    def gradient_accumulation_steps(self):
+        return self.gradient_state.num_steps
+
     @contextmanager
     def accumulate(self, model):
         """

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -317,12 +317,6 @@ class Accelerator:
         else:
             gradient_accumulation_plugin = GradientAccumulationPlugin(num_steps=gradient_accumulation_steps)
 
-        if self.state.distributed_type == DistributedType.TPU:
-            if gradient_accumulation_plugin.num_steps != 1:
-                raise ValueError(
-                    "Gradient accumulation is not supported on TPU. Please set `gradient_accumulation_steps` to 1 and don't pass in a `GradientAccumulationPlugin` object."
-                )
-
         # Kwargs handlers
         self.ddp_handler = None
         self.scaler_handler = None
@@ -365,6 +359,12 @@ class Accelerator:
             _from_accelerator=True,
             **kwargs,
         )
+
+        if self.state.distributed_type == DistributedType.TPU:
+            if gradient_accumulation_plugin.num_steps != 1:
+                raise ValueError(
+                    "Gradient accumulation is not supported on TPU. Please set `gradient_accumulation_steps` to 1 and don't pass in a `GradientAccumulationPlugin` object."
+                )
 
         trackers = filter_trackers(log_with, self.logging_dir)
         if len(trackers) < 1 and log_with is not None:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -27,8 +27,6 @@ from typing import Any, Callable, List, Optional, Union
 import torch
 import torch.utils.hooks as hooks
 
-from accelerate.utils.environment import parse_choice_from_env
-
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
 from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_batches
 from .logging import get_logger
@@ -68,6 +66,7 @@ from .utils import (
     is_torch_version,
     is_tpu_available,
     pad_across_processes,
+    parse_choice_from_env,
     recursively_apply,
     reduce,
     release_memory,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -317,6 +317,12 @@ class Accelerator:
         else:
             gradient_accumulation_plugin = GradientAccumulationPlugin(num_steps=gradient_accumulation_steps)
 
+        if self.state.distributed_type == DistributedType.TPU:
+            if gradient_accumulation_plugin.num_steps != 1:
+                raise ValueError(
+                    "Gradient accumulation is not supported on TPU. Please set `gradient_accumulation_steps` to 1 and don't pass in a `GradientAccumulationPlugin` object."
+                )
+
         # Kwargs handlers
         self.ddp_handler = None
         self.scaler_handler = None

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -73,18 +73,7 @@ class AcceleratedScheduler:
             gradient_accumulation_steps (`int`, *optional*, defaults to 1):
                 The number of gradient accumulation steps.
         """
-        if hasattr(self.scheduler, "total_iters"):
-            print(f'Adjusting scheduler total_iters from {self.scheduler.total_iters} to {self.scheduler.total_iters // gradient_accumulation_steps}')
-            self.scheduler.total_iters = self.scheduler.total_iters // gradient_accumulation_steps
-        elif hasattr(self.scheduler, "total_steps"):
-            print(f'Adjusting scheduler total_steps from {self.scheduler.total_steps} to {self.scheduler.total_steps // gradient_accumulation_steps}')
-            self.scheduler.total_steps = self.scheduler.total_steps // gradient_accumulation_steps
-        elif hasattr(self.scheduler, "T_max"):
-            print(f'Adjusting scheduler T_max from {self.scheduler.T_max} to {self.scheduler.T_max // gradient_accumulation_steps}')
-            self.scheduler.T_max = self.scheduler.T_max // gradient_accumulation_steps
-        elif hasattr(self.scheduler, "T_0"):
-            print(f'Adjusting scheduler T_0 from {self.scheduler.T_0} to {self.scheduler.T_0 // gradient_accumulation_steps}')
-            self.scheduler.T_0 = self.scheduler.T_0 // gradient_accumulation_steps
+        self.scheduler.last_epoch = self.scheduler.last_epoch // gradient_accumulation_steps
 
     def step(self, *args, **kwargs):
         if not self.step_with_optimizer:

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -74,12 +74,16 @@ class AcceleratedScheduler:
                 The number of gradient accumulation steps.
         """
         if hasattr(self.scheduler, "total_iters"):
+            print(f'Adjusting scheduler total_iters from {self.scheduler.total_iters} to {self.scheduler.total_iters // gradient_accumulation_steps}')
             self.scheduler.total_iters = self.scheduler.total_iters // gradient_accumulation_steps
         elif hasattr(self.scheduler, "total_steps"):
+            print(f'Adjusting scheduler total_steps from {self.scheduler.total_steps} to {self.scheduler.total_steps // gradient_accumulation_steps}')
             self.scheduler.total_steps = self.scheduler.total_steps // gradient_accumulation_steps
         elif hasattr(self.scheduler, "T_max"):
+            print(f'Adjusting scheduler T_max from {self.scheduler.T_max} to {self.scheduler.T_max // gradient_accumulation_steps}')
             self.scheduler.T_max = self.scheduler.T_max // gradient_accumulation_steps
         elif hasattr(self.scheduler, "T_0"):
+            print(f'Adjusting scheduler T_0 from {self.scheduler.T_0} to {self.scheduler.T_0 // gradient_accumulation_steps}')
             self.scheduler.T_0 = self.scheduler.T_0 // gradient_accumulation_steps
 
     def step(self, *args, **kwargs):

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -60,7 +60,6 @@ class AcceleratedScheduler:
         # Otherwise, first make sure the optimizer was stepped.
         if not self.gradient_state.sync_gradients:
             if self.gradient_state.adjust_scheduler:
-                # Check if this is what's needed here, if not the num accumulation steps
                 self.scheduler._step_count += 1
             return
 

--- a/src/accelerate/scheduler.py
+++ b/src/accelerate/scheduler.py
@@ -42,24 +42,10 @@ class AcceleratedScheduler:
             Whether or not the dataloaders split one batch across the different processes (so batch size is the same
             regardless of the number of processes) or create batches on each process (so batch size is the original
             batch size multiplied by the number of processes).
-        adjust_scheduler_to_accumulation (`bool`, *optional*, defaults to `False`):
-            Whether or not the scheduler should be adjusted to the gradient accumulation steps.
-        gradient_accumulation_steps (`int`, *optional*, defaults to 1):
-            The number of gradient accumulation steps.
     """
 
-    def __init__(
-        self,
-        scheduler,
-        optimizers,
-        step_with_optimizer: bool = True,
-        split_batches: bool = False,
-        adjust_scheduler_to_accumulation: bool = False,
-        gradient_accumulation_steps: int = 1,
-    ):
+    def __init__(self, scheduler, optimizers, step_with_optimizer: bool = True, split_batches: bool = False):
         self.scheduler = scheduler
-        self.adjust_scheduler_to_accumulation = adjust_scheduler_to_accumulation
-        self.gradient_accumulation_steps = gradient_accumulation_steps
         self.optimizers = optimizers if isinstance(optimizers, (list, tuple)) else [optimizers]
         self.split_batches = split_batches
         self.step_with_optimizer = step_with_optimizer
@@ -73,7 +59,8 @@ class AcceleratedScheduler:
 
         # Otherwise, first make sure the optimizer was stepped.
         if not self.gradient_state.sync_gradients:
-            if self.adjust_scheduler_to_accumulation:
+            if self.gradient_state.adjust_scheduler:
+                # Check if this is what's needed here, if not the num accumulation steps
                 self.scheduler._step_count += 1
             return
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -16,13 +16,14 @@ import os
 import warnings
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import torch
 
 from .utils import (
     DistributedType,
     DynamoBackend,
+    GradientAccumulationPlugin,
     get_ccl_version,
     get_int_from_env,
     is_ccl_available,
@@ -698,7 +699,7 @@ class GradientState:
 
     _shared_state = {}
 
-    def __init__(self):
+    def __init__(self, gradient_accumulation_plugin: Optional[GradientAccumulationPlugin] = None):
         self.__dict__ = self._shared_state
         if not self.initialized:
             self.sync_gradients = True
@@ -706,6 +707,17 @@ class GradientState:
             self.remainder = -1
             self.active_dataloader = None
             self.dataloader_references = [None]
+            self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
+
+    @property
+    def num_steps(self) -> int:
+        "Returns the number of steps to accumulate over"
+        return self.plugin_kwargs.get("num_steps", 1)
+
+    @property
+    def adjust_scheduler(self) -> bool:
+        "Returns whether the scheduler should be adjusted"
+        return self.plugin_kwargs.get("adjust_scheduler", False)
 
     @property
     def initialized(self) -> bool:
@@ -716,7 +728,8 @@ class GradientState:
         return (
             f"Sync Gradients: {self.sync_gradients}\n"
             f"At end of current dataloader: {self.end_of_dataloader}\n"
-            f"Extra samples added: {self.remainder}"
+            f"Extra samples added: {self.remainder}\n"
+            f"Gradient accumulation plugin: {self.plugin_kwargs}\n"
         )
 
     def _set_sync_gradients(self, sync_gradients):
@@ -747,3 +760,8 @@ class GradientState:
     def in_dataloader(self) -> bool:
         "Returns whether the current process is in a dataloader"
         return self.active_dataloader is not None
+
+    @staticmethod
+    def _reset_state():
+        "Resets `_shared_state`, is used internally and should not be called"
+        GradientState._shared_state = {}

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -695,6 +695,12 @@ class GradientState:
         - **end_of_dataloader** (`bool`) -- Whether we have reached the end the current dataloader
         - **remainder** (`int`) -- The number of extra samples that were added from padding the dataloader
         - **sync_gradients** (`bool`) -- Whether the gradients should be synced across all devices
+        - **active_dataloader** (`Optional[DataLoader]`) -- The dataloader that is currently being iterated over
+        - **dataloader_references** (`List[Optional[DataLoader]]`) -- A list of references to the dataloaders that are
+          being iterated over
+        - **num_steps** (`int`) -- The number of steps to accumulate over
+        - **adjust_scheduler** (`bool`) -- Whether the scheduler should be adjusted to account for the gradient
+          accumulation
     """
 
     _shared_state = {}
@@ -709,6 +715,7 @@ class GradientState:
             self.dataloader_references = [None]
             self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
 
+        # Plugin args are different and can be updated
         if gradient_accumulation_plugin is not None and self.plugin_kwargs != gradient_accumulation_plugin.to_kwargs():
             self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -709,6 +709,9 @@ class GradientState:
             self.dataloader_references = [None]
             self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
 
+        if gradient_accumulation_plugin is not None and self.plugin_kwargs != gradient_accumulation_plugin.to_kwargs():
+            self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
+
     @property
     def num_steps(self) -> int:
         "Returns the number of steps to accumulate over"

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -151,7 +151,7 @@ def test_distributed_sync(accelerator):
 
 
 def test_gradient_accumulation(split_batches=False, dispatch_batches=False):
-    plugin = GradientAccumulationPlugin(gradient_accumulation_steps=2, adjust_scheduler=True)
+    plugin = GradientAccumulationPlugin(num_steps=2, adjust_scheduler=True)
     GradientState._reset_state()
     accelerator = Accelerator(
         split_batches=split_batches, dispatch_batches=dispatch_batches, gradient_accumulation_plugin=plugin

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -23,7 +23,7 @@ from torch.utils.data import DataLoader
 from accelerate.accelerator import Accelerator
 from accelerate.state import GradientState
 from accelerate.test_utils import RegressionDataset, RegressionModel
-from accelerate.utils import DistributedType, GradientAccumulationPlugin, set_seed
+from accelerate.utils import DistributedType, set_seed
 
 
 def check_model_parameters(model_a, model_b, did_step, iteration):
@@ -151,10 +151,8 @@ def test_distributed_sync(accelerator):
 
 
 def test_gradient_accumulation(split_batches=False, dispatch_batches=False):
-    plugin = GradientAccumulationPlugin(num_steps=2, adjust_scheduler=True)
-    GradientState._reset_state()
     accelerator = Accelerator(
-        split_batches=split_batches, dispatch_batches=dispatch_batches, gradient_accumulation_plugin=plugin
+        split_batches=split_batches, dispatch_batches=dispatch_batches, gradient_accumulation_steps=2
     )
     # Test that context manager behaves properly
     model, ddp_model, dataloader = get_training_setup(accelerator)
@@ -187,13 +185,12 @@ def test_gradient_accumulation(split_batches=False, dispatch_batches=False):
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)
         ddp_input = ddp_input[torch.randperm(len(ddp_input))]
+    GradientState._reset_state()
 
 
 def test_gradient_accumulation_with_opt_and_scheduler(split_batches=False, dispatch_batches=False):
-    plugin = GradientAccumulationPlugin(num_steps=2, adjust_scheduler=True)
-    GradientState._reset_state()
     accelerator = Accelerator(
-        split_batches=split_batches, dispatch_batches=dispatch_batches, gradient_accumulation_plugin=plugin
+        split_batches=split_batches, dispatch_batches=dispatch_batches, gradient_accumulation_steps=2
     )
     # Test that context manager behaves properly
     model, opt, sched, dataloader, ddp_model, ddp_opt, ddp_sched = get_training_setup(accelerator, True)
@@ -231,6 +228,7 @@ def test_gradient_accumulation_with_opt_and_scheduler(split_batches=False, dispa
             check_model_parameters(model, ddp_model, did_step, iteration)
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)
+    GradientState._reset_state()
 
 
 def test_dataloader_break():

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -7,6 +7,7 @@ from .dataclasses import (
     DynamoBackend,
     FP8RecipeKwargs,
     FullyShardedDataParallelPlugin,
+    GradientAccumulationPlugin,
     GradScalerKwargs,
     InitProcessGroupKwargs,
     KwargsHandler,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -388,7 +388,7 @@ class GradientAccumulationPlugin(KwargsHandler):
 
     num_steps: int = field(default=None, metadata={"help": "The number of steps to accumulate gradients for."})
     adjust_scheduler: bool = field(
-        default=False,
+        default=True,
         metadata={
             "help": "Whether to adjust the scheduler steps to account for the number of steps being accumulated. Should be `True` if the used scheduler was not adjusted for gradient accumulation."
         },

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -394,10 +394,6 @@ class GradientAccumulationPlugin(KwargsHandler):
         },
     )
 
-    def __post_init__(self):
-        if self.num_steps is None:
-            self.num_steps = int(os.environ.get("ACCELERATE_GRADIENT_ACCUMULATION_STEPS", 1))
-
 
 @dataclass
 class TorchDynamoPlugin(KwargsHandler):

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -381,6 +381,25 @@ class ProjectConfiguration:
 
 
 @dataclass
+class GradientAccumulationPlugin(KwargsHandler):
+    """
+    A plugin to configure gradient accumulation behavior.
+    """
+
+    num_steps: int = field(default=None, metadata={"help": "The number of steps to accumulate gradients for."})
+    adjust_scheduler: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to adjust the scheduler steps to account for the number of steps being accumulated. Should be `True` if the used scheduler was not adjusted for gradient accumulation."
+        },
+    )
+
+    def __post_init__(self):
+        if self.num_steps is None:
+            self.num_steps = int(os.environ.get("ACCELERATE_GRADIENT_ACCUMULATION_STEPS", 1))
+
+
+@dataclass
 class TorchDynamoPlugin(KwargsHandler):
     """
     This plugin is used to compile a model with PyTorch 2.0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -119,7 +119,7 @@ class SchedulerTester(unittest.TestCase):
     def test_one_cycle_scheduler_not_step_with_optimizer_multiprocess(self):
         AcceleratorState._reset_state(True)
         debug_launcher(partial(one_cycle_test, step_scheduler_with_optimizer=False))
-    
+
     @require_huggingface_suite
     def test_accumulation(self):
         AcceleratorState._reset_state(True)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -66,7 +66,6 @@ def lambda_test(num_processes=2, step_scheduler_with_optimizer=True, split_batch
     ), f"Wrong lr found at second step, expected {expected_lr}, got {scheduler.get_last_lr()[0]}"
 
 
-@require_huggingface_suite
 def accumulation_test():
     from transformers import get_linear_schedule_with_warmup
 
@@ -120,7 +119,8 @@ class SchedulerTester(unittest.TestCase):
     def test_one_cycle_scheduler_not_step_with_optimizer_multiprocess(self):
         AcceleratorState._reset_state(True)
         debug_launcher(partial(one_cycle_test, step_scheduler_with_optimizer=False))
-
+    
+    @require_huggingface_suite
     def test_accumulation(self):
         AcceleratorState._reset_state(True)
         debug_launcher(accumulation_test)


### PR DESCRIPTION
# Let the `AcceleratedScheduler` handle gradient accumulation steppage

## What does this add?

This PR adjusts the logic in the `AcceleratedScheduler` to take into account gradient accumulation steps. 

## Who is it for?

Closes https://github.com/huggingface/accelerate/issues/1170
Closes https://github.com/huggingface/accelerate/issues/1160

## Why is it needed?

Currently a behavior does not exist that will automatically "cut" the LR scheduler of a user if they pass in `gradient_accumulation_steps`, so unless they are careful and adjust their LR scheduler beforehand, they're not actually stepping properly with the lr scheduler.

## What parts of the API does this impact?

### User-facing:

None, explicitly

### Internal structure:

`AcceleratedScheduler`'s `step` function now will run `n*num_processes` where `n==gradient_accumulation_steps` to account for the difference. 

To test performance, I ran the equivalent training of `gradient_accumulation_steps==2` on a bs of 16, and a regular batch size of 32, with negligible performance differences (accuracy += 0.5%, F1 of 0.3). Likely due to batch norm layers

## Usage Example:

When building the `Accelerator`, pass in `adjust_scheduler_to_accumulation` (default `False`) to enable this behavior:

```python
    accelerator = Accelerator(
        cpu=args.cpu, 
        mixed_precision=args.mixed_precision, 
        gradient_accumulation_steps=2,
        adjust_scheduler_to_accumulation=True,
    )
```