### PR TITLE
Arc 107 gpu fix offloading

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -163,7 +163,7 @@ def set_module_tensor_to_device(
     with torch.no_grad():
         if value is None:
             if is_xpu_available():
-                device = torch.device("xpu")
+                device =  torch.device("xpu")
             new_value = old_value.to(device)
             if dtype is not None and device in ["meta", torch.device("meta")]:
                 new_value = new_value.to(dtype)
@@ -172,18 +172,18 @@ def set_module_tensor_to_device(
                     module._parameters[tensor_name] = param_cls(new_value, requires_grad=old_value.requires_grad)
         elif isinstance(value, torch.Tensor):
             if is_xpu_available():
-                device = torch.device("xpu")
+                device =  torch.device("xpu")
             new_value = value.to(device)
         else:
             if is_xpu_available():
-                device = torch.device("xpu")
+                device =  torch.device("xpu")
             new_value = torch.tensor(value, device=device)
 
         if is_buffer:
             module._buffers[tensor_name] = new_value
         elif value is not None or torch.device(device) != module._parameters[tensor_name].device:
             if is_xpu_available():
-                device = torch.device("xpu")
+                device =  torch.device("xpu")
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
             if param_cls.__name__ in ["Int8Params", "FP4Params"]:
@@ -599,11 +599,8 @@ def get_balanced_memory(
             [
                 d
                 for d in max_memory
-                if (
-                    torch.device(d).type == "xpu"
-                    or torch.xpu.get_device_properties(d).dev_type == "gpu"
-                    and max_memory[d] > 0
-                )
+                if (torch.device(d).type == "xpu" or torch.xpu.get_device_properties(d).dev_type == "gpu"
+                and max_memory[d] > 0)
             ]
         )
 
@@ -660,7 +657,7 @@ def get_balanced_memory(
 
     if low_zero:
         min_zero = max(0, module_sizes[""] - sum([max_memory[i] for i in range(1, num_devices)]))
-        max_memory[0] = max(min_zero, max_memory[0])
+        max_memory[0] = min(min_zero, max_memory[0])
 
     return max_memory
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -649,7 +649,7 @@ def get_balanced_memory(
 
     if low_zero:
         min_zero = max(0, module_sizes[""] - sum([max_memory[i] for i in range(1, num_devices)]))
-        max_memory[0] = min(min_zero, max_memory[0])
+        max_memory[0] = max(min_zero, max_memory[0])
 
     return max_memory
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -162,10 +162,10 @@ def set_module_tensor_to_device(
 
     with torch.no_grad():
         if value is None:
-            if not torch.cuda.is_available():
-                device = "xpu"
+            if not is_xpu_available():
+                device = torch.device("cuda")
             else:
-                device = "cuda"
+                device = torch.device("xpu")
             new_value = old_value.to(device)
             if dtype is not None and device in ["meta", torch.device("meta")]:
                 new_value = new_value.to(dtype)
@@ -173,25 +173,25 @@ def set_module_tensor_to_device(
                     param_cls = type(module._parameters[tensor_name])
                     module._parameters[tensor_name] = param_cls(new_value, requires_grad=old_value.requires_grad)
         elif isinstance(value, torch.Tensor):
-            if not torch.cuda.is_available():
-                device = "xpu"
+            if not is_xpu_available():
+                device = torch.device("cuda")
             else:
-                device = "cuda"
+                device = torch.device("xpu")
             new_value = value.to(device)
         else:
-            if not torch.cuda.is_available():
-                device = "xpu"
+            if not is_xpu_available():
+                device = torch.device("cuda")
             else:
-                device = "cuda"
+                device = torch.device("xpu")
             new_value = torch.tensor(value, device=device)
 
         if is_buffer:
             module._buffers[tensor_name] = new_value
         elif value is not None or torch.device(device) != module._parameters[tensor_name].device:
-            if not torch.cuda.is_available():
-                device = "xpu"
+            if not is_xpu_available():
+                device = torch.device("cuda")
             else:
-                device = "cuda"
+                device = torch.device("xpu")
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
             if param_cls.__name__ in ["Int8Params", "FP4Params"]:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -162,10 +162,10 @@ def set_module_tensor_to_device(
 
     with torch.no_grad():
         if value is None:
-            if torch.cuda.is_available():
-                device = "cuda"
-            elif torch.xpu.is_available():
+            if not torch.cuda.is_available():
                 device = "xpu"
+            else:
+                device = "cuda"
             new_value = old_value.to(device)
             if dtype is not None and device in ["meta", torch.device("meta")]:
                 new_value = new_value.to(dtype)
@@ -173,25 +173,25 @@ def set_module_tensor_to_device(
                     param_cls = type(module._parameters[tensor_name])
                     module._parameters[tensor_name] = param_cls(new_value, requires_grad=old_value.requires_grad)
         elif isinstance(value, torch.Tensor):
-            if torch.cuda.is_available():
-                device = "cuda"
-            elif torch.xpu.is_available():
+            if not torch.cuda.is_available():
                 device = "xpu"
+            else:
+                device = "cuda"
             new_value = value.to(device)
         else:
-            if torch.cuda.is_available():
-                device = "cuda"
-            elif torch.xpu.is_available():
+            if not torch.cuda.is_available():
                 device = "xpu"
+            else:
+                device = "cuda"
             new_value = torch.tensor(value, device=device)
 
         if is_buffer:
             module._buffers[tensor_name] = new_value
         elif value is not None or torch.device(device) != module._parameters[tensor_name].device:
-            if torch.cuda.is_available():
-                device = "cuda"
-            elif torch.xpu.is_available():
+            if not torch.cuda.is_available():
                 device = "xpu"
+            else:
+                device = "cuda"
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
             if param_cls.__name__ in ["Int8Params", "FP4Params"]:
@@ -668,7 +668,7 @@ def get_balanced_memory(
 
     if low_zero:
         min_zero = max(0, module_sizes[""] - sum([max_memory[i] for i in range(1, num_devices)]))
-        max_memory[0] = min(min_zero, max_memory[0])
+        max_memory[0] = max(min_zero, max_memory[0])
 
     return max_memory
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -162,9 +162,7 @@ def set_module_tensor_to_device(
 
     with torch.no_grad():
         if value is None:
-            if not is_xpu_available():
-                device = torch.device("cuda")
-            else:
+            if is_xpu_available():
                 device = torch.device("xpu")
             new_value = old_value.to(device)
             if dtype is not None and device in ["meta", torch.device("meta")]:
@@ -173,24 +171,18 @@ def set_module_tensor_to_device(
                     param_cls = type(module._parameters[tensor_name])
                     module._parameters[tensor_name] = param_cls(new_value, requires_grad=old_value.requires_grad)
         elif isinstance(value, torch.Tensor):
-            if not is_xpu_available():
-                device = torch.device("cuda")
-            else:
+            if is_xpu_available():
                 device = torch.device("xpu")
             new_value = value.to(device)
         else:
-            if not is_xpu_available():
-                device = torch.device("cuda")
-            else:
+            if is_xpu_available():
                 device = torch.device("xpu")
             new_value = torch.tensor(value, device=device)
 
         if is_buffer:
             module._buffers[tensor_name] = new_value
         elif value is not None or torch.device(device) != module._parameters[tensor_name].device:
-            if not is_xpu_available():
-                device = torch.device("cuda")
-            else:
+            if is_xpu_available():
                 device = torch.device("xpu")
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -163,7 +163,7 @@ def set_module_tensor_to_device(
     with torch.no_grad():
         if value is None:
             if is_xpu_available():
-                device =  torch.device("xpu")
+                device = torch.device("xpu")
             new_value = old_value.to(device)
             if dtype is not None and device in ["meta", torch.device("meta")]:
                 new_value = new_value.to(dtype)
@@ -172,18 +172,18 @@ def set_module_tensor_to_device(
                     module._parameters[tensor_name] = param_cls(new_value, requires_grad=old_value.requires_grad)
         elif isinstance(value, torch.Tensor):
             if is_xpu_available():
-                device =  torch.device("xpu")
+                device = torch.device("xpu")
             new_value = value.to(device)
         else:
             if is_xpu_available():
-                device =  torch.device("xpu")
+                device = torch.device("xpu")
             new_value = torch.tensor(value, device=device)
 
         if is_buffer:
             module._buffers[tensor_name] = new_value
         elif value is not None or torch.device(device) != module._parameters[tensor_name].device:
             if is_xpu_available():
-                device =  torch.device("xpu")
+                device = torch.device("xpu")
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
             if param_cls.__name__ in ["Int8Params", "FP4Params"]:
@@ -599,8 +599,11 @@ def get_balanced_memory(
             [
                 d
                 for d in max_memory
-                if (torch.device(d).type == "xpu" or torch.xpu.get_device_properties(d).dev_type == "gpu"
-                and max_memory[d] > 0)
+                if (
+                    torch.device(d).type == "xpu"
+                    or torch.xpu.get_device_properties(d).dev_type == "gpu"
+                    and max_memory[d] > 0
+                )
             ]
         )
 


### PR DESCRIPTION
This mandatory fix is for offloading from cpu to respective xpu /arc devices .
Since ipex is out of pytorch tree , converting tensors back from cpu to devices must require this fix for xpu/arc graphics card devices (cuda is implicit).
@sgugger @muellerzr 