### PR TITLE
[documentation] minor grammar fixes in deferring_execution.mdx

### DIFF
--- a/docs/source/concept_guides/deferring_execution.mdx
+++ b/docs/source/concept_guides/deferring_execution.mdx
@@ -27,7 +27,7 @@ accelerator.wait_for_everyone()
 This instruction will block all the processes that arrive first until all the other processes have reached that
 point (if you run your script on just one GPU or CPU, this won't do anything).
 
-A few example cases for when to use this utility are listed below:
+A few example cases of when to use this utility are listed below:
 
 <Tip>
 
@@ -38,7 +38,7 @@ A few example cases for when to use this utility are listed below:
 
 ## Downloading a Dataset 
 
-When downloading a dataset, you should download it first on the main process and then loading the cached dataset in afterwards
+When downloading a dataset, you should download it first on the main process and then load the cached dataset afterward
 
 <Tip>
 


### PR DESCRIPTION
These are just a few more minor grammar fixes in deferring_execution.mdx. They do not affect the ideas communicated in the documentation.