### PR TITLE
Special transformers case from args

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -137,6 +137,9 @@ class PartialState:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
                     self.backend = kwargs.pop("backend", "nccl")
+                    # Special case from `TrainingArguments`
+                    if self.backend is None:
+                        self.backend = "nccl"
                     torch.distributed.init_process_group(backend=self.backend, **kwargs)
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -136,7 +136,10 @@ class PartialState:
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
-                    self.backend = kwargs.pop("backend") if "backend" in kwargs else "nccl"
+                    self.backend = kwargs.pop("backend", "nccl") 
+                    # Special case for `TrainingArguments`, where `backend` will be `None`
+                    if self.backend is None:
+                        self.backend = "nccl"
                     torch.distributed.init_process_group(backend=self.backend, **kwargs)
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -136,7 +136,7 @@ class PartialState:
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
-                    self.backend = kwargs.pop("backend", "nccl") 
+                    self.backend = kwargs.pop("backend", "nccl")
                     # Special case for `TrainingArguments`, where `backend` will be `None`
                     if self.backend is None:
                         self.backend = "nccl"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -136,10 +136,7 @@ class PartialState:
             elif int(os.environ.get("LOCAL_RANK", -1)) != -1 and not cpu:
                 self.distributed_type = DistributedType.MULTI_GPU
                 if not torch.distributed.is_initialized():
-                    self.backend = kwargs.pop("backend", "nccl")
-                    # Special case from `TrainingArguments`
-                    if self.backend is None:
-                        self.backend = "nccl"
+                    self.backend = kwargs.pop("backend") if "backend" in kwargs else "nccl"
                     torch.distributed.init_process_group(backend=self.backend, **kwargs)
                 self.num_processes = torch.distributed.get_world_size()
                 self.process_index = torch.distributed.get_rank()


### PR DESCRIPTION
`xpu_backend` can be `None`, and in the transformers integration we pass it to `PartialState` due to the fact that `no_cuda` is a toggleable option and can still be `True` on CPU. This PR makes it so that if the last case is hit in this block:
```python
        if self.no_cuda:
            self.distributed_state = PartialState(cpu=True)
            self._n_gpu = 0
        elif is_sagemaker_mp_enabled():
            local_rank = smp.local_rank()
            device = torch.device("cuda", local_rank)
            self._n_gpu = 1
            torch.cuda.set_device(device)
        elif self.deepspeed:
            # Need to do similar for Accelerator init
            os.environ["ACCELERATE_USE_DEEPSPEED"] = "true"
            self.distributed_state = PartialState(timeout=timedelta(seconds=self.ddp_timeout))
            del os.environ["ACCELERATE_USE_DEEPSPEED"]
            self._n_gpu = 1
        else:
            self.distributed_state = PartialState(backend=self.xpu_backend)
            self._n_gpu = 1
```
the `xpu_backend` will be set properly if it's `None` (the default)