### PR TITLE
Fixup deepspeed/cli tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,6 +76,7 @@ jobs:
           source activate accelerate
           make test_core
           make test_big_modeling
+          make test_cli
 
       - name: Run Integration tests on GPUs
         run: |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -84,7 +84,10 @@ class TpuConfigTester(unittest.TestCase):
 
     @staticmethod
     def clean_output(output):
-        return "".join(output).rstrip()
+        output = "".join(output).rstrip()
+        # Tempfix for deepspeed printing that we can't disable
+        output = output.replace("Setting ds_accelerator to cuda (auto detect)\n", "")
+        return output
 
     def test_base(self):
         output = run_command(


### PR DESCRIPTION
Adds check for print statement that deepspeed decided to add in the latest version causing a failure in our checking of the CLI outputs 🙃 Linked FR to hopefully make it a logger and not a print statement: https://github.com/microsoft/DeepSpeed/issues/3680

For now thought this can be merged w/o issue