### PR TITLE
Only use IPEX if available

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -322,11 +322,12 @@ class Accelerator:
             if not is_megatron_lm_available():
                 raise ImportError("Megatron is not installed. please build it from source.")
 
-        if ipex_plugin is None and is_ipex_available():  # init from env variables
-            ipex_plugin = IntelPyTorchExtensionPlugin()
-        else:
-            if not isinstance(ipex_plugin, IntelPyTorchExtensionPlugin):
-                raise TypeError("`ipex_plugin` must be a IntelPyTorchExtensionPlugin object.")
+        if is_ipex_available():
+            if ipex_plugin is None:  # init from env variables
+                ipex_plugin = IntelPyTorchExtensionPlugin()
+            else:
+                if not isinstance(ipex_plugin, IntelPyTorchExtensionPlugin):
+                    raise TypeError("`ipex_plugin` must be a IntelPyTorchExtensionPlugin object.")
 
         # Kwargs handlers
         self.ddp_handler = None

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -322,7 +322,7 @@ class Accelerator:
             if not is_megatron_lm_available():
                 raise ImportError("Megatron is not installed. please build it from source.")
 
-        if ipex_plugin is None:  # init from env variables
+        if ipex_plugin is None and is_ipex_available():  # init from env variables
             ipex_plugin = IntelPyTorchExtensionPlugin()
         else:
             if not isinstance(ipex_plugin, IntelPyTorchExtensionPlugin):


### PR DESCRIPTION
Currently will fail with the transformers integration because IPEX is *always* used due to the presence of the plugin, when it should only exist when being used/actually available. 

<s>In a follow-up PR I will change this to use an env variable as well, as the "create a plugin by default" breaks our norm</s>