### PR TITLE
Raise more explicit error when transformer_engine isn't installed

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -552,8 +552,7 @@ class AcceleratorState:
             )
             if mixed_precision == "fp8" and not is_fp8_available():
                 raise ValueError(
-                    "Using `fp8` precision requires `transformer_engine` to be installed and utilizing supported hardware. "
-                    "Currently your system is not supported."
+                    "Using `fp8` precision requires `transformer_engine` to be installed and utilizing supported hardware."
                 )
             self.dynamo_plugin = dynamo_plugin
             if not _from_accelerator:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -28,6 +28,7 @@ from .utils import (
     get_int_from_env,
     is_ccl_available,
     is_deepspeed_available,
+    is_fp8_available,
     is_mps_available,
     is_tpu_available,
     parse_choice_from_env,
@@ -549,6 +550,11 @@ class AcceleratorState:
                 if mixed_precision is None
                 else mixed_precision.lower()
             )
+            if mixed_precision == "fp8" and not is_fp8_available():
+                raise ValueError(
+                    "Using `fp8` precision requires `transformer_engine` to be installed and utilizing supported hardware. "
+                    "Currently your system is not supported."
+                )
             self.dynamo_plugin = dynamo_plugin
             if not _from_accelerator:
                 raise ValueError(

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -551,9 +551,7 @@ class AcceleratorState:
                 else mixed_precision.lower()
             )
             if mixed_precision == "fp8" and not is_fp8_available():
-                raise ValueError(
-                    "Using `fp8` precision requires `transformer_engine` to be installed."
-                )
+                raise ValueError("Using `fp8` precision requires `transformer_engine` to be installed.")
             self.dynamo_plugin = dynamo_plugin
             if not _from_accelerator:
                 raise ValueError(

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -552,7 +552,7 @@ class AcceleratorState:
             )
             if mixed_precision == "fp8" and not is_fp8_available():
                 raise ValueError(
-                    "Using `fp8` precision requires `transformer_engine` to be installed and utilizing supported hardware."
+                    "Using `fp8` precision requires `transformer_engine` to be installed."
                 )
             self.dynamo_plugin = dynamo_plugin
             if not _from_accelerator:


### PR DESCRIPTION
Addresses https://github.com/huggingface/accelerate/issues/1276 by raising an error in `PartialState` when passing in `fp8` to the precision and its unsupported. I don't believe we should address this in `accelerate config` as well, since config files can be passed around. If you disagree @sgugger and it would be good to include that check during the CLI questionnaire, I can do so. 