### PR TITLE
Fix TPU issues and actually initialize the device

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -88,16 +88,15 @@ def is_fp8_available():
 def is_tpu_available(check_device=True):
     "Checks if `torch_xla` is installed and potentially if a TPU is in the environment"
     # Due to bugs on the amp series GPUs, we disable torch-xla on them
-    if _tpu_available:
-        if _torch_distributed_available:
+    if torch.cuda.is_available():
+        return False
+    if _tpu_available and check_device:
+        try:
+            # Will raise a RuntimeError if no XLA configuration is found
+            _ = xm.xla_device()
+            return True
+        except RuntimeError:
             return False
-        if check_device:
-            try:
-                # Will raise a RuntimeError if no XLA configuration is found
-                _ = xm.xla_device()
-                return True
-            except RuntimeError:
-                return False
     return _tpu_available
 
 


### PR DESCRIPTION
Per discussion in google chat, the logic in the `is_tpu_available` check is incorrect and actually will not allow XLA to be ran at all. The proper check of just "is cuda available, if so return False" is used instead. This can be relied on as this is still a valid check even on a CPU-only build of torch.