### PR TITLE
fix attribute error in DataloaderShared

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -401,8 +401,8 @@ class DataLoaderShard(DataLoader):
         batch_sampler = self.sampler if isinstance(self.sampler, BatchSampler) else self.batch_sampler
         return (
             batch_sampler.batch_size
-            if batch_sampler.split_batches
-            else (batch_sampler.batch_size * batch_sampler.num_processes)
+            if getattr(batch_sampler, "split_batches", False)
+            else (batch_sampler.batch_size * getattr(batch_sampler, "num_processes", 1))
         )
 
     @property


### PR DESCRIPTION
When running in single GPU, the `batch_sampler` of `DataLoaderShared` is a `torch.utils.data.sampler.BatchSampler` object instead of `DataSamplerShared ` object, which does not contain necessary attributes to calculate `total_batch_size`.