### PR TITLE
Make mlflow logging dir optional

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -558,13 +558,13 @@ class MLflowTracker(GeneralTracker):
     """
 
     name = "mlflow"
-    requires_logging_directory = True
+    requires_logging_directory = False
 
     @on_main_process
     def __init__(
         self,
         experiment_name: str = None,
-        logging_dir: Optional[Union[str, os.PathLike]] = ".",
+        logging_dir: Optional[Union[str, os.PathLike]] = None,
         run_id: Optional[str] = None,
         tags: Optional[Union[Dict[str, Any], str]] = None,
         nested_run: Optional[bool] = False,


### PR DESCRIPTION
If we use an already existing experiment, having to specify a logging directory doesn't make sense.
If we create a new experiment, the logging dir is optional too and is picked automatically by mlflow if not provided.