### PR TITLE
Doc big model inference

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -22,7 +22,7 @@
   - local: usage_guides/training_zoo
     title: Example Zoo
   - local: usage_guides/big_modeling
-    title: How perform inference on large models with small resources
+    title: How to perform inference on large models with small resources
   - local: usage_guides/quantization
     title: How to quantize model 
   - local: usage_guides/distributed_inference

--- a/docs/source/usage_guides/big_modeling.md
+++ b/docs/source/usage_guides/big_modeling.md
@@ -74,7 +74,7 @@ initializes an empty model with a bit more than 100B parameters. Behind the scen
 
 It's possible your model is so big that even a single copy won't fit in RAM. That doesn't mean it can't be loaded: if you have one or several GPUs, this is more memory available to store your model. In this case, it's better if your checkpoint is split into several smaller files that we call checkpoint shards.
 
-🤗 Accelerate will handle sharded checkpoints as long as you follow the following format: your checkpoint should be in a folder, with several files containing the partial state dicts, and there should be an index in the JSON format that contains a dictionary mapping parameter names to the file containing their weights. You can easily shard your model with ["~Accelerator.save_model"]. For instance, we could have a folder containing:
+🤗 Accelerate will handle sharded checkpoints as long as you follow the following format: your checkpoint should be in a folder, with several files containing the partial state dicts, and there should be an index in the JSON format that contains a dictionary mapping parameter names to the file containing their weights. You can easily shard your model with [`~Accelerator.save_model`]. For instance, we could have a folder containing:
 
 ```bash
 first_state_dict.bin

--- a/docs/source/usage_guides/big_modeling.md
+++ b/docs/source/usage_guides/big_modeling.md
@@ -139,7 +139,7 @@ Then, load the checkpoint we just downloaded with:
 from accelerate import load_checkpoint_and_dispatch
 
 model = load_checkpoint_and_dispatch(
-    model, checkpoint = weights_location, device_map="auto", no_split_module_classes=['Block']
+    model, checkpoint=weights_location, device_map="auto", no_split_module_classes=['Block']
 )
 ```
 
@@ -215,7 +215,7 @@ model.hf_device_map
 You can also design your `device_map` yourself if you prefer to explicitly decide where each layer should be. In this case, the command above becomes:
 
 ```py
-model = load_checkpoint_and_dispatch(model, checkpoint = weights_location, device_map=my_device_map)
+model = load_checkpoint_and_dispatch(model, checkpoint=weights_location, device_map=my_device_map)
 ```
 
 ### Run the model

--- a/docs/source/usage_guides/big_modeling.md
+++ b/docs/source/usage_guides/big_modeling.md
@@ -74,7 +74,7 @@ initializes an empty model with a bit more than 100B parameters. Behind the scen
 
 It's possible your model is so big that even a single copy won't fit in RAM. That doesn't mean it can't be loaded: if you have one or several GPUs, this is more memory available to store your model. In this case, it's better if your checkpoint is split into several smaller files that we call checkpoint shards.
 
-🤗 Accelerate will handle sharded checkpoints as long as you follow the following format: your checkpoint should be in a folder, with several files containing the partial state dicts, and there should be an index in the JSON format that contains a dictionary mapping parameter names to the file containing their weights. For instance, we could have a folder containing:
+🤗 Accelerate will handle sharded checkpoints as long as you follow the following format: your checkpoint should be in a folder, with several files containing the partial state dicts, and there should be an index in the JSON format that contains a dictionary mapping parameter names to the file containing their weights. You can easily shard your model with ["~Accelerator.save_model"]. For instance, we could have a folder containing:
 
 ```bash
 first_state_dict.bin
@@ -98,6 +98,8 @@ and `first_state_dict.bin` containing the weights for `"linear1.weight"` and `"l
 ### Loading weights
 
 The second tool 🤗 Accelerate introduces is a function [`load_checkpoint_and_dispatch`], that will allow you to load a checkpoint inside your empty model. This supports full checkpoints (a single file containing the whole state dict) as well as sharded checkpoints. It will also automatically dispatch those weights across the devices you have available (GPUs, CPU RAM), so if you are loading a sharded checkpoint, the maximum RAM usage will be the size of the biggest shard.
+
+If you want to use big model inference with 🤗 Transformers models, check out this [documentation](https://huggingface.co/docs/transformers/main/en/main_classes/model#large-model-loading).
 
 Here is how we can use this to load the [GPT2-1.5B](https://huggingface.co/marcsun13/gpt2-xl-linear-sharded) model.
 


### PR DESCRIPTION
# What does this PR do? 
This PR modifies replaces the example in big model inference documentation so that we use a model that is not from the transformers library. Tested the new example in this [colab](https://colab.research.google.com/drive/1Mj6YOrETdrCzLWjEBjpC-pt1DvquMEW0?usp=sharing). 