### PR TITLE
Fix gather_obj

### DIFF
--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -17,6 +17,7 @@
 import torch
 
 from accelerate import PartialState
+from accelerate.utils.imports import is_torch_version
 from accelerate.utils.operations import broadcast, gather, gather_object, pad_across_processes, reduce
 
 
@@ -87,8 +88,9 @@ def main():
     state.print(f"State: {state}")
     state.print("testing gather")
     test_gather(state)
-    state.print("testing gather_object")
-    test_gather_object(state)
+    if is_torch_version(">=", "1.7.0"):
+        state.print("testing gather_object")
+        test_gather_object(state)
     state.print("testing broadcast")
     test_broadcast(state)
     state.print("testing pad_across_processes")

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -31,7 +31,7 @@ def test_gather(state):
 
 
 def test_gather_object(state):
-    obj = [state.local_process_index]
+    obj = [state.process_index]
     gathered_obj = gather_object(obj)
     assert len(gathered_obj) == state.num_processes, f"{gathered_obj}, {len(gathered_obj)} != {state.num_processes}"
     assert gathered_obj == list(range(state.num_processes)), f"{gathered_obj} != {list(range(state.num_processes))}"

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -17,7 +17,7 @@
 import torch
 
 from accelerate import PartialState
-from accelerate.utils.operations import broadcast, gather, pad_across_processes, reduce
+from accelerate.utils.operations import broadcast, gather, gather_object, pad_across_processes, reduce
 
 
 def create_tensor(state):
@@ -28,6 +28,13 @@ def test_gather(state):
     tensor = create_tensor(state)
     gathered_tensor = gather(tensor)
     assert gathered_tensor.tolist() == list(range(1, state.num_processes**2 + 1))
+
+
+def test_gather_object(state):
+    obj = [state.local_process_index]
+    gathered_obj = gather_object(obj)
+    assert len(gathered_obj) == state.num_processes, f"{gathered_obj}, {len(gathered_obj)} != {state.num_processes}"
+    assert gathered_obj == list(range(state.num_processes)), f"{gathered_obj} != {list(range(state.num_processes))}"
 
 
 def test_broadcast(state):
@@ -77,8 +84,11 @@ def _mp_fn(index):
 
 def main():
     state = PartialState()
+    state.print(f"State: {state}")
     state.print("testing gather")
     test_gather(state)
+    state.print("testing gather_object")
+    test_gather_object(state)
     state.print("testing broadcast")
     test_broadcast(state)
     state.print("testing pad_across_processes")

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -250,12 +250,10 @@ def gather(tensor):
 
 
 def _gpu_gather_object(object: Any):
-    def _gpu_gather_object_one(object: Any):
-        output_objects = [None for _ in range(PartialState().num_processes)]
-        torch.distributed.all_gather_object(output_objects, object)
-        return output_objects
-
-    return recursively_apply(_gpu_gather_object_one, object)
+    output_objects = [None for _ in range(PartialState().num_processes)]
+    torch.distributed.all_gather_object(output_objects, object)
+    # all_gather_object returns a list of lists, so we need to flatten it
+    return [x for y in output_objects for x in y]
 
 
 _cpu_gather_object = _gpu_gather_object

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -270,6 +270,8 @@ def gather_object(object: Any):
     Returns:
         The same data structure as `object` with all the objects sent to every device.
     """
+    if is_torch_version("<", "1.7"):
+        raise NotImplementedError("Gathering non-tensor objects requires PyTorch 1.7 or later")
     if PartialState().distributed_type == DistributedType.TPU:
         raise NotImplementedError("gather objects in TPU is not supported")
     elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -36,20 +36,21 @@ class MultiGPUTester(unittest.TestCase):
     @require_multi_gpu
     def test_multi_gpu(self):
         print(f"Found {torch.cuda.device_count()} devices.")
-        cmd = get_launch_prefix() + [self.test_file_path]
+        cmd = get_launch_prefix() + [f"--nproc_per_node={torch.cuda.device_count()}", self.test_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_multi_gpu
     def test_multi_gpu_ops(self):
         print(f"Found {torch.cuda.device_count()} devices.")
-        cmd = get_launch_prefix() + [self.operation_file_path]
+        cmd = get_launch_prefix() + [f"--nproc_per_node={torch.cuda.device_count()}", self.operation_file_path]
+        print(f"Command: {cmd}")
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_multi_gpu
     def test_pad_across_processes(self):
-        cmd = get_launch_prefix() + [inspect.getfile(self.__class__)]
+        cmd = get_launch_prefix() + [f"--nproc_per_node={torch.cuda.device_count()}", inspect.getfile(self.__class__)]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())
 


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1383

Currently `gather_object` doesn't actually work properly, because pytorch will gather the whole object as a whole. As a result, using the nested execution that is currently there will force pytorch to not actually return what the user wants. This PR fixes the implementation, based on the suggestion in #1383, and adds tests for it as well.

I also noticed that occasionally just doing `torchrun` wouldn't force the tests to be ran with multiple GPUs/all gpus available, so this PR adds `--nproc_per_node` manually