### PR TITLE
Expound error on `recursively_apply`

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -116,8 +116,8 @@ def recursively_apply(func, data, *args, test_type=is_torch_tensor, error_on_oth
         return func(data, *args, **kwargs)
     elif error_on_other_type:
         raise TypeError(
-            f"Can't apply {func.__name__} on object of type {type(data)}, only of nested list/tuple/dicts of objects "
-            f"that satisfy {test_type.__name__}."
+            f"Unsupported types ({type(data)}) passed to `{func.__name__}`. Only nested list/tuple/dicts of "
+            f"objects that are valid for `{test_type.__name__}` should be passed."
         )
     return data
 
@@ -206,7 +206,9 @@ def _tpu_gather(tensor, name="gather tensor"):
     elif isinstance(tensor, Mapping):
         return type(tensor)({k: _tpu_gather(v, name=f"{name}_{k}") for k, v in tensor.items()})
     elif not isinstance(tensor, torch.Tensor):
-        raise TypeError(f"Can't gather the values of type {type(tensor)}, only of nested list/tuple/dicts of tensors.")
+        raise TypeError(
+            f"Can't gather the values of type {type(tensor)}, only nested list/tuple/dicts of tensors are supported."
+        )
     if tensor.ndim == 0:
         tensor = tensor.clone()[None]
     return xm.mesh_reduce(name, tensor, torch.cat)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,12 +77,10 @@ class UtilsTester(unittest.TestCase):
     def test_honor_type(self):
         with self.assertRaises(TypeError) as cm:
             _ = recursively_apply(torch.tensor, (torch.tensor(1), 1), error_on_other_type=True)
-        for substring in [
-            "Can't apply",
-            "on object of type",
-            "only of nested list/tuple/dicts of objects that satisfy",
-        ]:
-            assert substring in str(cm.exception)
+        self.assertEqual(
+            str(cm.exception),
+            "Unsupported types (<class 'int'>) passed to `tensor`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed.",
+        )
 
     def test_patch_environment(self):
         with patch_environment(aa=1, BB=2):


### PR DESCRIPTION
Expands the error a bit more in `recursively_apply` to be more straightforward. Example:

```python
Traceback (most recent call last):
  File "/home/zach_mueller_huggingface_co/test_distrib.py", line 6, in <module>
    gathered_tensor, i = accelerator.gather((process_tensor, 1))
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/accelerator.py", line 1869, in gather
    return gather(tensor)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 243, in gather
    return _gpu_gather(tensor)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 223, in _gpu_gather
    return recursively_apply(_gpu_gather_one, tensor, error_on_other_type=True)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 97, in recursively_apply
    return honor_type(
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 71, in honor_type
    return type(obj)(generator)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 100, in <genexpr>
    recursively_apply(
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/operations.py", line 118, in recursively_apply
    raise TypeError(
TypeError: Unsupported types (<class 'int'>) passed to `_gpu_gather_one`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed.
```

cc @stas00 
