### PR TITLE
Default to nccl

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -127,7 +127,7 @@ class PartialState:
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
-                    self.backend = kwargs.pop("backend")
+                    self.backend = kwargs.pop("backend", "nccl")
                     torch.distributed.init_process_group(backend=self.backend, **kwargs)
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()


### PR DESCRIPTION
Defaults the `kwargs` to `nccl`, as the kwarg handler will sometimes not be used and we still need to use `nccl` as the default