### PR TITLE
Ignore low_zero option when only device is available

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -591,6 +591,10 @@ def get_balanced_memory(
             ]
         )
 
+    if num_devices == 1:
+        # We cannot do low_zero on just one GPU
+        low_zero = False
+
     module_sizes = compute_module_sizes(model, dtype=dtype, special_dtypes=special_dtypes)
     per_gpu = module_sizes[""] // (num_devices - 1 if low_zero else num_devices)
 


### PR DESCRIPTION
When only one device is available, there is nothing we can really do to minimize the memory on device 0, so let's just ignore that flag.

Fixes #1614