### PR TITLE
Support FP8 mixed precision training for Ada Lovelace GPUs

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1274,8 +1274,8 @@ class Accelerator:
             if not fp8_enabled:
                 logger.warn(
                     f"The current device has compute capability of {cuda_device_capacity} which is "
-                    "insufficient for FP8 mixed precision training (requires a GPU Hopper or higher, compute "
-                    "capability of 9 or higher). Will use FP16 instead."
+                    "insufficient for FP8 mixed precision training (requires a GPU Hopper/Ada Lovelace "
+                    "or higher, compute capability of 8.9 or higher). Will use FP16 instead."
                 )
             model.forward = fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe)(model.forward)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1267,10 +1267,11 @@ class Accelerator:
             if "fp8_format" in kwargs:
                 kwargs["fp8_format"] = getattr(te_recipe.Format, kwargs["fp8_format"])
             fp8_recipe = te_recipe.DelayedScaling(**kwargs)
-            fp8_enabled = torch.cuda.get_device_capability()[0] >= 9
+            cuda_device_capacity = torch.cuda.get_device_capability()
+            fp8_enabled = cuda_device_capacity[0] >= 9 or (cuda_device_capacity[0] == 8 and cuda_device_capacity[1] >= 9)    
             if not fp8_enabled:
                 logger.warn(
-                    f"The current device has compute capability of {torch.cuda.get_device_capability()} which is "
+                    f"The current device has compute capability of {cuda_device_capacity} which is "
                     "insufficient for FP8 mixed precision training (requires a GPU Hopper or higher, compute "
                     "capability of 9 or higher). Will use FP16 instead."
                 )

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1268,7 +1268,9 @@ class Accelerator:
                 kwargs["fp8_format"] = getattr(te_recipe.Format, kwargs["fp8_format"])
             fp8_recipe = te_recipe.DelayedScaling(**kwargs)
             cuda_device_capacity = torch.cuda.get_device_capability()
-            fp8_enabled = cuda_device_capacity[0] >= 9 or (cuda_device_capacity[0] == 8 and cuda_device_capacity[1] >= 9)    
+            fp8_enabled = cuda_device_capacity[0] >= 9 or (
+                cuda_device_capacity[0] == 8 and cuda_device_capacity[1] >= 9
+            )
             if not fp8_enabled:
                 logger.warn(
                     f"The current device has compute capability of {cuda_device_capacity} which is "


### PR DESCRIPTION
As mentioned in [https://github.com/NVIDIA/TransformerEngine/issues/15#issuecomment-1515703357](https://github.com/NVIDIA/TransformerEngine/issues/15#issuecomment-1515703357)

> Today a CUDA Toolkit 12.1 update 1 was released. It contains cuBLAS 12.1.3.1 enabling FP8 kernels for Ada. With this version of cuBLAS together with Transformer Engine 0.7 which added Ada to the compilation targets, FP8 computation is now supported on Ada.

GPUs with computation capacity 8.9, (Ada Lovelace, includes RTX4xxx and RTX6000ada) can now benifit from FP8 acceleration with CUDA Toolkit 12.1 update 1 and Transformer Engine 0.7.

This pull request reflects the change.