### PR TITLE
Only check for dtype if it has it in get_state_dict

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2576,7 +2576,7 @@ class Accelerator:
 
         if state_dict is not None:
             for k in state_dict:
-                if state_dict[k].dtype == torch.float16:
+                if getattr(state_dict[k], "dtype", None) == torch.float16:
                     state_dict[k] = state_dict[k].float()
 
         return state_dict


### PR DESCRIPTION
Partial solution to https://github.com/huggingface/accelerate/issues/1246 (I believe), which will always let the user pull the model, and we only check for fp16 if the state dict has the capability to do so
