### PR TITLE
Fix get_logger kwarg documentation issue

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -69,7 +69,7 @@ def get_logger(name: str, log_level: str = None):
     >>> logger.info("My log", main_process_only=False)
     >>> logger.debug("My log", main_process_only=True)
 
-    >>> logger = get_logger(__name__, accelerate_log_level="DEBUG")
+    >>> logger = get_logger(__name__, log_level="DEBUG")
     >>> logger.info("My log")
     >>> logger.debug("My second log")
     ```


### PR DESCRIPTION
The `get_logger` example's keyword argument is not aligned with the function, resulting in inconsistency. This pull request aims to fix this issue by adjusting the keyword argument used in the example to match the function.