### PR TITLE
Add ability to use SageMaker FileSystemInput

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+from ast import literal_eval
 import importlib
 import logging
 import os
@@ -764,8 +765,18 @@ def sagemaker_launcher(sagemaker_config: SageMakerConfig, args):
         )
 
     from sagemaker.huggingface import HuggingFace
+    from sagemaker.inputs import FileSystemInput
 
     args, sagemaker_inputs = prepare_sagemager_args_inputs(sagemaker_config, args)
+    for input_name, input_value in sagemaker_inputs.items():
+        try:
+            input_dict = literal_eval(input_value)
+            if isinstance(input_dict, dict):
+                sagemaker_inputs[input_name] = FileSystemInput(**input_dict)
+            else:
+                sagemaker_inputs[input_name] = input_value
+        except (ValueError, SyntaxError):
+            sagemaker_inputs[input_name] = input_value
 
     huggingface_estimator = HuggingFace(**args)
 


### PR DESCRIPTION
Add the ability to use FileSystemInput by specifying a dictionary in sagemaker_inputs. This is needed for using EFS or FSx on SageMaker.

https://aws.amazon.com/blogs/machine-learning/speed-up-training-on-amazon-sagemaker-using-amazon-efs-or-amazon-fsx-for-lustre-file-systems/

### Testing

Tested submitting a SageMaker job with SageMaker inputs data .tsv file with the following format
[sample_fsx_accelerate.tsv.txt](https://github.com/huggingface/accelerate/files/11163433/sample_fsx_accelerate.tsv.txt)