### PR TITLE
fix the issue that ipex is always imported if it's installed in python env.

### DIFF
--- a/docs/source/usage_guides/ipex.mdx
+++ b/docs/source/usage_guides/ipex.mdx
@@ -74,7 +74,7 @@ compute_environment: LOCAL_MACHINE
 distributed_type: 'NO'
 downcast_bf16: 'no'
 ipex_config:
-  ipex_enabled: true
+  ipex: true
 machine_rank: 0
 main_training_function: main
 mixed_precision: bf16
@@ -126,7 +126,7 @@ compute_environment: LOCAL_MACHINE
 distributed_type: MULTI_CPU
 downcast_bf16: 'no'
 ipex_config:
-  ipex_enabled: true
+  ipex: true
 machine_rank: 0
 main_process_ip: 36.112.23.24
 main_process_port: 29500

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -49,7 +49,6 @@ from .utils import (
     GradientAccumulationPlugin,
     GradScalerKwargs,
     InitProcessGroupKwargs,
-    IntelPyTorchExtensionPlugin,
     KwargsHandler,
     LoggerType,
     MegatronLMPlugin,
@@ -165,9 +164,6 @@ class Accelerator:
         megatron_lm_plugin (`MegatronLMPlugin`, *optional*):
             Tweak your MegatronLM related args using this argument. This argument is optional and can be configured
             directly using *accelerate config*
-        ipex_plugin (`IntelExtensionPlugin`, *optional*):
-            Tweak your Intel Extension for PyTorch related args using this argument for CPU and XPU. This argument is
-            optional and can be configured directly using *accelerate config*
         rng_types (list of `str` or [`~utils.RNGType`]):
             The list of random number generators to synchronize at the beginning of each iteration in your prepared
             dataloaders. Should be one or several of:
@@ -239,7 +235,6 @@ class Accelerator:
         deepspeed_plugin: DeepSpeedPlugin | None = None,
         fsdp_plugin: FullyShardedDataParallelPlugin | None = None,
         megatron_lm_plugin: MegatronLMPlugin | None = None,
-        ipex_plugin: IntelPyTorchExtensionPlugin | None = None,
         rng_types: list[str | RNGType] | None = None,
         log_with: str | LoggerType | GeneralTracker | list[str | LoggerType | GeneralTracker] | None = None,
         project_dir: str | os.PathLike | None = None,
@@ -323,13 +318,6 @@ class Accelerator:
             if not is_megatron_lm_available():
                 raise ImportError("Megatron is not installed. please build it from source.")
 
-        if is_ipex_available():
-            if ipex_plugin is None:  # init from env variables
-                ipex_plugin = IntelPyTorchExtensionPlugin()
-            else:
-                if not isinstance(ipex_plugin, IntelPyTorchExtensionPlugin):
-                    raise TypeError("`ipex_plugin` must be a IntelPyTorchExtensionPlugin object.")
-
         # Kwargs handlers
         self.ddp_handler = None
         self.scaler_handler = None
@@ -369,7 +357,6 @@ class Accelerator:
             deepspeed_plugin=deepspeed_plugin,
             fsdp_plugin=fsdp_plugin,
             megatron_lm_plugin=megatron_lm_plugin,
-            ipex_plugin=ipex_plugin,
             _from_accelerator=True,
             **kwargs,
         )
@@ -1191,9 +1178,9 @@ class Accelerator:
             old_named_params = self._get_named_parameters(*args)
 
         if self.distributed_type in [DistributedType.MULTI_CPU, DistributedType.MULTI_XPU, DistributedType.NO]:
-            if self.device.type == "cpu" and self.state.ipex_plugin is not None:
+            if self.device.type == "cpu" and self.state.use_ipex:
                 args = self._prepare_ipex(*args)
-            elif self.device.type == "xpu" and self.state.ipex_plugin is not None and is_xpu_available():
+            elif self.device.type == "xpu" and is_xpu_available():
                 args = self._prepare_ipex(*args)
         if self.distributed_type == DistributedType.DEEPSPEED:
             result = self._prepare_deepspeed(*args)
