### PR TITLE
[`core`] Fix possibility to pass`NoneType` objects in `prepare`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,8 @@ class Accelerator:
             result = self._prepare_fsdp(*result)
 
         for item in result:
-            setattr(item, "_is_accelerate_prepared", True)
+            if item is not None:
+                setattr(item, "_is_accelerate_prepared", True)
 
         return result if len(result) > 1 else result[0]
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -175,6 +175,18 @@ class AcceleratorTester(AccelerateTestCase):
             # mode.class_name is NOT loaded from config
             self.assertTrue(model.class_name != model.__class__.__name__)
 
+    def test_accelerator_none(self):
+        """Just test that passing None to accelerator.prepare() works."""
+        accelerator = Accelerator()
+        model, optimizer, scheduler, train_dl, valid_dl = create_components()
+        dummy_obj = None
+
+        # This should work
+        model, optimizer, scheduler, train_dl, valid_dl, dummy_obj = accelerator.prepare(
+            model, optimizer, scheduler, train_dl, valid_dl, dummy_obj
+        )
+        self.assertTrue(dummy_obj is None)
+
     @slow
     def test_accelerator_bnb(self):
         """Tests that the accelerator can be used with the BNB library."""


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/lvwerra/trl/issues/413 and the current CI in TRL :D https://github.com/lvwerra/trl/actions/runs/5204023029/jobs/9387749684?pr=412 

Before https://github.com/huggingface/accelerate/pull/1555 it was possible to pass `NoneType` objects into prepare and that function would do nothing with it and return it. 

Adding a simple check `if item is not None:`  before setting the `_is_accelerate_prepare` attribute circumvents the bug

cc @sgugger @muellerzr 