### PR TITLE
Officially support naive PP for quantized models + PEFT

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1258,7 +1258,7 @@ class Accelerator:
             model, "hf_device_map", False
         ):
             model_devices = set(model.hf_device_map.values())
-            if len(model_devices) > 1 and self.distributed_type == DistributedType.MULTI_GPU:
+            if len(model_devices) > 1 and self.distributed_type != DistributedType.NO:
                 raise ValueError(
                     "You can't train a model that has been loaded in 8-bit precision on multiple devices in any distributed mode."
                     " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1260,9 +1260,9 @@ class Accelerator:
             model_devices = set(model.hf_device_map.values())
             if len(model_devices) > 1 and self.distributed_type == DistributedType.MULTI_GPU:
                 raise ValueError(
-                    "You can't train a model that has been loaded in 8-bit precision on multiple devices in a multi-GPU setup (to use DDP)."
+                    "You can't train a model that has been loaded in 8-bit precision on multiple devices in any distributed mode."
                     " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."
-                    " Therefore you should not specify that you are under mutli GPU regime in your accelerate config."
+                    " Therefore you should not specify that you are under any distributed regime in your accelerate config."
                 )
             current_device = list(model_devices)[0]
             current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1258,9 +1258,11 @@ class Accelerator:
             model, "hf_device_map", False
         ):
             model_devices = set(model.hf_device_map.values())
-            if len(model_devices) > 1:
+            if len(model_devices) > 1 and self.distributed_type == DistributedType.MULTI_GPU:
                 raise ValueError(
-                    "You can't train a model that has been loaded in 8-bit precision on multiple devices."
+                    "You can't train a model that has been loaded in 8-bit precision on multiple devices in a multi-GPU setup (to use DDP)."
+                    " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."
+                    " Therefore you should not specify that you are under mutli GPU regime in your accelerate config."
                 )
             current_device = list(model_devices)[0]
             current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -241,6 +241,29 @@ class AcceleratorTester(AccelerateTestCase):
 
         PartialState._reset_state()
 
+    @slow
+    @require_multi_gpu
+    def test_accelerator_bnb_multi_gpu_no_distributed(self):
+        """Tests that the accelerator can be used with the BNB library."""
+        from transformers import AutoModelForCausalLM
+
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_pretrained(
+                "EleutherAI/gpt-neo-125m",
+            )
+            device_map = infer_auto_device_map(model)
+            device_map["lm_head"] = 1
+
+        model = AutoModelForCausalLM.from_pretrained(
+            "EleutherAI/gpt-neo-125m",
+            load_in_8bit=True,
+            device_map=device_map,
+        )
+        accelerator = Accelerator()
+
+        # This should work
+        _ = accelerator.prepare(model)
+
     @require_cuda
     def test_accelerator_cpu_flag_prepare(self):
         model = torch.nn.Linear(10, 10)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 import torch
 from torch.utils.data import DataLoader, TensorDataset
 
-from accelerate import infer_auto_device_map, init_empty_weights
+from accelerate import DistributedType, infer_auto_device_map, init_empty_weights
 from accelerate.accelerator import Accelerator
 from accelerate.state import GradientState, PartialState
 from accelerate.test_utils import require_multi_gpu, slow
@@ -219,6 +219,8 @@ class AcceleratorTester(AccelerateTestCase):
         """Tests that the accelerator can be used with the BNB library."""
         from transformers import AutoModelForCausalLM
 
+        PartialState._shared_state = {"distributed_type": DistributedType.MULTI_GPU}
+
         with init_empty_weights():
             model = AutoModelForCausalLM.from_pretrained(
                 "EleutherAI/gpt-neo-125m",
@@ -236,6 +238,8 @@ class AcceleratorTester(AccelerateTestCase):
         # This should not work and get value error
         with self.assertRaises(ValueError):
             _ = accelerator.prepare(model)
+
+        PartialState._reset_state()
 
     @require_cuda
     def test_accelerator_cpu_flag_prepare(self):


### PR DESCRIPTION
# What does this PR do?

Fixes #1515 

Naive Pipeline Parallelism should be supported by accelerate and should work, if we properly educate users on how to use it. 

## What is NPP? 

It is the simplest paradigm for running a model across multiple GPUs. It tries to evenly fit the model across all available GPUs (e.g. `device_map="auto"`)

![npp](https://huggingface.co/datasets/trl-internal-testing/example-images/resolve/main/images/trl-npp.png) 

## When to use it and when not to use it?

Initially I added that check because I was afraid users will train 8bit models that are loaded across multiple GPUs **and** under multi-GPU distributed regime. In that case the model will be converted to DDP (which is fine if the model fits in a single GPU and duplicated across multiple GPUs (Data Parallelism)) - which can lead to many breaking behaviours such as https://github.com/huggingface/peft/issues/269#issuecomment-1498776567 . 
The fix is to relax the check constraint and to also check if we are under multi GPU distributed regime (expects to use DDP).

In TRL library, it is possible to use the `PPOTrainer` (that calls `accelerator.prepare` under the hood) to apply Naive Pipeline Parallelism: https://huggingface.co/docs/trl/main/en/lora_tuning_peft#naive-pipeline-parallelism-npp-for-large-models-60b-models to train 60B+ scale models using RLHF. The error was never raised there because I forgot to store the attribute `hf_device_map` inside the model class we use in TRL.

To reproduce (you need PEFT and run this script in a multi-GPU env):
```python
from accelerate import Accelerator
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import LoraConfig, get_peft_model, prepare_model_for_int8_training

model_id = "facebook/opt-350m"
accelerator = Accelerator()

config = LoraConfig(
    r=16, 
    lora_alpha=32, 
    target_modules=["q_proj", "v_proj"], 
    lora_dropout=0.05, 
    bias="none", 
    task_type="CAUSAL_LM"
)

model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", load_in_8bit=True)
model = prepare_model_for_int8_training(model)

print(set(model.hf_device_map.values()))

model = get_peft_model(model, config)

model = accelerator.prepare(model)
```

cc @sgugger @muellerzr 