### PR TITLE
Add mps support to big inference modeling

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -358,7 +358,7 @@ def dispatch_model(
         name: main_device if device in ["cpu", "disk"] else device for name, device in device_map.items()
     }
     execution_device[""] = main_device
-    offloaded_devices = ["disk"] if main_device == "cpu" else ["cpu", "disk"]
+    offloaded_devices = ["disk"] if main_device == "cpu" or main_device == "mps" else ["cpu", "disk"]
     offload = {name: device in offloaded_devices for name, device in device_map.items()}
     save_folder = offload_dir if len(disk_modules) > 0 else None
     if state_dict is not None or save_folder is not None or offload_index is not None:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -695,7 +695,7 @@ def infer_auto_device_map(
     if "mps" in gpus:
         main_devices = ["mps"]
     elif len(gpus) > 0:
-        main_devices = [gpus[0], "cpu"] if len(gpus) > 0
+        main_devices = [gpus[0], "cpu"]
     else:
         main_devices = ["cpu"]
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -694,8 +694,10 @@ def infer_auto_device_map(
     # Devices that need to keep space for a potential offloaded layer.
     if "mps" in gpus:
         main_devices = ["mps"]
+    elif len(gpus) > 0:
+        main_devices = [gpus[0], "cpu"] if len(gpus) > 0
     else:
-        main_devices = [gpus[0], "cpu"] if len(gpus) > 0 else ["cpu"]
+        main_devices = ["cpu"]
 
     module_sizes = compute_module_sizes(model, dtype=dtype, special_dtypes=special_dtypes)
     tied_parameters = find_tied_parameters(model)

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -284,7 +284,7 @@ class BigModelingTester(unittest.TestCase):
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
-            
+
     @require_mps
     def test_dispatch_model_mps(self):
         model = ModelForTest()
@@ -389,7 +389,7 @@ class BigModelingTester(unittest.TestCase):
     @require_mps
     def test_dispatch_model_with_unused_submodules_mps(self):
         model = ModelWithUnusedSubModulesForTest()
-        device_map = {"linear1": "mps", "linear2": "mps", "batchnorm": "mps", "linear3":"mps", "linear4": "disk"}
+        device_map = {"linear1": "mps", "linear2": "mps", "batchnorm": "mps", "linear3": "mps", "linear4": "disk"}
 
         x = torch.randn(2, 3)
         expected = model(x)
@@ -400,7 +400,7 @@ class BigModelingTester(unittest.TestCase):
             )
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
-            
+
     @require_multi_gpu
     def test_dispatch_model_with_unused_submodules_multi_gpu(self):
         model = ModelWithUnusedSubModulesForTest()
@@ -451,7 +451,9 @@ class BigModelingTester(unittest.TestCase):
             torch.save(model.state_dict(), checkpoint)
 
             new_model = ModelForTest()
-            new_model = load_checkpoint_and_dispatch(new_model, checkpoint, device_map=device_map, offload_folder=tmp_dir)
+            new_model = load_checkpoint_and_dispatch(
+                new_model, checkpoint, device_map=device_map, offload_folder=tmp_dir
+            )
 
             # CPU-offloaded weights are on the meta device while waiting for the forward pass.
             self.assertEqual(new_model.linear1.weight.device, torch.device("mps:0"))
@@ -509,11 +511,11 @@ class BigModelingTester(unittest.TestCase):
 
         output = new_model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
-    
-    @require_mps 
+
+    @require_mps
     def test_load_checkpoint_and_dispatch_with_unused_submodules_mps(self):
         model = ModelWithUnusedSubModulesForTest()
-        device_map = {"linear1": "mps", "linear2": "mps", "batchnorm":"mps", "linear3": "disk", "linear4": "disk"}
+        device_map = {"linear1": "mps", "linear2": "mps", "batchnorm": "mps", "linear3": "disk", "linear4": "disk"}
 
         x = torch.randn(2, 3)
         expected = model(x)
@@ -524,7 +526,11 @@ class BigModelingTester(unittest.TestCase):
 
             new_model = ModelWithUnusedSubModulesForTest()
             new_model = load_checkpoint_and_dispatch(
-                new_model, checkpoint, device_map=device_map, preload_module_classes=["ModuleWithUnusedSubModules"],offload_folder=tmp_dir
+                new_model,
+                checkpoint,
+                device_map=device_map,
+                preload_module_classes=["ModuleWithUnusedSubModules"],
+                offload_folder=tmp_dir,
             )
 
             # CPU-offloaded weights are on the meta device while waiting for the forward pass.

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -284,6 +284,19 @@ class BigModelingTester(unittest.TestCase):
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            
+    @require_mps
+    def test_dispatch_model_mps(self):
+        model = ModelForTest()
+        device_map = {"linear1": "mps", "batchnorm": "disk", "linear2": "disk"}
+
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir)
+            output = model(x)
+            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
     @require_cuda
     def test_dispatch_model_tied_weights(self):
