### PR TITLE
Check tied parameters

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -48,6 +48,8 @@ from .imports import (
 from .modeling import (
     CustomDtype,
     check_device_map,
+    check_tied_parameters,
+    check_tied_parameters_on_same_device,
     compute_module_sizes,
     convert_file_size_to_int,
     dtype_byte_size,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -281,8 +281,8 @@ def check_tied_parameters_on_same_device(tied_params, device_map):
             tie_param_devices[param] = _get_param_device(param, device_map)
         if len(set(tie_param_devices.values())) > 1:
             raise RuntimeError(
-                f"Tied parameters are in different devices: {tie_param_devices}."
-                "Please modify your custom device map or set device_map = 'auto' "
+                f"Tied parameters are in different devices: {tie_param_devices}. "
+                "Please modify your custom device map or set device_map = 'auto'. "
             )
 
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -680,11 +680,10 @@ def infer_auto_device_map(
     module_sizes = compute_module_sizes(model, dtype=dtype, special_dtypes=special_dtypes)
     tied_parameters = find_tied_parameters(model)
 
-    if check_tied_parameters(model):
-        if len(tied_parameters) == 0:
-            raise RuntimeError(
-                "The model weights are not tied. Please run model.tie_weights() before using infer_auto_device."
-            )
+    if check_tied_parameters(model) and len(tied_parameters) == 0:
+        raise RuntimeError(
+            "The model weights are not tied. Please run model.tie_weights() before using infer_auto_device."
+        )
 
     device_map = {}
     current_device = 0
@@ -1011,11 +1010,10 @@ def load_checkpoint_in_model(
     """
     tied_params = find_tied_parameters(model)
 
-    if check_tied_parameters(model):
-        if len(tied_params) == 0:
-            raise RuntimeError(
-                "The model weights are not tied. Please run model.tie_weights() before using infer_auto_device."
-            )
+    if check_tied_parameters(model) and len(tied_params) == 0:
+        raise RuntimeError(
+            "The model weights are not tied. Please run model.tie_weights() before using infer_auto_device."
+        )
 
     check_tied_parameters_on_same_device()
 


### PR DESCRIPTION
# What does this PR do ? 

This PR fixes two issues user can have when using big inference model:
- Use their own device map but forget that parameters that are tied together should be on the same device. We return an error showing which parameters should be on the same device
- Forget to tie the parameters before using infer_auto_device_map() which can create a bad device_map. We also return an error asking to tie the weights before using this function.

# How to test it 

### Issue 1 
```python
import os
import torch
from transformers import AutoModelForCausalLM
from transformers import AutoTokenizer
from accelerate.utils import find_tied_parameters

checkpoint = "facebook/opt-350m"

device_map_work = {'model.decoder.embed_tokens': 'cpu',
 'model.decoder.embed_positions': 'cpu',
 'model.decoder.project_out': 'cpu',
 'model.decoder.project_in': 'cpu',
 'model.decoder.layers': 'cpu',
 'lm_head': 'cpu'}

device_map_do_no_work = {'model.decoder.embed_tokens': 'cpu',
 'model.decoder.embed_positions': 'cpu',
 'model.decoder.project_out': 'cpu',
 'model.decoder.project_in': 'cpu',
 'model.decoder.layers': 'cpu',
 'lm_head': 'disk'}

model = AutoModelForCausalLM.from_pretrained(checkpoint, device_map = device_map_do_no_work, offload_folder="offload",offload_state_dict = True)
tokenizer = AutoTokenizer.from_pretrained(checkpoint)
```

### Issue 2
```python
import torch
from transformers import AutoConfig,AutoModelForCausalLM
from accelerate import init_empty_weights, infer_auto_device_map, load_checkpoint_and_dispatch

checkpoint = "facebook/opt-350m"

config = AutoConfig.from_pretrained(checkpoint)
with init_empty_weights():
    model = AutoModelForCausalLM.from_config(config)
device_map = infer_auto_device_map(model, no_split_module_classes=["OPTDecoderLayer"])
```