### PR TITLE
Fix reduce operation

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -434,10 +434,7 @@ def reduce(tensor, reduction="mean"):
         state = PartialState()
         cloned_tensor = tensor.clone()
         if state.distributed_type == DistributedType.NO:
-            if reduction == "sum":
-                return cloned_tensor.sum()
-            else:
-                return cloned_tensor.mean()
+            return cloned_tensor
         if state.distributed_type == DistributedType.TPU:
             xm.all_reduce("sum", cloned_tensor)
         elif state.distributed_type.value in CUDA_DISTRIBUTED_TYPES:


### PR DESCRIPTION
Fixes #1266.

Fixes reduce to not change the input tensor if there's only one process.

Note: two tests failed even before I made any modifications. Other tests went fine. The short test summary info of `make test` is:
```
FAILED tests/test_grad_sync.py::SyncScheduler::test_gradient_sync_gpu_multi - RuntimeError: 'torchrun --nproc_per_node=2 /amax/xyf/accelerate/src/accelerate/test_utils/scripts/test_sync.py' failed with returncode 1
FAILED tests/test_memory_utils.py::MemoryTest::test_release_memory - AssertionError: 8519680 != 0
```