### PR TITLE
Raise import error if fp8 not available in `has_transfomer_engine_layers`

### DIFF
--- a/src/accelerate/utils/transformer_engine.py
+++ b/src/accelerate/utils/transformer_engine.py
@@ -72,6 +72,8 @@ def has_transformer_engine_layers(model):
     """
     Returns whether a given model has some `transformer_engine` layer or not.
     """
+    if not is_fp8_available():
+        raise ImportError("Using `has_transformer_engine_layers` requires transformer_engine to be installed.")
     for m in model.modules():
         if isinstance(m, (te.LayerNorm, te.Linear)):
             return True


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1276 by also including a check for `is_fp8_available`