### PR TITLE
Distributed prompting/inference utility

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -23,7 +23,7 @@
     title: Example Zoo
   - local: usage_guides/big_modeling
     title: How perform inference on large models with small resources
-  _ local: usage_guides/distributed_inference
+  - local: usage_guides/distributed_inference
     title: How to perform distributed inference with normal resources
   - local: usage_guides/gradient_accumulation
     title: Performing gradient accumulation

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -23,6 +23,8 @@
     title: Example Zoo
   - local: usage_guides/big_modeling
     title: How perform inference on large models with small resources
+  _ local: usage_guides/distributed_inference
+    title: How to perform distributed inference with normal resources
   - local: usage_guides/gradient_accumulation
     title: Performing gradient accumulation
   - local: usage_guides/checkpoint

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -17,7 +17,7 @@ send a number of different prompts, each to a different GPU, and then get the re
 outside of just NLP, however for this tutorial we will focus on just this idea of each GPU receiving a different prompt,
 and then returning the results.
 
-## The problem
+## The Problem
 
 Normally when doing this, users send the model to a specific device to load it from the CPU, and then move each prompt to a different device. 
 
@@ -48,7 +48,7 @@ def run_inference(rank, world_size):
 One will notice how we have to check the rank to know what prompt to send, which can be a bit tedious.
 
 A user might then also think that with 🤗 Accelerate, using the `Accelerator` to prepare a dataloader for such a task might also be 
