### PR TITLE
Raise better error on `notebook_launcher`

### DIFF
--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -17,7 +17,6 @@ import sys
 import tempfile
 
 import torch
-from torch.multiprocessing.spawn import ProcessRaisedException
 
 from .state import AcceleratorState
 from .utils import PrecisionType, PrepareForLaunch, is_mps_available, patch_environment
@@ -111,6 +110,7 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
         if num_processes > 1:
             # Multi-GPU launch
             from torch.multiprocessing import start_processes
+            from torch.multiprocessing.spawn import ProcessRaisedException
 
             if len(AcceleratorState._shared_state) > 0:
                 raise ValueError(
@@ -132,7 +132,6 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
                 world_size=num_processes, master_addr="127.0.01", master_port=use_port, mixed_precision=mixed_precision
             ):
                 launcher = PrepareForLaunch(function, distributed_type="MULTI_GPU")
-
                 print(f"Launching training on {num_processes} GPUs.")
                 try:
                     start_processes(launcher, args=args, nprocs=num_processes, start_method="fork")

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -17,6 +17,7 @@ import sys
 import tempfile
 
 import torch
+from torch.multiprocessing.spawn import ProcessRaisedException
 
 from .state import AcceleratorState
 from .utils import PrecisionType, PrepareForLaunch, is_mps_available, patch_environment
@@ -133,7 +134,15 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
                 launcher = PrepareForLaunch(function, distributed_type="MULTI_GPU")
 
                 print(f"Launching training on {num_processes} GPUs.")
-                start_processes(launcher, args=args, nprocs=num_processes, start_method="fork")
+                try:
+                    start_processes(launcher, args=args, nprocs=num_processes, start_method="fork")
+                except ProcessRaisedException as e:
+                    if "Cannot re-initialize CUDA in forked subprocess" in e.args[0]:
+                        raise RuntimeError(
+                            "CUDA has been initialized before the `notebook_launcher` could create a forked subprocess. "
+                            "Please make sure no code ran initializes CUDA by checking `import torch; torch.cuda.is_initialized()`, "
+                            "and ensure that no outside imports are causing issues once the `notebook_launcher()` is called."
+                        ) from e
 
         else:
             # No need for a distributed launch otherwise as it's either CPU, GPU or MPS.

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -140,8 +140,9 @@ def notebook_launcher(function, args=(), num_processes=None, mixed_precision="no
                     if "Cannot re-initialize CUDA in forked subprocess" in e.args[0]:
                         raise RuntimeError(
                             "CUDA has been initialized before the `notebook_launcher` could create a forked subprocess. "
-                            "Please make sure no code ran initializes CUDA by checking `import torch; torch.cuda.is_initialized()`, "
-                            "and ensure that no outside imports are causing issues once the `notebook_launcher()` is called."
+                            "This likely stems from an outside import causing issues once the `notebook_launcher()` is called. "
+                            "Please review your imports and test them when running the `notebook_launcher()` to identify "
+                            "which one is problematic."
                         ) from e
 
         else:


### PR DESCRIPTION
Currently we rely on PyTorch's standard error message when the `notebook_launcher` has issues, and it is *exceedingly* cryptic how to continue when an import is causing issues. I specifically mean the `Cannot re-initialize CUDA in a forked subprocess...`. 

Especially for the user, it doesn't actually explain what is *truly* going on. As a result, this PR introduces a better error message.

Example trace:
```python
---------------------------------------------------------------------------
ProcessRaisedException                    Traceback (most recent call last)
File ~/accelerate/src/accelerate/launchers.py:138, in notebook_launcher(function, args, num_processes, mixed_precision, use_port)
    137 try:
--> 138     start_processes(launcher, args=args, nprocs=num_processes, start_method="fork")
    139 except ProcessRaisedException as e:

File ~/miniconda3/envs/accelerate/lib/python3.9/site-packages/torch/multiprocessing/spawn.py:197, in start_processes(fn, args, nprocs, join, daemon, start_method)
    196 # Loop on join until it returns True or raises an exception.
--> 197 while not context.join():
    198     pass

File ~/miniconda3/envs/accelerate/lib/python3.9/site-packages/torch/multiprocessing/spawn.py:160, in ProcessContext.join(self, timeout)
    159 msg += original_trace
--> 160 raise ProcessRaisedException(msg, error_index, failed_process.pid)

ProcessRaisedException: 

-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/home/zach_mueller_huggingface_co/miniconda3/envs/accelerate/lib/python3.9/site-packages/torch/multiprocessing/spawn.py", line 69, in _wrap
    fn(i, *args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/launch.py", line 514, in __call__
    self.launcher(*args)
  File "/tmp/ipykernel_1146463/1934231147.py", line 10, in train_loop
    accelerator = Accelerator()
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/accelerator.py", line 358, in __init__
    self.state = AcceleratorState(
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/state.py", line 542, in __init__
    PartialState(cpu, **kwargs)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/state.py", line 137, in __init__
    torch.cuda.set_device(self.device)
  File "/home/zach_mueller_huggingface_co/miniconda3/envs/accelerate/lib/python3.9/site-packages/torch/cuda/__init__.py", line 350, in set_device
    torch._C._cuda_setDevice(device)
  File "/home/zach_mueller_huggingface_co/miniconda3/envs/accelerate/lib/python3.9/site-packages/torch/cuda/__init__.py", line 235, in _lazy_init
    raise RuntimeError(
RuntimeError: Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method


The above exception was the direct cause of the following exception:

RuntimeError                              Traceback (most recent call last)
Cell In [1], line 14
     11     print(accelerator.state)
     13 from accelerate import notebook_launcher
---> 14 notebook_launcher(train_loop, num_processes=2)

File ~/accelerate/src/accelerate/launchers.py:141, in notebook_launcher(function, args, num_processes, mixed_precision, use_port)
    139         except ProcessRaisedException as e:
    140             if "Cannot re-initialize CUDA in forked subprocess" in e.args[0]:
--> 141                 raise RuntimeError(
    142                     "CUDA has been initialized before the `notebook_launcher` could create a forked subprocess. "
    143                     "Please make sure no code ran initializes CUDA by checking `import torch; torch.cuda.is_initialized()`, "
    144                     "and ensure that no outside imports are causing issues after `notebook_launcher()` is called."
    145                     ) from e
    147 else:
    148     # No need for a distributed launch otherwise as it's either CPU, GPU or MPS.
    149     if is_mps_available():

RuntimeError: CUDA has been initialized before the `notebook_launcher` could create a forked subprocess. This likely stems from an outside import causing issues once the `notebook_launcher()` is called. Please review your imports and test them when running the `notebook_launcher()` to identify which one is problematic.
```

Note that in this case it is *directly* from an import, as earlier we check if `cuda` was initialized