### PR TITLE
use existing mlflow experiment if exists

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -579,11 +579,17 @@ class MLflowTracker(GeneralTracker):
 
         nested_run = os.getenv("MLFLOW_NESTED_RUN", nested_run)
 
-        experiment_id = mlflow.create_experiment(
-            name=experiment_name,
-            artifact_location=logging_dir,
-            tags=tags,
-        )
+        exps = mlflow.search_experiments(filter_string=f"name = '{experiment_name}'")
+        if len(exps) > 0:
+            if len(exps) > 1:
+                logger.warning("Multiple experiments with the same name found. Using first one.")
+            experiment_id = exps[0].experiment_id
+        else:
+            experiment_id = mlflow.create_experiment(
+                name=experiment_name,
+                artifact_location=logging_dir,
+                tags=tags,
+            )
 
         self.active_run = mlflow.start_run(
             run_id=run_id,


### PR DESCRIPTION
If mlflow experiment already exists, we can re-use its id for tracking. (otherwise it will fail)