-a simple way to manage this. (To learn more, check out the relvent section in the [Quick Tour](quicktour#distributed-evaluation))
+a simple way to manage this. (To learn more, check out the relvent section in the [Quick Tour](../quicktour#distributed-evaluation))
 
 Can it manage it? Yes. Does it add unneeded extra code however: also yes.
 

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -9,3 +9,94 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 -->
+
+# Distributed Inference with 🤗 Accelerate
+
+Distributed inference is a common use case, especially with natural language processing (NLP) models. Users often want to
+send a number of different prompts, each to a different GPU, and then get the results back. This also has other cases
+outside of just NLP, however for this tutorial we will focus on just this idea of each GPU receiving a different prompt,
+and then returning the results.
+
+## Common Confusions
+
+Normally when doing this, users send the model to a specific device to load it from the CPU, and then move each prompt to a different device. 
+
+A basic pipeline using the `diffusers` library might look something like so:
+
+```python
+import torch
+import torch.distributed as dist
+from diffusers import DiffusionPipeline
+
+pipe = DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", torch_dtype=torch.float16)
+```
+Followed then by performing inference based on the specific prompt:
+
+```python
+def run_inference(rank, world_size):
+    dist.init_process_group("nccl", rank=rank, world_size=world_size)
+    pipe.to(rank)
+
+    if torch.distributed.get_rank() == 0:
+        prompt = "a dog"
+    elif torch.distributed.get_rank() == 1:
+        prompt = "a cat"
+
+    result = pipe(prompt).images[0]
+    result.save(f"result_{rank}.png")
+```
+One will notice how we have to check the rank to know what prompt to send, which can be a bit tedious.
+
+A user might then also think that with 🤗 Accelerate, using the `Accelerator` to prepare a dataloader for such a task might also be 
+a simple way to manage this. 
+
+Can it manage it? Yes. Does it add unneeded extra code however: also yes.
+
+## The Solution
+
+With 🤗 Accelerate, we can simplify this process by using the [`Accelerator.split_across_processes`] context manager (which also exists in `PartialState` and `AcceleratorState`). 
+This function will automatically split whatever data you pass to it (be it a prompt, a set of tensors, a dictionary of the prior data, etc.) across all the processes (with a potential
+to be padded) for you to use right away.
+
+Let's rewrite the above example using this context manager:
+
+```python
+from accelerate import PartialState  # Can also be Accelerator or AcceleratorStaet
+from diffusers import DiffusionPipeline
+
+pipe = DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", torch_dtype=torch.float16)
+distributed_state = PartialState()
+
+# Assume two processes
+with distributed_state.split_across_processes(["a dog", "a cat"]) as prompt:
+    result = pipe(prompt).images[0]
+    result.save(f"result_{distributed_state.rank}.png")
+```
+
+We've now reduced the boilerplate code needed to split this data to a few lines of code quite easily.
+
+But what if we have an odd distribution of prompts to GPUs? For example, what if we have 3 prompts, but only 2 GPUs? 
+You can pass in `apply_padding=True` to ensure that prompts are padded to the same length, with extra data being taken 
+from the last sample.
+
+<Tip>
+This is only needed when trying to perform an action such as gathering the results, where the data on each device 
+needs to be the same length. Basic inference does not require this.
+</Tip>
+
+For instance:
+
+```python
+from accelerate import PartialState  # Can also be Accelerator or AcceleratorStaet
+from diffusers import DiffusionPipeline
+
+pipe = DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", torch_dtype=torch.float16)
+distributed_state = PartialState()
+
+# Assume two processes
+with distributed_state.split_across_processes(["a dog", "a cat", "a chicken"], apply_padding=True) as prompt:
+    result = pipe(prompt).images
+```
+
+On the first GPU, the prompts will be `["a dog", "a cat"]`, and on the second GPU it will be `["a chicken", "a chicken"]`.
+Make sure to drop the final sample, as it will be a duplicate of the previous one.

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -1,0 +1,11 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+-->

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -76,8 +76,13 @@ with distributed_state.split_across_processes(["a dog", "a cat"]) as prompt:
 We've now reduced the boilerplate code needed to split this data to a few lines of code quite easily.
 
 But what if we have an odd distribution of prompts to GPUs? For example, what if we have 3 prompts, but only 2 GPUs? 
+
+Under the context manager, the first GPU would receive the first two prompts and the second GPU the third, ensuring that 
+all prompts are split and no overhead is needed.
+
+*However*, what if we then wanted to do something with the results of *all the GPUs*? (Say gather them all and perform some kind of post processing)
 You can pass in `apply_padding=True` to ensure that prompts are padded to the same length, with extra data being taken 
-from the last sample.
+from the last sample. This way all GPUs will have the same number of prompts, and you can then gather the results.
 
 <Tip>
 This is only needed when trying to perform an action such as gathering the results, where the data on each device 

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -48,7 +48,7 @@ def run_inference(rank, world_size):
 One will notice how we have to check the rank to know what prompt to send, which can be a bit tedious.
 
 A user might then also think that with 🤗 Accelerate, using the `Accelerator` to prepare a dataloader for such a task might also be 
-a simple way to manage this. (To learn more, check out the relvent section in the [Quick Tour](quicktour# Distributed evaluation))
+a simple way to manage this. (To learn more, check out the relvent section in the [Quick Tour](quicktour#distributed-evaluation))
 
 Can it manage it? Yes. Does it add unneeded extra code however: also yes.
 

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -61,7 +61,7 @@ to be padded) for you to use right away.
 Let's rewrite the above example using this context manager:
 
 ```python
-from accelerate import PartialState  # Can also be Accelerator or AcceleratorStaet
+from accelerate import PartialState  # Can also be Accelerator or AcceleratorState
 from diffusers import DiffusionPipeline
 
 pipe = DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", torch_dtype=torch.float16)
@@ -81,12 +81,14 @@ Under the context manager, the first GPU would receive the first two prompts and
 all prompts are split and no overhead is needed.
 
 *However*, what if we then wanted to do something with the results of *all the GPUs*? (Say gather them all and perform some kind of post processing)
-You can pass in `apply_padding=True` to ensure that prompts are padded to the same length, with extra data being taken 
+You can pass in `apply_padding=True` to ensure that the lists of prompts are padded to the same length, with extra data being taken 
 from the last sample. This way all GPUs will have the same number of prompts, and you can then gather the results.
 
 <Tip>
+
 This is only needed when trying to perform an action such as gathering the results, where the data on each device 
 needs to be the same length. Basic inference does not require this.
+
 </Tip>
 
 For instance:

--- a/docs/source/usage_guides/distributed_inference.mdx
+++ b/docs/source/usage_guides/distributed_inference.mdx
@@ -17,7 +17,7 @@ send a number of different prompts, each to a different GPU, and then get the re
 outside of just NLP, however for this tutorial we will focus on just this idea of each GPU receiving a different prompt,
 and then returning the results.
 
-## Common Confusions
+## The problem
 
 Normally when doing this, users send the model to a specific device to load it from the CPU, and then move each prompt to a different device. 
 
@@ -48,7 +48,7 @@ def run_inference(rank, world_size):
 One will notice how we have to check the rank to know what prompt to send, which can be a bit tedious.
 
 A user might then also think that with 🤗 Accelerate, using the `Accelerator` to prepare a dataloader for such a task might also be 
-a simple way to manage this. 
+a simple way to manage this. (To learn more, check out the relvent section in the [Quick Tour](quicktour# Distributed evaluation))
 
 Can it manage it? Yes. Does it add unneeded extra code however: also yes.
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -527,6 +527,35 @@ class Accelerator:
     def mixed_precision(self):
         return self.state.mixed_precision
 
+    @contextmanager
+    def split_between_processes(self, inputs: list | tuple | dict):
+        """
+        Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
+        distributed inference, such as with different prompts.
+
+        Note that when using a `dict`, all keys need to have the same number of elements.
+
+        Args:
+            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`): The input to split between processes.
+
+        Example:
+
+        ```python
+        # Assume there are two processes
+        from accelerate import Accelerator
+
+        accelerator = Accelerator()
+        with accelerator.split_between_processes(["A", "B", "C"]) as inputs:
+            print(inputs)
+        # Process 0
+        ["A", "B"]
+        # Process 1
+        ["C"]
+        ```
+        """
+        with PartialState().split_between_processes(inputs) as inputs:
+            yield inputs
+
     def on_main_process(self, function: Callable[..., Any] = None):
         """
         A decorator that will run the decorated function on the main process only. Can also be called using the

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -781,7 +781,7 @@ class AcceleratorState:
         PartialState().wait_for_everyone()
 
     @contextmanager
-    def split_between_processes(self, inputs: list | tuple | dict):
+    def split_between_processes(self, inputs: list | tuple | dict, apply_padding: bool = False):
         """
         Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.
@@ -806,7 +806,7 @@ class AcceleratorState:
         ["C"]
         ```
         """
-        with PartialState().split_between_processes(inputs) as inputs:
+        with PartialState().split_between_processes(inputs, apply_padding=apply_padding) as inputs:
             yield inputs
 
     @contextmanager

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -328,7 +328,7 @@ class PartialState:
         """
         num_samples_per_process = len(inputs) // self.num_processes
         start_index = self.process_index * num_samples_per_process
-        yield inputs[start_index:self.process_index+num_samples_per_process]
+        yield inputs[start_index:self.process_index+num_samples_per_process+1]
 
     @contextmanager
     def main_process_first(self):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -329,7 +329,7 @@ class PartialState:
         Note that when using a `dict`, all keys need to have the same number of elements.
 
         Args:
-            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`): The input to split between processes.
+            inputs (`list`, `tuple`, or `dict`): The input to split between processes.
 
         Example:
 
@@ -361,17 +361,14 @@ class PartialState:
             elif isinstance(inputs, dict):
                 end_index = len(inputs[list(inputs.keys())[0]])
 
-        def _nested_index(item, start_index, end_index):
-            if isinstance(item, (list, tuple)):
-                return item[start_index:end_index]
-            elif isinstance(item, dict):
-                for key in item.keys():
-                    item[key] = item[key][start_index:end_index]
-                return item
-            else:
-                return item
-
-        yield _nested_index(inputs, start_index, end_index)
+        if isinstance(inputs, (list, tuple)):
+            return inputs[start_index:end_index]
+        elif isinstance(inputs, dict):
+            for key in inputs.keys():
+                inputs[key] = inputs[key][start_index:end_index]
+            return inputs
+        else:
+            return inputs
 
     @contextmanager
     def main_process_first(self):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from __future__ import annotations
+
 import math
 import os
 import threading
@@ -373,6 +374,7 @@ class PartialState:
                 return inputs
             else:
                 return inputs
+
         yield _split_values(inputs, start_index, end_index)
 
     @contextmanager

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import math
 import os
 import threading

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -320,13 +320,13 @@ class PartialState:
             self.wait_for_everyone()
 
     @contextmanager
-    def split_input_to_processes(self, inputs:Any):
+    def split_between_processes(self, inputs:Any):
         """
         Splits `input` between `self.num_processes` quickly and
         can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.  
         """
-        num_samples_per_process = inputs // self.num_processes
+        num_samples_per_process = len(inputs) // self.num_processes
         start_index = self.process_index * num_samples_per_process
         if len(inputs) % self.num_processes != 0:
             yield inputs[start_index:self.process_index+num_samples_per_process]

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -320,6 +320,20 @@ class PartialState:
             self.wait_for_everyone()
 
     @contextmanager
+    def split_input_to_processes(self, inputs:Any):
+        """
+        Splits `input` between `self.num_processes` quickly and
+        can be then used on that process. Useful when doing
+        distributed inference, such as with different prompts.  
+        """
+        num_samples_per_process = inputs // self.num_processes
+        start_index = self.process_index * num_samples_per_process
+        if len(inputs) % self.num_processes != 0:
+            yield inputs[start_index:self.process_index+num_samples_per_process]
+        else:
+            yield inputs[start_index:]
+
+    @contextmanager
     def main_process_first(self):
         """
         Lets the main process go first inside a with block.

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -321,10 +321,30 @@ class PartialState:
             self.wait_for_everyone()
 
     @contextmanager
-    def split_between_processes(self, inputs: Any):
+    def split_between_processes(self, inputs: list | tuple | dict):
         """
         Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.
+
+        Note that when using a `dict`, all keys need to have the same number of elements.
+
+        Args:
+            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`): The input to split between processes.
+
+        Example:
+
+        ```python
+        # Assume there are two processes
+        from accelerate import Accelerator
+
+        accelerator = Accelerator()
+        with accelerator.split_between_processes(["A", "B", "C"]) as inputs:
+            print(inputs)
+        # Process 0
+        ["A", "B"]
+        # Process 1
+        ["C"]
+        ```
         """
         # Nested dictionary of any types
         if isinstance(inputs, dict):
@@ -748,10 +768,30 @@ class AcceleratorState:
         PartialState().wait_for_everyone()
 
     @contextmanager
-    def split_between_processes(self, inputs: Any):
+    def split_between_processes(self, inputs: list | tuple | dict):
         """
         Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.
+
+        Note that when using a `dict`, all keys need to have the same number of elements.
+
+        Args:
+            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`): The input to split between processes.
+
+        Example:
+
+        ```python
+        # Assume there are two processes
+        from accelerate import Accelerator
+
+        accelerator = Accelerator()
+        with accelerator.split_between_processes(["A", "B", "C"]) as inputs:
+            print(inputs)
+        # Process 0
+        ["A", "B"]
+        # Process 1
+        ["C"]
+        ```
         """
         with PartialState().split_between_processes(inputs) as inputs:
             yield inputs

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -327,6 +327,11 @@ class PartialState:
         distributed inference, such as with different prompts.
         """
         # Nested dictionary of any types
+        if isinstance(inputs, dict):
+            length = len(inputs[list(inputs.keys())[0]])
+            assert all(
+                len(v) == length for v in inputs.values()
+            ), "All values in the dictionary must have the same length"
         num_samples_per_process = math.ceil(len(inputs) / self.num_processes)
         start_index = self.process_index * num_samples_per_process
         end_index = start_index + num_samples_per_process

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -335,23 +335,30 @@ class PartialState:
                 The input to split between processes.
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
-                number of elements. Useful when trying to perform actions such as `Accelerator.gather()` on the
-                outputs. If so, just remember to drop the padded elements afterwards.
+                number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
+                just remember to drop the padded elements afterwards.
 
 
         Example:
 
         ```python
         # Assume there are two processes
-        from accelerate import Accelerator
+        from accelerate import PartialState
 
-        accelerator = Accelerator()
-        with accelerator.split_between_processes(["A", "B", "C"]) as inputs:
+        state = PartialState()
+        with state.split_between_processes(["A", "B", "C"]) as inputs:
             print(inputs)
         # Process 0
         ["A", "B"]
         # Process 1
         ["C"]
+
+        with state.split_between_processes(["A", "B", "C"], apply_padding=True) as inputs:
+            print(inputs)
+        # Process 0
+        ["A", "B"]
+        # Process 1
+        ["C", "C"]
         ```
         """
         if self.num_processes == 1:
@@ -789,21 +796,34 @@ class AcceleratorState:
         Note that when using a `dict`, all keys need to have the same number of elements.
 
         Args:
-            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`): The input to split between processes.
+            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`):
+                The input to split between processes.
+            apply_padding (`bool`, `optional`, defaults to `False`):
+                Whether to apply padding by repeating the last element of the input so that all processes have the same
+                number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
+                just remember to drop the padded elements afterwards.
+
 
         Example:
 
         ```python
         # Assume there are two processes
-        from accelerate import Accelerator
+        from accelerate.state import AcceleratorState
 
-        accelerator = Accelerator()
-        with accelerator.split_between_processes(["A", "B", "C"]) as inputs:
+        state = AcceleratorState()
+        with state.split_between_processes(["A", "B", "C"]) as inputs:
             print(inputs)
         # Process 0
         ["A", "B"]
         # Process 1
         ["C"]
+
+        with state.split_between_processes(["A", "B", "C"], apply_padding=True) as inputs:
+            print(inputs)
+        # Process 0
+        ["A", "B"]
+        # Process 1
+        ["C", "C"]
         ```
         """
         with PartialState().split_between_processes(inputs, apply_padding=apply_padding) as inputs:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -350,6 +350,7 @@ class PartialState:
         """
         if self.num_processes == 1:
             yield inputs
+            return
         # Nested dictionary of any types
         if isinstance(inputs, dict):
             length = len(inputs[list(inputs.keys())[0]])

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 import os
 import threading
 import warnings
@@ -326,9 +327,12 @@ class PartialState:
         can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.  
         """
-        num_samples_per_process = len(inputs) // self.num_processes
+        num_samples_per_process = math.ceil(len(inputs) / self.num_processes)
         start_index = self.process_index * num_samples_per_process
-        yield inputs[start_index:self.process_index+num_samples_per_process+1]
+        end_index = start_index + num_samples_per_process
+        if (len(inputs) % self.num_processes != 0) and (self.process_index == self.num_processes - 1):
+            end_index = len(inputs)
+        yield inputs[start_index:end_index]
 
     @contextmanager
     def main_process_first(self):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -328,10 +328,7 @@ class PartialState:
         """
         num_samples_per_process = len(inputs) // self.num_processes
         start_index = self.process_index * num_samples_per_process
-        if len(inputs) % self.num_processes != 0:
-            yield inputs[start_index:self.process_index+num_samples_per_process]
-        else:
-            yield inputs[start_index:]
+        yield inputs[start_index:self.process_index+num_samples_per_process]
 
     @contextmanager
     def main_process_first(self):

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -32,6 +32,7 @@ from accelerate.utils import (
     gather,
     is_bf16_available,
     is_ipex_available,
+    is_torch_version,
     set_seed,
     synchronize_rng_states,
 )
@@ -467,14 +468,13 @@ def test_split_between_processes_nested_dict():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
-    # if state.local_process_index == 0:
-    #     print("\n**Test process execution**")
-    # process_execution_check()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
+    if state.local_process_index == 0:
+        print("\n**Test process execution**")
+    process_execution_check()
 
-    # if state.num_processes == 2:
     if state.local_process_index == 0:
         print("\n**Test split between processes as a list**")
     test_split_between_processes_list()
@@ -483,23 +483,23 @@ def main():
         print("\n**Test split between processes as a dict**")
     test_split_between_processes_nested_dict()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    if state.local_process_index == 0:
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-    #     central_dl_preparation_check()
+    if state.local_process_index == 0:
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+        central_dl_preparation_check()
 
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check()
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -31,6 +31,7 @@ from accelerate.utils import (
     gather,
     is_bf16_available,
     is_ipex_available,
+    is_torch_version,
     set_seed,
     synchronize_rng_states,
 )
@@ -433,30 +434,29 @@ def test_split_between_processes_list():
 
 def test_split_between_processes_nested_dict():
     state = AcceleratorState()
-    if state.num_processes == 2:
-        data = {"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"], "c": torch.tensor([0, 1, 2, 3])}
-        with state.split_between_processes(data) as results:
-            assert (
-                len(results["a"]) == 2
-            ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results['a'])}; Values: {results['a']}"
-            if state.process_index == 0:
-                assert results["a"] == [1, 2]
-            else:
-                assert results["a"] == [3, 4]
-            assert len(results["b"]) == 2
-            if state.process_index == 0:
-                assert results["b"] == ["w", "x"]
-            else:
-                assert results["b"] == ["y", "z"]
-            assert len(results["c"]) == 2
-            if state.process_index == 0:
-                assert torch.allclose(
-                    results["c"], torch.tensor([0, 1])
-                ), f"Did not obtain expected values on process 0, expected `torch.tensor([1,2])`, received: {results['c']}"
-            else:
-                assert torch.allclose(
-                    results["c"], torch.tensor([2, 3])
-                ), f"Did not obtain expected values on process 1, expected `torch.tensor([3,4])`, received: {results['c']}"
+    data = {"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"], "c": torch.tensor([0, 1, 2, 3])}
+    with state.split_between_processes(data) as results:
+        assert (
+            len(results["a"]) == 2
+        ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results['a'])}; Values: {results['a']}"
+        if state.process_index == 0:
+            assert results["a"] == [1, 2]
+        else:
+            assert results["a"] == [3, 4]
+        assert len(results["b"]) == 2
+        if state.process_index == 0:
+            assert results["b"] == ["w", "x"]
+        else:
+            assert results["b"] == ["y", "z"]
+        assert len(results["c"]) == 2
+        if state.process_index == 0:
+            assert torch.allclose(
+                results["c"], torch.tensor([0, 1])
+            ), f"Did not obtain expected values on process 0, expected `torch.tensor([1,2])`, received: {results['c']}"
+        else:
+            assert torch.allclose(
+                results["c"], torch.tensor([2, 3])
+            ), f"Did not obtain expected values on process 1, expected `torch.tensor([3,4])`, received: {results['c']}"
 
         data = {"a": [1, 2, 3], "b": ["w", "x", "y"], "c": torch.tensor([0, 1, 2])}
         with state.split_between_processes(data) as results:
@@ -473,38 +473,39 @@ def test_split_between_processes_nested_dict():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
-    # if state.local_process_index == 0:
-    #     print("\n**Test process execution**")
-    # process_execution_check()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
+    if state.local_process_index == 0:
+        print("\n**Test process execution**")
+    process_execution_check()
+
+    if state.num_processes == 2:
+        if state.local_process_index == 0:
+            print("\n**Test split between processes as a list**")
+        test_split_between_processes_list()
+
+        if state.local_process_index == 0:
+            print("\n**Test split between processes as a dict**")
+        test_split_between_processes_nested_dict()
 
     if state.local_process_index == 0:
-        print("\n**Test split between processes as a list**")
-    test_split_between_processes_list()
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
     if state.local_process_index == 0:
-        print("\n**Test split between processes as a dict**")
-    test_split_between_processes_nested_dict()
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+        central_dl_preparation_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-    #     central_dl_preparation_check()
-
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
-
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check()
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -473,39 +473,39 @@ def test_split_between_processes_nested_dict():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
-    if state.local_process_index == 0:
-        print("\n**Test process execution**")
-    process_execution_check()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test process execution**")
+    # process_execution_check()
 
-    if state.num_processes == 2:
-        if state.local_process_index == 0:
-            print("\n**Test split between processes as a list**")
-        test_split_between_processes_list()
-
-        if state.local_process_index == 0:
-            print("\n**Test split between processes as a dict**")
-        test_split_between_processes_nested_dict()
+    # if state.num_processes == 2:
+    if state.local_process_index == 0:
+        print("\n**Test split between processes as a list**")
+    test_split_between_processes_list()
 
     if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+        print("\n**Test split between processes as a dict**")
+    test_split_between_processes_nested_dict()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-        central_dl_preparation_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+    #     central_dl_preparation_check()
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check()
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
+
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -16,6 +16,7 @@
 
 import contextlib
 import io
+import math
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -431,6 +432,15 @@ def test_split_between_processes_list():
         assert (
             len(results) == 2
         ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results)}"
