### PR TITLE
Fix TensorBoard/logging dir issue

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -255,7 +255,7 @@ class Accelerator:
         else:
             self.project_configuration = ProjectConfiguration(project_dir=project_dir)
         if project_dir is not None and self.project_dir is None:
-            self.project_configuration.project_dir = project_dir
+            self.project_configuration.set_directories(project_dir)
         if mixed_precision is not None:
             mixed_precision = str(mixed_precision)
             if mixed_precision not in PrecisionType:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -377,9 +377,14 @@ class ProjectConfiguration:
         metadata={"help": "The current save iteration."},
     )
 
-    def __post_init__(self):
+    def set_directories(self, project_dir: str = None):
+        "Sets `self.project_dir` and `self.logging_dir` to the appropriate values."
+        self.project_dir = project_dir
         if self.logging_dir is None:
-            self.logging_dir = self.project_dir
+            self.logging_dir = project_dir
+
+    def __post_init__(self):
+        self.set_directories(self.project_dir)
 
 
 @dataclass

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -38,7 +38,7 @@ from accelerate.test_utils.testing import (
     skip,
 )
 from accelerate.tracking import CometMLTracker, GeneralTracker
-from accelerate.utils import is_comet_ml_available, is_tensorboard_available
+from accelerate.utils import ProjectConfiguration, is_comet_ml_available, is_tensorboard_available
 
 
 if is_comet_ml_available():
@@ -112,6 +112,11 @@ class TensorBoardTrackingTest(unittest.TestCase):
             _ = Accelerator(log_with="tensorboard")
         with tempfile.TemporaryDirectory() as dirpath:
             _ = Accelerator(log_with="tensorboard", project_dir=dirpath)
+
+    def test_project_dir_with_config(self):
+        config = ProjectConfiguration(total_limit=30)
+        with tempfile.TemporaryDirectory() as dirpath:
+            _ = Accelerator(log_with="tensorboard", project_dir=dirpath, project_config=config)
 
 
 @require_wandb


### PR DESCRIPTION
Fixes an issue where if you passed in a ProjectConfig and a `project_dir` but not a `logging_dir`, the logging_dir wouldn't be set due to th epost_init never being ran. This PR refactors that logic to be a bit more fullproof.

solves https://github.com/huggingface/accelerate/issues/1619