### PR TITLE
[`core`] Add Quantization support for `dispatch_model`

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -166,14 +166,14 @@ def set_module_tensor_to_device(
 
             if module.__class__.__name__ == "Linear8bitLt" and getattr(module.weight, "SCB", None) is None:
                 # quantize only if necessary
-                if not getattr(module.weight, "SCB", None) and isinstance(device, int):
+                device_index = torch.device(device).index if torch.device(device).type == "cuda" else None
+                if not getattr(module.weight, "SCB", None) and device_index is not None:
                     if module.bias is not None and module.bias.device.type != "meta":
                         # if a bias exists, we need to wait until the bias is set on the correct device
-                        module = module.cuda(device)
+                        module = module.cuda(device_index)
                     elif module.bias is None:
                         # if no bias exists, we can quantize right away
-                        module = module.cuda(device)
-
+                        module = module.cuda(device_index)
 
 def named_module_tensors(module: nn.Module, include_buffers: bool = True, recurse: bool = False):
     """

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -175,6 +175,7 @@ def set_module_tensor_to_device(
                         # if no bias exists, we can quantize right away
                         module = module.cuda(device_index)
 
+
 def named_module_tensors(module: nn.Module, include_buffers: bool = True, recurse: bool = False):
     """
     A helper function that gathers all the tensors (parameters + buffers) of a given module. If `include_buffers=True`

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -171,7 +171,7 @@ def set_module_tensor_to_device(
             ):
                 # quantize only if necessary
                 if module.bias.device.type != "meta" and not getattr(module.weight, "SCB", None):
-                    module = module.cuda()
+                    module = module.cuda(device)
 
 
 def named_module_tensors(module: nn.Module, include_buffers: bool = True, recurse: bool = False):

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -170,7 +170,11 @@ def set_module_tensor_to_device(
                 and module.bias is not None
             ):
                 # quantize only if necessary
-                if module.bias.device.type != "meta" and not getattr(module.weight, "SCB", None):
+                if (
+                    module.bias.device.type != "meta"
+                    and not getattr(module.weight, "SCB", None)
+                    and isinstance(device, int)
+                ):
                     module = module.cuda(device)
 
 

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -515,3 +515,99 @@ class BigModelingTester(unittest.TestCase):
 
         hook2.offload()
         self.assertEqual(model2.weight.device, torch.device("cpu"))
+
+    @slow
+    @require_multi_gpu
+    def test_dispatch_model_bnb(self):
+        """Tests that `dispatch_model` quantizes int8 layers"""
+        from huggingface_hub import hf_hub_download
+        from transformers import AutoConfig, AutoModel
+        from transformers.utils.bitsandbytes import replace_8bit_linear
+
+        with init_empty_weights():
+            model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
+
+        model = replace_8bit_linear(model)
+
+        # For some reason replace_8bit_linear creates parameters with requires_grad=True but it's irrelevant rn
+        for p in model.parameters():
+            p.requires_grad = False
+
+        model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")
+
+        model = load_checkpoint_and_dispatch(
+            model,
+            checkpoint=model_path,
+            # device_map="auto",
+            device_map="balanced",
+        )
+
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+
+        self.assertTrue(model.h[-1].self_attention.query_key_value.weight.dtype == torch.int8)
+        self.assertTrue(model.h[-1].self_attention.query_key_value.weight.device.index == 1)
+
+    @slow
+    def test_dipatch_model_int8_simple(self):
+        """Tests that `dispatch_model` quantizes int8 layers"""
+        from huggingface_hub import hf_hub_download
+        from transformers import AutoConfig, AutoModel
+        from transformers.utils.bitsandbytes import replace_8bit_linear
+
+        with init_empty_weights():
+            model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
+
+        model = replace_8bit_linear(model)
+
+        # For some reason replace_8bit_linear creates parameters with requires_grad=True but it's irrelevant rn
+        for p in model.parameters():
+            p.requires_grad = False
+
+        model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")
+
+        # test with auto
+        model = load_checkpoint_and_dispatch(
+            model,
+            checkpoint=model_path,
+            device_map="auto",
+        )
+
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+
+        with init_empty_weights():
+            model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
+
+        model = replace_8bit_linear(model)
+
+        for p in model.parameters():
+            p.requires_grad = False
+
+        # test with str device map
+        model = load_checkpoint_and_dispatch(
+            model,
+            checkpoint=model_path,
+            device_map={name: "cuda:0" for name, _ in model.named_parameters()},
+        )
+
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+
+        with init_empty_weights():
+            model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
+
+        model = replace_8bit_linear(model)
+
+        for p in model.parameters():
+            p.requires_grad = False
+
+        # test with torch.device device map
+        model = load_checkpoint_and_dispatch(
+            model,
+            checkpoint=model_path,
+            device_map={name: torch.device("cuda:0") for name, _ in model.named_parameters()},
+        )
+
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
+        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -529,7 +529,7 @@ class BigModelingTester(unittest.TestCase):
 
         model = replace_8bit_linear(model)
 
-        # For some reason replace_8bit_linear creates parameters with requires_grad=True but it's irrelevant rn
+        # TODO: @younesbelkada remove this block on the next `transformers` release
         for p in model.parameters():
             p.requires_grad = False
 
@@ -560,7 +560,7 @@ class BigModelingTester(unittest.TestCase):
 
         model = replace_8bit_linear(model)
 
-        # For some reason replace_8bit_linear creates parameters with requires_grad=True but it's irrelevant rn
+        # TODO: @younesbelkada remove this block on the next `transformers` release
         for p in model.parameters():
             p.requires_grad = False
 
@@ -599,6 +599,7 @@ class BigModelingTester(unittest.TestCase):
 
         model = replace_8bit_linear(model)
 
+        # TODO: @younesbelkada remove this block on the next `transformers` release
         for p in model.parameters():
             p.requires_grad = False
 


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/accelerate/issues/1228

Before this PR, if a user wants to call `dispatch_model` on a customly created model, the model remains unquantized and leads to some errors that are hard to understand and debug. This issue has been also observed several times on other libraries that uses `accelerate` + `bitsandbytes` such as in `PEFT` that calls `dispatch_model` under the hood as well.: https://github.com/huggingface/peft/issues/187 

Now with this PR, the script below returns the expected output: 
```python
import torch
from transformers import AutoConfig, AutoModel
from transformers.utils.bitsandbytes import replace_8bit_linear

from accelerate import init_empty_weights
from huggingface_hub import hf_hub_download

from accelerate import load_checkpoint_and_dispatch
from itertools import chain

with init_empty_weights():
    model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))


model = replace_8bit_linear(model)

# For some reason replace_8bit_linear creates parameters with requires_grad=True but it's irrelevant rn
for p in model.parameters():
    p.requires_grad = False

model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")

model = load_checkpoint_and_dispatch(
    model,
    checkpoint=model_path,
    device_map="auto",
)

print(f"{model.h[0].self_attention.query_key_value.weight.device}\n{model.h[0].self_attention.query_key_value.weight.dtype}")
```

Also, this PR is fully backward compatible with `transformers` + `bitsandbytes` integration, I ran all the bnb slow tests and they pass.

cc @sgugger @pacman100 