### PR TITLE
Fixup passing overlapping args to the script

### DIFF
--- a/src/accelerate/commands/accelerate_cli.py
+++ b/src/accelerate/commands/accelerate_cli.py
@@ -24,7 +24,7 @@ from accelerate.commands.tpu import tpu_command_parser
 
 
 def main():
-    parser = ArgumentParser("Accelerate CLI tool", usage="accelerate <command> [<args>]")
+    parser = ArgumentParser("Accelerate CLI tool", usage="accelerate <command> [<args>]", allow_abbrev=False)
     subparsers = parser.add_subparsers(help="accelerate command helpers")
 
     # Register commands

--- a/src/accelerate/commands/config/__init__.py
+++ b/src/accelerate/commands/config/__init__.py
@@ -23,7 +23,7 @@ from .update import update_command_parser
 
 
 def get_config_parser(subparsers=None):
-    parent_parser = argparse.ArgumentParser(add_help=False)
+    parent_parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
     # The main config parser
     config_parser = config_command_parser(subparsers)
     # The subparser to add commands to

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -124,9 +124,9 @@ class _CustomHelpAction(argparse._HelpAction):
 
 def launch_command_parser(subparsers=None):
     if subparsers is not None:
-        parser = subparsers.add_parser("launch", add_help=False)
+        parser = subparsers.add_parser("launch", add_help=False, allow_abbrev=False)
     else:
-        parser = argparse.ArgumentParser("Accelerate launch command", add_help=False)
+        parser = argparse.ArgumentParser("Accelerate launch command", add_help=False, allow_abbrev=False)
 
     parser.register("action", "help", _CustomHelpAction)
     parser.add_argument("-h", "--help", action="help", help="Show this help message and exit.")


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1195

TL;DR argparse has a behavior where by default if the passed args to the script align partially to the args in the parser, it will raise the error described in the issue