### PR TITLE
Set the state device dependant to Accelerator on multigpu

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2385,7 +2385,7 @@ class Accelerator:
         for hook in self._load_model_state_pre_hook.values():
             hook(models, input_dir)
 
-        optimizer_map_location = "cpu" if self.num_processes < 2 else self.device
+        optimizer_map_location = "on_device" if self.num_processes > 1 else "cpu"
 
         load_accelerator_state(
             input_dir,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2385,7 +2385,7 @@ class Accelerator:
         for hook in self._load_model_state_pre_hook.values():
             hook(models, input_dir)
 
-        optimizer_device = "cpu" if self.num_processes < 2 else self.device
+        optimizer_map_location = "cpu" if self.num_processes < 2 else self.device
 
         load_accelerator_state(
             input_dir,
@@ -2394,7 +2394,7 @@ class Accelerator:
             schedulers,
             self.state.process_index,
             self.scaler,
-            optimizer_device,
+            optimizer_map_location,
             **load_model_func_kwargs,
         )
         custom_checkpoints = [f for f in os.listdir(input_dir) if "custom_checkpoint" in f]

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2322,7 +2322,8 @@ class Accelerator:
                 The name of the folder all relevant weights and states were saved in.
             load_model_func_kwargs (`dict`, *optional*):
                 Additional keyword arguments for loading model which can be passed to the underlying load function,
-                such as optional arguments for DeepSpeed's `load_checkpoint` function.
+                such as optional arguments for DeepSpeed's `load_checkpoint` function or a `map_location` to load the
+                model and optimizer on.
 
         Example:
 
@@ -2385,12 +2386,12 @@ class Accelerator:
         for hook in self._load_model_state_pre_hook.values():
             hook(models, input_dir)
 
-        optimizer_map_location = load_model_func_kwargs.pop("optimizer_map_location", None)
-        if optimizer_map_location is None:
+        map_location = load_model_func_kwargs.pop("map_location", None)
+        if map_location is None:
             if self.num_processes > 1 and self.distributed_type == DistributedType.MULTI_GPU:
-                optimizer_map_location = "on_device"
+                map_location = "on_device"
             else:
-                optimizer_map_location = "cpu"
+                map_location = "cpu"
 
         load_accelerator_state(
             input_dir,
@@ -2399,7 +2400,7 @@ class Accelerator:
             schedulers,
             self.state.process_index,
             self.scaler,
-            optimizer_map_location,
+            map_location,
             **load_model_func_kwargs,
         )
         custom_checkpoints = [f for f in os.listdir(input_dir) if "custom_checkpoint" in f]

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2385,7 +2385,10 @@ class Accelerator:
         for hook in self._load_model_state_pre_hook.values():
             hook(models, input_dir)
 
-        optimizer_map_location = "on_device" if self.num_processes > 1 else "cpu"
+        if self.num_processes > 1 and self.distributed_type == DistributedType.MULTI_GPU:
+            optimizer_map_location = "on_device"
+        else:
+            optimizer_map_location = "cpu"
 
         load_accelerator_state(
             input_dir,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2385,8 +2385,17 @@ class Accelerator:
         for hook in self._load_model_state_pre_hook.values():
             hook(models, input_dir)
 
+        optimizer_device = "cpu" if self.num_processes < 2 else self.device
+
         load_accelerator_state(
-            input_dir, models, optimizers, schedulers, self.state.process_index, self.scaler, **load_model_func_kwargs
+            input_dir,
+            models,
+            optimizers,
+            schedulers,
+            self.state.process_index,
+            self.scaler,
+            optimizer_device,
+            **load_model_func_kwargs,
         )
         custom_checkpoints = [f for f in os.listdir(input_dir) if "custom_checkpoint" in f]
         if len(custom_checkpoints) != len(self._custom_objects):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2385,10 +2385,12 @@ class Accelerator:
         for hook in self._load_model_state_pre_hook.values():
             hook(models, input_dir)
 
-        if self.num_processes > 1 and self.distributed_type == DistributedType.MULTI_GPU:
-            optimizer_map_location = "on_device"
-        else:
-            optimizer_map_location = "cpu"
+        optimizer_map_location = load_model_func_kwargs.pop("optimizer_map_location", None)
+        if optimizer_map_location is None:
+            if self.num_processes > 1 and self.distributed_type == DistributedType.MULTI_GPU:
+                optimizer_map_location = "on_device"
+            else:
+                optimizer_map_location = "cpu"
 
         load_accelerator_state(
             input_dir,

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -110,7 +110,14 @@ def save_accelerator_state(
 
 
 def load_accelerator_state(
-    input_dir, models, optimizers, schedulers, process_index, scaler=None, **load_model_func_kwargs
+    input_dir,
+    models,
+    optimizers,
+    schedulers,
+    process_index,
+    scaler=None,
+    optimizer_map_location="cpu",
+    **load_model_func_kwargs,
 ):
     """
     Loads states of the models, optimizers, scaler, and RNG generators from a given directory.
@@ -128,6 +135,8 @@ def load_accelerator_state(
             The current process index in the Accelerator state
         scaler (`torch.cuda.amp.GradScaler`, *optional*):
             An optional *GradScaler* instance to load
+        optimizer_map_location (`torch.device`, *optional*):
+            What device to load the optimizer state onto. By default uses "cpu".
         load_model_func_kwargs (`dict`, *optional*):
             Additional arguments that can be passed to the model's `load_state_dict` method.
     """
@@ -142,7 +151,7 @@ def load_accelerator_state(
     for i, opt in enumerate(optimizers):
         optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
         input_optimizer_file = os.path.join(input_dir, optimizer_name)
-        optimizers[i].load_state_dict(torch.load(input_optimizer_file, map_location="cpu"))
+        optimizers[i].load_state_dict(torch.load(input_optimizer_file, map_location=optimizer_map_location))
     logger.info("All optimizer states loaded successfully")
 
     # Scheduler states

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -143,7 +143,7 @@ def load_accelerator_state(
     """
     if map_location not in [None, "cpu", "on_device"]:
         raise TypeError(
-            "Unsupported optimizer map location passed, please choose one of `None`, `cpu`, or `on_device`"
+            "Unsupported optimizer map location passed, please choose one of `None`, `'cpu'`, or `'on_device'`"
         )
     if map_location is None:
         map_location = "cpu"
@@ -153,8 +153,6 @@ def load_accelerator_state(
     for i, model in enumerate(models):
         weights_name = f"{MODEL_NAME}.bin" if i == 0 else f"{MODEL_NAME}_{i}.bin"
         input_model_file = os.path.join(input_dir, weights_name)
-        if map_location != "cpu":
-            models[i].to(map_location)
         models[i].load_state_dict(torch.load(input_model_file, map_location=map_location), **load_model_func_kwargs)
     logger.info("All model weights loaded successfully")
 

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -21,7 +21,6 @@ import numpy as np
 import torch
 from torch.cuda.amp import GradScaler
 
-from .state import PartialState
 from .utils import (
     MODEL_NAME,
     OPTIMIZER_NAME,
@@ -38,6 +37,7 @@ if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
 from .logging import get_logger
+from .state import PartialState
 
 
 logger = get_logger(__name__)

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -27,6 +27,7 @@ from .utils import (
     RNG_STATE_NAME,
     SCALER_NAME,
     SCHEDULER_NAME,
+    DistributedType,
     get_pretty_name,
     is_tpu_available,
     save,
@@ -153,10 +154,14 @@ def load_accelerator_state(
         raise TypeError(
             "Unsupported optimizer map location passed, please choose one of `None`, `cpu`, or `on_device`"
         )
+    current_device = PartialState().device
     if optimizer_map_location is None:
-        optimizer_map_location = "cpu"
+        if PartialState().distributed_type == DistributedType.MULTI_GPU:
+            optimizer_map_location = current_device
+        else:
+            optimizer_map_location = "cpu"
     elif optimizer_map_location == "on_device":
-        optimizer_map_location = PartialState().device
+        optimizer_map_location = current_device
     for i, opt in enumerate(optimizers):
         optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
         input_optimizer_file = os.path.join(input_dir, optimizer_name)

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -15,15 +15,16 @@
 import logging
 import os
 import random
+import shutil
 import tempfile
 import unittest
 
+import pytest
 import torch
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.test_utils import require_cuda
 from accelerate.utils import ProjectConfiguration, set_seed
 
 
@@ -250,52 +251,58 @@ class CheckpointTest(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_9")))
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_10")))
 
-    @require_cuda
-    def test_map_location(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            model = DummyModel()
-            optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
-            scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.99)
-            train_dataloader, valid_dataloader = dummy_dataloaders()
-            project_config = ProjectConfiguration(automatic_checkpoint_naming=True)
-            # Train baseline
-            accelerator = Accelerator(project_dir=tmpdir, project_config=project_config)
-            model, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
-                model, optimizer, train_dataloader, valid_dataloader, scheduler
-            )
-            model, optimizer = accelerator.prepare(model, optimizer)
-            train(3, model, train_dataloader, optimizer, accelerator, scheduler)
-            # Check that the intial optimizer is loaded on the GPU
-            for group in optimizer.param_groups:
-                param_device = group["params"][0].device
-                break
-            self.assertEqual(param_device.type, accelerator.device.type)
-            model = model.cpu()
-            accelerator.save_state()
 
-            # Check CPU state
-            accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="cpu")
-            for group in optimizer.param_groups:
-                param_device = group["params"][0].device
-                break
-            self.assertEqual(
-                param_device.type,
-                torch.device("cpu").type,
-                f"Loaded optimizer states did not match, expected to be loaded on the CPU but got {param_device}",
-            )
+if __name__ == "__main__":
+    savedir = "/tmp/accelerate/state_checkpointing"
+    model = DummyModel()
+    optimizer = torch.optim.Adam(params=model.parameters(), lr=1e-3)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.99)
+    train_dataloader, valid_dataloader = dummy_dataloaders()
+    project_config = ProjectConfiguration(automatic_checkpoint_naming=True)
+    # Train baseline
+    accelerator = Accelerator(project_dir=savedir, project_config=project_config, mixed_precision="no")
+    if accelerator.process_index == 0:
+        if os.path.exists(savedir):
+            shutil.rmtree(savedir)
+        os.makedirs(savedir)
+    model, optimizer, train_dataloader, valid_dataloader, scheduler = accelerator.prepare(
+        model, optimizer, train_dataloader, valid_dataloader, scheduler
+    )
+    model, optimizer = accelerator.prepare(model, optimizer)
+    train(3, model, train_dataloader, optimizer, accelerator, scheduler)
+    # Check that the intial optimizer is loaded on the GPU
+    for group in optimizer.param_groups:
+        param_device = group["params"][0].device
+        break
+    assert param_device.type == accelerator.device.type
+    model = model.cpu()
+    accelerator.wait_for_everyone()
+    accelerator.save_state()
+    accelerator.wait_for_everyone()
 
-            # Check device state
-            model.to(accelerator.device)
-            accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="on_device")
-            for group in optimizer.param_groups:
-                param_device = group["params"][0].device
-                break
-            self.assertEqual(
-                param_device.type,
-                accelerator.device.type,
-                f"Loaded optimizer states did not match, expected to be loaded on {accelerator.device} but got {param_device}",
-            )
+    # Check CPU state
+    accelerator.load_state(os.path.join(savedir, "checkpoints", "checkpoint_0"), map_location="cpu")
+    for group in optimizer.param_groups:
+        param_device = group["params"][0].device
+        break
+    assert (
+        param_device.type == torch.device("cpu").type
+    ), f"Loaded optimizer states did not match, expected to be loaded on the CPU but got {param_device}"
 
-            # Check error
-            with self.assertRaises(TypeError, msg="Unsupported optimizer map location passed"):
-                accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="invalid")
+    # Check device state
+    model.to(accelerator.device)
+    accelerator.load_state(os.path.join(savedir, "checkpoints", "checkpoint_0"), map_location="on_device")
+    for group in optimizer.param_groups:
+        param_device = group["params"][0].device
+        break
+    assert (
+        param_device.type == accelerator.device.type
+    ), f"Loaded optimizer states did not match, expected to be loaded on {accelerator.device} but got {param_device}"
+
+    # Check error
+    with pytest.raises(TypeError, match="Unsupported optimizer map location passed"):
+        accelerator.load_state(os.path.join(savedir, "checkpoints", "checkpoint_0"), map_location="invalid")
+    accelerator.wait_for_everyone()
+    if accelerator.process_index == 0:
+        shutil.rmtree(savedir)
+    accelerator.wait_for_everyone()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -285,6 +285,7 @@ class CheckpointTest(unittest.TestCase):
             )
 
             # Check device state
+            model.to(accelerator.device)
             accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="on_device")
             for group in optimizer.param_groups:
                 param_device = group["params"][0].device

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
 import os
 import random
@@ -25,7 +26,8 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.utils import ProjectConfiguration, set_seed
+from accelerate.test_utils import execute_subprocess_async
+from accelerate.utils import ProjectConfiguration, get_launch_prefix, set_seed
 
 
 logger = logging.getLogger(__name__)
@@ -250,6 +252,11 @@ class CheckpointTest(unittest.TestCase):
             self.assertTrue(not os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_0")))
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_9")))
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_10")))
+
+    def test_map_location(self):
+        cmd = get_launch_prefix()
+        cmd += [f"--nproc_per_node={torch.cuda.device_count()}", inspect.getfile(self.__class__)]
+        execute_subprocess_async(cmd, env=os.environ.copy())
 
 
 if __name__ == "__main__":

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -26,7 +26,7 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.test_utils import execute_subprocess_async
+from accelerate.test_utils import execute_subprocess_async, require_cuda
 from accelerate.utils import ProjectConfiguration, get_launch_prefix, set_seed
 
 
@@ -253,6 +253,7 @@ class CheckpointTest(unittest.TestCase):
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_9")))
             self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_10")))
 
+    @require_cuda
     def test_map_location(self):
         cmd = get_launch_prefix()
         cmd += [f"--nproc_per_node={torch.cuda.device_count()}", inspect.getfile(self.__class__)]

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -285,9 +285,7 @@ class CheckpointTest(unittest.TestCase):
             )
 
             # Check device state
-            accelerator.load_state(
-                os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="on_device"
-            )
+            accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="on_device")
             for group in optimizer.param_groups:
                 param_device = group["params"][0].device
                 break
@@ -299,6 +297,4 @@ class CheckpointTest(unittest.TestCase):
 
             # Check error
             with self.assertRaises(TypeError, msg="Unsupported optimizer map location passed"):
-                accelerator.load_state(
-                    os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="invalid"
-                )
+                accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"), map_location="invalid")


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1210 by setting the optimizer state to `accelerator.device` when `num_processes > 1` and calling `load_state`.
