### PR TITLE
Check attribute 'overflow' exists in optimizer.

### DIFF
--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -190,6 +190,7 @@ class DeepSpeedOptimizerWrapper(AcceleratedOptimizer):
 
     def __init__(self, optimizer):
         super().__init__(optimizer, device_placement=False, scaler=None)
+        self.__has_overflow__ = hasattr(self.optimizer, 'overflow')
 
     def zero_grad(self, set_to_none=None):
         pass  # `accelerator.backward(loss)` is doing that automatically. Therefore, its implementation is not needed
@@ -200,7 +201,9 @@ class DeepSpeedOptimizerWrapper(AcceleratedOptimizer):
     @property
     def step_was_skipped(self):
         """Whether or not the optimizer step was done, or skipped because of gradient overflow."""
-        return self.optimizer.overflow
+        if self.__has_overflow__:
+            return self.optimizer.overflow
+        return False
 
 
 class DeepSpeedSchedulerWrapper(AcceleratedScheduler):

--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -190,7 +190,7 @@ class DeepSpeedOptimizerWrapper(AcceleratedOptimizer):
 
     def __init__(self, optimizer):
         super().__init__(optimizer, device_placement=False, scaler=None)
-        self.__has_overflow__ = hasattr(self.optimizer, 'overflow')
+        self.__has_overflow__ = hasattr(self.optimizer, "overflow")
 
     def zero_grad(self, set_to_none=None):
         pass  # `accelerator.backward(loss)` is doing that automatically. Therefore, its implementation is not needed


### PR DESCRIPTION
Dear contributers and maintainers.

- Include your OS type and version, the versions of Python and PyTorch.
```
> uname -a
Linux debian-cglab 5.10.0-21-amd64 #1 SMP Debian 5.10.162-1 (2023-01-21) x86_64 GNU/Linux
> pip list
...
accelerate               0.12.0
...
deepspeed                0.8.3
...
open-clip-torch          2.7.0
pytorch-lightning        1.7.6
torch                    1.13.1
torchaudio               0.13.1
torchdiffeq              0.2.3
torchmetrics             0.11.4
torchsde                 0.2.5
torchvision              0.14.1
vector-quantize-pytorch  1.1.2

```
- A short, self-contained, code snippet that allows us to reproduce the bug in less than 30s;

When I use the deepspeed setting with single precision (fp32) data type,
I got an error message below

```
    if opt.step_was_skipped:
  File "/home/kakakim/miniconda3/envs/torch113/lib/python3.10/site-packages/accelerate/utils/deepspeed.py", line 191, in step_was_skipped
    return self.optimizer.overflow
AttributeError: 'Adam' object has no attribute 'overflow'
```
```
-- config.yml --
compute_environment: LOCAL_MACHINE
deepspeed_config:
  gradient_accumulation_steps: 2
  gradient_clipping: 1.0
  zero3_init_flag: false
  zero_stage: 0
distributed_type: DEEPSPEED
downcast_bf16: 'no'
fsdp_config: {}
machine_rank: 0
main_process_ip: null
main_process_port: null
main_training_function: main
mixed_precision: 'no'
num_machines: 1
num_processes: 2
use_cpu: false
```
```
-- config_fp16.yml --
compute_environment: LOCAL_MACHINE
deepspeed_config:
  gradient_accumulation_steps: 2
  gradient_clipping: 1.0
  zero3_init_flag: false
  zero_stage: 0
distributed_type: DEEPSPEED
downcast_bf16: 'no'
fsdp_config: {}
machine_rank: 0
main_process_ip: null
main_process_port: null
main_training_function: main
mixed_precision: fp16
num_machines: 1
num_processes: 2
use_cpu: false
```

example code:
```
from accelerate import Accelerator
import torch
from torch.utils.data import TensorDataset

def main():
    accelerator = Accelerator(log_with="all")

    model = torch.nn.Sequential(
        torch.nn.Linear(3, 16),
        torch.nn.Linear(16, 3)
    )

    dset = TensorDataset(torch.rand([40, 3]))
    train_dataloader = torch.utils.data.DataLoader(dset, batch_size=4, shuffle=True, num_workers=4, pin_memory=True, drop_last=True, persistent_workers=True)

    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
    lr_scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, 0.05, epochs=10, steps_per_epoch=len(train_dataloader))

    model, optimizer, train_dataloader, lr_scheduler = accelerator.prepare(
        model, optimizer, train_dataloader, lr_scheduler
    )

    for epoch in range(10):
        model.train()
        for step, batch in enumerate(train_dataloader):
            batch = batch[0]
            outputs = model(batch)
            loss = torch.nn.functional.mse_loss(batch, outputs)
            accelerator.backward(loss)
            optimizer.step()
            lr_scheduler.step()
            optimizer.zero_grad()
        
if __name__ == "__main__":
    main()
```

This error does not occur with the half(fp16) setting.
So I modified the DeepSpeedOptimizerWrapper class in src/accelerate/utils/deepspeed.py to make sure the optimizer has an overflow property.

If my PR is duplicate or unnecessary, please close it.

Thank you.