### PR TITLE
Reset dataloader end_of_datalaoder at each iter

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -316,6 +316,10 @@ class DataLoaderStateMixin:
         cls.end_of_dataloader = False
         cls.remainder = -1
 
+    def reset(self):
+        self.end_of_dataloader = False
+        self.remainder = -1
+
 
 class DataLoaderShard(DataLoader, DataLoaderStateMixin):
     """
@@ -361,6 +365,7 @@ class DataLoaderShard(DataLoader, DataLoaderStateMixin):
     def __iter__(self):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.synchronized_generator)
+        self.reset()
         self.gradient_state._add_dataloader(self)
         # We can safely pass because the default is -1
         with suppress(Exception):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -903,7 +903,9 @@ class GradientState:
             self.sync_gradients = True
             self.active_dataloader = None
             self.dataloader_references = [None]
-            self.plugin_kwargs = gradient_accumulation_plugin.to_kwargs()
+            self.plugin_kwargs = (
+                gradient_accumulation_plugin.to_kwargs() if gradient_accumulation_plugin is not None else {}
+            )
 
         # Plugin args are different and can be updated
         if gradient_accumulation_plugin is not None and self.plugin_kwargs != gradient_accumulation_plugin.to_kwargs():

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -19,6 +19,7 @@ from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 
 from accelerate.data_loader import (
     BatchSamplerShard,
+    DataLoaderShard,
     IterableDatasetShard,
     SkipBatchSampler,
     SkipDataLoader,
@@ -374,3 +375,12 @@ class DataLoaderTester(unittest.TestCase):
         dataloader = DataLoader(list(range(16)), batch_size=4)
         new_dataloader = skip_first_batches(dataloader, num_batches=2)
         self.assertListEqual([t.tolist() for t in new_dataloader], [[8, 9, 10, 11], [12, 13, 14, 15]])
+
+    def test_end_of_dataloader(self):
+        dataloader = DataLoaderShard(list(range(16)), batch_size=4)
+        for idx, _ in enumerate(dataloader):
+            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+
+        # Test it also works on the second iteration
+        for idx, _ in enumerate(dataloader):
+            self.assertEqual(dataloader.end_of_dataloader, idx == 3)


### PR DESCRIPTION
The `end_of_dataloader` from the `DataLoaderMixin` is set to `True` at the end of an iter, but never reset to False...