### PR TITLE
Update dataloader

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -347,6 +347,10 @@ class _DataLoaderWrapper:
             self.__dict__[attr] = val
         setattr(self.dataloader, attr, val)
 
+    def __len__(self):
+        # Make `len()` work with dataloader wrapper
+        return len(self.dataloader)
+
 
 class DataLoaderShard(_DataLoaderWrapper, DataLoaderStateMixin):
     """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -833,7 +833,12 @@ def prepare_data_loader(
 def _dataloader_forcibly_setattr(dataloader, name, val):
     # NOTE After initialization, `DataLoader` prevents one from updating its internal attrs
     # We need to be careful of what we are doing here.
-    super(DataLoader, dataloader).__setattr__(name, val)
+    if isinstance(dataloader, DataLoader):
+        super(DataLoader, dataloader).__setattr__(name, val)
+    elif isinstance(dataloader, _DataLoaderWrapper):
+        _dataloader_forcibly_setattr(dataloader.dataloader, name, val)
+    else:
+        raise NotImplementedError
 
 
 class SkipBatchSampler(BatchSampler):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -741,8 +741,7 @@ def prepare_data_loader(
         )
 
     new_dataset = dataloader.dataset
-    # Iterable dataset doesn't like batch_sampler, but data_loader creates a default one for it
-    new_batch_sampler = dataloader.batch_sampler if not isinstance(new_dataset, IterableDataset) else None
+    new_batch_sampler = dataloader.batch_sampler
     sampler_is_batch_sampler = False
     synchronized_generator = None
     # No change if no multiprocess
@@ -757,6 +756,8 @@ def prepare_data_loader(
                 process_index=process_index,
                 split_batches=split_batches,
             )
+            if new_batch_sampler is not None and split_batches:
+                new_batch_sampler.batch_size = new_batch_sampler.batch_size // num_processes
         else:
             # New batch sampler for the current process.
             sampler_is_batch_sampler = isinstance(dataloader.sampler, BatchSampler) or dataloader.batch_sampler is None

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -217,7 +217,17 @@ class BatchSamplerShard(BatchSampler):
                     idx += 1
 
 
-class IterableDatasetShard(IterableDataset):
+if is_torch_version(">=", "1.11.0"):
+    from torch.utils.data import IterDataPipe
+
+    # Inherit from `IterDataPipe` so that we can benefit from `DataLoader`'s forward compatibilities
+    # (e.g. use synced seeds to shuffle the datapipe every epoch)
+    IterableDatasetShardBaseClass = IterDataPipe
+else:
+    IterableDatasetShardBaseClass = IterableDataset
+
+
+class IterableDatasetShard(IterableDatasetShardBaseClass):
     """
     Wraps a PyTorch `IterableDataset` to generate samples for one of the processes only. Instances of this class will
     always yield a number of samples that is a round multiple of the actual batch size (depending of the value of

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -370,7 +370,7 @@ class DataLoaderTester(unittest.TestCase):
         self.assertListEqual(list(new_batch_sampler), [[8, 9, 10, 11], [12, 13, 14, 15]])
 
     def test_skip_data_loader(self):
-        dataloader = SkipDataLoader(list(range(16)), batch_size=4, skip_batches=2)
+        dataloader = SkipDataLoader(DataLoader(list(range(16)), batch_size=4), skip_batches=2)
         self.assertListEqual([t.tolist() for t in dataloader], [[8, 9, 10, 11], [12, 13, 14, 15]])
 
     def test_skip_first_batches(self):
@@ -379,7 +379,7 @@ class DataLoaderTester(unittest.TestCase):
         self.assertListEqual([t.tolist() for t in new_dataloader], [[8, 9, 10, 11], [12, 13, 14, 15]])
 
     def test_end_of_dataloader(self):
-        dataloader = DataLoaderShard(list(range(16)), batch_size=4)
+        dataloader = DataLoaderShard(DataLoader(list(range(16)), batch_size=4))
         for idx, _ in enumerate(dataloader):
             self.assertEqual(dataloader.end_of_dataloader, idx == 3)
 
@@ -389,7 +389,7 @@ class DataLoaderTester(unittest.TestCase):
 
     def test_end_of_dataloader_dispatcher(self):
         Accelerator()
-        dataloader = DataLoaderDispatcher(range(16), batch_size=4)
+        dataloader = DataLoaderDispatcher(DataLoader(range(16), batch_size=4))
         for idx, _ in enumerate(dataloader):
             self.assertEqual(dataloader.end_of_dataloader, idx == 3)
 


### PR DESCRIPTION
This PR does the following:

1. The current ``SkipDataLoader`` and ``SkipBatchSampler`` keep skipping batches every epoch. I think it's more useful if they only skip batches for the first epoch

2. PyTorch DataLoader adds forward compatibilities for DataPipes. In particular, it broadcasts a shared seed across all dist processes to shuffle a datapipe when ``__iter__`` is called (See [here](https://github.com/pytorch/pytorch/blob/89fcfc1b8c449f072dbd694c55d790e33c19b781/torch/utils/data/dataloader.py#L574)). This causes ``DataLoaderDispatcher`` to fall into an infinite wait, since ``DataLoaderDispatcher`` only creates an iterator for the main process.

3. Currently, ``prepare_data_loader`` re-builds a new DataLoader and completely discards the user's DataLoader. This could be problematic when a user subclass ``DataLoader`` and adds some custom behavior to the DataLoader. This PR proposes to turn ``DataLoaderShard`` and ``DataLoaderDispatcher`` into a wrapper that wraps user's DataLoader. They should hehave exactly the same as before except that ``DataLoaderShard`` and ``DataLoaderDispatcher`` are no longer ``DataLoader`` instances (e.g. isinstance check will fail)