### PR TITLE
Add rdzv_backend c10d to distributed run args for multi node multi gpu training in utils/launch.py

### DIFF
--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -121,6 +121,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
             setattr(args, "master_addr", str(main_process_ip))
             setattr(args, "master_port", str(main_process_port))
         else:
+            setattr(args, "rdzv_backend", "c10d")
             setattr(args, "rdzv_endpoint", f"{main_process_ip}:{main_process_port}")
     else:
         setattr(args, "nproc_per_node", str(num_processes))


### PR DESCRIPTION
When launching multi_gpu training without fsdp or deepspeed with multiple nodes/machines, `rdzv_endpoint` is correctly set before passing args to `torch.distributed.run` but `rdzv_backend` is not set and stays at default `static` which doesn't work for multi-node, `rdzv_backend` needs to be set to `"c10d"` for this. Change is made in `prepare_multi_gpu_env` inside `utils/launch.py`

Tested by launch the `launch_script.sh` below on 2 nodes with 8 GPU each. 
```
export NCCL_SOCKET_IFNAME="ib0,bond0,eth0,eth"
CUDA_VISIBLE_DEVICES="0,1,2,3,4,5,6,7" accelerate launch \
    --mixed_precision=bf16 --gpu_ids "0,1,2,3,4,5,6,7" --num_processes 16 --num_machines $1 --machine_rank $2 --main_process_ip $3 --main_process_port 9999 --max_restarts 3  --multi_gpu MyScript.py
```
as below on master node

`launch_script.sh 2 0 "127.0.0.1"`

and on child node as

`launch_script.sh 2 1 "master-ip"`

Same script without this change doesn't work.

[Torch Elastic](https://pytorch.org/docs/stable/elastic/run.html#usage) usage also shows that for non-standalone mode (num_machines>1) we need to add `--rdzv-backend=c10d` to `torchrun` commandline params.


