### PR TITLE
Fix flakey thread issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 extras = {}
-extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0"]
+extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 <= 2.0.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
 extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm"]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 extras = {}
-extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 <= 2.0.0"]
+extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 < 2.0.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
 extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm"]

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -82,7 +82,7 @@ def process_execution_check():
             path.unlink()
             raise
 
-    if accelerator.is_main_process() and path.exists():
+    if accelerator.is_main_process and path.exists():
         path.unlink()
     accelerator.wait_for_everyone()
     # Test the decorators

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -59,8 +59,6 @@ def process_execution_check():
 
     # Test main_process_first context manager
     path = Path("check_main_process_first.txt")
-    if path.exists():
-        path.unlink()
     with accelerator.main_process_first():
         if accelerator.is_main_process:
             time.sleep(0.1)  # ensure main process takes longest
@@ -84,9 +82,9 @@ def process_execution_check():
             path.unlink()
             raise
 
-    if path.exists():
+    if accelerator.is_main_process() and path.exists():
         path.unlink()
-
+    accelerator.wait_for_everyone()
     # Test the decorators
     f = io.StringIO()
     with contextlib.redirect_stdout(f):


### PR DESCRIPTION
Should fix the thread issue with `pathlib.unlink()`, moves the removal under the first check that passes the conditional and waits for everyone, and has the main process only remove it. Going to rerun the CI multiple times to ensure it's no longer flaky