### PR TITLE
Swap env vars for XPU and IPEX + CLI

### DIFF
--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -176,7 +176,7 @@ The following arguments are only useful when `tpu` is passed or TPU training is 
 * `--main_training_function MAIN_TRAINING_FUNCTION` (`str`) -- The name of the main function to be executed in your script.
 * `--downcast_bf16` (`bool`) -- Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.
 
-**Ipex Arguments**:
+**IPEX Arguments**:
 
 The following arguments are only useful when `ipex` is passed or IPEX training is configured through `accelerate config`:
 

--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -154,6 +154,7 @@ The following arguments are useful for selecting which training paradigm to use.
 * `--use_deepspeed` (`bool`) -- Whether or not to use DeepSpeed for training.
 * `--use_fsdp` (`bool`) -- Whether or not to use FullyShardedDataParallel for training.
 * `--use_megatron_lm` (`bool`) -- Whether or not to use Megatron-LM for training.
+* `--use_xpu` (`bool`) -- Whether to use IPEX plugin to speed up training on XPU specifically.
 
 **Distributed GPU Arguments**:
 
@@ -175,12 +176,6 @@ The following arguments are only useful when `tpu` is passed or TPU training is 
 
 * `--main_training_function MAIN_TRAINING_FUNCTION` (`str`) -- The name of the main function to be executed in your script.
 * `--downcast_bf16` (`bool`) -- Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.
-
-**IPEX Arguments**:
-
-The following arguments are only useful when `ipex` is passed or IPEX training is configured through `accelerate config`:
-
-* `--use_xpu` (`bool`) -- Whether to use IPEX plugin to speed up training on XPU specifically.
 
 **DeepSpeed Arguments**:
 

--- a/docs/source/package_reference/cli.mdx
+++ b/docs/source/package_reference/cli.mdx
@@ -136,6 +136,7 @@ values. They can also be passed in manually.
 * `--cpu` (`bool`) -- Whether or not to force the training on the CPU.
 * `--multi_gpu` (`bool`) -- Whether or not this should launch a distributed GPU training.
 * `--tpu` (`bool`) -- Whether or not this should launch a TPU training.
+* `--ipex` (`bool`) -- Whether or not this should launch an Intel Pytorch Extension (IPEX) training.
 
 **Resource Selection Arguments**:
 
@@ -174,6 +175,12 @@ The following arguments are only useful when `tpu` is passed or TPU training is 
 
 * `--main_training_function MAIN_TRAINING_FUNCTION` (`str`) -- The name of the main function to be executed in your script.
 * `--downcast_bf16` (`bool`) -- Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.
+
+**Ipex Arguments**:
+
+The following arguments are only useful when `ipex` is passed or IPEX training is configured through `accelerate config`:
+
+* `--use_xpu` (`bool`) -- Whether to use IPEX plugin to speed up training on XPU specifically.
 
 **DeepSpeed Arguments**:
 

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -104,15 +104,14 @@ def get_cluster_input():
 
     ipex_config = {}
     if use_cpu:
