### PR TITLE
Raise error when logging improperly

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -41,6 +41,10 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         Accepts a new kwarg of `main_process_only`, which will dictate whether it will be logged across all processes
         or only the main executed one. Default is `True` if not passed
         """
+        if PartialState._shared_state == {}:
+            raise RuntimeError(
+                "You must create a `PartialState` through either `PartialState()` or `Accelerator()` before using the logging utility."
+            )
         main_process_only = kwargs.pop("main_process_only", True)
         if self.isEnabledFor(level) and self._should_log(main_process_only):
             msg, kwargs = self.process(msg, kwargs)

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -43,7 +43,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         """
         if PartialState._shared_state == {}:
             raise RuntimeError(
-                "You must create a `PartialState` through either `PartialState()` or `Accelerator()` before using the logging utility."
+                "You must initialize the accelerate state by calling either `PartialState()` or `Accelerator()` before using the logging utility."
             )
         main_process_only = kwargs.pop("main_process_only", True)
         if self.isEnabledFor(level) and self._should_log(main_process_only):


### PR DESCRIPTION
A user cannot call the logging utility in `Accelerate` without first building the state in some form. This PR introduces an error raising it as such and fixes https://github.com/huggingface/accelerate/issues/1445