### PR TITLE
Fix transformers sync bug with accumulate

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -857,10 +857,7 @@ class Accelerator:
 
     def _do_sync(self):
         "Sets the right `sync_gradients` context and either resets or increases `self.step`"
-        if (
-            self.gradient_state.plugin_kwargs.get("sync_with_dataloader", True)
-            and self.gradient_state.end_of_dataloader
-        ):
+        if self.gradient_state.sync_with_dataloader and self.gradient_state.end_of_dataloader:
             self.step = 0
             self.gradient_state._set_sync_gradients(True)
         else:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -857,7 +857,10 @@ class Accelerator:
 
     def _do_sync(self):
         "Sets the right `sync_gradients` context and either resets or increases `self.step`"
-        if self.gradient_state.end_of_dataloader:
+        if (
+            self.gradient_state.plugin_kwargs.get("sync_with_dataloader", True)
+            and self.gradient_state.end_of_dataloader
+        ):
             self.step = 0
             self.gradient_state._set_sync_gradients(True)
         else:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -911,10 +911,12 @@ class GradientState:
         - **sync_gradients** (`bool`) -- Whether the gradients should be synced across all devices
         - **active_dataloader** (`Optional[DataLoader]`) -- The dataloader that is currently being iterated over
         - **dataloader_references** (`List[Optional[DataLoader]]`) -- A list of references to the dataloaders that are
-          being iterated over
+            being iterated over
         - **num_steps** (`int`) -- The number of steps to accumulate over
         - **adjust_scheduler** (`bool`) -- Whether the scheduler should be adjusted to account for the gradient
-          accumulation
+            accumulation
+        - **sync_with_dataloader** (`bool`) -- Whether the gradients should be synced at the end of the dataloader
+            iteration and the number of total steps reset
     """
 
     _shared_state = SharedDict()
@@ -942,6 +944,11 @@ class GradientState:
     def adjust_scheduler(self) -> bool:
         "Returns whether the scheduler should be adjusted"
         return self.plugin_kwargs.get("adjust_scheduler", False)
+
+    @property
+    def sync_with_dataloader(self) -> bool:
+        "Returns whether the gradients should be synced at the end of the dataloader iteration and the number of total steps reset"
+        return self.plugin_kwargs.get("sync_with_dataloader", True)
 
     @property
     def initialized(self) -> bool:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -395,6 +395,12 @@ class GradientAccumulationPlugin(KwargsHandler):
             "help": "Whether to adjust the scheduler steps to account for the number of steps being accumulated. Should be `True` if the used scheduler was not adjusted for gradient accumulation."
         },
     )
+    sync_with_dataloader: int = field(
+        default=True,
+        metadata={
+            "help": "Whether to synchronize setting the gradients when at the end of the dataloader. Should only be set to `False` if you know what you're doing."
+        },
+    )
 
 
 @dataclass

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -395,7 +395,7 @@ class GradientAccumulationPlugin(KwargsHandler):
             "help": "Whether to adjust the scheduler steps to account for the number of steps being accumulated. Should be `True` if the used scheduler was not adjusted for gradient accumulation."
         },
     )
-    sync_with_dataloader: int = field(
+    sync_with_dataloader: bool = field(
         default=True,
         metadata={
             "help": "Whether to synchronize setting the gradients when at the end of the dataloader. Should only be set to `False` if you know what you're doing."

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -395,9 +395,11 @@ class GradientAccumulationPlugin(KwargsHandler):
             "help": "Whether to adjust the scheduler steps to account for the number of steps being accumulated. Should be `True` if the used scheduler was not adjusted for gradient accumulation."
         },
     )
-    max_steps: int = field(
+    sync_with_dataloader: int = field(
         default=True,
-        metadata={"help": "The maximum steps to accumulate over. Default is `None`"},
+        metadata={
+            "help": "Whether to synchronize setting the gradients when at the end of the dataloader. Should only be set to `False` if you know what you're doing."
+        },
     )
 
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -395,11 +395,9 @@ class GradientAccumulationPlugin(KwargsHandler):
             "help": "Whether to adjust the scheduler steps to account for the number of steps being accumulated. Should be `True` if the used scheduler was not adjusted for gradient accumulation."
         },
     )
-    sync_with_dataloader: int = field(
+    max_steps: int = field(
         default=True,
-        metadata={
-            "help": "Whether to synchronize setting the gradients when at the end of the dataloader. Should only be set to `False` if you know what you're doing."
-        },
+        metadata={"help": "The maximum steps to accumulate over. Default is `None`"},
     )
 
 


### PR DESCRIPTION
Adds a new `sync_with_dataloader` arg to the `GradientAccumulationPlugin`, to assist with using it across epochs via `total_batched_samples` (https://github.com/huggingface/transformers/issues/23935#issuecomment-1588134562)