### PR TITLE
ds offload optim fix to use CPUAdam

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1399,7 +1399,7 @@ class Accelerator:
                         from deepspeed.ops.adam import DeepSpeedCPUAdam
 
                         defaults = {k: v for k, v in optimizer.defaults.items() if k in ["lr", "weight_decay"]}
-                        optimizer = DeepSpeedCPUAdam(optimizer.param_groups[0], **defaults)
+                        optimizer = DeepSpeedCPUAdam(optimizer.param_groups, **defaults)
                     kwargs["optimizer"] = optimizer
                     if scheduler is not None:
                         if type(scheduler).__name__ in deepspeed.runtime.lr_schedules.VALID_LR_SCHEDULES:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1392,6 +1392,14 @@ class Accelerator:
                 if isinstance(optimizer, (DummyOptim)):
                     kwargs["model_parameters"] = optimizer.params
                 else:
+                    if (
+                        self.deepspeed_config["zero_optimization"].get("offload_optimizer", {}).get("device", "none")
+                        != "none"
+                    ):
+                        from deepspeed.ops.adam import DeepSpeedCPUAdam
+
+                        defaults = {k: v for k, v in optimizer.defaults.items() if k in ["lr", "weight_decay"]}
+                        optimizer = DeepSpeedCPUAdam(optimizer.param_groups[0], **defaults)
                     kwargs["optimizer"] = optimizer
                     if scheduler is not None:
                         if type(scheduler).__name__ in deepspeed.runtime.lr_schedules.VALID_LR_SCHEDULES:


### PR DESCRIPTION
### What does this PR do?
1. Use `DeepSpeedCPUAdam` when offloading optimizer to CPU/NVME