### PR TITLE
Bump integration python version tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,10 +32,10 @@ jobs:
         ]
     steps:
     - uses: actions/checkout@v3.1.0
-    - name: Set up python 3.7
+    - name: Set up python 3.8
       uses: actions/setup-python@v3
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install Accelerate from source
       run: |


### PR DESCRIPTION
Transformers removed support for 3.7 today. Until we decide if Accelerate should do something similar, this PR changes the workflow to use 3.8 for the integration tests