### PR TITLE
Upgrade torch version on main tests

### DIFF
--- a/.github/workflows/run_merge_tests.yml
+++ b/.github/workflows/run_merge_tests.yml
@@ -26,7 +26,7 @@ jobs:
           source activate accelerate
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
-          pip install -e .[testing,test_trackers]
+          pip install -e .[testing,test_trackers] -U
           pip install pytest-reportlog
 
       - name: Run CLI tests
@@ -64,7 +64,7 @@ jobs:
           source activate accelerate
           git config --global --add safe.directory '*'
           git fetch && git checkout ${{ github.sha }}
-          pip install -e .[testing,test_trackers]
+          pip install -e .[testing,test_trackers] -U
           pip install pytest-reportlog
 
       - name: Run CLI tests

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -4,7 +4,7 @@
 # Use base conda image to reduce time
 FROM continuumio/miniconda3:latest AS compile-image
 # Specify py version
-ENV PYTHON_VERSION=3.7.3
+ENV PYTHON_VERSION=3.8
 # Install apt libs
 RUN apt-get update && \
     apt-get install -y curl git wget && \
@@ -23,7 +23,7 @@ SHELL ["/bin/bash", "-c"]
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
     git+https://github.com/huggingface/accelerate#egg=accelerate[testing,test_trackers] \
-    --extra-index-url https://download.pytorch.org/whl/cu113
+    --extra-index-url https://download.pytorch.org/whl/cu117
 
 RUN python3 -m pip install --no-cache-dir bitsandbytes
 


### PR DESCRIPTION
After noticing https://github.com/huggingface/accelerate/pull/1322, the torch version ran on our merge tests isn't actually a high enough one to have `torch.compile`, so this PR makes sure that the latest torch/torchvision is always installed/upgraded

This PR also upgrades the CUDA docker python + CUDA versions, so that compile can be ran + installed