### PR TITLE
Hardware Auto-Setup Example/Tutorial for Distributed Launch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -67,7 +67,7 @@ doc-builder preview {package_name} {path_to_docs}
 For example:
 
 ```bash
-doc-builder preview transformers docs/source/en/
+doc-builder preview accelerate docs/source/
 ```
 
 The docs will be viewable at [http://localhost:3000](http://localhost:3000). You can also preview the docs once you have opened a PR. You will see a bot add a comment to a link where the documentation with your changes lives.

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -15,6 +15,8 @@
     title: Launching distributed code
   - local: basic_tutorials/notebook
     title: Launching distributed training from Jupyter Notebooks
+  - local: basic_tutorials/launch_auto_hardware
+    title: Launching distributed on remote hardware (auto setup)
   title: Tutorials
 - sections:
   - local: usage_guides/explore

--- a/docs/source/basic_tutorials/launch_auto_hardware.mdx
+++ b/docs/source/basic_tutorials/launch_auto_hardware.mdx
@@ -1,0 +1,113 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->
+
+# Launching Distributed on Remote Hardware (with Auto Setup)
+
+This page demonstrates how to run accelerate launch on remote, self-hosted hardware, with automatic dependency and
+environment setup, via [Runhouse](https://github.com/run-house/runhouse). You can develop fully locally on a Colab
+or local Python script, while submitting distributed launching to a remote cluster to take advantage of accelerators
+like GPUs or TPUs.
+
+Remote hardware includes both on-demand clusters through cloud providers and existing clusters with SSH credentials.
+For more info, see the
+[Runhouse compute overview](https://runhouse-docs.readthedocs-hosted.com/en/latest/overview/compute.html).
+
+This tutorial is also available as a Colab [here]().
+
+## Instantiate Remote Cluster
+
+Install Runhouse, which is used for creating a local Cluster object and sending remote function calls.
+
+```python
+import runhouse as rh
+```
+
+### On-Demand Clusters (AWS, Azure, GCP, LambdaLabs)
+
+On-Demand clusters are cloud clusters that are spun up/down automatically for you.
+For instructions on setting up cloud access for on-demand clusters, please refer to
+[Hardware Setup](https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup).
+
+```python
+# Single GPU
+# gpu = rh.cluster(name="rh-cluster", instance_type="V100:1", provider="cheapest").up_if_not()
+
+# Multi GPU
+gpu = rh.cluster(name="rh-cluster", instance_type="V100:4", provider="cheapest").up_if_not()
+gpu.autostop_mins = 60  # automatically terminate gpu after this long of inactivity (-1 to disable)
+```
+
+### On-Premise Cluster
+
+To instantiate a BYO or on-prem cluster, you will need to provide the IP addresses and SSH credentials as follows.
+
+```python
+gpu = rh.cluster(
+    ips=["<ip of the cluster>"], ssh_creds={"ssh_user": "...", "ssh_private_key": "<path_to_key>"}, name="rh-a10x"
+)
+```
+
+# Define Distributed Launch Function
+
+The following function, `launch_train`, takes in a training function callable, along with it's config and hyperparameter
+arguments, and abstracts away the process to launch mutli-GPU processing.
+
+```python
+import torch
+from accelerate.utils import PrepareForLaunch, patch_environment
+
+def launch_train(training_function, *args):
+    num_processes = torch.cuda.device_count()
+    print(f'Device count: {num_processes}')
+    with patch_environment(world_size=num_processes, master_addr="127.0.01", master_port="29500",
+                           mixed_precision=args[1].mixed_precision):
+        launcher = PrepareForLaunch(training_function, distributed_type="MULTI_GPU")
+        torch.multiprocessing.start_processes(launcher, args=args, nprocs=num_processes, start_method="spawn")
+
+```
+
+# Hardware Auto Setup
+
+To set up the hardware environment to be able to seamlessly run the distributed launch function, first define the dependencies
+necessary for running the training function with accelerate.
+
+```python
+reqs = ['./', 'accelerate', 'transformers', 'datasets', 'evaluate','tqdm', 'scipy', 'scikit-learn', 'tensorboard',
+        'torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117']
+```
+
+Then, we can create a callable to launch our training function, setting the hardware/system that it is intended to be run on,
+as well as the requiremnts for running the function.
+
+```python
+launch_train_gpu = rh.function(fn=launch_train).to(system=gpu, reqs=reqs)
+```
+
+# Distributed Launching
+
+Now we're ready to run our distributed launch function with our training function! For simplicity, let's import the
+training function from (nlp_example.py)[https://github.com/huggingface/accelerate/blob/main/examples/nlp_example.py]
+in the accelerate repo, and define some train arguments and configs.
+
+```python
+from nlp_example import training_function as train_nlp
+
+train_args = argparse.Namespace(cpu=False, mixed_precision='fp16')
+config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}
+```
+
+The following line of code uses the `launch_train_gpu` function to launch accelerate training on the gpu, and handles
+the underlying environment dependencies as well, specified by the requirements above.
+
+```python
+launch_train_gpu(train_nlp, config, train_args, stream_logs=True)
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -190,6 +190,14 @@ To run it in each of these various modes, use the following commands:
 
 ### Using AWS SageMaker integration
 - [Examples showcasing AWS SageMaker integration of 🤗 Accelerate.](https://github.com/pacman100/accelerate-aws-sagemaker)
+
+
+## Simple Multi-GPU Hardware Launcher
+
+[multigpu_hardware_launcher.py](./multigpu_hardware_launcher.py) is a minimal script to demonstrating an alternative way to launch
+accelerate on multiple GPUs. You can easily customize the training function used, training arguments, hyperparameters, and type of
+compute hardware, and then run the script to automatically launch multi GPU training on your remote hardware.
+
     
 ## Finer Examples
 

--- a/examples/multigpu_hardware_launcher.py
+++ b/examples/multigpu_hardware_launcher.py
@@ -1,0 +1,43 @@
+
+import torch
+import argparse
+import runhouse as rh
+
+from nlp_example import training_function
+from accelerate.utils import PrepareForLaunch, patch_environment
+
+def launch_train(*args):
+    num_processes = torch.cuda.device_count()
+    print(f'Device count: {num_processes}')
+    with patch_environment(world_size=num_processes, master_addr="127.0.01", master_port="29500",
+                           mixed_precision=args[1].mixed_precision):
+        launcher = PrepareForLaunch(training_function, distributed_type="MULTI_GPU")
+        torch.multiprocessing.start_processes(launcher, args=args, nprocs=num_processes, start_method="spawn")
+
+if __name__ == "__main__":
+    # Refer to https://runhouse-docs.readthedocs-hosted.com/en/main/rh_primitives/cluster.html#hardware-setup for cloud access
+    # setup instructions, if using on-demand hardware
+
+    # single GPU
+    # gpu = rh.cluster(name='rh-cluster', instance_type='V100:1', provider='cheapest', use_spot=False)
+    
+    # multi GPU
+    gpu = rh.cluster(name='rh-cluster', instance_type='V100:4', provider='cheapest', use_spot=False)
+    gpu.up_if_not()
+
+    # Set up remote function
+    reqs = ['pip:./', 'transformers', 'datasets', 'evaluate','tqdm', 'scipy', 'scikit-learn', 'tensorboard',
+            'torch --upgrade --extra-index-url https://download.pytorch.org/whl/cu117']
+    launch_train_gpu = rh.function(fn=launch_train,
+                                   system=gpu,
+                                   reqs=reqs,
+                                   name='train_bert_glue')
+
+    # Define train args/config, run train function
+    train_args = argparse.Namespace(cpu=False, mixed_precision='fp16')
+    config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}
+    launch_train_gpu(config, train_args, stream_logs=True)
+
+    # Alternatively, we can just run as instructed in the README (but only because there's already a wrapper CLI):
+    # gpu.install_packages(reqs)
+    # gpu.run(['accelerate launch --multi_gpu accelerate/examples/nlp_example.py'])


### PR DESCRIPTION
Previously discussed with @sgugger and @LysandreJik (cc @dongreenberg), to add hardware auto-setup and remote hardware distributed launching examples for accelerate.

[see also huggingface/transformers/pull/22318 for more context; parallel PR for transformers]

This PR adds
* example multigpu launch script for nlp_example (remote hardware, with auto env dependency setup)
* tutorial in HF docs on how to auto setup and launch distributed code on remote hardware, along with link out to Colab
* small fix in docs build instructions