+
+    data = list(range(0, (2 * state.num_processes) + 1))
+    with state.split_between_processes(data, apply_padding=True) as results:
+        if state.is_last_process:
+            # Test that the last process gets the extra item(s)
+            num_samples_per_device = math.ceil(len(data) / state.num_processes)
+            assert (
+                len(results) == num_samples_per_device
+            ), f"Last process did not get the extra item(s). Process index: {state.process_index}; Length: {len(results)}"
 
 
 def test_split_between_processes_nested_dict():

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -31,7 +31,6 @@ from accelerate.utils import (
     gather,
     is_bf16_available,
     is_ipex_available,
-    is_torch_version,
     set_seed,
     synchronize_rng_states,
 )
@@ -426,43 +425,60 @@ def training_check():
 def test_split_between_processes_list():
     state = AcceleratorState()
     data = list(range(0, 2 * state.num_processes))
-    results = state.split_between_processes(data)
-    assert (
-        len(results) == 2
-    ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results)}"
+    with state.split_between_processes(data) as results:
+        assert (
+            len(results) == 2
+        ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results)}"
 
 
 def test_split_between_processes_nested_dict():
     state = AcceleratorState()
     if state.num_processes == 2:
         data = {"a": [1, 2, 3, 4], "b": ["w", "x", "y", "z"], "c": torch.tensor([0, 1, 2, 3])}
