### PR TITLE
Handle auto choice in Trainer for mixed precision

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -580,10 +580,9 @@ class AcceleratorState:
                     self.ipex_plugin = ipex_plugin if ipex_plugin.use_ipex else None
             self._init_mixed_precision(mixed_precision=mixed_precision)
 
-    def _init_mixed_precision(self, mixed_precision:str = "no"):
+    def _init_mixed_precision(self, mixed_precision: str = "no"):
         """
-        Internal private function to update the mixed precision type after the `AcceleratorState`
-        has been initialized.
+        Internal private function to update the mixed precision type after the `AcceleratorState` has been initialized.
         """
         if mixed_precision != self.mixed_precision and self.mixed_precision != "no":
             raise ValueError(
@@ -615,7 +614,6 @@ class AcceleratorState:
             and self.device.type == "cuda"
         ):
             torch.backends.cuda.matmul.allow_tf32 = True
-        
 
     @property
     def initialized(self) -> bool:


### PR DESCRIPTION
The `Trainer` has a `self.half_precision_backend == "auto"` option, which will pick `fp16` or `bf16` based on what is available. This PR refactors `AcceleratorState` to allow for a late-init of mixed precision, so that if `auto` is chosen we can look at the `AcceleratorState` which was generated to pick what device precision we should use (`bf16` if CPU or `fp16` if GPU).

Another option is for us to support `"auto"` directly in Accelerate instead, let me know if you'd prefer this @sgugger 