### PR TITLE
Fix gradient state bugs in multiple dataloader

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -300,13 +300,16 @@ class IterableDatasetShard(IterableDataset):
 
 class DataLoaderStateMixin:
     """
-    Mixin class that adds a state to a `DataLoader` to keep track of the status inside the dataloader such as at the end of the iteration, the number of items in the dataset in the last batch relative to the batch size, and other useful information that might be needed.
-    
+    Mixin class that adds a state to a `DataLoader` to keep track of the status inside the dataloader such as at the
+    end of the iteration, the number of items in the dataset in the last batch relative to the batch size, and other
+    useful information that might be needed.
+
     **Available attributes:**
-    
+
         - **end_of_dataloader** (`bool`) -- Whether at the last iteration or batch
-        - **remainder** (`int`) -- The number of items that are remaining in the last batch, relative to the total batch size
-    
+        - **remainder** (`int`) -- The number of items that are remaining in the last batch, relative to the total
+          batch size
+
     """
 
     def __init_subclass__(cls, **kwargs):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -298,7 +298,18 @@ class IterableDatasetShard(IterableDataset):
                 yield current_batch[i]
 
 
-class DataLoaderShard(DataLoader):
+class DataLoaderStateMixin:
+    """
+    Mixin class that adds state to a `DataLoader` to keep track of the current state such as is end of dataloader or
+    not and the remainder of the current batch, etc.
+    """
+
+    def __init_subclass__(cls, **kwargs):
+        cls.end_of_dataloader = False
+        cls.remainder = -1
+
+
+class DataLoaderShard(DataLoader, DataLoaderStateMixin):
     """
     Subclass of a PyTorch `DataLoader` that will deal with device placement and current distributed setup.
 
@@ -346,7 +357,7 @@ class DataLoaderShard(DataLoader):
         # We can safely pass because the default is -1
         with suppress(Exception):
             length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
-            self.gradient_state._set_remainder(length % self.total_batch_size)
+            self.remainder = length % self.total_batch_size
         dataloader_iter = super().__iter__()
         # We iterate one batch ahead to check when we are at the end
         try:
@@ -366,10 +377,11 @@ class DataLoaderShard(DataLoader):
                 batch_index += 1
                 current_batch = next_batch
             except StopIteration:
-                self.gradient_state._remove_dataloader(self)
+                self.end_of_dataloader = True
                 if batch_index >= self.skip_batches:
                     yield current_batch
                 break
+        self.gradient_state._remove_dataloader(self)
 
     @property
     def total_batch_size(self):
@@ -390,6 +402,7 @@ class DataLoaderShard(DataLoader):
 
 if is_tpu_available(check_device=False):
     import torch_xla.distributed.parallel_loader as xpl
+
 
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
         """
@@ -428,7 +441,7 @@ if is_tpu_available(check_device=False):
             return self._loader.total_dataset_length
 
 
-class DataLoaderDispatcher(DataLoader):
+class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
     """
     Subclass of a PyTorch `DataLoader` that will iterate and preprocess on process 0 only, then dispatch on each
     process their part of the batch.
@@ -477,7 +490,7 @@ class DataLoaderDispatcher(DataLoader):
         # We can safely pass because the default is -1
         with suppress(Exception):
             length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
-            self.gradient_state._set_remainder(length % self.total_batch_size)
+            self.remainder = length % self.total_batch_size
 
     def _fetch_batches(self, iterator):
         batches, batch = None, None
@@ -563,11 +576,12 @@ class DataLoaderDispatcher(DataLoader):
             batch = slice_tensors(batch, data_slice)
 
             if stop_iteration:
-                self.gradient_state._remove_dataloader(self)
-                self.gradient_state._set_remainder(observed_batch_size)
+                self.end_of_dataloader = True
+                self.remainder = observed_batch_size
             if batch_index >= self.skip_batches:
                 yield batch
             batch_index += 1
+        self.gradient_state._remove_dataloader(self)
 
     def __len__(self):
         whole_length = super().__len__()

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -300,8 +300,13 @@ class IterableDatasetShard(IterableDataset):
 
 class DataLoaderStateMixin:
     """