-        results = state.split_between_processes(data)
-        assert len(results["a"]) == 2
-        if state.process_index == 0:
-            assert results["a"] == [1, 2]
-        else:
-            assert results["a"] == [3, 4]
-        assert len(results["b"]) == 2
-        if state.process_index == 0:
-            assert results["b"] == ["w", "x"]
-        else:
-            assert results["b"] == ["y", "z"]
-        assert len(results["c"]) == 2
-        if state.process_index == 0:
-            assert results["c"] == torch.tensor([1, 2])
-        else:
-            assert results["c"] == torch.tensor([3, 4])
+        with state.split_between_processes(data) as results:
+            assert (
+                len(results["a"]) == 2
+            ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results['a'])}; Values: {results['a']}"
+            if state.process_index == 0:
+                assert results["a"] == [1, 2]
+            else:
+                assert results["a"] == [3, 4]
+            assert len(results["b"]) == 2
+            if state.process_index == 0:
+                assert results["b"] == ["w", "x"]
+            else:
+                assert results["b"] == ["y", "z"]
+            assert len(results["c"]) == 2
+            if state.process_index == 0:
+                assert torch.allclose(
+                    results["c"], torch.tensor([0, 1])
+                ), f"Did not obtain expected values on process 0, expected `torch.tensor([1,2])`, received: {results['c']}"
+            else:
+                assert torch.allclose(
+                    results["c"], torch.tensor([2, 3])
+                ), f"Did not obtain expected values on process 1, expected `torch.tensor([3,4])`, received: {results['c']}"
+
+        data = {"a": [1, 2, 3], "b": ["w", "x", "y"], "c": torch.tensor([0, 1, 2])}
+        with state.split_between_processes(data) as results:
+            if state.process_index == 0:
+                assert len(results["a"]) == 2
+                assert len(results["b"]) == 2
+                assert len(results["c"]) == 2
+            else:
+                assert len(results["a"]) == 1
+                assert len(results["b"]) == 1
+                assert len(results["c"]) == 1
 
 
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
-    if state.local_process_index == 0:
-        print("\n**Test process execution**")
-    process_execution_check()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test process execution**")
+    # process_execution_check()
 
     if state.local_process_index == 0:
         print("\n**Test split between processes as a list**")
