### PR TITLE
Support TPU v4 with new PyTorch/XLA TPU runtime

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -116,6 +116,7 @@ if is_torch_version(">", "1.10.0"):
 
 
 if is_tpu_available(check_device=False):
+    import torch_xla.core.xla_model as xm
     import torch_xla.distributed.xla_multiprocessing as xmp
 
 
@@ -2293,6 +2294,10 @@ class Accelerator:
                 )
         os.makedirs(output_dir, exist_ok=True)
         logger.info(f"Saving current state to {output_dir}")
+
+        if self.distributed_type == DistributedType.TPU:
+            # Finish running the previous step before checkpointing
+            xm.mark_step()
 
         # Save the models taking care of FSDP and DeepSpeed nuances
         weights = []

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -407,6 +407,7 @@ if is_tpu_available(check_device=False):
 
         - **total_dataset_length** (`int`) -- Total length of the inner dataset across all processes.
         """
+
         def __init__(self, dataloader: DataLoaderShard, device: torch.device):
             super().__init__(dataloader, device)
             self._rng_types = self._loader.rng_types

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -452,10 +452,5 @@ def main():
     training_check()
 
 
-def _mp_fn(index):
-    # For xla_spawn (TPUs)
-    main()
-
-
 if __name__ == "__main__":
     main()

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -292,8 +292,6 @@ def prepare_tpu(
     """
     Prepares and returns an environment with the correct TPU environment variables.
     """
-    current_env["XLA_USE_BF16"] = "0"
-    current_env["XLA_DOWNCAST_BF16"] = "0"
     if args.mixed_precision == "bf16":
         if args.downcast_bf16:
             current_env["XLA_DOWNCAST_BF16"] = "1"

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -202,10 +202,10 @@ def find_batch_size(data):
 
 def _tpu_gather(tensor):
     def _tpu_gather_one(tensor):
-      if tensor.ndim == 0:
-          tensor = tensor.clone()[None]
+        if tensor.ndim == 0:
+            tensor = tensor.clone()[None]
 
-      return xm.all_gather(tensor)
+        return xm.all_gather(tensor)
 
     res = recursively_apply(_tpu_gather_one, tensor, error_on_other_type=True)
     xm.mark_step()

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -200,18 +200,16 @@ def find_batch_size(data):
     return data.shape[0]
 
 
-def _tpu_gather(tensor, name="gather tensor"):
-    if isinstance(tensor, (list, tuple)):
-        return honor_type(tensor, (_tpu_gather(t, name=f"{name}_{i}") for i, t in enumerate(tensor)))
-    elif isinstance(tensor, Mapping):
-        return type(tensor)({k: _tpu_gather(v, name=f"{name}_{k}") for k, v in tensor.items()})
-    elif not isinstance(tensor, torch.Tensor):
-        raise TypeError(
-            f"Can't gather the values of type {type(tensor)}, only nested list/tuple/dicts of tensors are supported."
-        )
-    if tensor.ndim == 0:
-        tensor = tensor.clone()[None]
-    return xm.mesh_reduce(name, tensor, torch.cat)
+def _tpu_gather(tensor):
+    def _tpu_gather_one(tensor):
+      if tensor.ndim == 0:
+          tensor = tensor.clone()[None]
+
+      return xm.all_gather(tensor)
+
+    res = recursively_apply(_tpu_gather_one, tensor, error_on_other_type=True)
+    xm.mark_step()
+    return res
 
 
 def _gpu_gather(tensor):
@@ -240,7 +238,7 @@ def gather(tensor):
         The same data structure as `tensor` with all tensors sent to the proper device.
     """
     if PartialState().distributed_type == DistributedType.TPU:
-        return _tpu_gather(tensor, name="accelerate.utils.gather")
+        return _tpu_gather(tensor)
     elif PartialState().distributed_type in CUDA_DISTRIBUTED_TYPES:
         return _gpu_gather(tensor)
     elif PartialState().distributed_type == DistributedType.MULTI_CPU:


### PR DESCRIPTION
I've been working on migrating PyTorch/XLA from our legacy XRT runtime to PJRT. We have detailed documentation on the differences and changes here: https://github.com/pytorch/xla/blob/master/docs/pjrt.md

This PR collects all of the fixes that I've made so far to support XRT and PJRT interchangeably through Accelerate. In order of significance:

1. Update implementation of `synchronize_rng_types` to use `xm.collective_broadcast` to broadcast the RNG state tensor. Collective operations in general should be called from the main thread of each process to avoid unpredictable behaviors in XLA. But, our implementation of [`MpDeviceLoader` calls `accelerate.DataLoaderShard`'s `__iter__`](https://github.com/pytorch/xla/blob/f763d0d2a4dac0872e2e1670332fd490f524b8be/torch_xla/distributed/parallel_loader.py#L138) (which [synchronizes the RNG](https://github.com/huggingface/accelerate/blob/75a693c9b47635074a72b716af14bb55b0033750/src/accelerate/data_loader.py#L368-L369)) in all of the preloading threads. To ensure that the RNG is synchronized once from the main thread, call it in the `MpDeviceLoaderWrapper`'s `__iter__` instead.
2. In general, you should call `xm.mark_step` to finish any remaining steps before checkpointing. `MpDeviceLoader` is responsible for calling `xm.mark_step` at the beginning of each [new step and at the end of the dataset iterator](https://github.com/pytorch/xla/blob/f763d0d2a4dac0872e2e1670332fd490f524b8be/torch_xla/distributed/parallel_loader.py#L40-L48). If you checkpoint in the middle of iteration, replica 0 won't reach the `mark_step` at the beginning of the next iteration before it tries to checkpoint. To avoid making the user call `mark_step` themselves, call it for them on replica 0 before checkpointing in `save_state`.
3. Use XLA's `all_gather` in `gather` instead of `mesh_reduce` + `torch.cat`. With PJRT, `rendezvous` and `mesh_reduce` both use XLA collective ops to broadcast pickled data ([docs](https://github.com/pytorch/xla/blob/master/docs/pjrt.md#changes-to-xmrendezvous)) and move it back to the CPU. Batching all of the recursive `all_gather` calls together and calling `xm.mark_step` once reduces the number of transfers between host and device.
4. Don't override `XLA_USE_BF16` when `mixed_precision` is not set. This isn't really mixed precision as much as it is a mechanism to silently convert _all_ `torch.floats` to BF16 on the TPU. Real mixed precision support in PT/XLA is still a WIP, and we can update back here when it's stable.
5. Remove obsolete/unused `_mp_fn` in test script.

Tested:

- `accelerate test` on v4-8 with XRT and PJRT
- [`diffusers` Stable Diffusion fine-tuning example](https://github.com/huggingface/diffusers/blob/main/examples/text_to_image/README.md) on TPU v4-8

Accelerate will not work on TPU v2 and v3 with this PR, because both of them use use multithreading due to TPU design constraints. I'll follow up with the remaining fixes for TPU v2 and v3 in #1385.

cc @sgugger @jackcaog