### PR TITLE
Make sure that we only set is_accelerator_prepared on items accelerate actually prepares

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,7 @@ class Accelerator:
             result = self._prepare_fsdp(*result)
 
         for item in result:
-            if item is not None:
+            if item in self._models or item in self._optimizers or item in self._schedulers:
                 setattr(item, "_is_accelerate_prepared", True)
 
         return result if len(result) > 1 else result[0]

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,10 @@ class Accelerator:
             result = self._prepare_fsdp(*result)
 
         for item in result:
-            if item in self._models or item in self._optimizers or item in self._schedulers:
+            if any(
+                item in container
+                for container in (self._dataloaders, self._models, self._optimizers, self._schedulers)
+            ):
                 setattr(item, "_is_accelerate_prepared", True)
 
         return result if len(result) > 1 else result[0]

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -200,7 +200,7 @@ class AcceleratorTester(AccelerateTestCase):
         self.assertEqual(
             getattr(dummy_obj, "_is_accelerate_prepared", False),
             False,
-            "Dummy object should have `_is_accelerate_prepared` set to `True`"
+            "Dummy object should have `_is_accelerate_prepared` set to `True`",
         )
         self.assertEqual(
             getattr(model, "_is_accelerate_prepared", False),

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -197,7 +197,11 @@ class AcceleratorTester(AccelerateTestCase):
         model, optimizer, scheduler, train_dl, valid_dl, dummy_obj = accelerator.prepare(
             model, optimizer, scheduler, train_dl, valid_dl, dummy_obj
         )
-        self.assertTrue(dummy_obj == [1, 2, 3])
+        self.assertEqual(
+            getattr(dummy_obj, "_is_accelerate_prepared", False),
+            False,
+            "Dummy object should have `_is_accelerate_prepared` set to `True`"
+        )
         self.assertEqual(
             getattr(model, "_is_accelerate_prepared", False),
             True,

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -187,6 +187,18 @@ class AcceleratorTester(AccelerateTestCase):
         )
         self.assertTrue(dummy_obj is None)
 
+    def test_accelerator_immutable_object(self):
+        """Just test that passing a non-supported item or object to accelerator.prepare() works."""
+        accelerator = Accelerator()
+        model, optimizer, scheduler, train_dl, valid_dl = create_components()
+        dummy_obj = [1, 2, 3]
+
+        # This should work
+        model, optimizer, scheduler, train_dl, valid_dl, dummy_obj = accelerator.prepare(
+            model, optimizer, scheduler, train_dl, valid_dl, dummy_obj
+        )
+        self.assertTrue(dummy_obj == [1, 2, 3])
+
     @slow
     def test_accelerator_bnb(self):
         """Tests that the accelerator can be used with the BNB library."""

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -187,8 +187,8 @@ class AcceleratorTester(AccelerateTestCase):
         )
         self.assertTrue(dummy_obj is None)
 
-    def test_accelerator_immutable_object(self):
-        """Just test that passing a non-supported item or object to accelerator.prepare() works."""
+    def test_is_accelerator_prepared(self):
+        """Checks that `_is_accelerator_prepared` is set properly"""
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()
         dummy_obj = [1, 2, 3]
@@ -198,6 +198,31 @@ class AcceleratorTester(AccelerateTestCase):
             model, optimizer, scheduler, train_dl, valid_dl, dummy_obj
         )
         self.assertTrue(dummy_obj == [1, 2, 3])
+        self.assertEqual(
+            getattr(model, "_is_accelerate_prepared", False),
+            True,
+            "Model is missing `_is_accelerator_prepared` or is set to `False`",
+        )
+        self.assertEqual(
+            getattr(optimizer, "_is_accelerate_prepared", False),
+            True,
+            "Optimizer is missing `_is_accelerator_prepared` or is set to `False`",
+        )
+        self.assertEqual(
+            getattr(scheduler, "_is_accelerate_prepared", False),
+            True,
+            "Scheduler is missing `_is_accelerator_prepared` or is set to `False`",
+        )
+        self.assertEqual(
+            getattr(train_dl, "_is_accelerate_prepared", False),
+            True,
+            "Train Dataloader is missing `_is_accelerator_prepared` or is set to `False`",
+        )
+        self.assertEqual(
+            getattr(valid_dl, "_is_accelerate_prepared", False),
+            True,
+            "Valid Dataloader is missing `_is_accelerator_prepared` or is set to `False`",
+        )
 
     @slow
     def test_accelerator_bnb(self):


### PR DESCRIPTION
Another solution to our `_is_accelerator_prepared`, checking that the object must be in one of the `self._{type}` that is designated for storing

Solves https://github.com/huggingface/accelerate/issues/1574 