### PR TITLE
fix config bug for 'mixed_precision' from 'yaml.safe_load()'

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -123,7 +123,7 @@ class BaseConfig:
 
         if "mixed_precision" not in config_dict:
             config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else None
-        if type(config_dict["mixed_precision"]) is bool and not config_dict["mixed_precision"]:
+        if isinstance(config_dict["mixed_precision"], bool) and not config_dict["mixed_precision"]:
             config_dict["mixed_precision"] = "no"
         if "fp16" in config_dict:  # Convert the config to the new format.
             del config_dict["fp16"]

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -123,6 +123,8 @@ class BaseConfig:
 
         if "mixed_precision" not in config_dict:
             config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else None
+        if type(config_dict["mixed_precision"]) is bool and not config_dict["mixed_precision"]:
+            config_dict["mixed_precision"] = "no"
         if "fp16" in config_dict:  # Convert the config to the new format.
             del config_dict["fp16"]
         if "dynamo_backend" in config_dict:  # Convert the config to the new format.


### PR DESCRIPTION
I have used the below versions of packages for accelerate.
```
python==3.8.13
accelerate==0.18.0
PyYAML==6.0
```
And, I have used the below config files.

``` yaml
compute_environment: LOCAL_MACHINE
deepspeed_config: {}
distributed_type: MULTI_GPU
fsdp_config: {}
machine_rank: 0
main_process_ip: null
main_process_port: null
main_training_function: main
mixed_precision: no
num_machines: 1
num_processes: 2
use_cpu: false
```

I wanted to use "fp32", I tried to train my model using **"mixed_precision"** as **"no"**, but I couldn't because of the error below.

${MY_PKG_PATH}/accelerate/utils/launch.py

``` python
mixed_precision = args.mixed_precision.lower()
```
**AttributeError: 'bool' object has no attribute 'lower'**


As a result of debugging, I found that the safe_load() function in the PyYAML package is throwing an error.

So, I suggest this pull request.

Thanks.
