### PR TITLE
Prevent using extra VRAM for static device_map

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -469,15 +469,15 @@ def load_checkpoint_and_dispatch(
             "If passing a string for `device_map`, please choose 'auto', 'balanced', 'balanced_low_0' or "
             "'sequential'."
         )
-    if device_map != "sequential":
-        max_memory = get_balanced_memory(
-            model,
-            max_memory=max_memory,
-            no_split_module_classes=no_split_module_classes,
-            dtype=dtype,
-            low_zero=(device_map == "balanced_low_0"),
-        )
     if isinstance(device_map, str):
+        if device_map != "sequential":
+            max_memory = get_balanced_memory(
+                model,
+                max_memory=max_memory,
+                no_split_module_classes=no_split_module_classes,
+                dtype=dtype,
+                low_zero=(device_map == "balanced_low_0"),
+            )
         device_map = infer_auto_device_map(
             model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
         )


### PR DESCRIPTION
When using `load_checkpoint_and_dispatch` with a user provided `device_map`, the function first computes the `max_memory` for each device. This has a side-effect of allocating one tensor, and thus cuda, on each available device, even if the device is not present in the values of the `device_map`.

Since this argument is not used with a user provided `device_map`, this PR simply move the `max_memory` computation out of the execution path, to prevent extra memory allocation on unused devices.