### PR TITLE
Ensure that tabulate gets installed on main tests

### DIFF
--- a/.github/workflows/run_merge_tests.yml
+++ b/.github/workflows/run_merge_tests.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Generate Report
         if: always()
         run: |
+          pip install tabulate
           python utils/log_reports.py >> $GITHUB_STEP_SUMMARY
 
   run_all_tests_multi_gpu:
@@ -86,4 +87,5 @@ jobs:
       - name: Generate Report
         if: always()
         run: |
+          pip install tabulate
           python utils/log_reports.py >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
The last step of the workflow doesn't do `source activate accelerate` so `tabulate` isn't installed. Ensures that when needed, tabulate is available. 