### PR TITLE
Fix a bug when parameters tied belong to the same module

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -731,8 +731,12 @@ def infer_auto_device_map(
                 current_memory_used += module_size_with_ties
                 device_map[name] = devices[current_device]
                 for tied_module_name in tied_module_names:
-                    tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n == tied_module_name][0]
-                    modules_to_treat.pop(tied_module_index)
+                    if tied_module_name in [m[0] for m in modules_to_treat]:
+                        # The module may have been removed by a previous iteration of this loop.
+                        tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n == tied_module_name][
+                            0
+                        ]
+                        modules_to_treat.pop(tied_module_index)
                     device_map[tied_module_name] = devices[current_device]
 
             else:
@@ -790,6 +794,7 @@ def infer_auto_device_map(
                     )
             current_memory_used += module_size
             device_map[name] = devices[current_device]
+        print(modules_to_treat)
 
     return clean_device_map(device_map)
 


### PR DESCRIPTION
This fixes a edge case in `infer_auto_device_map` when two sets of parameters are tied and belong to the same module (see #1510 for a reproducer).

Fixes #1510