### PR TITLE
Document how to use commands with python module instead of argparse

### DIFF
--- a/docs/source/basic_tutorials/launch.mdx
+++ b/docs/source/basic_tutorials/launch.mdx
@@ -147,7 +147,7 @@ If you want to execute the script with any other python flags, you can pass them
 the below example enabling unbuffered stdout and stderr:
 
 ```bash
-python -m -u accelerate.commands.launch --num_processes=2 {script_name.py} {--arg1} {--arg2}
+python -u -m accelerate.commands.launch --num_processes=2 {script_name.py} {--arg1} {--arg2}
 ```
 
 

--- a/docs/source/basic_tutorials/launch.mdx
+++ b/docs/source/basic_tutorials/launch.mdx
@@ -140,6 +140,13 @@ You can also launch your script utilizing the launch CLI as a python module itse
 launching behaviors. To do so, use `accelerate.commands.launch` instead of `accelerate launch`:
 
 ```bash
+python -m accelerate.commands.launch --num_processes=2 {script_name.py} {--arg1} {--arg2}
+```
+
+If you want to execute the script with any other python flags, you can pass them in as well similar to `-m`, such as 
+the below example enabling unbuffered stdout and stderr:
+
+```bash
 python -m -u accelerate.commands.launch --num_processes=2 {script_name.py} {--arg1} {--arg2}
 ```
 

--- a/docs/source/basic_tutorials/launch.mdx
+++ b/docs/source/basic_tutorials/launch.mdx
@@ -136,6 +136,14 @@ For a visualization of this difference, that earlier `accelerate launch` on mult
 MIXED_PRECISION="fp16" torchrun --nproc_per_node=2 --num_machines=1 {script_name.py} {--arg1} {--arg2} ...
 ```
 
+You can also launch your script utilizing the launch CLI as a python module itself, enabling the ability to pass in other python-specific
+launching behaviors. To do so, use `accelerate.commands.launch` instead of `accelerate launch`:
+
+```bash
+python -m -u accelerate.commands.launch --num_processes=2 {script_name.py} {--arg1} {--arg2}
+```
+
+
 ## Why you should always use `accelerate config`
 
 Why is it useful to the point you should **always** run `accelerate config`? 

--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -83,7 +83,7 @@ accelerate config update [arguments]
 
 **Command**:
 
-`accelerate env` or `accelerate-env`
+`accelerate env` or `accelerate-env` or `python -m accelerate.commands.env`
 
 Lists the contents of the passed 🤗 Accelerate configuration file. Should always be used when opening an issue on the [GitHub repository](https://github.com/huggingface/accelerate).
 
@@ -103,7 +103,7 @@ accelerate env [arguments]
 
 **Command**:
 
-`accelerate launch` or `accelerate-launch`
+`accelerate launch` or `accelerate-launch` or `python -m accelerate.commands.launch`
 
 Launches a specified script on a distributed system with the right parameters.
 


### PR DESCRIPTION
Documents how to use `python -m` when running launch instead of using the CLI. cc @stas00 

Also documents the other available module-calling option: `env`