### PR TITLE
Apply deprecations

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -244,7 +244,6 @@ class Accelerator:
         log_with: str | LoggerType | GeneralTracker | list[str | LoggerType | GeneralTracker] | None = None,
         project_dir: str | os.PathLike | None = None,
         project_config: ProjectConfiguration | None = None,
-        logging_dir: str | os.PathLike | None = None,
         gradient_accumulation_plugin: GradientAccumulationPlugin | None = None,
         dispatch_batches: bool | None = None,
         even_batches: bool = True,
@@ -256,13 +255,6 @@ class Accelerator:
             self.project_configuration = project_config
         else:
             self.project_configuration = ProjectConfiguration(project_dir=project_dir)
-
-        if logging_dir is not None:
-            warnings.warn(
-                "`logging_dir` is deprecated and will be removed in version 0.18.0 of 🤗 Accelerate. Use `project_dir` instead.",
-                FutureWarning,
-            )
-            self.project_configuration.logging_dir = logging_dir
         if project_dir is not None and self.project_dir is None:
             self.project_configuration.project_dir = project_dir
         if mixed_precision is not None:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -196,7 +196,6 @@ class DistributedType(str, enum.Enum):
     DEEPSPEED = "DEEPSPEED"
     FSDP = "FSDP"
     TPU = "TPU"
-    MPS = "MPS"  # here for backward compatibility. Remove in v0.18.0
     MEGATRON_LM = "MEGATRON_LM"
 
 

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -159,12 +159,6 @@ def is_boto3_available():
 
 def is_rich_available():
     if _is_package_available("rich"):
-        if parse_flag_from_env("DISABLE_RICH"):
-            warnings.warn(
-                "The `DISABLE_RICH` flag is deprecated and will be removed in version 0.17.0 of 🤗 Accelerate. Use `ACCELERATE_DISABLE_RICH` instead.",
-                FutureWarning,
-            )
-            return not parse_flag_from_env("DISABLE_RICH")
         return not parse_flag_from_env("ACCELERATE_DISABLE_RICH")
     return False
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -50,7 +50,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
     def test_init_trackers(self):
         project_name = "test_project_with_config"
         with tempfile.TemporaryDirectory() as dirpath:
-            accelerator = Accelerator(log_with="tensorboard", logging_dir=dirpath)
+            accelerator = Accelerator(log_with="tensorboard", project_dir=dirpath)
             config = {"num_iterations": 12, "learning_rate": 1e-2, "some_boolean": False, "some_string": "some_value"}
             accelerator.init_trackers(project_name, config)
             accelerator.end_training()
@@ -76,8 +76,6 @@ class TensorBoardTrackingTest(unittest.TestCase):
             _ = Accelerator(log_with="tensorboard")
         with tempfile.TemporaryDirectory() as dirpath:
             _ = Accelerator(log_with="tensorboard", project_dir=dirpath)
-        with tempfile.TemporaryDirectory() as dirpath:
-            _ = Accelerator(log_with="tensorboard", logging_dir=dirpath)
 
 
 @require_wandb


### PR DESCRIPTION
Applies all deprecation from the last few accelerate versions, `no_trainer` scripts will also be updated today.

List of deprecations:

- Fully remove `DistributedType.MPS`
- Fully remove `logging_dir` argument from `Accelerator`
- Fully remove `DISABLE_RICH` flag in favor of `ACCELERATE_DISABLE_RICH`