### PR TITLE
Introduce listify, fix tensorboard silently failing

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -32,6 +32,7 @@ from .utils import (
     is_mlflow_available,
     is_tensorboard_available,
     is_wandb_available,
+    untensorify,
 )
 
 
@@ -236,6 +237,7 @@ class TensorBoardTracker(GeneralTracker):
                 Additional key word arguments passed along to either `SummaryWriter.add_scaler`,
                 `SummaryWriter.add_text`, or `SummaryWriter.add_scalers` method based on the contents of `values`.
         """
+        values = untensorify(values)
         for k, v in values.items():
             if isinstance(v, (int, float)):
                 self.writer.add_scalar(k, v, global_step=step, **kwargs)

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -32,7 +32,7 @@ from .utils import (
     is_mlflow_available,
     is_tensorboard_available,
     is_wandb_available,
-    untensorify,
+    listify,
 )
 
 
@@ -237,7 +237,7 @@ class TensorBoardTracker(GeneralTracker):
                 Additional key word arguments passed along to either `SummaryWriter.add_scaler`,
                 `SummaryWriter.add_text`, or `SummaryWriter.add_scalers` method based on the contents of `values`.
         """
-        values = untensorify(values)
+        values = listify(values)
         for k, v in values.items():
             if isinstance(v, (int, float)):
                 self.writer.add_scalar(k, v, global_step=step, **kwargs)

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -90,12 +90,12 @@ from .operations import (
     is_namedtuple,
     is_tensor_information,
     is_torch_tensor,
+    listify,
     pad_across_processes,
     recursively_apply,
     reduce,
     send_to_device,
     slice_tensors,
-    untensorify,
 )
 from .versions import compare_versions, is_torch_version
 

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -95,6 +95,7 @@ from .operations import (
     reduce,
     send_to_device,
     slice_tensors,
+    untensorify,
 )
 from .versions import compare_versions, is_torch_version
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -224,6 +224,29 @@ def find_batch_size(data):
     return data.shape[0]
 
 
+def untensorify(data):
+    """
+    Recursively finds tensors in a nested list/tuple/dictionary and converts them to a list of numbers.
+
+    Args:
+        data (nested list/tuple/dictionary of `torch.Tensor`): The data from which to convert to regular numbers.
+
+    Returns:
+        The same data structure as `data` with lists of numbers instead of `torch.Tensor`.
+    """
+
+    def _convert_to_list(tensor):
+        tensor = tensor.detach().cpu()
+        if tensor.dtype == torch.bfloat16:
+            # As of Numpy 1.21.4, NumPy does not support bfloat16 (see
+            # https://github.com/numpy/numpy/blob/a47ecdea856986cd60eabbd53265c2ca5916ad5d/doc/source/user/basics.types.rst ).
+            # Until Numpy adds bfloat16, we must convert float32.
+            tensor = tensor.to(torch.float32)
+        return tensor.tolist()
+
+    return recursively_apply(_convert_to_list, data)
+
+
 def _tpu_gather(tensor):
     def _tpu_gather_one(tensor):
         if tensor.ndim == 0:

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -224,7 +224,7 @@ def find_batch_size(data):
     return data.shape[0]
 
 
-def untensorify(data):
+def listify(data):
     """
     Recursively finds tensors in a nested list/tuple/dictionary and converts them to a list of numbers.
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -25,6 +25,8 @@ from pathlib import Path
 from typing import Optional
 from unittest import mock
 
+import torch
+
 # We use TF to parse the logs
 from accelerate import Accelerator
 from accelerate.test_utils.testing import (
@@ -70,6 +72,38 @@ class TensorBoardTrackingTest(unittest.TestCase):
             # Names are randomly generated each time
             log = list(filter(lambda x: x.is_file(), Path(f"{dirpath}/{project_name}").iterdir()))[0]
             self.assertNotEqual(str(log), "")
+
+    def test_log_with_tensor(self):
+        import tensorboard.compat.proto.event_pb2 as event_pb2
+
+        project_name = "test_project_with_log"
+        with tempfile.TemporaryDirectory() as dirpath:
+            accelerator = Accelerator(log_with="tensorboard", project_dir=dirpath)
+            accelerator.init_trackers(project_name)
+            values = {"tensor": torch.tensor(1)}
+            accelerator.log(values, step=0)
+            accelerator.end_training()
+            # Logged values are stored in the outermost-tfevents file and can be read in as a TFRecord
+            # Names are randomly generated each time
+            log = list(filter(lambda x: x.is_file(), Path(f"{dirpath}/{project_name}").iterdir()))[0]
+            with open(log, "rb") as f:
+                data = f.read()
+            import struct
+
+            found_tensor = False
+            while data:
+                header = struct.unpack("Q", data[:8])
+
+                event_str = data[12 : 12 + int(header[0])]  # 8+4
+                data = data[12 + int(header[0]) + 4 :]
+                event = event_pb2.Event()
+
+                event.ParseFromString(event_str)
+                if event.HasField("summary"):
+                    for value in event.summary.value:
+                        if value.simple_value == 1.0 and value.tag == "tensor":
+                            found_tensor = True
+            self.assertTrue(found_tensor, "Converted tensor was not found in the log file!")
 
     def test_project_dir(self):
         with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `logging_dir`"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,10 +25,10 @@ from accelerate.utils import (
     convert_outputs_to_fp32,
     extract_model_from_parallel,
     find_device,
+    listify,
     patch_environment,
     recursively_apply,
     send_to_device,
-    untensorify,
 )
 
 
@@ -83,16 +83,16 @@ class UtilsTester(unittest.TestCase):
             "Unsupported types (<class 'int'>) passed to `tensor`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed.",
         )
 
-    def test_untensorify(self):
+    def test_listify(self):
         tensor = torch.tensor([1, 2, 3, 4, 5])
-        self.assertEqual(untensorify(tensor), [1, 2, 3, 4, 5])
+        self.assertEqual(listify(tensor), [1, 2, 3, 4, 5])
 
         tensor = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
-        self.assertEqual(untensorify(tensor), [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+        self.assertEqual(listify(tensor), [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
 
         tensor = torch.tensor([[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]])
         self.assertEqual(
-            untensorify(tensor), [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
+            listify(tensor), [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
         )
 
     def test_patch_environment(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,6 +28,7 @@ from accelerate.utils import (
     patch_environment,
     recursively_apply,
     send_to_device,
+    untensorify,
 )
 
 
@@ -80,6 +81,18 @@ class UtilsTester(unittest.TestCase):
         self.assertEqual(
             str(cm.exception),
             "Unsupported types (<class 'int'>) passed to `tensor`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed.",
+        )
+
+    def test_untensorify(self):
+        tensor = torch.tensor([1, 2, 3, 4, 5])
+        self.assertEqual(untensorify(tensor), [1, 2, 3, 4, 5])
+
+        tensor = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+        self.assertEqual(untensorify(tensor), [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+
+        tensor = torch.tensor([[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]])
+        self.assertEqual(
+            untensorify(tensor), [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
         )
 
     def test_patch_environment(self):


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1546 by introducing a utility which will recursively convert all tensors in a dictionary/list of dictionaries/etc/etc into pure lists of digits. This is needed for tensorboard to log, as it also can't take in numpy arrays either (tried this first, to just bring in `numpify` from `transformers`). Should be a useful util in the future however, which is why I decided to bring it out fully rather than just have it specific to tensorboard