### PR TITLE
Remove unused amp import util

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -25,7 +25,6 @@ from .environment import get_int_from_env, parse_choice_from_env, parse_flag_fro
 from .imports import (
     get_ccl_version,
     is_aim_available,
-    is_apex_available,
     is_bf16_available,
     is_boto3_available,
     is_ccl_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -61,10 +61,6 @@ def get_ccl_version():
     return importlib_metadata.version("oneccl_bind_pt")
 
 
-def is_apex_available():
-    return importlib.util.find_spec("apex") is not None
-
-
 def is_fp8_available():
     return importlib.util.find_spec("transformer_engine") is not None
 


### PR DESCRIPTION
As Accelerate doesn't support `amp` anymore, removes last traces of it :) 