### PR TITLE
Small progress bar fix

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -858,9 +858,10 @@ def load_state_dict(checkpoint_file, device_map=None):
                     for key in device_weights[device]:
                         if progress_bar is not None:
                             progress_bar.set_postfix(dev=device, refresh=False)
-                            progress_bar.set_description(key, refresh=False)
-                            progress_bar.update()
+                            progress_bar.set_description(key)
                         tensors[key] = f.get_tensor(key)
+                        if progress_bar is not None:
+                            progress_bar.update()
             if progress_bar is not None:
                 progress_bar.close()
 


### PR DESCRIPTION
Fixes an off-by-one appearance issue at 0% and 100% with the safetensors device_map loading progress bar.

I had this tacked onto my previous progress bar contribution but lost internet before the merge happened.
