### PR TITLE
Support TPU v2 and v3 on new PyTorch/XLA TPU runtime

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -56,18 +56,41 @@ def do_nothing(*args, **kwargs):
 
 
 class GlobalSharedDict:
-  def __init__(self, thread_local: bool = False):
-    self._storage = {}
+    """
+    Descriptor that holds shared between instances of a class.
 
-  def __get__(self, obj, objtype=None):
-    return self._storage
+    See Python documentation for an explanation of descriptors: https://docs.python.org/3/howto/descriptor.html
 
-  def __set__(self, obj, value):
-    self._storage = value
+    Note: Descriptors have slightly different semantics than just a dict field on its own.
+    `PartialState(...)._shared_state` and `PartialState._shared_state` (instance vs class) give the same value: the
+    underlying _storage dict. Likewise, `PartialState(...)._shared_state = {...}` overrides the _storage dict inside the
+    descriptor as you would expect. However, `PartialState._shared_state = {}` actually replaces the descriptor object with
+    a dict instead Thus, you should modify the _storage dict in-place (e.g. `_shared_state.clear()`).
+
+    See https://docs.python.org/3/howto/descriptor.html#invocation-from-a-class
+    """
+    def __init__(self, thread_local: bool = False):
+        self._storage = {}
+
+    def __get__(self, obj, objtype=None):
+        return self._storage
+
+    def __set__(self, obj, value):
+        self._storage = value
+
 
 class ThreadLocalSharedDict(GlobalSharedDict, threading.local):
-  pass
+    """
+    Same as GlobalSharedDict, but the shared dictionary is scoped to each thread separately.
 
+    This is required for using PyTorch/XLA with PJRT in multithreaded mode (required for TPU v2 and v3).
+
+    See https://github.com/pytorch/xla/blob/r2.0/docs/pjrt.md#multithreading-on-tpu-v2v3
+    """
+    pass
+
+
+# Prefer global shared dictionary, except when using TPU.
 SharedDict = GlobalSharedDict if not is_tpu_available(check_device=False) else ThreadLocalSharedDict
 
 # Inspired by Alex Martelli's 'Borg'.

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -71,6 +71,7 @@ class ThreadLocalSharedDict(threading.local):
 
     See https://github.com/pytorch/xla/blob/r2.0/docs/pjrt.md#multithreading-on-tpu-v2v3
     """
+
     def __init__(self, thread_local: bool = False):
         self._storage = {}
 
@@ -83,6 +84,7 @@ class ThreadLocalSharedDict(threading.local):
 
 # Prefer global shared dictionary, except when using TPU.
 SharedDict = dict if not is_tpu_available(check_device=False) else ThreadLocalSharedDict
+
 
 # Inspired by Alex Martelli's 'Borg'.
 class PartialState:
@@ -105,6 +107,7 @@ class PartialState:
         - **is_main_process** (`bool`) -- Whether or not the current process is the main one.
         - **is_local_main_process** (`bool`) -- Whether or not the current process is the main one on the local node.
     """
+
     _shared_state = SharedDict()
 
     def __init__(self, cpu: bool = False, **kwargs):
@@ -556,6 +559,7 @@ class AcceleratorState:
         - **is_main_process** (`bool`) -- Whether or not the current process is the main one.
         - **is_local_main_process** (`bool`) -- Whether or not the current process is the main one on the local node.
     """
+
     _shared_state = SharedDict()
 
     def __init__(
@@ -749,6 +753,7 @@ class GradientState:
         - **adjust_scheduler** (`bool`) -- Whether the scheduler should be adjusted to account for the gradient
           accumulation
     """
+
     _shared_state = SharedDict()
 
     def __init__(self, gradient_accumulation_plugin: Optional[GradientAccumulationPlugin] = None):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -61,9 +61,9 @@ class ThreadLocalSharedDict(threading.local):
 
     Note: Descriptors have slightly different semantics than just a dict field on its own.
     `PartialState(...)._shared_state` and `PartialState._shared_state` (instance vs class) give the same value: the
-    underlying _storage dict. Likewise, `PartialState(...)._shared_state = {...}` overrides the _storage dict inside the
-    descriptor as you would expect. However, `PartialState._shared_state = {}` actually replaces the descriptor object with
-    a dict instead Thus, you should modify the _storage dict in-place (e.g. `_shared_state.clear()`).
+    underlying _storage dict. Likewise, `PartialState(...)._shared_state = {...}` overrides the _storage dict inside
+    the descriptor as you would expect. However, `PartialState._shared_state = {}` actually replaces the descriptor
+    object with a dict instead Thus, you should modify the _storage dict in-place (e.g. `_shared_state.clear()`).
 
     See Python documentation for an explanation of descriptors: https://docs.python.org/3/howto/descriptor.html
 

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -278,7 +278,7 @@ def central_dl_preparation_check():
 def mock_training(length, batch_size, generator):
     set_seed(42)
     generator.manual_seed(42)
-    train_set = RegressionDataset(length=length)
+    train_set = RegressionDataset(length=length, seed=42)
     train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
     model = RegressionModel()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)

--- a/src/accelerate/test_utils/training.py
+++ b/src/accelerate/test_utils/training.py
@@ -21,7 +21,7 @@ from accelerate.utils.dataclasses import DistributedType
 
 class RegressionDataset:
     def __init__(self, a=2, b=3, length=64, seed=None):
-        rng  = np.random.default_rng(seed)
+        rng = np.random.default_rng(seed)
         self.length = length
         self.x = rng.normal(size=(length,)).astype(np.float32)
         self.y = a * self.x + b + rng.normal(scale=0.1, size=(length,)).astype(np.float32)

--- a/src/accelerate/test_utils/training.py
+++ b/src/accelerate/test_utils/training.py
@@ -21,11 +21,10 @@ from accelerate.utils.dataclasses import DistributedType
 
 class RegressionDataset:
     def __init__(self, a=2, b=3, length=64, seed=None):
-        if seed is not None:
-            np.random.seed(seed)
+        rng  = np.random.default_rng(seed)
         self.length = length
-        self.x = np.random.normal(size=(length,)).astype(np.float32)
-        self.y = a * self.x + b + np.random.normal(scale=0.1, size=(length,)).astype(np.float32)
+        self.x = rng.normal(size=(length,)).astype(np.float32)
+        self.y = a * self.x + b + rng.normal(scale=0.1, size=(length,)).astype(np.float32)
 
     def __len__(self):
         return self.length


### PR DESCRIPTION
Depends on #1393

I've been working on migrating PyTorch/XLA from our legacy XRT runtime to PJRT. We have detailed documentation on the differences and changes here: https://github.com/pytorch/xla/blob/master/docs/pjrt.md

Due to TPU design constraints, PJRT must use multithreading on TPU v2 and v3 ([docs](https://github.com/pytorch/xla/blob/master/docs/pjrt.md#multithreading-on-tpu-v2v3)). 

- This means we cannot use global state for `AcceleratorState`, since two replicas would end up sharing the same `accelerator.device` and `accelerator.process_index`. I implemented a [descriptor](https://docs.python.org/3/howto/descriptor.html) that wraps the global `_shared_state` dicts in `state.py` and optionally makes it thread-local when using XLA.
- Use numpy `Generator`s in the `accelerate test` script instead of the global `numpy.random.seed`. This makes the test thread-safe for TPU v2 and v3. Numpy recommends using `Generators` as a best practice in their docs: https://numpy.org/doc/stable/reference/random/generated/numpy.random.seed.html


Tested:

- `accelerate test` on TPU v2-8 with XRT and PJRT