### PR TITLE
Fix AttributeError: AccelerateState has no attribute _mixed_precision

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -593,6 +593,7 @@ class AcceleratorState:
         if PartialState._shared_state == {}:
             PartialState(cpu, **kwargs)
         self.__dict__.update(PartialState._shared_state)
+        self._mixed_precision = "no" if self.distributed_type == DistributedType.DEEPSPEED else mixed_precision  # _mixed_precision is not set yet used in _check_initialized, raising AttributeError
         self._check_initialized(mixed_precision, cpu)
         if not self.initialized:
             self.deepspeed_plugin = None


### PR DESCRIPTION
```
from accelerate import Accelerator
accelerator = Accelerator(mixed_precision='fp16')
```

This snippet causes `AttributeError: AccelerateState has no attribute _mixed_precision`. This is because `AccelerateState._check_initialized` uses the `_mixed_precision` attribute at
https://github.com/huggingface/accelerate/blob/dcde1e93d09abea02a8e7f4a07a2c5734b87b60e/src/accelerate/state.py#LL673C61-L673C61
before it is even set at https://github.com/huggingface/accelerate/blob/dcde1e93d09abea02a8e7f4a07a2c5734b87b60e/src/accelerate/state.py#L614