### PR TITLE
Fix example in accumulate method documentation

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -841,8 +841,8 @@ class Accelerator:
         >>> accelerator = Accelerator(gradient_accumulation_steps=1)
         >>> dataloader, model, optimizer, scheduler = accelerator.prepare(dataloader, model, optimizer, scheduler)
 
-        >>> with accelerator.accumulate(model):
-        ...     for input, output in dataloader:
+        >>> for input, output in dataloader:
+        ...     with accelerator.accumulate(model):
         ...         outputs = model(input)
         ...         loss = loss_func(outputs)
         ...         loss.backward()


### PR DESCRIPTION
The accumulate method has an example of how to do gradient accumulation that has the context manager and the for loop in the wrong order.  The _do_sync method is called only when the context manager is entered, so it needs to go inside the loop.

(I was wondering why my model wasn't converging well!)