### PR TITLE
Update dataclasses.py

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -315,7 +315,7 @@ def get_cluster_input():
                 fsdp_config["fsdp_min_num_params"] = _ask_field(
                     "What should be your FSDP's minimum number of parameters for Default Auto Wrapping Policy? [1e8]: ",
                     int,
-                    default=1e8,
+                    default=100000000,
                 )
             fsdp_backward_prefetch_query = "What should be your FSDP's backward prefetch policy?"
             fsdp_config["fsdp_backward_prefetch_policy"] = _ask_options(

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -844,7 +844,7 @@ class FullyShardedDataParallelPlugin:
                     transformer_layer_cls=transformer_cls_to_wrap,
                 )
             elif auto_wrap_policy == FSDP_AUTO_WRAP_POLICY[1]:
-                min_num_params = int(os.environ.get("FSDP_MIN_NUM_PARAMS", 0))
+                min_num_params = int(float(os.environ.get("FSDP_MIN_NUM_PARAMS", 0)))
                 if min_num_params > 0:
                     self.auto_wrap_policy = functools.partial(
                         size_based_auto_wrap_policy, min_num_params=min_num_params


### PR DESCRIPTION
Hello,

I received the following error after trying to use the default minimum parameters option for FSDP:

```
Traceback (most recent call last):
  File "/home/hiekense/GPT2/ChatGPTDetector/train-accel.py", line 71, in <module>
    model, optimizer, train_dl, scheduler = accelerator.prepare(
  File "/home/hiekense/.local/lib/python3.9/site-packages/accelerate/accelerator.py", line 1122, in prepare
    result = tuple(
  File "/home/hiekense/.local/lib/python3.9/site-packages/accelerate/accelerator.py", line 1123, in <genexpr>
    self._prepare_one(obj, first_pass=True, device_placement=d) for obj, d in zip(args, device_placement)
  File "/home/hiekense/.local/lib/python3.9/site-packages/accelerate/accelerator.py", line 977, in _prepare_one
    return self.prepare_model(obj, device_placement=device_placement)
  File "/home/hiekense/.local/lib/python3.9/site-packages/accelerate/accelerator.py", line 1211, in prepare_model
    self.state.fsdp_plugin.set_auto_wrap_policy(model)
  File "/home/hiekense/.local/lib/python3.9/site-packages/accelerate/utils/dataclasses.py", line 846, in set_auto_wrap_policy
        min_num_params = int(os.environ.get("FSDP_MIN_NUM_PARAMS", 0))
min_num_params = int(os.environ.get("FSDP_MIN_NUM_PARAMS", 0))ValueError
ValueError: : invalid literal for int() with base 10: '100000000.0'invalid literal for int() with base 10: '100000000.0'
```

It can be solved by just wrapping the string in a float first, so I figured I'd just skip an issue and open a PR.

Thanks