### PR TITLE
[`core`] Introducing `CustomDtype` enum for custom dtypes

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -46,6 +46,7 @@ from .imports import (
     is_xpu_available,
 )
 from .modeling import (
+    CustomDtype,
     check_device_map,
     compute_module_sizes,
     convert_file_size_to_int,
@@ -62,7 +63,6 @@ from .modeling import (
     named_module_tensors,
     retie_parameters,
     set_module_tensor_to_device,
-    CustomDtype,
 )
 from .offload import (
     OffloadedWeightsLoader,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -62,6 +62,7 @@ from .modeling import (
     named_module_tensors,
     retie_parameters,
     set_module_tensor_to_device,
+    CustomDtype,
 )
 from .offload import (
     OffloadedWeightsLoader,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import re
+import enum
 import shutil
 import tempfile
 from collections import defaultdict
@@ -41,6 +42,14 @@ WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
 
 
 logger = logging.getLogger(__name__)
+
+
+class CustomDtype(enum.Enum):
+    r"""
+    An enum that contains multiple custom dtypes for the type.
+    """
+    FP8 = "fp8"
+    INT4 = "int4"
 
 
 def convert_file_size_to_int(size: Union[int, str]):
@@ -90,6 +99,10 @@ def dtype_byte_size(dtype: torch.dtype):
     """
     if dtype == torch.bool:
         return 1 / 8
+    elif dtype == CustomDtype.INT4:
+        return 1 / 2
+    elif dtype == CustomDtype.FP8:  
+        return 1 
     bit_search = re.search(r"[^\d](\d+)$", str(dtype))
     if bit_search is None:
         raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")
@@ -162,7 +175,7 @@ def set_module_tensor_to_device(
             if param_cls.__name__ == "Int8Params":
                 # downcast to fp16 if any
                 if new_value.dtype == torch.float32:
-                    new_value = new_value.to(torch.float16)
+                   new_value = new_value.to(torch.float16)
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
             else:
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 
 class CustomDtype(enum.Enum):
     r"""
-    An enum that contains multiple custom dtypes for the type.
+    An enum that contains multiple custom dtypes that can be used for `infer_auto_device_map`.
     """
     FP8 = "fp8"
     INT4 = "int4"

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 import contextlib
+import enum
 import gc
 import json
 import logging
 import os
 import re
-import enum
 import shutil
 import tempfile
 from collections import defaultdict
@@ -101,8 +101,8 @@ def dtype_byte_size(dtype: torch.dtype):
         return 1 / 8
     elif dtype == CustomDtype.INT4:
         return 1 / 2
-    elif dtype == CustomDtype.FP8:  
-        return 1 
+    elif dtype == CustomDtype.FP8:
+        return 1
     bit_search = re.search(r"[^\d](\d+)$", str(dtype))
     if bit_search is None:
         raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")
@@ -175,7 +175,7 @@ def set_module_tensor_to_device(
             if param_cls.__name__ == "Int8Params":
                 # downcast to fp16 if any
                 if new_value.dtype == torch.float32:
-                   new_value = new_value.to(torch.float16)
+                    new_value = new_value.to(torch.float16)
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
             else:
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)


### PR DESCRIPTION
# What does this PR do?

This PR adds a new utility class, termed as `CustomDtype` to handle custom dtypes that does not exists natively in PyTorch for future users that want to use `infer_auto_device_map` on exotic dtypes, such as FP8, int4, etc.

cc @sgugger 