### PR TITLE
fix logger level

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -108,4 +108,5 @@ def get_logger(name: str, log_level: str = None):
     logger = logging.getLogger(name)
     if log_level is not None:
         logger.setLevel(log_level.upper())
+        logger.root.setLevel(log_level.upper())
     return MultiProcessAdapter(logger, {})


### PR DESCRIPTION
[#1178](https://github.com/huggingface/accelerate/issues/1178)
This pull request addresses an issue where the root logger's default level was set to WARNING, making `log_level` in get_logger out of work.