### PR TITLE
Make grad accum steps mutable on the Accelerator object

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -819,9 +819,17 @@ class Accelerator:
     def sync_gradients(self):
         return self.gradient_state.sync_gradients
 
+    @sync_gradients.setter
+    def sync_gradients(self, sync_gradients):
+        self.gradient_state.sync_gradients = sync_gradients
+
     @property
     def gradient_accumulation_steps(self):
         return self.gradient_state.num_steps
+
+    @gradient_accumulation_steps.setter
+    def gradient_accumulation_steps(self, gradient_accumulation_steps):
+        self.gradient_state.plugin_kwargs.update({"num_steps": gradient_accumulation_steps})
 
     @contextmanager
     def accumulate(self, model):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -53,6 +53,7 @@ class AcceleratorTester(AccelerateTestCase):
         assert state.sync_gradients is True
         accelerator.sync_gradients = False
         assert state.sync_gradients is False
+        GradientState._reset_state()
 
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import infer_auto_device_map, init_empty_weights
 from accelerate.accelerator import Accelerator
-from accelerate.state import PartialState
+from accelerate.state import GradientState, PartialState
 from accelerate.test_utils import require_multi_gpu, slow
 from accelerate.test_utils.testing import AccelerateTestCase, require_cuda
 from accelerate.utils import patch_environment
@@ -42,6 +42,17 @@ class AcceleratorTester(AccelerateTestCase):
         assert PartialState._shared_state["device"].type == "cuda"
         with self.assertRaises(ValueError):
             _ = Accelerator(cpu=True)
+
+    def test_mutable_states(self):
+        accelerator = Accelerator()
+        state = GradientState()
+        assert state.num_steps == 1
+        accelerator.gradient_accumulation_steps = 4
+        assert state.num_steps == 4
+
+        assert state.sync_gradients is True
+        accelerator.sync_gradients = False
+        assert state.sync_gradients is False
 
     def test_prepared_objects_are_referenced(self):
         accelerator = Accelerator()


### PR DESCRIPTION
Mild regression and expansion on the new gradient accumulation API change. 

Keeps all main areas of the `gradient_state` to be mutable if needed/wanted from the `Accelerator` object that users may wish to do (so `sync_gradients` and `gradient_accumulation_steps`)

Solves https://github.com/huggingface/accelerate/issues/1230