### PR TITLE
Bump torch version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         ]
     },
     python_requires=">=3.7.0",
-    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.4.0"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.6.0"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Per https://github.com/huggingface/accelerate/pull/638, it never actually bumped the minimal torch version to 1.6.0, which is the minimum we test on now and support.