### PR TITLE
fix the typo when setting the "_accelerator_prepared" attribute

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,7 @@ class Accelerator:
             result = self._prepare_fsdp(*result)
 
         for item in result:
-            setattr(item, "_is_accelerate_prepared", True)
+            setattr(item, "_accelerator_prepared", True)
 
         return result if len(result) > 1 else result[0]
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,7 @@ class Accelerator:
             result = self._prepare_fsdp(*result)
 
         for item in result:
-            setattr(item, "_accelerator_prepared", True)
+            setattr(item, "_is_accelerate_prepared", True)
 
         return result if len(result) > 1 else result[0]
 
@@ -1695,7 +1695,7 @@ class Accelerator:
         ```
         """
         # Ensure we can't double wrap a DataLoader due to `find_batch_size`
-        if getattr(data_loader, "_accelerator_prepared", False):
+        if getattr(data_loader, "_is_accelerate_prepared", False):
             if data_loader not in self._dataloaders:
                 self._dataloaders.append(data_loader)
             return data_loader
@@ -1738,7 +1738,7 @@ class Accelerator:
         ```
         """
         # Ensure we can't double wrap an optimizer due to `find_batch_size`
-        if getattr(optimizer, "_accelerator_prepared", False):
+        if getattr(optimizer, "_is_accelerate_prepared", False):
             if optimizer not in self._optimizers:
                 self._optimizers.append(optimizer)
             return optimizer
@@ -1770,7 +1770,7 @@ class Accelerator:
         ```
         """
         # Ensure we can't double wrap a scheduler due to `find_batch_size`
-        if getattr(scheduler, "_accelerator_prepared", False):
+        if getattr(scheduler, "_is_accelerate_prepared", False):
             if scheduler not in self._schedulers:
                 self._schedulers.append(scheduler)
             return scheduler


### PR DESCRIPTION
Fixes the typo from #1555 (setattr and the corresponding getattr currently use different attribute names, which is a bug)