### PR TITLE
Handle missing deepspeed config

### DIFF
--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -51,9 +51,9 @@ class HfDeepSpeedConfig:
             try:
                 config_decoded = base64.urlsafe_b64decode(config_file_or_dict).decode("utf-8")
                 config = json.loads(config_decoded)
-            except (UnicodeDecodeError, AttributeError):
+            except (UnicodeDecodeError, AttributeError, ValueError):
                 raise ValueError(
-                    f"Expected a string path to an existing deepspeed config, or a dictionary, or a base64 encoded string. Received: {config}"
+                    f"Expected a string path to an existing deepspeed config, or a dictionary, or a base64 encoded string. Received: {config_file_or_dict}"
                 )
 
         self.config = config


### PR DESCRIPTION
This PR improves the handling of cases where users provide a non-existing deepspeed config path

- Parsing non-base64 strings with `base64.urlsafe_b64decode` raises `binascii.Error`, which is a subclass of `ValueError`. The previous error handling code won't catch it
- `config` is not defined if this piece of code errors out so we need to use `config_file_or_dict` instead in the error handling