### PR TITLE
Set torch.Generator device

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -740,7 +740,7 @@ def prepare_data_loader(
                 sampler = dataloader.batch_sampler.sampler
             if hasattr(sampler, "generator"):
                 if sampler.generator is None:
-                    sampler.generator = torch.Generator()
+                    sampler.generator = torch.Generator(device=device)
                 synchronized_generator = sampler.generator
 
             batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler


### PR DESCRIPTION
Can help with issues like this one: https://discuss.huggingface.co/t/runtime-error-trainer-api-dataloader-using-cpu-but-expecting-cuda/38746

(not too sure though - I just looked for torch.Generator without device=device in the codebase)