### PR TITLE
remove empty dicts while saving accelerate config

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -85,6 +85,8 @@ class BaseConfig:
         for key, value in result.items():
             if isinstance(value, Enum):
                 result[key] = value.value
+            if isinstance(value, dict) and not bool(value):
+                result[key] = None
         result = {k: v for k, v in result.items() if v is not None}
         return result
 


### PR DESCRIPTION
### What does this PR do?
1. Accelerate config is flooding with many empty dict fields as the number of integrations is increasing. This help accelerate config to only contain the necessary config