### PR TITLE
Ensure that dynamo is compatible with mixed precision

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -517,8 +517,8 @@ class ConvertOutputsToFp32:
 def convert_outputs_to_fp32(model_forward):
     model_forward = ConvertOutputsToFp32(model_forward)
 
-    def forward(x):
-        return model_forward(x)
+    def forward(*args, **kwargs):
+        return model_forward(*args, **kwargs)
 
     # To act like a decorator so that it can be popped when doing `extract_model_from_parallel`
     forward.__wrapped__ = model_forward

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -514,7 +514,16 @@ class ConvertOutputsToFp32:
         )
 
 
-convert_outputs_to_fp32 = ConvertOutputsToFp32
+def convert_outputs_to_fp32(model_forward):
+    model_forward = ConvertOutputsToFp32(model_forward)
+
+    def forward(x):
+        return model_forward(x)
+
+    # To act like a decorator so that it can be popped when doing `extract_model_from_parallel`
+    forward.__wrapped__ = model_forward
+
+    return forward
 
 
 def find_device(data):


### PR DESCRIPTION
According to the PyTorch docs (and the error that comes up from https://github.com/huggingface/diffusers/issues/2775), we need to wrap around a function separately when doing a class decorator and applying torch.compile, rather than calling it directly. This PR solves this by creating the new function it requires, and then adding it to `__wrapped__` so that `unwrap_model` knows to pop it. (Basically manually creating a decorator).

Also added some tests to ensure it'll still work and does work.