@@ -1669,7 +1656,7 @@ class Accelerator:
                 optimizer = obj
         if optimizer is not None and model is not None:
             dtype = torch.bfloat16 if self.state.mixed_precision == "bf16" else torch.float32
-            if is_xpu_available() and self.device.type == "xpu":
+            if self.device.type == "xpu" and is_xpu_available():
                 model = model.to(self.device)
                 model, optimizer = torch.xpu.optimize(
                     model, optimizer=optimizer, dtype=dtype, inplace=True, level="O1"

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -401,11 +401,8 @@ def training_check():
     # IPEX support is only for CPU
     if is_ipex_available():
         print("ipex BF16 training check.")
-        from accelerate.utils.dataclasses import IntelPyTorchExtensionPlugin
-
         AcceleratorState._reset_state()
-        ipex_plugin = IntelPyTorchExtensionPlugin()
-        accelerator = Accelerator(mixed_precision="bf16", cpu=True, ipex_plugin=ipex_plugin)
+        accelerator = Accelerator(mixed_precision="bf16", cpu=True)
         train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
         model = RegressionModel()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
@@ -428,11 +425,8 @@ def training_check():
     # XPU support is only for XPU
     if is_xpu_available():
         print("xpu BF16 training check.")
-        from accelerate.utils.dataclasses import IntelPyTorchExtensionPlugin
-
         AcceleratorState._reset_state()
-        ipex_plugin = IntelPyTorchExtensionPlugin()
-        accelerator = Accelerator(mixed_precision="bf16", cpu=False, ipex_plugin=ipex_plugin)
+        accelerator = Accelerator(mixed_precision="bf16", cpu=False)
         train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
         model = RegressionModel()
         optimizer = torch.optim.SGD(model.parameters(), lr=0.1)

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -10,7 +10,6 @@ from .dataclasses import (
     GradientAccumulationPlugin,
     GradScalerKwargs,
     InitProcessGroupKwargs,
-    IntelPyTorchExtensionPlugin,
     KwargsHandler,
     LoggerType,
     MegatronLMPlugin,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1352,10 +1352,3 @@ class MegatronLMPlugin:
                 self.megatron_lm_default_args[key] = True
             elif key.startswith("no_log_"):
                 self.megatron_lm_default_args[key.replace("no_", "")] = True
-
-
-@dataclass
-class IntelPyTorchExtensionPlugin:
-    """
-    This plugin is used to enable Intel PyTorch Extension (IPEX).
-    """

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -210,6 +210,9 @@ def is_ipex_available():
 
 @lru_cache()
 def is_xpu_available(check_device=False):
+    "check if user disables it explicitly"
+    if not parse_flag_from_env("ACCELERATE_USE_XPU", default=True):
+        return False
     "Checks if `intel_extension_for_pytorch` is installed and potentially if a XPU is in the environment"
     if is_ipex_available():
         import torch

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -100,12 +100,9 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
     current_env["ACCELERATE_DYNAMO_USE_DYNAMIC"] = str(args.dynamo_use_dynamic)
 
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
-
     if is_ipex_available():
-        if (args.cpu or args.use_cpu) and args.ipex:
-            current_env["ACCELERATE_USE_IPEX"] = str(args.ipex).lower()
-        elif args.use_xpu and is_xpu_available():
-            current_env["ACCELERATE_USE_XPU"] = str(args.use_xpu).lower()
+        current_env["ACCELERATE_USE_IPEX"] = str(args.ipex).lower()
+        current_env["ACCELERATE_USE_XPU"] = str(args.use_xpu).lower()
     return cmd, current_env
 
 


### PR DESCRIPTION
 even we answer "NO" to "Do you want to use Intel PyTorch Extension (IPEX) to speed up training on CPU?" in accelerate config