### PR TITLE
Fix failing test on main

### DIFF
--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -107,9 +107,9 @@ class MemoryTest(unittest.TestCase):
 
     @require_cuda
     def test_release_memory(self):
-        self.assertEqual(torch.cuda.memory_allocated(), 0)
+        starting_memory = torch.cuda.memory_allocated()
         model = ModelForTest()
         model.cuda()
-        self.assertGreater(torch.cuda.memory_allocated(), 0)
+        self.assertGreater(torch.cuda.memory_allocated(), starting_memory)
         model = release_memory(model)
-        self.assertEqual(torch.cuda.memory_allocated(), 0)
+        self.assertEqual(torch.cuda.memory_allocated(), starting_memory)


### PR DESCRIPTION
This PR fixes the failing test by instead checking the current used CUDA memory vs what's there. For some reason after the modeling tests memory is no longer being freed on the updated CUDA/PyTorch version, leading to this failure. 