### PR TITLE
Integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,6 +52,7 @@ jobs:
     
     - name: Clone and install transformers
       run: |
+        cd ..
         git clone https://github.com/huggingface/transformers
         cd transformers
         if [[ ${{ matrix.transformers-version }} = pypi ]]; then 
@@ -65,6 +66,6 @@ jobs:
 
     - name: Run Trainer tests
       run: |
-        cd transformers
+        cd ../transformers
         pytest -sv tests/trainer
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,14 +37,6 @@ jobs:
       with:
         python-version: 3.7
 
-    - name: Activate python cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ env.pythonLocation }}
-          ${{ env.HF_HOME }}
-        key: ${{ env.pythonLocation }}-integration-tests
-      
     - name: Install Accelerate from source
       run: |
         pip install --upgrade pip

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,69 @@
+# CI for specifically ensuring integrations work fine (`transformers` mainly)
+# Useful tips:
+#  - New integrations to test should have its own job, and follow a strategy method where we check both
+#    the pypi and github versions.
+#  - When checking the latest release of the integration, use
+#    git checkout $(git describe --tags `git rev-list --tags --max-count=1`) to get the latest release.
+
+name: Integration Tests
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "tests/**"
+      - ".github/**"
+      - "examples/**"
+      - "setup.py"
+    types: [opened, synchronize, reopened]
+
+env:
+  HF_HOME: ~/hf_cache
+
+jobs:
+  run-trainer-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        transformers-version: [
+          pypi,
+          github
+        ]
+    steps:
+    - uses: actions/checkout@v3.1.0
+    - name: Set up python 3.7
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.7
+
+    - name: Activate python cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ${{ env.pythonLocation }}
+          ${{ env.HF_HOME }}
+        key: ${{ env.pythonLocation }}-integration-tests
+      
+    - name: Install Accelerate from source
+      run: |
+        pip install --upgrade pip
+        pip install -e .
+    
+    - name: Clone and install transformers
+      run: |
+        git clone https://github.com/huggingface/transformers
+        cd tranformers
+        if [[ ${{ matrix.transformers-version }} = pypi ]]; then 
+          git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+        fi
+        pip install .[torch,testing]
+
+    - name: Show installed libraries
+      run: |
+        pip freeze
+
+    - name: Run Trainer tests
+      run: |
+        pytest -sv tests/test_trainer
+

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -66,5 +66,5 @@ jobs:
     - name: Run Trainer tests
       run: |
         cd transformers
-        pytest -sv tests/test_trainer
+        pytest -sv tests/trainer
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Clone and install transformers
       run: |
         git clone https://github.com/huggingface/transformers
-        cd tranformers
+        cd transformers
         if [[ ${{ matrix.transformers-version }} = pypi ]]; then 
           git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
         fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -65,5 +65,6 @@ jobs:
 
     - name: Run Trainer tests
       run: |
+        cd transformers
         pytest -sv tests/test_trainer
 

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -1,0 +1,78 @@
+# CI for specifically ensuring integrations work fine (`transformers` mainly) on GPUs
+# Useful tips:
+#  - `working-directory` should be set to the root of the repo, which is cloned on the actual CI runner.
+#    It follows the directory structure of `actions-runner/_work/{repo_name}/{repo_name}/{cloned_repo} on 
+#    prem, but in Actions setting `working-directory` looks just in the `{repo_name}` level.
+#  - New integrations to test should have its own job, and follow a strategy method where we check both
+#    the pypi and github versions.
+#  - Workflow call lets this be called from `build_and_run_tests.yml`
+#  - When using a docker container, it's recommended to set `--shm-size`, we use 16gb.
+name: Integration Tests (push to "main")
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+env:
+  HF_HOME: ~/hf_cache
+
+jobs:
+  run-trainer-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        transformers-version: [
+          pypi,
+          github
+        ]
+        cuda_visible_devices: [
+          "0", 
+          "0,1"
+        ]
+    container:
+      image: huggingface/accelerate-gpu:latest
+      options: --gpus all --shm-size "16gb"
+    defaults:
+      run:
+        shell: bash
+      steps:
+        - name: Update transformers clone & pip install
+          working-directory: transformers/
+          run: |
+            git pull
+            if [[ ${{ matrix.transformers-version }} = pypi ]]; then 
+              git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+            fi
+            source activate accelerate
+            pip install .[torch,deepspeed-testing]
+        
+        - name: Update accelerate clone and pip install
+          working-directory: accelerate/
+          run: 
+            source activate accelerate
+            git config --global --add safe.directory '*'
+            git fetch && git checkout ${{ github.sha }}
+            pip install -e .
+
+        - name: Show installed libraries
+          run: |
+            source activate accelerate
+            pip freeze
+
+        - name: Run trainer tests
+          working-directory: transformers/
+          env:
+            CUDA_VISIBLE_DEVICES: ${{ matrix.cuda_visible_devices }}
+          run: |
+            source activate accelerate
+            pytest -sv tests/test_trainer
+
+        - name: Run deepspeed tests
+          working-directory: transformers/
+          env:
+            CUDA_VISIBLE_DEVICES: ${{ matrix.cuda_visible_devices }}
+          run: |
+            source activate accelerate
+            pytest -sv tests/deepspeed
+

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -66,7 +66,7 @@ jobs:
             CUDA_VISIBLE_DEVICES: ${{ matrix.cuda_visible_devices }}
           run: |
             source activate accelerate
-            pytest -sv tests/test_trainer
+            pytest -sv tests/trainer
 
         - name: Run deepspeed tests
           working-directory: transformers/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pytorch-version: [
-          latest,
-          minimum
-        ]
         test-kind: [
           test_prod,
           test_core,
@@ -50,7 +46,7 @@ jobs:
         path: |
           ${{ env.pythonLocation }}
           ${{ env.HF_HOME }}
-        key: ${{ env.pythonLocation }}-${{ matrix.pytorch-version }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
+        key: ${{ env.pythonLocation }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
     
     - name: Install the library
       run: |
@@ -58,12 +54,11 @@ jobs:
         if [[ ${{ matrix.test-kind }} = test_prod ]]; then pip install -e .[test_prod]; fi
         if [[ ${{ matrix.test-kind }} != test_prod ]]; then pip install -e .[testing,test_trackers]; fi
         if [[ ${{ matrix.test-kind }} = test_rest ]]; then pip uninstall comet_ml -y; fi
-        if [[ ${{ matrix.pytorch-version }} = minimum ]]; then pip install torch==1.6.0; fi
         pip install pytest-reportlog tabulate
     
     - name: Run Tests
       env: 
-        PYTORCH_VERSION: ${{ matrix.pytorch-version }}
+        PYTORCH_VERSION: latest
       run: |
         make ${{ matrix.test-kind }}
 


### PR DESCRIPTION
Adds integration CI's as we try to catch issues with accelerate breaking main or released versions for core libraries.

Currently just has `transformers`, will eventually add `skorch`.

Built in a way that lets us quickly add in more tests to run. (and whatever other libs we want to add along the way)

Will monitor the runner integration after it's been merged so I can manually run that afterwards, since it relies on our hosted runner. 
