### PR TITLE
*Critical Fix* Check for xpu specifically and disable when using GPUs

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -87,13 +87,17 @@ def is_fp8_available():
 @lru_cache()
 def is_tpu_available(check_device=True):
     "Checks if `torch_xla` is installed and potentially if a TPU is in the environment"
-    if _tpu_available and check_device:
-        try:
-            # Will raise a RuntimeError if no XLA configuration is found
-            _ = xm.xla_device()
-            return True
-        except RuntimeError:
+    # Due to bugs on the amp series GPUs, we disable torch-xla on them
+    if _tpu_available:
+        if _torch_distributed_available:
             return False
+        if check_device:
+            try:
+                # Will raise a RuntimeError if no XLA configuration is found
+                _ = xm.xla_device()
+                return True
+            except RuntimeError:
+                return False
     return _tpu_available
 
 


### PR DESCRIPTION
Should solve https://github.com/huggingface/accelerate/issues/788 (*finally*) by disabling the use of torch-xla when on a GPU. While they have GPU support currently it will break amp series GPUs, so as a safety precaution until it becomes more stable we are disabling it entirely unless they are running on a TPU.

Will be testing in a moment on some A100's as well. 