### PR TITLE
[`BigModeling`] Add missing check for quantized models

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -387,11 +387,11 @@ def dispatch_model(
         retie_parameters(model, tied_params)
     else:
         device = list(device_map.values())[0]
-        if device != "disk" and not (
-            getattr(model, "is_quantized", False) or getattr(model, "is_loaded_in_8bit", False)
-        ):
+        # for backward compatibility
+        is_quantized = getattr(model, "is_quantized", False) or getattr(model, "is_loaded_in_8bit", False)
+        if device != "disk" and not is_quantized:
             model.to(device)
-        elif getattr(model, "is_quantized", False):
+        elif is_quantized:
             pass
         else:
             raise ValueError(

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -387,7 +387,9 @@ def dispatch_model(
         retie_parameters(model, tied_params)
     else:
         device = list(device_map.values())[0]
-        if device != "disk" and not getattr(model, "is_quantized", False):
+        if device != "disk" and not (
+            getattr(model, "is_quantized", False) or getattr(model, "is_loaded_in_8bit", False)
+        ):
             model.to(device)
         elif getattr(model, "is_quantized", False):
             pass

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -387,8 +387,10 @@ def dispatch_model(
         retie_parameters(model, tied_params)
     else:
         device = list(device_map.values())[0]
-        if device != "disk":
+        if device != "disk" and not getattr(model, "is_quantized", False):
             model.to(device)
+        elif getattr(model, "is_quantized", False):
+            pass
         else:
             raise ValueError(
                 "You are trying to offload the whole model to the disk. Please use the `disk_offload` function instead."

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -391,9 +391,7 @@ def dispatch_model(
         is_quantized = getattr(model, "is_quantized", False) or getattr(model, "is_loaded_in_8bit", False)
         if device != "disk" and not is_quantized:
             model.to(device)
-        elif is_quantized:
-            pass
-        else:
+        elif not is_quantized:
             raise ValueError(
                 "You are trying to offload the whole model to the disk. Please use the `disk_offload` function instead."
             )


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/24540 and the failing test: https://github.com/huggingface/accelerate/actions/runs/5396594202/jobs/9800396637

Currently on the main branch loading a quantized model on a single GPU fails:
```python
from transformers import AutoModelForCausalLM, AutoConfig, AutoTokenizer
import torch

model_path="facebook/opt-350m"

config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
model = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True, load_in_8bit=True, device_map="auto")

tokenizer = AutoTokenizer.from_pretrained(model_path)

input_text = "Describe the solar system."
input_ids = tokenizer(input_text, return_tensors="pt").input_ids.to("cuda")

outputs = model.generate(input_ids, max_length=100)
print(tokenizer.decode(outputs[0]))
```

In https://github.com/huggingface/accelerate/pull/1648 it seems that a check was missing before calling `.to` to the model in case of single GPU model dispatching. Adding a small check circunvemts this issue

cc @sgugger @SunMarc 