### PR TITLE
Fix failing multinode tests

### DIFF
--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -82,21 +82,21 @@ def process_execution_check():
     if accelerator.is_main_process:
         with open(path, "r") as f:
             text = "".join(f.readlines())
-        try:
-            assert text.startswith("Currently in the main process\n"), "Main process was not first"
-            if num_processes > 1:
-                assert text.endswith("Now on another process\n"), "Main process was not first"
-            if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
-                num_gpus_per_node = torch.cuda.device_count()
-                assert (
-                    text.count("Now on another process\n") == num_gpus_per_node - 1
-                ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
-        except AssertionError:
-            path.unlink()
-            raise
+        # try:
+        assert text.startswith("Currently in the main process\n"), "Main process was not first"
+        if num_processes > 1:
+            assert text.endswith("Now on another process\n"), "Main process was not first"
+        if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
+            num_gpus_per_node = torch.cuda.device_count()
+            assert (
+                text.count("Now on another process\n") == num_gpus_per_node - 1
+            ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
+        # except AssertionError:
+        #     path.unlink()
+        #     raise
 
-    if accelerator.is_main_process and path.exists():
-        path.unlink()
+    # if accelerator.is_main_process and path.exists():
+    #     path.unlink()
     accelerator.wait_for_everyone()
     # Test the decorators
     f = io.StringIO()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -82,21 +82,22 @@ def process_execution_check():
     if accelerator.is_main_process:
         with open(path, "r") as f:
             text = "".join(f.readlines())
-        # try:
-        assert text.startswith("Currently in the main process\n"), "Main process was not first"
-        if num_processes > 1:
-            assert text.endswith("Now on another process\n"), "Main process was not first"
-        if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
-            num_gpus_per_node = torch.cuda.device_count()
-            assert (
-                text.count("Now on another process\n") == num_gpus_per_node - 1
-            ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
-        # except AssertionError:
-        #     path.unlink()
-        #     raise
+        try:
+            if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
+                num_gpus_per_node = torch.cuda.device_count()
+                if num_gpus_per_node == accelerator.state.num_processes:
+                    assert text.startswith("Currently in the main process\n"), "Main process was not first"
+                    if num_processes > 1:
+                        assert text.endswith("Now on another process\n"), "Main process was not first"
+                    assert (
+                        text.count("Now on another process\n") == num_gpus_per_node - 1
+                    ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
+        except AssertionError:
+            path.unlink()
+            raise
 
-    # if accelerator.is_main_process and path.exists():
-    #     path.unlink()
+    if accelerator.is_main_process and path.exists():
+        path.unlink()
     accelerator.wait_for_everyone()
     # Test the decorators
     f = io.StringIO()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -66,78 +66,80 @@ def print_on(state, process_idx):
 def process_execution_check():
     accelerator = Accelerator()
     num_processes = accelerator.num_processes
+    if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
+        num_gpus_per_node = torch.cuda.device_count()
+    else:
+        num_gpus_per_node = accelerator.state.num_processes
+    # We only run this test on non-multinode
+    if num_gpus_per_node == accelerator.state.num_processes:
+        # Test main_process_first context manager
+        path = Path("check_main_process_first.txt")
+        with accelerator.main_process_first():
+            if accelerator.is_main_process:
+                time.sleep(0.1)  # ensure main process takes longest
+                with open(path, "a+") as f:
+                    f.write("Currently in the main process\n")
+            else:
+                with open(path, "a+") as f:
+                    f.write("Now on another process\n")
+        accelerator.wait_for_everyone()
 
-    # Test main_process_first context manager
-    path = Path("check_main_process_first.txt")
-    with accelerator.main_process_first():
         if accelerator.is_main_process:
-            time.sleep(0.1)  # ensure main process takes longest
-            with open(path, "a+") as f:
-                f.write("Currently in the main process\n")
-        else:
-            with open(path, "a+") as f:
-                f.write("Now on another process\n")
-    accelerator.wait_for_everyone()
+            with open(path, "r") as f:
+                text = "".join(f.readlines())
+            try:
+                assert text.startswith("Currently in the main process\n"), "Main process was not first"
+                if num_processes > 1:
+                    assert text.endswith("Now on another process\n"), "Main process was not first"
+                assert (
+                    text.count("Now on another process\n") == num_gpus_per_node - 1
+                ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
+            except AssertionError:
+                path.unlink()
+                raise
 
-    if accelerator.is_main_process:
-        with open(path, "r") as f:
-            text = "".join(f.readlines())
-        try:
-            if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
-                num_gpus_per_node = torch.cuda.device_count()
-                if num_gpus_per_node == accelerator.state.num_processes:
-                    assert text.startswith("Currently in the main process\n"), "Main process was not first"
-                    if num_processes > 1:
-                        assert text.endswith("Now on another process\n"), "Main process was not first"
-                    assert (
-                        text.count("Now on another process\n") == num_gpus_per_node - 1
-                    ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
-        except AssertionError:
+        if accelerator.is_main_process and path.exists():
             path.unlink()
-            raise
-
-    if accelerator.is_main_process and path.exists():
-        path.unlink()
-    accelerator.wait_for_everyone()
-    # Test the decorators
-    f = io.StringIO()
-    with contextlib.redirect_stdout(f):
-        accelerator.on_main_process(print_main)(accelerator.state)
-    result = f.getvalue().rstrip()
-    if accelerator.is_main_process:
-        assert result == "Printing from the main process 0", f"{result} != Printing from the main process 0"
-    else:
-        assert f.getvalue().rstrip() == "", f'{result} != ""'
-    f.truncate(0)
-    f.seek(0)
-
-    with contextlib.redirect_stdout(f):
-        accelerator.on_local_main_process(print_local_main)(accelerator.state)
-    if accelerator.is_local_main_process:
-        assert f.getvalue().rstrip() == "Printing from the local main process 0"
-    else:
-        assert f.getvalue().rstrip() == ""
-    f.truncate(0)
-    f.seek(0)
-
-    with contextlib.redirect_stdout(f):
-        accelerator.on_last_process(print_last)(accelerator.state)
-    if accelerator.is_last_process:
-        assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
-    else:
-        assert f.getvalue().rstrip() == ""
-    f.truncate(0)
-    f.seek(0)
-
-    for process_idx in range(num_processes):
+        accelerator.wait_for_everyone()
+        # Test the decorators
+        f = io.StringIO()
         with contextlib.redirect_stdout(f):
-            accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
-        if accelerator.process_index == process_idx:
-            assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
+            accelerator.on_main_process(print_main)(accelerator.state)
+        result = f.getvalue().rstrip()
+        if accelerator.is_main_process:
+            assert result == "Printing from the main process 0", f"{result} != Printing from the main process 0"
+        else:
+            assert f.getvalue().rstrip() == "", f'{result} != ""'
+        f.truncate(0)
+        f.seek(0)
+
+        with contextlib.redirect_stdout(f):
+            accelerator.on_local_main_process(print_local_main)(accelerator.state)
+        if accelerator.is_local_main_process:
+            assert f.getvalue().rstrip() == "Printing from the local main process 0"
         else:
             assert f.getvalue().rstrip() == ""
         f.truncate(0)
         f.seek(0)
+
+        with contextlib.redirect_stdout(f):
+            accelerator.on_last_process(print_last)(accelerator.state)
+        if accelerator.is_last_process:
+            assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
+        else:
+            assert f.getvalue().rstrip() == ""
+        f.truncate(0)
+        f.seek(0)
+
+        for process_idx in range(num_processes):
+            with contextlib.redirect_stdout(f):
+                accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
+            if accelerator.process_index == process_idx:
+                assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
+            else:
+                assert f.getvalue().rstrip() == ""
+            f.truncate(0)
+            f.seek(0)
 
 
 def init_state_check():

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -526,9 +526,9 @@ def test_split_between_processes_tensor():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
     if state.local_process_index == 0:
         print("\n**Test process execution**")
     process_execution_check()
@@ -537,31 +537,31 @@ def main():
         print("\n**Test split between processes as a list**")
     test_split_between_processes_list()
 
-    if state.local_process_index == 0:
-        print("\n**Test split between processes as a dict**")
-    test_split_between_processes_nested_dict()
+    # if state.local_process_index == 0:
+    #     print("\n**Test split between processes as a dict**")
+    # test_split_between_processes_nested_dict()
 
-    if state.local_process_index == 0:
-        print("\n**Test split between processes as a tensor**")
-    test_split_between_processes_tensor()
+    # if state.local_process_index == 0:
+    #     print("\n**Test split between processes as a tensor**")
+    # test_split_between_processes_tensor()
 
-    if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-        central_dl_preparation_check()
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+    #     central_dl_preparation_check()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -63,83 +63,77 @@ def print_on(state, process_idx):
     print(f"Printing from process {process_idx}: {state.process_index}")
 
 
-def process_execution_check():
+def process_execution_check(num_gpus_per_node):
     accelerator = Accelerator()
     num_processes = accelerator.num_processes
-    if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
-        num_gpus_per_node = torch.cuda.device_count()
-    else:
-        num_gpus_per_node = accelerator.state.num_processes
-    # We only run this test on non-multinode
-    if num_gpus_per_node == accelerator.state.num_processes:
-        # Test main_process_first context manager
-        path = Path("check_main_process_first.txt")
-        with accelerator.main_process_first():
-            if accelerator.is_main_process:
-                time.sleep(0.1)  # ensure main process takes longest
-                with open(path, "a+") as f:
-                    f.write("Currently in the main process\n")
-            else:
-                with open(path, "a+") as f:
-                    f.write("Now on another process\n")
-        accelerator.wait_for_everyone()
-
+    # Test main_process_first context manager
+    path = Path("check_main_process_first.txt")
+    with accelerator.main_process_first():
         if accelerator.is_main_process:
-            with open(path, "r") as f:
-                text = "".join(f.readlines())
-            try:
-                assert text.startswith("Currently in the main process\n"), "Main process was not first"
-                if num_processes > 1:
-                    assert text.endswith("Now on another process\n"), "Main process was not first"
-                assert (
-                    text.count("Now on another process\n") == num_gpus_per_node - 1
-                ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
-            except AssertionError:
-                path.unlink()
-                raise
+            time.sleep(0.1)  # ensure main process takes longest
+            with open(path, "a+") as f:
+                f.write("Currently in the main process\n")
+        else:
+            with open(path, "a+") as f:
+                f.write("Now on another process\n")
+    accelerator.wait_for_everyone()
 
-        if accelerator.is_main_process and path.exists():
+    if accelerator.is_main_process:
+        with open(path, "r") as f:
+            text = "".join(f.readlines())
+        try:
+            assert text.startswith("Currently in the main process\n"), "Main process was not first"
+            if num_processes > 1:
+                assert text.endswith("Now on another process\n"), "Main process was not first"
+            assert (
+                text.count("Now on another process\n") == num_gpus_per_node - 1
+            ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
+        except AssertionError:
             path.unlink()
-        accelerator.wait_for_everyone()
-        # Test the decorators
-        f = io.StringIO()
-        with contextlib.redirect_stdout(f):
-            accelerator.on_main_process(print_main)(accelerator.state)
-        result = f.getvalue().rstrip()
-        if accelerator.is_main_process:
-            assert result == "Printing from the main process 0", f"{result} != Printing from the main process 0"
-        else:
-            assert f.getvalue().rstrip() == "", f'{result} != ""'
-        f.truncate(0)
-        f.seek(0)
+            raise
 
+    if accelerator.is_main_process and path.exists():
+        path.unlink()
+    accelerator.wait_for_everyone()
+    # Test the decorators
+    f = io.StringIO()
+    with contextlib.redirect_stdout(f):
+        accelerator.on_main_process(print_main)(accelerator.state)
+    result = f.getvalue().rstrip()
+    if accelerator.is_main_process:
+        assert result == "Printing from the main process 0", f"{result} != Printing from the main process 0"
+    else:
+        assert f.getvalue().rstrip() == "", f'{result} != ""'
+    f.truncate(0)
+    f.seek(0)
+
+    with contextlib.redirect_stdout(f):
+        accelerator.on_local_main_process(print_local_main)(accelerator.state)
+    if accelerator.is_local_main_process:
+        assert f.getvalue().rstrip() == "Printing from the local main process 0"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    with contextlib.redirect_stdout(f):
+        accelerator.on_last_process(print_last)(accelerator.state)
+    if accelerator.is_last_process:
+        assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
+    else:
+        assert f.getvalue().rstrip() == ""
+    f.truncate(0)
+    f.seek(0)
+
+    for process_idx in range(num_processes):
         with contextlib.redirect_stdout(f):
-            accelerator.on_local_main_process(print_local_main)(accelerator.state)
-        if accelerator.is_local_main_process:
-            assert f.getvalue().rstrip() == "Printing from the local main process 0"
+            accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
+        if accelerator.process_index == process_idx:
+            assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
         else:
             assert f.getvalue().rstrip() == ""
         f.truncate(0)
         f.seek(0)
-
-        with contextlib.redirect_stdout(f):
-            accelerator.on_last_process(print_last)(accelerator.state)
-        if accelerator.is_last_process:
-            assert f.getvalue().rstrip() == f"Printing from the last process {accelerator.state.num_processes - 1}"
-        else:
-            assert f.getvalue().rstrip() == ""
-        f.truncate(0)
-        f.seek(0)
-
-        for process_idx in range(num_processes):
-            with contextlib.redirect_stdout(f):
-                accelerator.on_process(print_on, process_index=process_idx)(accelerator.state, process_idx)
-            if accelerator.process_index == process_idx:
-                assert f.getvalue().rstrip() == f"Printing from process {process_idx}: {accelerator.process_index}"
-            else:
-                assert f.getvalue().rstrip() == ""
-            f.truncate(0)
-            f.seek(0)
 
 
 def init_state_check():
@@ -532,21 +526,28 @@ def main():
     # if state.local_process_index == 0:
     #     print("**Initialization**")
     # init_state_check()
-    if state.local_process_index == 0:
-        print("\n**Test process execution**")
-    process_execution_check()
+    
+    if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
+        num_gpus_per_node = torch.cuda.device_count()
+    else:
+        num_gpus_per_node = accelerator.state.num_processes
+    # We only run this test on non-multinode
+    if num_gpus_per_node == accelerator.state.num_processes:
+        if state.local_process_index == 0:
+            print("\n**Test process execution**")
+        process_execution_check()
 
-    if state.local_process_index == 0:
-        print("\n**Test split between processes as a list**")
-    test_split_between_processes_list()
+        if state.local_process_index == 0:
+            print("\n**Test split between processes as a list**")
+        test_split_between_processes_list()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test split between processes as a dict**")
-    # test_split_between_processes_nested_dict()
+        if state.local_process_index == 0:
+            print("\n**Test split between processes as a dict**")
+        test_split_between_processes_nested_dict()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test split between processes as a tensor**")
-    # test_split_between_processes_tensor()
+        if state.local_process_index == 0:
+            print("\n**Test split between processes as a tensor**")
+        test_split_between_processes_tensor()
 
     # if state.local_process_index == 0:
     #     print("\n**Test random number generator synchronization**")

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -63,7 +63,7 @@ def print_on(state, process_idx):
     print(f"Printing from process {process_idx}: {state.process_index}")
 
 
-def process_execution_check(num_gpus_per_node):
+def process_execution_check():
     accelerator = Accelerator()
     num_processes = accelerator.num_processes
     # Test main_process_first context manager
@@ -86,8 +86,8 @@ def process_execution_check(num_gpus_per_node):
             if num_processes > 1:
                 assert text.endswith("Now on another process\n"), "Main process was not first"
             assert (
-                text.count("Now on another process\n") == num_gpus_per_node - 1
-            ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {num_gpus_per_node}"
+                text.count("Now on another process\n") == accelerator.num_processes - 1
+            ), f"Only wrote to file {text.count('Now on another process') + 1} times, not {accelerator.num_processes}"
         except AssertionError:
             path.unlink()
             raise

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -523,10 +523,10 @@ def test_split_between_processes_tensor():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
-    
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
+
     if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
         num_gpus_per_node = torch.cuda.device_count()
     else:
@@ -549,23 +549,23 @@ def main():
             print("\n**Test split between processes as a tensor**")
         test_split_between_processes_tensor()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    if state.local_process_index == 0:
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
-    #     central_dl_preparation_check()
+    if state.local_process_index == 0:
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.TPU and is_torch_version(">=", "1.8.0"):
+        central_dl_preparation_check()
 
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check()
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -527,26 +527,23 @@ def main():
         print("**Initialization**")
     init_state_check()
 
-    if accelerator.state.distributed_type == DistributedType.MULTI_GPU:
-        num_gpus_per_node = torch.cuda.device_count()
+    if state.distributed_type == DistributedType.MULTI_GPU:
+        num_processes_per_node = torch.cuda.device_count()
     else:
-        num_gpus_per_node = accelerator.state.num_processes
+        num_processes_per_node = state.num_processes
+
     # We only run this test on non-multinode
-    if num_gpus_per_node == accelerator.state.num_processes:
-        if state.local_process_index == 0:
-            print("\n**Test process execution**")
+    if state.process_index == 0 and num_processes_per_node == state.num_processes:
+        print("\n**Test process execution**")
         process_execution_check()
 
-        if state.local_process_index == 0:
-            print("\n**Test split between processes as a list**")
+        print("\n**Test split between processes as a list**")
         test_split_between_processes_list()
 
-        if state.local_process_index == 0:
-            print("\n**Test split between processes as a dict**")
+        print("\n**Test split between processes as a dict**")
         test_split_between_processes_nested_dict()
 
-        if state.local_process_index == 0:
-            print("\n**Test split between processes as a tensor**")
+        print("\n**Test split between processes as a tensor**")
         test_split_between_processes_tensor()
 
     if state.local_process_index == 0:


### PR DESCRIPTION
These particular tests shouldn't be ran on multinode, as the printing etc it relies on is not always able to be recreated well across nodes, and same with the split_between_processes.

Solves https://github.com/huggingface/accelerate/issues/1606