### PR TITLE
Expand `prepare()` doc

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1092,7 +1092,7 @@ class Accelerator:
 
             device_placement (`list[bool]`, *optional*):
                 Used to customize whether automatic device placement should be performed for each object passed. Needs
-                to be a list of the same length as `args`.
+                to be a list of the same length as `args`. Not compatible with DeepSpeed or FSDP.
 
         <Tip>
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1100,7 +1100,7 @@ class Accelerator:
 
         </Tip>
 
-        Example:
+        Examples:
 
         ```python
         >>> from accelerate import Accelerator
@@ -1108,6 +1108,20 @@ class Accelerator:
         >>> accelerator = Accelerator()
         >>> # Assume a model, optimizer, data_loader and scheduler are defined
         >>> model, optimizer, data_loader, scheduler = accelerator.prepare(model, optimizer, data_loader, scheduler)
+        ```
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator()
+        >>> # Assume a model, optimizer, data_loader and scheduler are defined
+        >>> device_placement = [True, True, False, False]
+        >>> # Will place the first to items passed in automatically to the right device
+        >>> # The second two will not
+        >>> model, optimizer, data_loader, scheduler = accelerator.prepare(
+        ...     model, optimizer, data_loader, scheduler, device_placement=device_placement
+        ... )
+        ```
         ```
         """
         if device_placement is None:


### PR DESCRIPTION
Helps again on a pain-point in https://github.com/huggingface/accelerate/issues/1574#issuecomment-1587719420 by directly stating how to properly send in device placement items and objects to `prepare()` at once