### PR TITLE
Fix nested context manager for main_process_first()

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -755,7 +755,8 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.process_index}")
         ```
         """
-        yield self.state.main_process_first()
+        with self.state.main_process_first():
+            yield
 
     @contextmanager
     def local_main_process_first(self):
@@ -776,7 +777,8 @@ class Accelerator:
         ...     print(f"This will be printed by process {accelerator.local_process_index}")
         ```
         """
-        yield self.state.local_main_process_first()
+        with self.state.local_main_process_first():
+            yield
 
     @contextmanager
     def no_sync(self, model):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -681,7 +681,8 @@ class AcceleratorState:
 
         The other processes will enter the with block after the main process exits.
         """
-        yield PartialState().main_process_first()
+        with PartialState().main_process_first():
+            yield
 
     @contextmanager
     def local_main_process_first(self):
@@ -690,7 +691,8 @@ class AcceleratorState:
 
         The other processes will enter the with block after the main process exits.
         """
-        yield PartialState().local_main_process_first()
+        with PartialState().local_main_process_first():
+            yield
 
     def print(self, *args, **kwargs):
         PartialState().print(*args, **kwargs)

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -18,6 +18,7 @@ import contextlib
 import io
 import os
 import time
+from pathlib import Path
 
 import torch
 from torch.utils.data import DataLoader
@@ -56,14 +57,31 @@ def print_on(state, process_idx):
 def process_execution_check():
     accelerator = Accelerator()
     num_processes = accelerator.num_processes
+
+    # Test main_process_first context manager
+    path = Path("check_main_process_first.txt")
+    if path.exists():
+        path.unlink()
     with accelerator.main_process_first():
         if accelerator.is_main_process:
             time.sleep(0.1)  # ensure main process takes longest
-            open("check_main_process_first.txt", "w").close()
-        assert os.path.isfile("check_main_process_first.txt"), "Main process did not create check file yet."
+            with open(path, "a+") as f:
+                f.write("Currently in the main process\n")
+        else:
+            with open(path, "a+") as f:
+                f.write("Now on another process\n")
     accelerator.wait_for_everyone()
     if accelerator.is_main_process:
-        os.remove("check_main_process_first.txt")
+        with open(path, "r") as f:
+            text = "".join(f.readlines())
+        try:
+            assert text.startswith("Currently in the main process\n"), f"Main process was not first"
+            assert text.endswith("Now on another process\n"), f"Main process was not first"
+            assert text.count("Now on another process\n") == num_processes - 1, \
+                f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_processes}"
+        except AssertionError:
+            path.unlink()
+            raise
 
     # Test the decorators
     f = io.StringIO()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -16,7 +16,6 @@
 
 import contextlib
 import io
-import os
 import time
 from pathlib import Path
 
@@ -75,10 +74,11 @@ def process_execution_check():
         with open(path, "r") as f:
             text = "".join(f.readlines())
         try:
-            assert text.startswith("Currently in the main process\n"), f"Main process was not first"
-            assert text.endswith("Now on another process\n"), f"Main process was not first"
-            assert text.count("Now on another process\n") == num_processes - 1, \
-                f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_processes}"
+            assert text.startswith("Currently in the main process\n"), "Main process was not first"
+            assert text.endswith("Now on another process\n"), "Main process was not first"
+            assert (
+                text.count("Now on another process\n") == num_processes - 1
+            ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_processes}"
         except AssertionError:
             path.unlink()
             raise

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -75,7 +75,8 @@ def process_execution_check():
             text = "".join(f.readlines())
         try:
             assert text.startswith("Currently in the main process\n"), "Main process was not first"
-            assert text.endswith("Now on another process\n"), "Main process was not first"
+            if num_processes > 1:
+                assert text.endswith("Now on another process\n"), "Main process was not first"
             assert (
                 text.count("Now on another process\n") == num_processes - 1
             ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_processes}"


### PR DESCRIPTION
This PR proposes a fix for #1303.

The bug seems to be in delegation from one context manager (for example from `Accelerator`) to another one (from `AccelerateState`). Currently, the following pattern is used:

```python
@contextmanager
def main_process_first(self):
    yield self.state.main_process_first()
```
However, when executed, this context manager simply yields without entering `self.state.main_process_first()`, causing the bug. The solution is to correctly enter the inner context manager using `with`.

This was a very interesting bug. Since I haven't defined nested context managers like this before, I wanted to understand what the right way to do this is, and whether the current implementation in the library was correct. Like the cool kids I even asked ChatGPT, which explained what the current implementation was trying to do and how to use `yield context_manager()` or `yield from context_manager()`. Unfortunately it turned out that ChatGPT was hallucinating its explanation and use of these concepts, and even the code examples which it produced did not run and produced an error instead. 

In summary, according to ChatGPT the current implementation is correct, though it's not. So I'm very curious if I'm understanding it correctly now, and whether GPT-3/Copilot/ChatGPT had anything to do with the original implementation :)