@@ -472,23 +488,23 @@ def main():
         print("\n**Test split between processes as a dict**")
     test_split_between_processes_nested_dict()
 
-    if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-        central_dl_preparation_check()
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+    #     central_dl_preparation_check()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -31,7 +31,6 @@ from accelerate.utils import (
     gather,
     is_bf16_available,
     is_ipex_available,
-    is_torch_version,
     set_seed,
     synchronize_rng_states,
 )


### PR DESCRIPTION
This PR introduces a new utility in `Accelerator`, `AcceleratorState`, and `PartialState`: `Accelerator.split_between_processes`.

It is often useful when performing distributed inference in applications such as stable diffusion to send one prompt to GPU A, another prompt to GPU B, and so forth. This PR introduces a new context manager that let's the user send some data in and split it evenly across all instances for them to use. An example application might look like such:

```python
from accelerate import PartialState
from diffusers import DiffusionPipeline

state = PartialState()
pipe= DiffusionPipeline.from_pretrained("runwayml/stable-diffusion-v1-5", torch_dtype=torch.float16)

with state.split_between_processes(["a dog", "a cat"]) as prompt:
    pipe.to(state.device)
    image = pipe(prompt).images[0]
```

On a two process system, GPU A would receive `"a dog"` and GPU B would receive `"a cat"`. 

This is also especially useful for cases where using a `DataLoader` to perform the task is too much code, and the user just wants to send in strings or already preprocessed dictionaries and split them.