### PR TITLE
Fix ci reporter

### DIFF
--- a/utils/log_reports.py
+++ b/utils/log_reports.py
@@ -53,6 +53,7 @@ for log in Path().glob("*.log"):
     log.unlink()
 
 message = ""
+all_files2failed = []
 if total_num_failed > 0:
     for name, num_failed, failed_tests in group_info:
         if num_failed > 0:
@@ -85,6 +86,7 @@ if total_num_failed > 0:
                 stralign="right",
             )
             message += f"\n```\n{failed_table}\n```"
+            all_files2failed.append(files2failed)
     if len(message) > 3000:
         err = "Too many failed tests, please see the full report in the Action results."
         offset = len(err) + 10
@@ -137,25 +139,26 @@ if os.environ.get("TEST_TYPE", "") != "":
         payload.append(date_report)
     response = client.chat_postMessage(channel="#accelerate-ci-daily", text=message, blocks=payload)
     ts = response.data["ts"]
-    for test_location, test_failures in files2failed.items():
-        # Keep only the first instance of the test name
-        test_class = ""
-        for i, row in enumerate(test_failures):
-            if row[0] != test_class:
-                test_class = row[0]
-            else:
-                test_failures[i][0] = ""
+    for failed_file in all_files2failed:
+        for test_location, test_failures in failed_file.items():
+            # Keep only the first instance of the test name
+            test_class = ""
+            for i, row in enumerate(test_failures):
+                if row[0] != test_class:
+                    test_class = row[0]
+                else:
+                    test_failures[i][0] = ""
 
-        payload = {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"Test location: {test_location}\n```\n{tabulate(test_failures, headers=['Class', 'Test'], tablefmt=hf_table_format, stralign='right')}\n```",
-            },
-        }
+            payload = {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"Test location: {test_location}\n```\n{tabulate(test_failures, headers=['Class', 'Test'], tablefmt=hf_table_format, stralign='right')}\n```",
+                },
+            }
 
-        client.chat_postMessage(
-            channel="#accelerate-ci-daily",
-            thread_ts=ts,
-            blocks=[payload],
-        )
+            client.chat_postMessage(
+                channel="#accelerate-ci-daily",
+                thread_ts=ts,
+                blocks=[payload],
+            )


### PR DESCRIPTION
Small fix on the CI reporter where `files2failed` wasn't being made for the section on creating a list of messages on what failed, leading to an error and causing an all passing message to never be sent. 