### PR TITLE
remove repetitive entries from device lists

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -811,7 +811,7 @@ def load_state_dict(checkpoint_file, device_map=None):
         if device_map is None:
             return safe_load_file(checkpoint_file)
         else:
-            devices = [device for device in device_map.values() if device not in ["disk"]]
+            devices = list(set(device_map.values()) - {"disk"})
 
             # if we only have one device we can load everything directly
             if len(devices) == 1:


### PR DESCRIPTION
I found when loading that each tensor for a device was reloaded for every layer in an `n**2` manner.

It seemed the device list in `load_state_dict` was loaded as device map keys, but then treated as a unique set despite having an element for every entry in the map, i.e. each device was in the list many times over.

I searched the file for `devices`, found two uses of lists as if they were sets, and added code to remove duplicate entries from both instances. I used a dict rather than a set so that order of entries is preserved, keeping the first device as the primary one.

EDIT: the other list I found already had unique entries and that change has been removed.

With this change, for me, the loading code no longer reloads every tensor for each map entry, instead loading them once for each device.