### PR TITLE
update readme in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -51,13 +51,13 @@ To run it in each of these various modes, use the following commands:
     python ./nlp_example.py  # from a server with a GPU
     ```
 - with fp16 (mixed-precision)
-    * from any server by passing `fp16=True` to the `Accelerator`.
+    * from any server by passing `mixed_precison=fp16` to the `Accelerator`.
         ```bash
-        python ./nlp_example.py --fp16
+        python ./nlp_example.py --mixed_precision fp16
         ```
     * from any server with Accelerate launcher
         ```bash
-        accelerate launch --fp16 ./nlp_example.py
+        accelerate launch --mixed_precision fp16 ./nlp_example.py
 - multi GPUs (using PyTorch distributed mode)
     * With Accelerate config and launcher
         ```bash
@@ -139,13 +139,13 @@ To run it in each of these various modes, use the following commands:
     python ./cv_example.py  # from a server with a GPU
     ```
 - with fp16 (mixed-precision)
-    * from any server by passing `fp16=True` to the `Accelerator`.
+    * from any server by passing `mixed_precison=fp16` to the `Accelerator`.
         ```bash
-        python ./cv_example.py --data_dir path_to_data --fp16
+        python ./cv_example.py --data_dir path_to_data --mixed_precison fp16
         ```
     * from any server with Accelerate launcher
         ```bash
-        accelerate launch --fp16 ./cv_example.py --data_dir path_to_data
+        accelerate launch --mixed_precison fp16 ./cv_example.py --data_dir path_to_data
 - multi GPUs (using PyTorch distributed mode)
     * With Accelerate config and launcher
         ```bash


### PR DESCRIPTION
This PR updates the readme in exmaples, when using fp16(mixed-precision), we should pass in `--mixed_precision fp16` rather than `--fp16`

If you run `nlp_examle.py` with `--fp16`
 ```python
python ./nlp_example.py --fp16
 ```
will get the following error message:
```text
usage: nlp_example.py [-h] [--mixed_precision {no,fp16,bf16,fp8}] [--cpu]
nlp_example.py: error: unrecognized arguments: --fp16
```
@sgugger 