### PR TITLE
Raise ValueError on iterable dataset if we've hit the end and attempting to go beyond it

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -561,6 +561,9 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                 # We keep at least num processes elements of the first batch to be able to complete the last batch
                 first_batch = slice_tensors(batch, slice(0, self.state.num_processes))
 
+            if batch is None:
+                raise ValueError(f'Batch does not contain any data (`{batch}`). At the end of all iterable data available before expected stop iteration.')
+
             observed_batch_size = find_batch_size(batch)
             batch_size = observed_batch_size // self.state.num_processes
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -562,7 +562,9 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                 first_batch = slice_tensors(batch, slice(0, self.state.num_processes))
 
             if batch is None:
-                raise ValueError(f'Batch does not contain any data (`{batch}`). At the end of all iterable data available before expected stop iteration.')
+                raise ValueError(
+                    f"Batch does not contain any data (`{batch}`). At the end of all iterable data available before expected stop iteration."
+                )
 
             observed_batch_size = find_batch_size(batch)
             batch_size = observed_batch_size // self.state.num_processes


### PR DESCRIPTION
Replaces the following confusing error:
```python
../accelerate/src/accelerate/data_loader.py:564: in __iter__
    observed_batch_size = find_batch_size(batch)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

data = None

    def find_batch_size(data):
        """
        Recursively finds the batch size in a nested list/tuple/dictionary of lists of tensors.
    
        Args:
            data (nested list/tuple/dictionary of `torch.Tensor`): The data from which to find the batch size.
    
        Returns:
            `int`: The batch size.
        """
        if isinstance(data, (tuple, list)):
            return find_batch_size(data[0])
        elif isinstance(data, Mapping):
            for k in data.keys():
                return find_batch_size(data[k])
        elif not isinstance(data, torch.Tensor):
>           raise TypeError(f"Can only find the batch size of tensors but got {type(data)}.")
E           TypeError: Can only find the batch size of tensors but got <class 'NoneType'>.

../accelerate/src/accelerate/utils/operations.py:223: TypeError
```
With what is actually happening:
```python
src/transformers/trainer.py:1531: in train
    return inner_training_loop(
src/transformers/trainer.py:1779: in _inner_training_loop
    for step, inputs in enumerate(epoch_iterator):
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <accelerate.data_loader.DataLoaderDispatcher object at 0x7fe22c27b2e0>

    def __iter__(self):
        self.gradient_state._add_dataloader(self)
        main_iterator = None
        if self.state.process_index == 0:
            # We only iterate through the DataLoader on process 0.
            main_iterator = super().__iter__()
        stop_iteration = False
        self._stop_iteration = False
        first_batch = None
        next_batch, next_batch_info = self._fetch_batches(main_iterator)
        batch_index = 0
        while not stop_iteration:
            batch, batch_info = next_batch, next_batch_info
    
            if self.state.process_index != 0:
                # Initialize tensors on other processes than process 0.
                batch = initialize_tensors(batch_info[0])
            batch = send_to_device(batch, self.state.device)
            # Broadcast the batch before splitting it.
            batch = broadcast(batch, from_process=0)
    
            if not self._drop_last and first_batch is None:
                # We keep at least num processes elements of the first batch to be able to complete the last batch
                first_batch = slice_tensors(batch, slice(0, self.state.num_processes))
    
            if batch is None:
>               raise ValueError(f'Batch does not contain any data ({batch}). At the end of all iterable data available before expected stop iteration.')
E               ValueError: Batch does not contain any data (None). At the end of all iterable data available before expected stop iteration.

../accelerate/src/accelerate/data_loader.py:565: ValueError
```