### PR TITLE
adjust overriding of model's forward function

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1305,9 +1305,9 @@ class Accelerator:
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = MethodType(torch.cuda.amp.autocast(dtype=torch.float16)(model.forward.__func__), model)
             elif self.mixed_precision == "bf16" and self.distributed_type != DistributedType.TPU:
-                model.forward = torch.autocast(device_type=self.device.type, dtype=torch.bfloat16)(model.forward)
+                model.forward = MethodType(torch.autocast(device_type=self.device.type, dtype=torch.bfloat16)(model.forward.__func__), model)
             else:
-                model.forward = torch.cuda.amp.autocast()(model.forward)
+                model.forward = MethodType(torch.cuda.amp.autocast()(model.forward.__func__), model)
             model.forward = MethodType(convert_outputs_to_fp32(model.forward.__func__), model)
         elif self.mixed_precision == "fp8":
             if not has_transformer_engine_layers(model):
@@ -1330,7 +1330,7 @@ class Accelerator:
                     "insufficient for FP8 mixed precision training (requires a GPU Hopper/Ada Lovelace "
                     "or higher, compute capability of 8.9 or higher). Will use FP16 instead."
                 )
-            model.forward = fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe)(model.forward)
+            model.forward = MethodType(fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe)(model.forward.__func__), model)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         # torch.compile should be called last.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1305,7 +1305,9 @@ class Accelerator:
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
                 model.forward = MethodType(torch.cuda.amp.autocast(dtype=torch.float16)(model.forward.__func__), model)
             elif self.mixed_precision == "bf16" and self.distributed_type != DistributedType.TPU:
-                model.forward = MethodType(torch.autocast(device_type=self.device.type, dtype=torch.bfloat16)(model.forward.__func__), model)
+                model.forward = MethodType(
+                    torch.autocast(device_type=self.device.type, dtype=torch.bfloat16)(model.forward.__func__), model
+                )
             else:
                 model.forward = MethodType(torch.cuda.amp.autocast()(model.forward.__func__), model)
             model.forward = MethodType(convert_outputs_to_fp32(model.forward.__func__), model)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1330,7 +1330,7 @@ class Accelerator:
                     "insufficient for FP8 mixed precision training (requires a GPU Hopper/Ada Lovelace "
                     "or higher, compute capability of 8.9 or higher). Will use FP16 instead."
                 )
-            model.forward = MethodType(fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe)(model.forward.__func__), model)
+            model.forward = fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe)(model.forward)
         if self.distributed_type == DistributedType.TPU and self.state.fork_launched:
             model = xmp.MpModelWrapper(model).to(self.device)
         # torch.compile should be called last.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1303,12 +1303,12 @@ class Accelerator:
         if self.native_amp:
             model._original_forward = model.forward
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
-                model.forward = MethodType(torch.cuda.amp.autocast(dtype=torch.float16)(model.forward), model)
+                model.forward = MethodType(torch.cuda.amp.autocast(dtype=torch.float16)(model.forward.__func__), model)
             elif self.mixed_precision == "bf16" and self.distributed_type != DistributedType.TPU:
                 model.forward = torch.autocast(device_type=self.device.type, dtype=torch.bfloat16)(model.forward)
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
-            model.forward = MethodType(convert_outputs_to_fp32(model.forward), model)
+            model.forward = MethodType(convert_outputs_to_fp32(model.forward.__func__), model)
         elif self.mixed_precision == "fp8":
             if not has_transformer_engine_layers(model):
                 with torch.no_grad():

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -25,6 +25,7 @@ import warnings
 from collections import OrderedDict
 from contextlib import contextmanager
 from functools import partial
+from types import MethodType
 from typing import Any, Callable
 
 import torch
@@ -1302,12 +1303,12 @@ class Accelerator:
         if self.native_amp:
             model._original_forward = model.forward
             if self.mixed_precision == "fp16" and is_torch_version(">=", "1.10"):
-                model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
+                model.forward = MethodType(torch.cuda.amp.autocast(dtype=torch.float16)(model.forward), model)
             elif self.mixed_precision == "bf16" and self.distributed_type != DistributedType.TPU:
                 model.forward = torch.autocast(device_type=self.device.type, dtype=torch.bfloat16)(model.forward)
             else:
                 model.forward = torch.cuda.amp.autocast()(model.forward)
-            model.forward = convert_outputs_to_fp32(model.forward)
+            model.forward = MethodType(convert_outputs_to_fp32(model.forward), model)
         elif self.mixed_precision == "fp8":
             if not has_transformer_engine_layers(model):
                 with torch.no_grad():


### PR DESCRIPTION
During ONNX Runtime optimization, the forward function's signature is inspected to perform downstream tasks. The current way of overriding the model's forward function results in the following error:

`AttributeError: 'function' object has no attribute '__func__'`

This PR improves the function signature override by using `types.MethodType` which doesn't impact the function signature for downstream tasks.