### PR TITLE
fixes offload dtype

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -163,7 +163,6 @@ def set_module_tensor_to_device(
     with torch.no_grad():
         if value is None:
             new_value = old_value.to(device)
-            # change the dtype of a tensor on meta device
             if dtype is not None and device in ["meta", torch.device("meta")]:
                 new_value = new_value.to(dtype)
                 if not is_buffer:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1124,9 +1124,13 @@ def load_checkpoint_in_model(
 
                 if param_device == "disk":
                     if offload_buffers or param_name not in buffer_names:
+                        if dtype is None:
+                            dtype = param.dtype
                         set_module_tensor_to_device(model, param_name, "meta", dtype=dtype)
                     offload_weight(param, param_name, offload_folder, index=offload_index)
                 elif param_device == "cpu" and offload_state_dict:
+                    if dtype is None:
+                        dtype = param.dtype
                     set_module_tensor_to_device(model, param_name, "meta", dtype=dtype)
                     offload_weight(param, param_name, state_dict_folder, index=state_dict_index)
                 else:


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes a problem I had when I tried to offload a tensor to `meta` device using `set_module_tensor_to_device` with a specific dtype. The `dtype` of the meta tensor is not changed by the `dtype` arg. 

When we move back the meta tensor to `cpu` or `cuda`, if we don't indicate the `dtype` ,which is the case when we added the hook, it will take the `dtype` of the `meta` tensor. 
```python
    if value is not None:
        if dtype is None:
            value = value.to(old_value.dtype)
```
