### PR TITLE
Fix pypi image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 <p align="center">
     <br>
-    <img src="docs/source/imgs/accelerate_logo.png" width="400"/>
+    <img src="https://raw.githubusercontent.com/huggingface/accelerate/main/docs/source/imgs/accelerate_logo.png" width="400"/>
     <br>
 <p>
 


### PR DESCRIPTION
Needs to be a full `raw.githubusercontent.com/*` for the image to show up on pypi, solves the logo not showing here: https://pypi.org/project/accelerate