### PR TITLE
Allow xpu backend

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -78,7 +78,7 @@ class PartialState:
 
     _shared_state = {}
 
-    def __init__(self, cpu: bool = False, **kwargs):
+    def __init__(self, cpu: bool = False, backend=None, **kwargs):
         self.__dict__ = self._shared_state
         if not self.initialized:
             self._cpu = cpu
@@ -127,8 +127,12 @@ class PartialState:
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
-                    torch.distributed.init_process_group(backend="nccl", **kwargs)
-                    self.backend = "nccl"
+                    if backend and backend in ("mpi", "gloo"):
+                        torch.distributed.init_process_group(backend=backend, **kwargs)
+                        self.backend = backend
+                    else:
+                        torch.distributed.init_process_group(backend="nccl", **kwargs)
+                        self.backend = "nccl"
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()
                 self.local_process_index = int(os.environ.get("LOCAL_RANK", -1))


### PR DESCRIPTION
Let's a backend be passed to the `PartialState`. For now internal only while we migrate over the `Trainer`, afterwards will be configurable through the CLI/config (and the `Accelerator` object?)