### PR TITLE
Let quality yell at the user if it's a version difference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ extra_quality_checks:
 
 # this target runs checks on all files
 quality:
-	black --check $(check_dirs)
+	black --required-version 23 --check $(check_dirs)
 	ruff $(check_dirs)
 	doc-builder style src/accelerate docs/source --max_len 119 --check_only
 


### PR DESCRIPTION
`black` let's you do a `--required-version`, which let's us pin it at 23 (there was no 23.0, only 23.1 so that's fine with our minimals). This lets the user have a much clearer error if something happened locally when we request they do `make quality`:

```
Oh no! 💥 💔 💥 The required version `23.1` does not match the running version `23.3.0`!
```