-        ipex_config["ipex_enabled"] = _ask_field(
+        ipex_config["ipex"] = _ask_field(
             "Do you want to use Intel PyTorch Extension (IPEX) to speed up training on CPU? [yes/NO]:",
             _convert_yes_no_to_bool,
             default=False,
             error_message="Please enter yes or no.",
         )
-    xpu_config = {}
     if not use_cpu and is_xpu_available():
-        ipex_config["xpu_enabled"] = _ask_field(
+        ipex_config["use_xpu"] = _ask_field(
             "Do you want to use XPU plugin to speed up training on XPU? [yes/NO]:",
             _convert_yes_no_to_bool,
             default=False,
@@ -567,7 +566,6 @@ def get_cluster_input():
         fsdp_config=fsdp_config,
         megatron_lm_config=megatron_lm_config,
         ipex_config=ipex_config,
-        xpu_config=xpu_config,
         use_cpu=use_cpu,
         rdzv_backend=rdzv_backend,
         same_network=same_network,

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -170,8 +170,6 @@ class ClusterConfig(BaseConfig):
     megatron_lm_config: dict = None
     # args for ipex
     ipex_config: dict = None
-    # args for xpu
-    xpu_config: dict = None
     # args for TPU
     downcast_bf16: bool = False
 
@@ -197,8 +195,6 @@ class ClusterConfig(BaseConfig):
             self.megatron_lm_config = {}
         if self.ipex_config is None:
             self.ipex_config = {}
-        if self.xpu_config is None:
-            self.xpu_config = {}
         return super().__post_init__()
 
 

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -61,6 +61,7 @@ logger = logging.getLogger(__name__)
 options_to_group = {
     "--multi-gpu": "Distributed GPUs",
     "--tpu": "TPU",
+    "--ipex": "IPEX",
     "--use_deepspeed": "DeepSpeed Arguments",
     "--use_fsdp": "FSDP Arguments",
     "--use_megatron_lm": "Megatron-LM Arguments",
@@ -154,6 +155,12 @@ def launch_command_parser(subparsers=None):
     )
     hardware_args.add_argument(
         "--tpu", default=False, action="store_true", help="Whether or not this should launch a TPU training."
+    )
+    hardware_args.add_argument(
+        "--ipex",
+        default=False,
+        action="store_true",
+        help="Whether or not this should launch a Intel PyTorch Extension (IPEX) training.",
     )
 
     # Resource selection arguments
@@ -351,6 +358,15 @@ def launch_command_parser(subparsers=None):
         "--downcast_bf16",
         action="store_true",
         help="Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.",
+    )
+
+    # ipex args
+    ipex_args = parser.add_argument_group("IPEX", "Arguments related to training with Intel IPEX.")
+    ipex_args.add_argument(
+        "--xpu_enabled",
+        default=False,
+        action="store_true",
+        help="Whether to use IPEX plugin to speed up training on XPU specifically.",
     )
 
     # DeepSpeed arguments
@@ -571,23 +587,6 @@ def launch_command_parser(subparsers=None):
             "The full path to the script to be launched in parallel, followed by all the arguments for the training "
             "script."
         ),
-    )
-
-    # ipex args
-    ipex_args = parser.add_argument_group("IPEX Arguments", "Arguments related to IPEX.")
-    ipex_args.add_argument(
-        "--ipex_enabled",
-        default=False,
-        action="store_true",
-        help="Whether to use Intel PyTorch Extension (IPEX) to speed up training on CPU and XPU?",
-    )
-    # xpu args
-    xpu_args = parser.add_argument_group("XPU Arguments", "Arguments related to XPU.")
-    xpu_args.add_argument(
-        "--xpu_enabled",
-        default=False,
-        action="store_true",
-        help="Whether to use IPEX plugin to speed up training on XPU?",
     )
 
     # Other arguments of the training scripts

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -852,8 +852,6 @@ def _validate_launch_command(args):
                         setattr(args, k, defaults.dynamo_config[k])
                     for k in defaults.ipex_config:
                         setattr(args, k, defaults.ipex_config[k])
-                    for k in defaults.xpu_config:
-                        setattr(args, k, defaults.xpu_config[k])
                     continue
 
                 # Those args are handled separately

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -363,7 +363,7 @@ def launch_command_parser(subparsers=None):
     # ipex args
     ipex_args = parser.add_argument_group("IPEX", "Arguments related to training with Intel IPEX.")
     ipex_args.add_argument(
-        "--xpu_enabled",
+        "--use_xpu",
         default=False,
         action="store_true",
         help="Whether to use IPEX plugin to speed up training on XPU specifically.",

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -61,7 +61,6 @@ logger = logging.getLogger(__name__)
 options_to_group = {
     "--multi-gpu": "Distributed GPUs",
     "--tpu": "TPU",
-    "--ipex": "IPEX",
     "--use_deepspeed": "DeepSpeed Arguments",
     "--use_fsdp": "FSDP Arguments",
     "--use_megatron_lm": "Megatron-LM Arguments",
@@ -238,6 +237,12 @@ def launch_command_parser(subparsers=None):
         action="store_true",
         help="Whether to use Megatron-LM.",
     )
+    paradigm_args.add_argument(
+        "--use_xpu",
+        default=False,
+        action="store_true",
+        help="Whether to use IPEX plugin to speed up training on XPU specifically.",
+    )
 
     # distributed GPU training arguments
     distributed_args = parser.add_argument_group("Distributed GPUs", "Arguments related to distributed GPU training.")
@@ -358,15 +363,6 @@ def launch_command_parser(subparsers=None):
         "--downcast_bf16",
         action="store_true",
         help="Whether when using bf16 precision on TPUs if both float and double tensors are cast to bfloat16 or if double tensors remain as float32.",
-    )
-
-    # ipex args
-    ipex_args = parser.add_argument_group("IPEX", "Arguments related to training with Intel IPEX.")
-    ipex_args.add_argument(
-        "--use_xpu",
-        default=False,
-        action="store_true",
-        help="Whether to use IPEX plugin to speed up training on XPU specifically.",
     )
 
     # DeepSpeed arguments

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -102,11 +102,11 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
 
     if args.cpu or args.use_cpu:
