### PR TITLE
Seperate out contextmanager generation

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -61,6 +61,7 @@ from .utils import (
     convert_outputs_to_fp32,
     extract_model_from_parallel,
     gather,
+    get_mixed_precision_context_manager,
     get_pretty_name,
     has_transformer_engine_layers,
     is_bf16_available,
@@ -2640,7 +2641,7 @@ class Accelerator:
         self._custom_objects.extend(objects)
 
     @contextmanager
-    def autocast(self):
+    def autocast(self, cache_enabled: bool = False):
         """
         Will apply automatic mixed-precision inside the block inside this context manager, if it is enabled. Nothing
         different will happen otherwise.
@@ -2655,20 +2656,10 @@ class Accelerator:
         ...     train()
         ```
         """
-        if self.native_amp:
-            if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
-                autocast_context = torch.cuda.amp.autocast(dtype=torch.float16)
-            elif self.mixed_precision == "bf16":
-                if self.distributed_type in [DistributedType.NO, DistributedType.MULTI_CPU, DistributedType.MULTI_GPU]:
-                    autocast_context = torch.autocast(dtype=torch.bfloat16, device_type=self.device.type)
-            else:
-                autocast_context = torch.cuda.amp.autocast()
-
-            autocast_context.__enter__()
-            yield
-            autocast_context.__exit__(*sys.exc_info())
-        else:
-            yield
+        autocast_context = get_mixed_precision_context_manager(self.native_amp, cache_enabled=cache_enabled)
+        autocast_context.__enter__()
+        yield
+        autocast_context.__exit__(*sys.exc_info())
 
     @property
     def optimizer_step_was_skipped(self):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -81,6 +81,7 @@ from .operations import (
     gather,
     gather_object,
     get_data_structure,
+    get_mixed_precision_context_manager,
     honor_type,
     initialize_tensors,
     is_namedtuple,


### PR DESCRIPTION
This PR refactors the `autocast` capability by introducing a new `get_mixed_precision_context_manager`.

For the general user, this changes nothing. However for the `transformers` integration this allows us to fully remove the `autocast_smart_context_manager` function and let's `Accelerate` handle/generate it instead. 

See this chunk of code we're replacing:

https://github.com/huggingface/transformers/blob/main/src/transformers/trainer.py#L2661-L2678