### PR TITLE
offload the previous module hook before the current module is moved to…

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -538,9 +538,9 @@ class CpuOffload(ModelHook):
         return module.to("cpu")
 
     def pre_forward(self, module, *args, **kwargs):
-        module.to(self.execution_device)
         if self.prev_module_hook is not None:
             self.prev_module_hook.offload()
+        module.to(self.execution_device)
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 
 


### PR DESCRIPTION
… the execution device

Moving the previous module afterwards unnecessarily puts both on the device at the same time