-        if args.ipex_enabled:
-            current_env["ACCELERATE_USE_IPEX"] = str(args.ipex_enabled).lower()
+        if args.ipex:
+            current_env["ACCELERATE_USE_IPEX"] = str(args.ipex).lower()
     elif is_xpu_available():
         if args.xpu_enabled:
-            current_env["ACCELERATE_USE_XPU"] = str(args.xpu_enabled).lower()
+            current_env["ACCELERATE_USE_XPU"] = str(args.use_xpu).lower()
     return cmd, current_env
 
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -103,10 +103,10 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
 
     if args.cpu or args.use_cpu:
         if args.ipex_enabled:
-            current_env["IPEX_ENABLED"] = str(args.ipex_enabled).lower()
+            current_env["ACCELERATE_USE_IPEX"] = str(args.ipex_enabled).lower()
     elif is_xpu_available():
         if args.xpu_enabled:
-            current_env["XPU_ENABLED"] = str(args.xpu_enabled).lower()
+            current_env["ACCELERATE_USE_XPU"] = str(args.xpu_enabled).lower()
     return cmd, current_env
 
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -22,7 +22,7 @@ import torch
 
 from ..commands.config.config_args import SageMakerConfig
 from ..commands.config.config_utils import DYNAMO_BACKENDS
-from ..utils import DynamoBackend, PrecisionType, is_torch_version, is_xpu_available
+from ..utils import DynamoBackend, PrecisionType, is_ipex_available, is_torch_version, is_xpu_available
 from ..utils.constants import DEEPSPEED_MULTINODE_LAUNCHERS
 from ..utils.other import merge_dicts
 from .dataclasses import DistributedType, SageMakerDistributedType
@@ -101,7 +101,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
 
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
 
-    if args.cpu or args.use_cpu:
+    if is_ipex_available():
         if args.ipex:
             current_env["ACCELERATE_USE_IPEX"] = str(args.ipex).lower()
     elif is_xpu_available():

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -105,7 +105,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
         if args.ipex:
             current_env["ACCELERATE_USE_IPEX"] = str(args.ipex).lower()
     elif is_xpu_available():
-        if args.xpu_enabled:
+        if args.use_xpu:
             current_env["ACCELERATE_USE_XPU"] = str(args.use_xpu).lower()
     return cmd, current_env
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -102,10 +102,9 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
     current_env["OMP_NUM_THREADS"] = str(args.num_cpu_threads_per_process)
 
     if is_ipex_available():
-        if args.ipex:
+        if (args.cpu or args.use_cpu) and args.ipex:
             current_env["ACCELERATE_USE_IPEX"] = str(args.ipex).lower()
-    elif is_xpu_available():
-        if args.use_xpu:
+        elif args.use_xpu and is_xpu_available():
             current_env["ACCELERATE_USE_XPU"] = str(args.use_xpu).lower()
     return cmd, current_env
 


### PR DESCRIPTION
Keeps in line with the rest of Accelerate's env vars and CLI args to make it clear where it comes from and how to disable it:

* `IPEX_ENABLED` -> `ACCLERATE_USE_IPEX`
* `XPU_ENABLED` -> `ACCELERATE_USE_XPU`

Also cleans up CLI so we can properly do:

```bash
accelerate launch --ipex -h
```

CLI changes:

* `--ipex_enabled` -> `--ipex`
* `--xpu_enabled` -> `--use_xpu`

(And since `ipex` and `xpu` are enabled, unless I'm mistaken we should always do `--ipex` when doing `--use_xpu`

cc @sywangyi @abhilash1910 

I did not find any docs to update outside of this change, however the new CLI changes were added to the CLI documentation