### PR TITLE
Simplify MPS implementation

### DIFF
--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -135,7 +135,6 @@ values. They can also be passed in manually.
 
 * `--cpu` (`bool`) -- Whether or not to force the training on the CPU.
 * `--multi_gpu` (`bool`) -- Whether or not this should launch a distributed GPU training.
-* `--mps` (`bool`) -- Whether or not this should use MPS-enabled GPU device on MacOS machines.
 * `--tpu` (`bool`) -- Whether or not this should launch a TPU training.
 
 **Resource Selection Arguments**:

--- a/docs/source/usage_guides/megatron_lm.mdx
+++ b/docs/source/usage_guides/megatron_lm.mdx
@@ -115,7 +115,7 @@ An example of thr corresponding questions for using Megatron-LM features is show
 ```bash
 :~$ accelerate config --config_file "megatron_gpt_config.yaml"
 In which compute environment are you running? ([0] This machine, [1] AWS (Amazon SageMaker)): 0
-Which type of machine are you using? ([0] No distributed training, [1] multi-CPU, [2] multi-GPU, [3] TPU [4] MPS): 2
+Which type of machine are you using? ([0] No distributed training, [1] multi-CPU, [2] multi-GPU, [3] TPU): 2
 How many different machines will you use (use more than 1 for multi-node training)? [1]: 
 Do you want to use DeepSpeed? [yes/NO]: 
 Do you want to use FullyShardedDataParallel? [yes/NO]: 

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -803,12 +803,7 @@ def _validate_launch_command(args):
         if args.multi_gpu and args.num_machines is None:
             args.num_machines = defaults.num_machines
 
-        if (
-            len(args.gpu_ids.split(",")) < 2
-            and (args.gpu_ids != "all")
-            and args.multi_gpu
-            and args.num_machines <= 1
-        ):
+        if len(args.gpu_ids.split(",")) < 2 and (args.gpu_ids != "all") and args.multi_gpu and args.num_machines <= 1:
             raise ValueError(
                 "Less than two GPU ids were configured and tried to run on on multiple GPUs. "
                 "Please ensure at least two are specified for `--gpu_ids`, or use `--gpu_ids='all'`."

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -61,7 +61,6 @@ logger = logging.getLogger(__name__)
 options_to_group = {
     "--multi-gpu": "Distributed GPUs",
     "--tpu": "TPU",
-    "--mps": "MPS",
     "--use_deepspeed": "DeepSpeed Arguments",
     "--use_fsdp": "FSDP Arguments",
     "--use_megatron_lm": "Megatron-LM Arguments",
@@ -146,13 +145,6 @@ def launch_command_parser(subparsers=None):
     )
     hardware_args.add_argument(
         "--cpu", default=False, action="store_true", help="Whether or not to force the training on the CPU."
-    )
-    hardware_args.add_argument(
-        "--mps",
-        default=False,
-        action="store_true",
-        help="This argument is deprecated. MPS device will be enabled by default when available and can be disabled via `--cpu`."
-        " Whether or not this should use MPS-enabled GPU device on MacOS machines.",
     )
     hardware_args.add_argument(
         "--multi_gpu",
@@ -775,9 +767,9 @@ def sagemaker_launcher(sagemaker_config: SageMakerConfig, args):
 
 def _validate_launch_command(args):
     # Sanity checks
-    if sum([args.multi_gpu, args.cpu, args.tpu, args.mps, args.use_deepspeed, args.use_fsdp]) > 1:
+    if sum([args.multi_gpu, args.cpu, args.tpu, args.use_deepspeed, args.use_fsdp]) > 1:
         raise ValueError(
-            "You can only use one of `--cpu`, `--multi_gpu`, `--mps`, `--tpu`, `--use_deepspeed`, `--use_fsdp` at a time."
+            "You can only use one of `--cpu`, `--multi_gpu`, `--tpu`, `--use_deepspeed`, `--use_fsdp` at a time."
         )
     if args.multi_gpu and (args.num_processes is not None) and (args.num_processes < 2):
         raise ValueError("You need to use at least 2 processes to use `--multi_gpu`.")
@@ -792,7 +784,6 @@ def _validate_launch_command(args):
             not args.multi_gpu
             and not args.tpu
             and not args.tpu_use_cluster
-            and not args.mps
             and not args.use_deepspeed
             and not args.use_fsdp
             and not args.use_megatron_lm
@@ -801,29 +792,27 @@ def _validate_launch_command(args):
             args.multi_gpu = defaults.distributed_type == DistributedType.MULTI_GPU
             args.tpu = defaults.distributed_type == DistributedType.TPU
             args.use_fsdp = defaults.distributed_type == DistributedType.FSDP
-            args.mps = defaults.distributed_type == DistributedType.MPS
             args.use_megatron_lm = defaults.distributed_type == DistributedType.MEGATRON_LM
             args.tpu_use_cluster = defaults.tpu_use_cluster if args.tpu else False
-        if not args.mps:
-            if args.gpu_ids is None:
-                if defaults.gpu_ids is not None:
-                    args.gpu_ids = defaults.gpu_ids
-                else:
-                    args.gpu_ids = "all"
+        if args.gpu_ids is None:
+            if defaults.gpu_ids is not None:
+                args.gpu_ids = defaults.gpu_ids
+            else:
+                args.gpu_ids = "all"
 
-            if args.multi_gpu and args.num_machines is None:
-                args.num_machines = defaults.num_machines
+        if args.multi_gpu and args.num_machines is None:
+            args.num_machines = defaults.num_machines
 
-            if (
-                len(args.gpu_ids.split(",")) < 2
-                and (args.gpu_ids != "all")
-                and args.multi_gpu
-                and args.num_machines <= 1
-            ):
-                raise ValueError(
-                    "Less than two GPU ids were configured and tried to run on on multiple GPUs. "
-                    "Please ensure at least two are specified for `--gpu_ids`, or use `--gpu_ids='all'`."
-                )
+        if (
+            len(args.gpu_ids.split(",")) < 2
+            and (args.gpu_ids != "all")
+            and args.multi_gpu
+            and args.num_machines <= 1
+        ):
+            raise ValueError(
+                "Less than two GPU ids were configured and tried to run on on multiple GPUs. "
+                "Please ensure at least two are specified for `--gpu_ids`, or use `--gpu_ids='all'`."
+            )
         if defaults.compute_environment == ComputeEnvironment.LOCAL_MACHINE:
             # Update args with the defaults
             for name, attr in defaults.__dict__.items():

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -18,10 +18,10 @@ from typing import Dict, List, Mapping, Optional, Union
 import torch
 import torch.nn as nn
 
+from .state import PartialState
 from .utils import (
     PrefixedDataset,
     find_device,
-    is_mps_available,
     named_module_tensors,
     send_to_device,
     set_module_tensor_to_device,
@@ -533,13 +533,7 @@ class CpuOffload(ModelHook):
         self.prev_module_hook = prev_module_hook
 
         if execution_device is not None:
-            self.execution_device = execution_device
-        elif is_mps_available():
-            self.execution_device = torch.device("mps")
-        elif torch.cuda.is_available():
-            self.execution_device = torch.device(0)
-        else:
-            self.execution_device = torch.device("cpu")
+        self.execution_device = execution_device if execution_device is not None else PartialState().default_device
 
     def init_hook(self, module):
         return module.to("cpu")

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -532,7 +532,6 @@ class CpuOffload(ModelHook):
     ):
         self.prev_module_hook = prev_module_hook
 
-        if execution_device is not None:
         self.execution_device = execution_device if execution_device is not None else PartialState().default_device
 
     def init_hook(self, module):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -481,7 +481,7 @@ class PartialState:
     def default_device(self) -> torch.device:
         """
         Returns the default device which is:
-        - MPS if `torch.backends.mps.is_available()` and `torch.backends.mps.is_built()` bother return True.
+        - MPS if `torch.backends.mps.is_available()` and `torch.backends.mps.is_built()` both return True.
         - CUDA if `torch.cuda.is_available()`
         - CPU otherwise
         """

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -33,6 +33,7 @@ from ..utils import (
     is_comet_ml_available,
     is_datasets_available,
     is_deepspeed_available,
+    is_mps_available,
     is_safetensors_available,
     is_tensorboard_available,
     is_torch_version,
@@ -93,8 +94,7 @@ def require_mps(test_case):
     Decorator marking a test that requires MPS backend. These tests are skipped when torch doesn't support `mps`
     backend.
     """
-    is_mps_supported = hasattr(torch.backends, "mps") and torch.backends.mps.is_available()
-    return unittest.skipUnless(is_mps_supported, "test requires a `mps` backend support in `torch`")(test_case)
+    return unittest.skipUnless(is_mps_available(), "test requires a `mps` backend support in `torch`")(test_case)
 
 
 def require_huggingface_suite(test_case):

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -70,14 +70,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
 
     current_env = os.environ.copy()
     current_env["ACCELERATE_USE_CPU"] = str(args.cpu or args.use_cpu)
-    current_env["ACCELERATE_USE_MPS_DEVICE"] = str(args.mps)
-    if args.mps:
-        warnings.warn(
-            "`mps` is deprecated and will be removed in version 0.18.0 of 🤗 Accelerate."
-            " MPS device will be enabled by default when available and can be disabled via `--cpu`.",
-            FutureWarning,
-        )
-    elif args.gpu_ids != "all" and args.gpu_ids is not None:
+    if args.gpu_ids != "all" and args.gpu_ids is not None:
         current_env["CUDA_VISIBLE_DEVICES"] = args.gpu_ids
     if args.num_machines > 1:
         current_env["MASTER_ADDR"] = args.main_process_ip

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -15,7 +15,6 @@
 import argparse
 import os
 import sys
-import warnings
 from ast import literal_eval
 from typing import Any, Dict, List, Tuple
 


### PR DESCRIPTION
This PR simplifies the MPS implementation by removing all deprecated code (we did mention it would be good until v0.18). It also paves the way for an easier integration of other default devices later on by adding a `default_device` property on `PartialState`.
