### PR TITLE
Add additional check when patching env

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -116,7 +116,8 @@ def patch_environment(**kwargs):
     yield
 
     for key in kwargs:
-        del os.environ[key.upper()]
+        if key.upper() in os.environ:
+            del os.environ[key.upper()]
 
 
 def get_pretty_name(obj):


### PR DESCRIPTION
This PR adds an additional check to ensure that an environment variable exists before deleting it when patching an environment. 
This prevents a `KeyError` being raised when training Multi-GPU using AzureML with the latest version of accelerate.


It would be awesome if this could be released quickly as a patch!


