### PR TITLE
Make model conversion compatible with TE < v0.4

### DIFF
--- a/src/accelerate/utils/transformer_engine.py
+++ b/src/accelerate/utils/transformer_engine.py
@@ -41,6 +41,10 @@ def convert_model(model, to_transformer_engine=True, _convert_linear=True, _conv
             setattr(model, name, te_module)
         elif isinstance(module, nn.LayerNorm) and to_transformer_engine and _convert_ln:
             te_module = te.LayerNorm(module.normalized_shape[0], eps=module.eps)
+            if not hasattr(te_module, "weight"):
+                setattr(te_module, "weight", te_module.layer_norm_weight)
+            if not hasattr(te_module, "bias"):
+                setattr(te_module, "bias", te_module.layer_norm_bias)
             te_module.weight.data = module.weight.data.clone()
             te_module.bias.data = module.bias.data.clone()
 
@@ -55,6 +59,10 @@ def convert_model(model, to_transformer_engine=True, _convert_linear=True, _conv
             setattr(model, name, new_module)
         elif isinstance(module, te.LayerNorm) and not to_transformer_engine and _convert_ln:
             new_module = nn.LayerNorm(module.normalized_shape[0], eps=module.eps)
+            if not hasattr(module, "weight"):
+                setattr(module, "weight", module.layer_norm_weight)
+            if not hasattr(module, "bias"):
+                setattr(module, "bias", module.layer_norm_bias)
             new_module.weight.data = module.weight.data.clone()
             new_module.bias.data = module.bias.data.clone()
 


### PR DESCRIPTION
In Transformer Engine version less than v0.4, te.LayerNorm uses `layer_norm_weight/layer_norm_bias` attributes instead of `weight/bias`, which will break `convert_model` to/from transformer engine models.

This PR adds the backward compatibility for layer norm in lower TE versions, [reference](https://github.com/NVIDIA/TransformerEngine/blob/v0.4/transformer_engine/pytorch/module.py#L2580-L2584).