### PR TITLE
Make sure torch compiled model can also be unwrapped

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -33,7 +33,9 @@ if is_tpu_available(check_device=False):
 
 
 def is_compiled_module(module):
-    """Check whether the module was compiled with torch.compile()"""
+    """
+    Check whether the module was compiled with torch.compile()
+    """
     if is_torch_version("<", "2.0.0") or not hasattr(torch, "_dynamo"):
         return False
     return isinstance(module, torch._dynamo.eval_frame.OptimizedModule)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -19,10 +19,10 @@ import torch
 
 from ..commands.config.default import write_basic_config  # noqa: F401
 from ..state import PartialState
-from .versions import is_torch_version
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
 from .transformer_engine import convert_model
+from .versions import is_torch_version
 
 
 if is_deepspeed_available():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,6 @@ import torch
 
 from accelerate.test_utils.testing import require_cuda, require_torch_min_version
 from accelerate.test_utils.training import RegressionModel
-from accelerate.utils.other import extract_model_from_parallel
 from accelerate.utils import (
     convert_outputs_to_fp32,
     extract_model_from_parallel,
@@ -121,7 +120,6 @@ class UtilsTester(unittest.TestCase):
     def test_extract_model(self):
         model = RegressionModel()
         # could also do a test with DistributedDataParallel, but difficult to run on CPU or single GPU
-        # skip for now
         distributed_model = torch.nn.parallel.DataParallel(model)
         model_unwrapped = extract_model_from_parallel(distributed_model)
 
@@ -132,6 +130,7 @@ class UtilsTester(unittest.TestCase):
         model = RegressionModel()
         compiled_model = torch.compile(model)
 
+        # could also do a test with DistributedDataParallel, but difficult to run on CPU or single GPU
         distributed_model = torch.nn.parallel.DataParallel(model)
         distributed_compiled_model = torch.compile(distributed_model)
         compiled_model_unwrapped = extract_model_from_parallel(distributed_compiled_model)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ import torch
 
 from accelerate.test_utils.testing import require_cuda, require_torch_min_version
 from accelerate.test_utils.training import RegressionModel
+from accelerate.utils.other import extract_model_from_parallel
 from accelerate.utils import (
     convert_outputs_to_fp32,
     extract_model_from_parallel,
@@ -116,6 +117,26 @@ class UtilsTester(unittest.TestCase):
         model.forward = torch.compile(model.forward, backend="inductor")
         inputs = torch.randn(4, 10).cuda()
         _ = model(inputs)
+
+    def test_extract_model(self):
+        model = RegressionModel()
+        # could also do a test with DistributedDataParallel, but difficult to run on CPU or single GPU
+        # skip for now
+        distributed_model = torch.nn.parallel.DataParallel(model)
+        model_unwrapped = extract_model_from_parallel(distributed_model)
+
+        self.assertEqual(model, model_unwrapped)
+
+    @require_torch_min_version(version="2.0")
+    def test_dynamo_extract_model(self):
+        model = RegressionModel()
+        compiled_model = torch.compile(model)
+
+        distributed_model = torch.nn.parallel.DataParallel(model)
+        distributed_compiled_model = torch.compile(distributed_model)
+        compiled_model_unwrapped = extract_model_from_parallel(distributed_compiled_model)
+
+        self.assertEqual(compiled_model._orig_mod, compiled_model_unwrapped._orig_mod)
 
     def test_find_device(self):
         self.assertEqual(find_device([1, "a", torch.tensor([1, 2, 3])]), torch.device("cpu"))


### PR DESCRIPTION
When torch compile is used in addition to multi-GPU training the PyTorch module is wrapped twice and looks more or less as follows:
```
model: torch._dynamo.eval_frame.OptimizedModule(torch.nn.parallel.DistributedDataParallel(model))
```

The model is not unwrapped from distributed data parallel to just model. This PR adds more logic to `unwrap_model()` so that calling:

```py
accelerator.unwrap_model(model)
```

results in:
```
model: torch._dynamo.eval_frame.OptimizedModule(model)
```

which I think is a better fit here