### PR TITLE
[`bnb`] Fix bnb slow test

### DIFF
--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import unittest
 from unittest.mock import patch
 
 import torch
@@ -184,7 +183,7 @@ class AcceleratorTester(AccelerateTestCase):
         model = AutoModelForCausalLM.from_pretrained(
             "EleutherAI/gpt-neo-125m",
             load_in_8bit=True,
-            device_map="auto",
+            device_map={"": 0},
         )
         accelerator = Accelerator()
 
@@ -192,7 +191,6 @@ class AcceleratorTester(AccelerateTestCase):
         model = accelerator.prepare(model)
 
     @slow
-    @unittest.skip("Skip until the next `transformers` release")
     def test_accelerator_bnb_cpu_error(self):
         """Tests that the accelerator can be used with the BNB library. This should fail as we are trying to load a model
         that is loaded between cpu and gpu"""


### PR DESCRIPTION
# What does this PR do?

Link to failing tests: https://github.com/huggingface/accelerate/actions/runs/4792971906

Since the latest `transformers` release, a fix has been introduced to make use of the correct behavior of `device_map="auto"` and 8bit models. 
As for now you can't train a model using the `Accelerator` + 8bit models that have been trained on multiple devices, the fix should be to force the model to be on the first GPU, so that the multi GPU test passes

I also removed a test skip since the Docker image uses the latest `transformers` and I made sure it passes

cc @muellerzr 