### PR TITLE
Avoid double wrapping of all accelerate.prepare objects

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1729,6 +1729,10 @@ class Accelerator:
         >>> optimizer = accelerator.prepare_optimizer(optimizer, device_placement=True)
         ```
         """
+        if isinstance(optimizer, AcceleratedOptimizer):
+            if optimizer not in self._optimizers:
+                self._optimizers.append(optimizer)
+            return optimizer
         if device_placement is None:
             device_placement = self.device_placement
         optimizer = AcceleratedOptimizer(optimizer, device_placement=device_placement, scaler=self.scaler)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2546,7 +2546,7 @@ class Accelerator:
     def free_memory(self):
         """
         Will release all references to the internal objects stored and call the garbage collector. You should call this
-        method between two trainings with different models/optimizers.
+        method between two trainings with different models/optimizers. Also will reset `Accelerator.step` to 0.
 
         Example:
 
@@ -2565,6 +2565,7 @@ class Accelerator:
         self._models = []
         self._dataloaders = []
         self.deepspeed_engine_wrapped = None
+        self.step = 0
         release_memory()
 
     def clear(self):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -32,7 +32,7 @@ import torch
 import torch.utils.hooks as hooks
 
 from .checkpointing import load_accelerator_state, load_custom_state, save_accelerator_state, save_custom_state
-from .data_loader import DataLoaderDispatcher, prepare_data_loader, skip_first_batches
+from .data_loader import DataLoaderDispatcher, DataLoaderShard, prepare_data_loader, skip_first_batches
 from .logging import get_logger
 from .optimizer import AcceleratedOptimizer
 from .scheduler import AcceleratedScheduler
@@ -119,6 +119,8 @@ if is_torch_version(">", "1.10.0"):
 if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
     import torch_xla.distributed.xla_multiprocessing as xmp
+
+    from .data_loader import MpDeviceLoaderWrapper
 
 
 try:
@@ -1691,6 +1693,13 @@ class Accelerator:
         >>> data_loader = accelerator.prepare_data_loader(data_loader, device_placement=True)
         ```
         """
+        # Ensure we can't double wrap a DataLoader due to `find_batch_size`
+        if isinstance(data_loader, (DataLoaderDispatcher, DataLoaderShard)) or (
+            is_tpu_available() and isinstance(data_loader, MpDeviceLoaderWrapper)
+        ):
+            if data_loader not in self._dataloaders:
+                self._dataloaders.append(data_loader)
+                return data_loader
         if device_placement is None:
             device_placement = self.device_placement if self.distributed_type != DistributedType.TPU else False
         prepared_data_loader = prepare_data_loader(
@@ -1729,6 +1738,7 @@ class Accelerator:
         >>> optimizer = accelerator.prepare_optimizer(optimizer, device_placement=True)
         ```
         """
+        # Ensure we can't double wrap an optimizer due to `find_batch_size`
         if isinstance(optimizer, AcceleratedOptimizer):
             if optimizer not in self._optimizers:
                 self._optimizers.append(optimizer)
@@ -1760,6 +1770,11 @@ class Accelerator:
         >>> scheduler = accelerator.prepare_scheduler(scheduler)
         ```
         """
+        # Ensure we can't double wrap a scheduler due to `find_batch_size`
+        if isinstance(scheduler, AcceleratedScheduler):
+            if scheduler not in self._schedulers:
+                self._schedulers.append(scheduler)
+            return scheduler
         # We try to find the optimizer associated with `scheduler`, the default is the full list.
         optimizer = self._optimizers
         for opt in self._optimizers:

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -69,6 +69,8 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
                 else:
                     state_dict = move_to_device(state_dict, self.accelerator_state.device)
                 self.optimizer.load_state_dict(state_dict)
+        else:
+            self.optimizer = optimizer.optimizer
 
     @property
     def state(self):

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -53,24 +53,21 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
     """
 
     def __init__(self, optimizer, device_placement=True, scaler=None):
-        if not isinstance(optimizer, AcceleratedOptimizer):
-            self.optimizer = optimizer
-            self.scaler = scaler
-            self.accelerator_state = AcceleratorState()
-            self.gradient_state = GradientState()
-            self.device_placement = device_placement
-            self._is_overflow = False
+        self.optimizer = optimizer
+        self.scaler = scaler
+        self.accelerator_state = AcceleratorState()
+        self.gradient_state = GradientState()
+        self.device_placement = device_placement
+        self._is_overflow = False
 
-            # Handle device placement
-            if device_placement:
-                state_dict = self.optimizer.state_dict()
-                if self.accelerator_state.distributed_type == DistributedType.TPU:
-                    xm.send_cpu_data_to_device(state_dict, self.accelerator_state.device)
-                else:
-                    state_dict = move_to_device(state_dict, self.accelerator_state.device)
-                self.optimizer.load_state_dict(state_dict)
-        else:
-            self.optimizer = optimizer.optimizer
+        # Handle device placement
+        if device_placement:
+            state_dict = self.optimizer.state_dict()
+            if self.accelerator_state.distributed_type == DistributedType.TPU:
+                xm.send_cpu_data_to_device(state_dict, self.accelerator_state.device)
+            else:
+                state_dict = move_to_device(state_dict, self.accelerator_state.device)
+            self.optimizer.load_state_dict(state_dict)
 
     @property
     def state(self):


### PR DESCRIPTION
Solves double nested wrapping issues linked as a side-effect to https://github.com/huggingface/transformers/issues/24050.

Also resets step to 0 during free_memory