### PR TITLE
reset end_of_dataloader for dataloader_dispatcher

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -542,6 +542,7 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
         return batch, batch_info
 
     def __iter__(self):
+        self.reset()
         self.gradient_state._add_dataloader(self)
         main_iterator = None
         if self.state.process_index == 0:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -17,16 +17,16 @@ import unittest
 
 from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 
+from accelerate import Accelerator
 from accelerate.data_loader import (
     BatchSamplerShard,
-    DataLoaderShard,
     DataLoaderDispatcher,
+    DataLoaderShard,
     IterableDatasetShard,
     SkipBatchSampler,
     SkipDataLoader,
     skip_first_batches,
 )
-from accelerate import Accelerator
 
 
 class RandomIterableDataset(IterableDataset):
@@ -388,7 +388,7 @@ class DataLoaderTester(unittest.TestCase):
             self.assertEqual(dataloader.end_of_dataloader, idx == 3)
 
     def test_end_of_dataloader_dispatcher(self):
-        accelerator = Accelerator()
+        Accelerator()
         dataloader = DataLoaderDispatcher(range(16), batch_size=4)
         for idx, _ in enumerate(dataloader):
             self.assertEqual(dataloader.end_of_dataloader, idx == 3)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -20,11 +20,13 @@ from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 from accelerate.data_loader import (
     BatchSamplerShard,
     DataLoaderShard,
+    DataLoaderDispatcher,
     IterableDatasetShard,
     SkipBatchSampler,
     SkipDataLoader,
     skip_first_batches,
 )
+from accelerate import Accelerator
 
 
 class RandomIterableDataset(IterableDataset):
@@ -378,6 +380,16 @@ class DataLoaderTester(unittest.TestCase):
 
     def test_end_of_dataloader(self):
         dataloader = DataLoaderShard(list(range(16)), batch_size=4)
+        for idx, _ in enumerate(dataloader):
+            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+
+        # Test it also works on the second iteration
+        for idx, _ in enumerate(dataloader):
+            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+
+    def test_end_of_dataloader_dispatcher(self):
+        accelerator = Accelerator()
+        dataloader = DataLoaderDispatcher(range(16), batch_size=4)
         for idx, _ in enumerate(dataloader):
             self.assertEqual(dataloader.end_of_dataloader, idx == 3)
 


### PR DESCRIPTION
Reset `end_of_dataloader` to `False` at each iteration as in [PR#1562](https://github.com/huggingface/accelerate/pull/1562) but for the `DataLoaderDispatcher`. 