### PR TITLE
Check for port usage before launch

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -156,6 +156,7 @@ from .memory import find_executable_batch_size, release_memory
 from .other import (
     extract_model_from_parallel,
     get_pretty_name,
+    is_port_in_use,
     merge_dicts,
     patch_environment,
     save,

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -24,7 +24,7 @@ from ..commands.config.config_args import SageMakerConfig
 from ..commands.config.config_utils import DYNAMO_BACKENDS
 from ..utils import DynamoBackend, PrecisionType, is_ipex_available, is_torch_version, is_xpu_available
 from ..utils.constants import DEEPSPEED_MULTINODE_LAUNCHERS
-from ..utils.other import merge_dicts
+from ..utils.other import is_port_in_use, merge_dicts
 from .dataclasses import DistributedType, SageMakerDistributedType
 
 
@@ -127,6 +127,14 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
         setattr(args, "nproc_per_node", str(num_processes))
         if main_process_port is not None:
             setattr(args, "master_port", str(main_process_port))
+
+    master_port = getattr(args, "master_port", 29500)
+    if is_port_in_use(master_port):
+        raise ConnectionError(
+            f"Tried to launch distributed training communication on port `{master_port}`, but another process is utilizing it. "
+            "Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file)"
+            " and rerun your script."
+        )
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")
@@ -251,6 +259,14 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict
         setattr(args, "nproc_per_node", str(num_processes))
         if main_process_port is not None:
             setattr(args, "master_port", str(main_process_port))
+
+    master_port = getattr(args, "master_port", 29500)
+    if is_port_in_use(master_port):
+        raise ConnectionError(
+            f"Tried to launch distributed training communication on port `{master_port}`, but another process is utilizing it. "
+            "Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file)"
+            " and rerun your script."
+        )
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -128,10 +128,12 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
         if main_process_port is not None:
             setattr(args, "master_port", str(main_process_port))
 
-    master_port = getattr(args, "master_port", 29500)
-    if is_port_in_use(master_port):
+    if main_process_port is None:
+        main_process_port = 29500
+
+    if is_port_in_use(main_process_port):
         raise ConnectionError(
-            f"Tried to launch distributed communication on port `{master_port}`, but another process is utilizing it. "
+            f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
             "Please specify a different port (such as using the `----main_process_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script."
         )
@@ -260,11 +262,13 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict
         if main_process_port is not None:
             setattr(args, "master_port", str(main_process_port))
 
-    master_port = getattr(args, "master_port", 29500)
-    if is_port_in_use(master_port):
+    if main_process_port is None:
+        main_process_port = 29500
+
+    if is_port_in_use(main_process_port):
         raise ConnectionError(
-            f"Tried to launch distributed communication on port `{master_port}`, but another process is utilizing it. "
-            "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
+            f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
+            "Please specify a different port (such as using the `----main_process_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script."
         )
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -132,7 +132,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
     if is_port_in_use(master_port):
         raise ConnectionError(
             f"Tried to launch distributed communication on port `{master_port}`, but another process is utilizing it. "
-            "Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file)"
+            "Please specify a different port (such as using the `----main_process_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script."
         )
 
@@ -264,7 +264,7 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict
     if is_port_in_use(master_port):
         raise ConnectionError(
             f"Tried to launch distributed communication on port `{master_port}`, but another process is utilizing it. "
-            "Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file)"
+            "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script."
         )
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -131,7 +131,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
     master_port = getattr(args, "master_port", 29500)
     if is_port_in_use(master_port):
         raise ConnectionError(
-            f"Tried to launch distributed training communication on port `{master_port}`, but another process is utilizing it. "
+            f"Tried to launch distributed communication on port `{master_port}`, but another process is utilizing it. "
             "Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script."
         )
@@ -263,7 +263,7 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict
     master_port = getattr(args, "master_port", 29500)
     if is_port_in_use(master_port):
         raise ConnectionError(
-            f"Tried to launch distributed training communication on port `{master_port}`, but another process is utilizing it. "
+            f"Tried to launch distributed communication on port `{master_port}`, but another process is utilizing it. "
             "Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script."
         )

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -173,10 +173,12 @@ def merge_dicts(source, destination):
     return destination
 
 
-def is_port_in_use(port: int = 29500) -> bool:
+def is_port_in_use(port: int = None) -> bool:
     """
     Checks if a port is in use on `localhost`. Useful for checking if multiple `accelerate launch` commands have been
     run and need to see if the port is already in use.
     """
+    if port is None:
+        port = 29500
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("localhost", port)) == 0

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import socket
 from contextlib import contextmanager
 
 import torch
@@ -170,3 +171,12 @@ def merge_dicts(source, destination):
             destination[key] = value
 
     return destination
+
+
+def is_port_in_use(port: int = 29500) -> bool:
+    """
+    Checks if a port is in use on `localhost`. Useful for checking if multiple `accelerate launch` commands have been
+    run and need to see if the port is already in use.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        return s.connect_ex(("localhost", port)) == 0


### PR DESCRIPTION
Helps https://github.com/huggingface/accelerate/issues/1649 by checking under the following circumstances:

- If a user has multiple `accelerate launch` they wish to perform and is training on multi-GPU (or deepspeed)
- See if the connection port `torch.distributed` relies on for communication is already in use
- If so, direct them to specify a different communication port

This directly helps catch the following error before it occurs:

```python
RuntimeError: The server socket has failed to listen on any local network address. The server socket has failed to bind to [::]:29500 (errno: 98 - Address already in use). The server socket has failed to bind to 0.0.0.0:29500 (errno: 98 - Address already in use).
```

And replaces it with:
```python
Traceback (most recent call last):
  File "/home/zach_mueller_huggingface_co/miniconda3/envs/accelerate/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/accelerate_cli.py", line 45, in main
    args.func(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/launch.py", line 960, in launch_command
    multi_gpu_launcher(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/commands/launch.py", line 639, in multi_gpu_launcher
    current_env = prepare_multi_gpu_env(args)
  File "/home/zach_mueller_huggingface_co/accelerate/src/accelerate/utils/launch.py", line 133, in prepare_multi_gpu_env
    raise ConnectionError(
ConnectionError: Tried to launch distributed communication on port `29500`, but another process is utilizing it. Please specify a different port (such as using the `--master_port` flag or specifying a different `main_process_port` in your config file) and rerun your script.
```