### PR TITLE
Split tensors as part of `split_between_processes`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -544,8 +544,7 @@ class Accelerator:
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
                 number of elements. Useful when trying to perform actions such as `Accelerator.gather()` on the
-                outputs. If so, just remember to drop the padded elements afterwards. If `inputs` contains a `tensor`
-                to be split, it will be padded with `-1` to keep consistent with padding of the last value.
+                outputs. If so, just remember to drop the padded elements afterwards.
 
         Example:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -531,7 +531,7 @@ class Accelerator:
         return self.state.mixed_precision
 
     @contextmanager
-    def split_between_processes(self, inputs: list | tuple | dict, apply_padding: bool = False):
+    def split_between_processes(self, inputs: list | tuple | dict | torch.Tensor, apply_padding: bool = False):
         """
         Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.
@@ -539,12 +539,13 @@ class Accelerator:
         Note that when using a `dict`, all keys need to have the same number of elements.
 
         Args:
-            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`):
+            inputs (`list`, `tuple`, `torch.Tensor`, or `dict` of `list`/`tuple`/`torch.Tensor`):
                 The input to split between processes.
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
-                number of elements. Useful when trying to perform actions such as `Accelerator.gather()` on the
-                outputs. If so, just remember to drop the padded elements afterwards.
+                number of elements. Useful when trying to perform actions such as `Accelerator.gather()` on the outputs
+                or passing in less inputs than there are processes. If so, just remember to drop the padded elements
+                afterwards.
 
         Example:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -544,7 +544,8 @@ class Accelerator:
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
                 number of elements. Useful when trying to perform actions such as `Accelerator.gather()` on the
-                outputs. If so, just remember to drop the padded elements afterwards.
+                outputs. If so, just remember to drop the padded elements afterwards. If `inputs` contains a `tensor`
+                to be split, it will be padded with `-1` to keep consistent with padding of the last value.
 
         Example:
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -403,8 +403,8 @@ class PartialState:
                         from accelerate.utils import pad_across_processes, send_to_device
 
                         # The tensor needs to be on the device before we can pad it
-                        result = send_to_device(result, self.device)
-                        result = pad_across_processes(result, pad_index=-1)
+                        tensorized_result = send_to_device(result, self.device)
+                        result = pad_across_processes(tensorized_result, pad_index=inputs[-1])
                     else:
                         result += [result[-1]] * (num_samples_per_process - len(result))
                 return result

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -36,6 +36,7 @@ from .utils import (
     is_mps_available,
     is_tpu_available,
     is_xpu_available,
+    pad_across_processes,
     parse_choice_from_env,
     parse_flag_from_env,
 )
@@ -398,7 +399,10 @@ class PartialState:
             if isinstance(inputs, (list, tuple, torch.Tensor)):
                 result = inputs[start_index:end_index]
                 if apply_padding:
-                    result += [result[-1]] * (num_samples_per_process - len(result))
+                    if isinstance(result, torch.Tensor):
+                        result = pad_across_processes(result, pad_index=-1)
+                    else:
+                        result += [result[-1]] * (num_samples_per_process - len(result))
                 return result
             elif isinstance(inputs, dict):
                 for key in inputs.keys():

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -404,7 +404,7 @@ class PartialState:
 
                         # The tensor needs to be on the device before we can pad it
                         result = send_to_device(result, self.device)
-                        result = pad_across_processes(result, pad_index=result[-1])
+                        result = pad_across_processes(result, pad_index=-1)
                     else:
                         result += [result[-1]] * (num_samples_per_process - len(result))
                 return result

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -352,7 +352,8 @@ class PartialState:
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
                 number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
-                just remember to drop the padded elements afterwards.
+                just remember to drop the padded elements afterwards. If `inputs` contains a `tensor` to be split, it
+                will be padded with `-1` to keep consistent with padding of the last value.
 
 
         Example:
@@ -830,7 +831,8 @@ class AcceleratorState:
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
                 number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
-                just remember to drop the padded elements afterwards.
+                just remember to drop the padded elements afterwards. If `inputs` contains a `tensor` to be split, it
+                will be padded with `-1` to keep consistent with padding of the last value.
 
 
         Example:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -404,7 +404,7 @@ class PartialState:
 
                         # The tensor needs to be on the device before we can pad it
                         result = send_to_device(result, self.device)
-                        result = pad_across_processes(result, pad_index=-1)
+                        result = pad_across_processes(result, pad_index=result[-1])
                     else:
                         result += [result[-1]] * (num_samples_per_process - len(result))
                 return result

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -339,7 +339,7 @@ class PartialState:
             self.wait_for_everyone()
 
     @contextmanager
-    def split_between_processes(self, inputs: list | tuple | dict, apply_padding: bool = False):
+    def split_between_processes(self, inputs: list | tuple | dict | torch.Tensor, apply_padding: bool = False):
         """
         Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.
@@ -347,12 +347,12 @@ class PartialState:
         Note that when using a `dict`, all keys need to have the same number of elements.
 
         Args:
-            inputs (`list`, `tuple`, or `dict`):
+            inputs (`list`, `tuple`, `torch.Tensor`, or `dict` of `list`/`tuple`/`torch.Tensor`):
                 The input to split between processes.
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
-                number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
-                just remember to drop the padded elements afterwards.
+                number of elements. Useful when trying to perform actions such as `gather()` on the outputs or passing
+                in less inputs than there are processes. If so, just remember to drop the padded elements afterwards.
 
 
         Example:
@@ -817,7 +817,7 @@ class AcceleratorState:
         PartialState().wait_for_everyone()
 
     @contextmanager
-    def split_between_processes(self, inputs: list | tuple | dict, apply_padding: bool = False):
+    def split_between_processes(self, inputs: list | tuple | dict | torch.Tensor, apply_padding: bool = False):
         """
         Splits `input` between `self.num_processes` quickly and can be then used on that process. Useful when doing
         distributed inference, such as with different prompts.
@@ -825,12 +825,12 @@ class AcceleratorState:
         Note that when using a `dict`, all keys need to have the same number of elements.
 
         Args:
-            inputs (`list`, `tuple`, or `dict` of `list`/`tuple`):
+            inputs (`list`, `tuple`, `torch.Tensor`, or `dict` of `list`/`tuple`/`torch.Tensor`):
                 The input to split between processes.
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
-                number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
-                just remember to drop the padded elements afterwards.
+                number of elements. Useful when trying to perform actions such as `gather()` on the outputs or passing
+                in less inputs than there are processes. If so, just remember to drop the padded elements afterwards.
 
 
         Example:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -399,7 +399,10 @@ class PartialState:
                 result = inputs[start_index:end_index]
                 if apply_padding:
                     if isinstance(result, torch.Tensor):
-                        from accelerate.utils import pad_across_processes
+                        from accelerate.utils import pad_across_processes, send_to_device
+
+                        # The tensor needs to be on the device before we can pad it
+                        result = send_to_device(result, self.device)
                         result = pad_across_processes(result, pad_index=-1)
                     else:
                         result += [result[-1]] * (num_samples_per_process - len(result))

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -36,7 +36,6 @@ from .utils import (
     is_mps_available,
     is_tpu_available,
     is_xpu_available,
-    pad_across_processes,
     parse_choice_from_env,
     parse_flag_from_env,
 )
@@ -400,6 +399,7 @@ class PartialState:
                 result = inputs[start_index:end_index]
                 if apply_padding:
                     if isinstance(result, torch.Tensor):
+                        from accelerate.utils import pad_across_processes
                         result = pad_across_processes(result, pad_index=-1)
                     else:
                         result += [result[-1]] * (num_samples_per_process - len(result))

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -352,8 +352,7 @@ class PartialState:
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
                 number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
-                just remember to drop the padded elements afterwards. If `inputs` contains a `tensor` to be split, it
-                will be padded with `-1` to keep consistent with padding of the last value.
+                just remember to drop the padded elements afterwards.
 
 
         Example:
@@ -831,8 +830,7 @@ class AcceleratorState:
             apply_padding (`bool`, `optional`, defaults to `False`):
                 Whether to apply padding by repeating the last element of the input so that all processes have the same
                 number of elements. Useful when trying to perform actions such as `gather()` on the outputs. If so,
-                just remember to drop the padded elements afterwards. If `inputs` contains a `tensor` to be split, it
-                will be padded with `-1` to keep consistent with padding of the last value.
+                just remember to drop the padded elements afterwards.
 
 
         Example:

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -503,6 +503,17 @@ def test_split_between_processes_nested_dict():
                 ), f"Did not obtain expected values on process 4, expected `{data['c'][3]}`, received: {results['c']}"
 
 
+def test_split_between_processes_tensor():
+    state = AcceleratorState()
+    if state.num_processes > 1:
+        data = torch.tensor([0, 1, 2, 3], [4, 5, 6, 7]).to(state.device)
+        with state.split_between_processes(data) as results:
+            if state.process_index == 0:
+                assert torch.allclose(results, torch.tensor([0, 1, 2, 3]))
+            else:
+                assert torch.allclose(results, torch.tensor([4, 5, 6, 7]))
+
+
 def main():
     accelerator = Accelerator()
     state = accelerator.state
@@ -520,6 +531,10 @@ def main():
     if state.local_process_index == 0:
         print("\n**Test split between processes as a dict**")
     test_split_between_processes_nested_dict()
+
+    if state.local_process_index == 0:
+        print("\n**Test split between processes as a tensor**")
+    test_split_between_processes_tensor()
 
     if state.local_process_index == 0:
         print("\n**Test random number generator synchronization**")

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -506,7 +506,7 @@ def test_split_between_processes_nested_dict():
 def test_split_between_processes_tensor():
     state = AcceleratorState()
     if state.num_processes > 1:
-        data = torch.tensor([0, 1, 2, 3], [4, 5, 6, 7]).to(state.device)
+        data = torch.tensor([[0, 1, 2, 3], [4, 5, 6, 7]]).to(state.device)
         with state.split_between_processes(data) as results:
             if state.process_index == 0:
                 assert torch.allclose(results, torch.tensor([0, 1, 2, 3]))


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1400 by also letting the tensors be split if added. Note that similar to the list version, the tensors padded will have the value of the last item in the tensor being used. Such that on four processes:

```python
t = torch.tensor([[0,1,2,3], [4,5,6,7]])
with PartialState().split_between_processes(t) as t:
    print(t)
# Process 1:
tensor([[0,1,2,3]])
# Process 2:
tensor([[4,5,6,7]])
# Process 3:
tensor([[4,5,6,7]])
# Process 4:
tensor([[4,5,6,7]])
```