### PR TITLE
Fix 4bit model on multiple devices

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1243,14 +1243,15 @@ class Accelerator:
                 has_hf_device_map = True
                 break
 
-        if getattr(model, "is_loaded_in_8bit", False) and getattr(model, "hf_device_map", False):
+        if (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)) and getattr(model, "hf_device_map", False):
             model_devices = set(model.hf_device_map.values())
             if len(model_devices) > 1:
                 raise ValueError(
                     "You can't train a model that has been loaded in 8-bit precision on multiple devices."
                 )
-
-            current_device_index = list(model_devices)[0]
+            current_device = list(model_devices)[0]
+            current_device_index = current_device.index if isinstance(current_device,torch.device) else current_device
+            
             if torch.device(current_device_index) != self.device:
                 # if on the first device (GPU 0) we don't care
                 if (self.device.index is not None) or (current_device_index != 0):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1243,15 +1243,17 @@ class Accelerator:
                 has_hf_device_map = True
                 break
 
-        if (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)) and getattr(model, "hf_device_map", False):
+        if (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)) and getattr(
+            model, "hf_device_map", False
+        ):
             model_devices = set(model.hf_device_map.values())
             if len(model_devices) > 1:
                 raise ValueError(
                     "You can't train a model that has been loaded in 8-bit precision on multiple devices."
                 )
             current_device = list(model_devices)[0]
-            current_device_index = current_device.index if isinstance(current_device,torch.device) else current_device
-            
+            current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device
+
             if torch.device(current_device_index) != self.device:
                 # if on the first device (GPU 0) we don't care
                 if (self.device.index is not None) or (current_device_index != 0):


### PR DESCRIPTION
This small PR fixes the issue when the user prepare a 4-bit model on multiple devices. It will return an error just like for the 8-bit model. Furthermore, i have fixed how we get the device index as the device_map values can be of type torch.device. 
