### PR TITLE
Bug fix for `check_tied_parameters_in_config`

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -259,7 +259,7 @@ def check_tied_parameters_in_config(model: nn.Module):
         has_tied_encoder_decoder = (
             hasattr(model, "config")
             and getattr(model.config, "is_encoder_decoder", False)
-            and getattr(model.config, "tie_encoder_decoder", False),
+            and getattr(model.config, "tie_encoder_decoder", False)
         )
         has_tied_module = any(hasattr(module, "_tie_weights") for module in model.modules())
 


### PR DESCRIPTION
In current codes, there is a comma for `has_tied_encoder_decoder`, which makes it a tuple rather than bool. Therefore, the result of `check_tied_parameters_in_config` is always `True`.

For example, `has_tied_encoder_decoder = (False,)`

However, `any([False, (False, ), False]) == True`. We should make it a `bool` rather than `tuple[bool]`