### PR TITLE
Fix tied weights load

### DIFF
--- a/docs/source/usage_guides/big_modeling.mdx
+++ b/docs/source/usage_guides/big_modeling.mdx
@@ -118,7 +118,15 @@ with init_empty_weights():
     model = AutoModelForCausalLM.from_config(config)
 ```
 
-and load the checkpoint we just downloaded with:
+Note that loading the model with `from_config` in Transformers does not tie the weights, which may cause issue when
+loading a checkpoint that does not contain duplicate keys for the tied weights. So you should tie the weights before
+loading the checkpoint.
+
+```py
+model.tie_weights()
+```
+
+Then load the checkpoint we just downloaded with:
 
 ```py
 from accelerate import load_checkpoint_and_dispatch

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -784,6 +784,7 @@ def load_checkpoint_in_model(
         offload_buffers (`bool`, *optional*, defaults to `False):
             Whether or not to include the buffers in the weights offloaded to disk.
     """
+    tied_params = find_tied_parameters(model)
     if offload_folder is None and device_map is not None and "disk" in device_map.values():
         raise ValueError(
             "At least one of the model submodule will be offloaded to disk, please pass along an `offload_folder`."
@@ -871,3 +872,5 @@ def load_checkpoint_in_model(
     if offload_state_dict:
         load_offloaded_weights(model, state_dict_index, state_dict_folder)
         shutil.rmtree(state_dict_folder)
+
+    retie_parameters(model, tied_params)


### PR DESCRIPTION
This PR fixes the tied weights load. Since loading a checkpoint in a model that was instantiated on the meta device recreates the tensors, it breaks the connection between tied weights. This PR fixes that and also fixes the example in the doc to make sure weights are tied.

Fixes #1197