@@ -373,6 +386,21 @@ class BigModelingTester(unittest.TestCase):
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
+    @require_mps
+    def test_dispatch_model_with_unused_submodules_mps(self):
+        model = ModelWithUnusedSubModulesForTest()
+        device_map = {"linear1": "mps", "linear2": "mps", "batchnorm": "mps", "linear3":"mps", "linear4": "disk"}
+
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(
+                model, device_map, offload_dir=tmp_dir, preload_module_classes=["ModuleWithUnusedSubModules"]
+            )
+            output = model(x)
+            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            
     @require_multi_gpu
     def test_dispatch_model_with_unused_submodules_multi_gpu(self):
         model = ModelWithUnusedSubModulesForTest()
@@ -409,6 +437,28 @@ class BigModelingTester(unittest.TestCase):
 
         output = new_model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+
+    @require_mps
+    def test_load_checkpoint_and_dispatch_mps(self):
+        model = ModelForTest()
+        device_map = {"linear1": "mps", "batchnorm": "mps", "linear2": "disk"}
+
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            checkpoint = os.path.join(tmp_dir, "pt_model.bin")
+            torch.save(model.state_dict(), checkpoint)
+
+            new_model = ModelForTest()
+            new_model = load_checkpoint_and_dispatch(new_model, checkpoint, device_map=device_map, offload_folder=tmp_dir)
+
+            # CPU-offloaded weights are on the meta device while waiting for the forward pass.
+            self.assertEqual(new_model.linear1.weight.device, torch.device("mps:0"))
+            self.assertEqual(new_model.linear2.weight.device, torch.device("meta"))
+
+            output = new_model(x)
+            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
     @require_multi_gpu
     def test_load_checkpoint_and_dispatch_multi_gpu(self):
@@ -459,6 +509,32 @@ class BigModelingTester(unittest.TestCase):
 
         output = new_model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+    
+    @require_mps 
+    def test_load_checkpoint_and_dispatch_with_unused_submodules_mps(self):
+        model = ModelWithUnusedSubModulesForTest()
+        device_map = {"linear1": "mps", "linear2": "mps", "batchnorm":"mps", "linear3": "disk", "linear4": "disk"}
+
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            checkpoint = os.path.join(tmp_dir, "pt_model.bin")
+            torch.save(model.state_dict(), checkpoint)
+
+            new_model = ModelWithUnusedSubModulesForTest()
+            new_model = load_checkpoint_and_dispatch(
+                new_model, checkpoint, device_map=device_map, preload_module_classes=["ModuleWithUnusedSubModules"],offload_folder=tmp_dir
+            )
+
+            # CPU-offloaded weights are on the meta device while waiting for the forward pass.
+            self.assertEqual(new_model.linear1.linear.weight.device, torch.device("mps:0"))
+            self.assertEqual(new_model.linear2.linear.weight.device, torch.device("mps:0"))
+            self.assertEqual(new_model.linear3.linear.weight.device, torch.device("meta"))
+            self.assertEqual(new_model.linear4.linear.weight.device, torch.device("meta"))
+
+            output = new_model(x)
+            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
     @require_multi_gpu
     def test_load_checkpoint_and_dispatch_multi_gpu_with_unused_submodules(self):


### PR DESCRIPTION
# What does this PR do

This PR add the support for M1/M2 MacOS to big inference modeling. 

The main highlights of this PR are as follows:
- device_map = 'auto' will now detect mps device if available and set the device_map correctly. Since memory is shared between the GPU and CPU, modules are placed on the MPS device, and if necessary, offloaded to the disk.
- add tests for mps device

Reminder: mps backend can be slower than cpu in some cases.


Fix [#23916](https://github.com/huggingface/transformers/issues/23916) 