-    Mixin class that adds state to a `DataLoader` to keep track of the current state such as is end of dataloader or
-    not and the remainder of the current batch, etc.
+    Mixin class that adds a state to a `DataLoader` to keep track of the status inside the dataloader such as at the end of the iteration, the number of items in the dataset in the last batch relative to the batch size, and other useful information that might be needed.
+    
+    **Available attributes:**
+    
+        - **end_of_dataloader** (`bool`) -- Whether at the last iteration or batch
+        - **remainder** (`int`) -- The number of items that are remaining in the last batch, relative to the total batch size
+    
     """
 
     def __init_subclass__(cls, **kwargs):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -403,7 +403,6 @@ class DataLoaderShard(DataLoader, DataLoaderStateMixin):
 if is_tpu_available(check_device=False):
     import torch_xla.distributed.parallel_loader as xpl
 
-
     class MpDeviceLoaderWrapper(xpl.MpDeviceLoader):
         """
         Wrapper for the xpl.MpDeviceLoader class that knows the total batch size.

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -930,12 +930,14 @@ class GradientState:
 
     @property
     def end_of_dataloader(self) -> bool:
+        "Returns whether we have reached the end of the current dataloader"
         if not self.in_dataloader:
             return False
         return self.active_dataloader.end_of_dataloader
 
     @property
     def remainder(self) -> int:
+        "Returns the number of extra samples that were added from padding the dataloader"
         if not self.in_dataloader:
             return -1
         return self.active_dataloader.remainder

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -905,8 +905,6 @@ class GradientState:
         self.__dict__ = self._shared_state
         if not self.initialized:
             self.sync_gradients = True
-            self.end_of_dataloader = False
-            self.remainder = -1
             self.active_dataloader = None
             self.dataloader_references = [None]
             self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
@@ -930,6 +928,18 @@ class GradientState:
         "Returns whether the `GradientState` has been initialized"
         return GradientState._shared_state != {}
 
+    @property
+    def end_of_dataloader(self) -> bool:
+        if not self.in_dataloader:
+            return False
+        return self.active_dataloader.end_of_dataloader
+
+    @property
+    def remainder(self) -> int:
+        if not self.in_dataloader:
+            return -1
+        return self.active_dataloader.remainder
+
     def __repr__(self):
         return (
             f"Sync Gradients: {self.sync_gradients}\n"
@@ -942,25 +952,15 @@ class GradientState:
         "Private function that sets whether gradients should be synchronized. Users should not have to call this."
         self.sync_gradients = sync_gradients
 
-    def _set_end_of_dataloader(self, end_of_dataloader):
-        "Private function that sets whether the end of the current dataloader has been reached. Users should not have to call this."
-        self.end_of_dataloader = end_of_dataloader
-
-    def _set_remainder(self, remainder):
-        "Private function that sets the number of remaining samples at the end of the dataloader. Users should not have to call this."
-        self.remainder = remainder
-
     def _add_dataloader(self, dataloader):
         "Private function that adds a dataloader to `self.dataloader_references` and sets `in_dataloader` to `True`. Users should not have to call this."
         self.active_dataloader = dataloader
         self.dataloader_references.append(self.active_dataloader)
-        self._set_end_of_dataloader(False)
 
     def _remove_dataloader(self, dataloader):
         "Private function that removes a dataloader from `self.dataloader_references` and sets `in_dataloader` to `False` if there are no more dataloaders. Users should not have to call this."
         self.dataloader_references.remove(dataloader)
         self.active_dataloader = self.dataloader_references[-1]
-        self._set_end_of_dataloader(True)
 
     @property
     def in_dataloader(self) -> bool:


### PR DESCRIPTION
1. Add `DataLoaderStateMixin`: Each dataloader should have it own states like `end_of_dataloader` and `remainder`
2. Changed `_remove_dataloader`: This should be called after last `yield`. Otherwise the active dataloader will be wrong in the last iteration.
3. Changed test: active_dataloader should be the current dataloader whether is the last iteration or not.

Solves #1050

@muellerzr 