### PR TITLE
fix bnb tests

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2353,8 +2353,10 @@ class Accelerator:
             # Safetensors does not allow tensor aliasing.
             # We're going to remove aliases before saving
             ptrs = collections.defaultdict(list)
+            # when bnb serialization is used the weights in the state dict can be strings
             for name, tensor in state_dict.items():
-                ptrs[id_tensor_storage(tensor)].append(name)
+                if not isinstance(tensor, str):
+                    ptrs[id_tensor_storage(tensor)].append(name)
 
             # These are all the pointers of shared tensors.
             shared_ptrs = {ptr: names for ptr, names in ptrs.items() if len(names) > 1}

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -183,7 +183,12 @@ def shard_checkpoint(
     storage_id_to_block = {}
 
     for key, weight in state_dict.items():
-        storage_id = id_tensor_storage(weight)
+        # when bnb serialization is used the weights in the state dict can be strings
+        # check: https://github.com/huggingface/transformers/pull/24416 for more details
+        if isinstance(weight, str):
+            continue
+        else:
+            storage_id = id_tensor_storage(weight)
 
         # If a `weight` shares the same underlying storage as another tensor, we put `weight` in the same `block`
         if storage_id in storage_id_to_block:

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn as nn
 
 from accelerate import Accelerator, init_empty_weights
-from accelerate.test_utils import require_bnb, require_cuda, require_huggingface_suite, require_multi_gpu, skip, slow
+from accelerate.test_utils import require_bnb, require_cuda, require_huggingface_suite, require_multi_gpu, slow
 from accelerate.utils.bnb import load_and_quantize_model
 from accelerate.utils.dataclasses import BnbQuantizationConfig
 
@@ -306,7 +306,6 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             )
             self.check_inference_correctness(model_8bit)
 
-    @skip
     def test_int8_serialization(self):
         r"""
         Test whether it is possible to serialize a model in 8-bit.
@@ -339,7 +338,6 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
 
             self.check_inference_correctness(model_8bit_from_saved)
 
-    @skip
     def test_int8_serialization_shard(self):
         r"""
         Test whether it is possible to serialize a model in 8-bit.

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -20,7 +20,7 @@ import torch
 import torch.nn as nn
 
 from accelerate import Accelerator, init_empty_weights
-from accelerate.test_utils import require_bnb, require_cuda, require_huggingface_suite, slow
+from accelerate.test_utils import require_bnb, require_cuda, require_huggingface_suite, require_multi_gpu, skip, slow
 from accelerate.utils.bnb import load_and_quantize_model
 from accelerate.utils.dataclasses import BnbQuantizationConfig
 
@@ -74,7 +74,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             self.model_8bit,
             self.bnb_quantization_config,
             weights_location=self.weights_location,
-            device_map="auto",
+            device_map={"": 0},
             no_split_module_classes=["BloomBlock"],
         )
 
@@ -190,6 +190,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
         )
         self.assertTrue(model.lm_head.weight.dtype == torch.float32)
 
+    @require_multi_gpu
     def test_cpu_gpu_loading_random_device_map(self):
         from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -242,6 +243,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
         )
         self.check_inference_correctness(model_8bit)
 
+    @require_multi_gpu
     def test_cpu_gpu_loading_custom_device_map(self):
         from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -271,6 +273,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
         )
         self.check_inference_correctness(model_8bit)
 
+    @require_multi_gpu
     def test_cpu_gpu_disk_loading_custom_device_map_kwargs(self):
         from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -303,6 +306,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             )
             self.check_inference_correctness(model_8bit)
 
+    @skip
     def test_int8_serialization(self):
         r"""
         Test whether it is possible to serialize a model in 8-bit.
@@ -335,6 +339,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
 
             self.check_inference_correctness(model_8bit_from_saved)
 
+    @skip
     def test_int8_serialization_shard(self):
         r"""
         Test whether it is possible to serialize a model in 8-bit.
@@ -606,6 +611,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
         )
         self.assertTrue(model.lm_head.weight.dtype == torch.float32)
 
+    @require_multi_gpu
     def test_cpu_gpu_loading_random_device_map(self):
         from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -658,6 +664,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
         )
         self.check_inference_correctness(model_4bit)
 
+    @require_multi_gpu
     def test_cpu_gpu_loading_custom_device_map(self):
         from transformers import AutoConfig, AutoModelForCausalLM
 
@@ -687,6 +694,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
         )
         self.check_inference_correctness(model_4bit)
 
+    @require_multi_gpu
     def test_cpu_gpu_disk_loading_custom_device_map_kwargs(self):
         from transformers import AutoConfig, AutoModelForCausalLM
 


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes the bnb tests that did not pass the Accelerate nightly single_gpu and multi_gpu test. I added decorators to function that should only be run on multi_gpu. I also fixed the 8-bit serialization tests because of the new version of bnb (check this PR for more [details](https://github.com/huggingface/transformers/pull/24416))