### PR TITLE
Update Apex build command

### DIFF
--- a/docs/source/usage_guides/megatron_lm.md
+++ b/docs/source/usage_guides/megatron_lm.md
@@ -100,7 +100,10 @@ conda install pytorch torchvision torchaudio cudatoolkit=11.3 -c pytorch
 ```
 git clone https://github.com/NVIDIA/apex
 cd apex
-pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./
+# if pip >= 23.1 (ref: https://pip.pypa.io/en/stable/news/#v23-1) which supports multiple `--config-settings` with the same key... 
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --config-settings "--build-option=--cpp_ext" --config-settings "--build-option=--cuda_ext" ./
+# otherwise
+pip install -v --disable-pip-version-check --no-cache-dir --no-build-isolation --global-option="--cpp_ext" --global-option="--cuda_ext" ./
 cd ..
 ```
 


### PR DESCRIPTION
Due to pip having deprecated `--global-option` and `--build-option`, the new build command will be highly relevant in the future (removal is planned for 23.3, see https://github.com/pypa/pip/issues/11859).

See also https://github.com/NVIDIA/apex/pull/1690 for why the command is different from the Apex README.