### PR TITLE
Better error message when using multi-GPU and Accelerate on torch <1.9.1

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -584,7 +584,9 @@ def multi_gpu_launcher(args):
     if is_torch_version(">=", "1.9.1"):
         import torch.distributed.run as distrib_run
     else:
-        raise NotImplementedError("Native multi-GPU training requires pytorch>=1.9.1")
+        raise NotImplementedError(
+            "Native multi-GPU training through `accelerate launch` requires pytorch>=1.9.1. Please call `torch.distributed.launch` directly instead."
+        )
 
     current_env = prepare_multi_gpu_env(args)
 

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -585,7 +585,8 @@ def multi_gpu_launcher(args):
         import torch.distributed.run as distrib_run
     else:
         raise NotImplementedError(
-            "Native multi-GPU training through `accelerate launch` requires pytorch>=1.9.1. Please call `torch.distributed.launch` directly instead."
+            "Native multi-GPU training through `accelerate launch` requires pytorch>=1.9.1. "
+            "Please call `torch.distributed.launch` directly instead."
         )
 
     current_env = prepare_multi_gpu_env(args)


### PR DESCRIPTION
This PR closes https://github.com/huggingface/accelerate/issues/1199 and adds another sentence to the raised error telling the user to use `torch.distributed.launch` to start their script directly. 