### PR TITLE
Use a new Exception to catch second type error

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -22,6 +22,7 @@ from .dataclasses import (
     TorchDynamoPlugin,
 )
 from .environment import get_int_from_env, parse_choice_from_env, parse_flag_from_env
+from .exceptions import TypedApplyException
 from .imports import (
     get_ccl_version,
     is_aim_available,

--- a/src/accelerate/utils/exceptions.py
+++ b/src/accelerate/utils/exceptions.py
@@ -1,0 +1,22 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class TypedApplyException(Exception):
+    """
+    An exception that acts the same as a `TypeError`, except can be used in places where `TypeError`'s are already
+    being suppressed.
+    """
+
+    pass

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -25,6 +25,7 @@ import torch
 from ..state import PartialState
 from .constants import CUDA_DISTRIBUTED_TYPES
 from .dataclasses import DistributedType, TensorInformation
+from .exceptions import TypedApplyException
 from .imports import is_torch_distributed_available, is_tpu_available
 from .versions import is_torch_version
 
@@ -100,7 +101,7 @@ def recursively_apply(func, data, *args, test_type=is_torch_tensor, error_on_oth
     elif test_type(data):
         return func(data, *args, **kwargs)
     elif error_on_other_type:
-        raise ValueError(
+        raise TypedApplyException(
             f"Can't apply {func.__name__} on object of type {type(data)}, only of nested list/tuple/dicts of objects "
             f"that satisfy {test_type.__name__}."
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,10 +22,12 @@ import torch
 from accelerate.test_utils.testing import require_cuda
 from accelerate.test_utils.training import RegressionModel
 from accelerate.utils import (
+    TypedApplyException,
     convert_outputs_to_fp32,
     extract_model_from_parallel,
     find_device,
     patch_environment,
+    recursively_apply,
     send_to_device,
 )
 
@@ -72,6 +74,10 @@ class UtilsTester(unittest.TestCase):
         self.assertTrue(torch.equal(result4["b"][0].cpu(), tensor))
         self.assertTrue(torch.equal(result4["b"][1].cpu(), tensor))
         self.assertEqual(result4["c"], 1)
+
+    def test_honor_type(self):
+        with self.assertRaises(TypedApplyException):
+            _ = recursively_apply(torch.tensor, (torch.tensor(1), 1), error_on_other_type=True)
 
     def test_patch_environment(self):
         with patch_environment(aa=1, BB=2):


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1263

The basic issue relies on the fact that a `TypeError` was raised initially, and in turn can't really be raised "again" for a second test of if something can be done, due to the `else` in `honor_type`:
```python
def honor_type(obj, generator):
    """
    Cast a generator to the same type as obj (list, tuple, or namedtuple)
    """
    try:
        return type(obj)(generator)
    except TypeError: <- Our culprit
        # Some objects may not be able to instantiate from a generator directly
        return type(obj)(*list(generator))
```
This PR solves it by adding a `TypedApplyException` which will raise the true error better.

This PR also added a test.

Proof it works with the example @stas00 showed:

```bash
Traceback (most recent call last):
  File "/home/zach_mueller_huggingface_co/test_distrib.py", line 6, in <module>
    gathered_tensor, i = accelerator.gather((process_tensor, 1))
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/accelerator.py", line 1869, in gather
    return gather(tensor)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 229, in gather
    return _gpu_gather(tensor)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 209, in _gpu_gather
    return recursively_apply(_gpu_gather_one, tensor, error_on_other_type=True)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 83, in recursively_apply
    return honor_type(
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 54, in honor_type
    return type(obj)(generator)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 86, in <genexpr>
    recursively_apply(
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 104, in recursively_apply
    raise TypedApplyException(
accelerate.utils.exceptions.TypedApplyException: Can't apply _gpu_gather_one on object of type <class 'int'>, only of nested list/tuple/dicts of objects that satisfy is_torch_tensor.
ERROR:torch.distributed.elastic.multiprocessing.api:failed (exitcode: 1) local_rank: 0 (pid: 4009209) of binary: 
...
```
