### PR TITLE
[`bnb`] Add fp4 support for dispatch

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -191,6 +191,11 @@ def set_module_tensor_to_device(
                     elif module.bias is None:
                         # if no bias exists, we can quantize right away
                         module = module.cuda(device_index)
+            elif module.__class__.__name__ == "Linear4bit" and getattr(module.weight, "quant_state", None) is None:
+                # quantize only if necessary
+                device_index = torch.device(device).index if torch.device(device).type == "cuda" else None
+                if not getattr(module.weight, "quant_state", None) and device_index is not None:
+                    module.weight = module.weight.cuda(device_index)
 
 
 def named_module_tensors(module: nn.Module, include_buffers: bool = True, recurse: bool = False):

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -620,17 +620,19 @@ class BigModelingTester(unittest.TestCase):
     @slow
     @unittest.skip("Un-skip in the next transformers release")
     def test_dipatch_model_fp4_simple(self):
-        """Tests that `dispatch_model` quantizes int8 layers"""
+        """Tests that `dispatch_model` quantizes fp4 layers"""
         from huggingface_hub import hf_hub_download
         from transformers import AutoConfig, AutoModel, BitsAndBytesConfig
-        from transformers.utils.bitsandbytes import replace_8bit_linear
+        from transformers.utils.bitsandbytes import replace_with_bnb_linear
 
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
         quantization_config = BitsAndBytesConfig(load_in_4bit=True)
 
-        model = replace_8bit_linear(model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config)
+        model = replace_with_bnb_linear(
+            model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
+        )
 
         model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")
 
@@ -647,7 +649,9 @@ class BigModelingTester(unittest.TestCase):
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
-        model = replace_8bit_linear(model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config)
+        model = replace_with_bnb_linear(
+            model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
+        )
 
         # test with str device map
         model = load_checkpoint_and_dispatch(
@@ -662,7 +666,9 @@ class BigModelingTester(unittest.TestCase):
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
-        model = replace_8bit_linear(model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config)
+        model = replace_with_bnb_linear(
+            model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
+        )
 
         # test with torch.device device map
         model = load_checkpoint_and_dispatch(


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/accelerate/issues/1504

This PR applies the similar enhancement as #1228 for FP4 layers

Now the script below outputs the desired dtype:

```python
import torch
from transformers import AutoConfig, AutoModel, BitsAndBytesConfig
from transformers.utils.bitsandbytes import replace_8bit_linear

from accelerate import init_empty_weights
from huggingface_hub import hf_hub_download

from accelerate import load_checkpoint_and_dispatch


with init_empty_weights():
    model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))

quantization_config = BitsAndBytesConfig(
    load_in_4bit=True
)

model = replace_8bit_linear(model, quantization_config=quantization_config)

# For some reason replace_8bit_linear creates parameters with requires_grad=True but it's irrelevant rn
for p in model.parameters():
    p.requires_grad = False

model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")

model = load_checkpoint_and_dispatch(
    model,
    checkpoint=model_path,
    device_map="auto",
)

print(f"{model.h[0].self_attention.query_key_value.weight.device}\n{model.h[0].self_attention.query_key_value.weight.dtype}")
>>> torch.uint8
```

cc @sgugger @BlackSamorez 