### PR TITLE
Fix tests not being ran on multi-GPU nightly

### DIFF
--- a/.github/workflows/run_merge_tests.yml
+++ b/.github/workflows/run_merge_tests.yml
@@ -68,11 +68,6 @@ jobs:
           pip install -e .[testing,test_trackers] -U
           pip install pytest-reportlog tabulate
 
-      - name: Run CLI tests
-        run: |
-          source activate accelerate
-          make test_cli
-
       - name: Run test on GPUs
         run: |
           source activate accelerate

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_all.log",)
 
 test_big_modeling:
-	python -m pytest -s -v ./tests/test_big_modeling.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_big_modeling.log",)
+	python -m pytest -s -v ./tests/test_big_modeling.py ./tests/test_modeling_utils.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_big_modeling.log",)
 
 test_core:
 	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py --ignore=./tests/deepspeed --ignore=./tests/test_big_modeling.py \


### PR DESCRIPTION
It's still... *strange* that the workflows running `make test` (we have a number of them) didn't pick up on https://github.com/huggingface/accelerate/pull/1557... but at least this solves some of it...