### PR TITLE
Improve quality errors

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Check if failure
       if: ${{ failure() }}
       run: |
-        echo "Quality check failed. Please ensure the right dependency versions are installed with `pip install -e .[quality]` and rerun `make style; make quality;`" >> $GITHUB_STEP_SUMMARY
+        echo "Quality check failed. Please ensure the right dependency versions are installed with 'pip install -e .[quality]' and rerun 'make style; make quality;'" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -15,3 +15,8 @@ jobs:
       run: pip install -e .[quality]
     - name: Run Quality check
       run: make quality
+    - name: Check if failure
+      if: ${{ failure() }}
+      run: 
+        echo "Quality check failed. Please ensure the right quality versions are installed with `pip install -e .[quality]` and rerun `make style; make quality;`"
+

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,5 +18,5 @@ jobs:
     - name: Check if failure
       if: ${{ failure() }}
       run: 
-        echo "Quality check failed. Please ensure the right quality versions are installed with `pip install -e .[quality]` and rerun `make style; make quality;`"
+        echo "Quality check failed. Please ensure the right dependency versions are installed with `pip install -e .[quality]` and rerun `make style; make quality;`" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,6 +17,6 @@ jobs:
       run: make quality
     - name: Check if failure
       if: ${{ failure() }}
-      run: 
+      run: |
         echo "Quality check failed. Please ensure the right dependency versions are installed with `pip install -e .[quality]` and rerun `make style; make quality;`" >> $GITHUB_STEP_SUMMARY
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2938,4 +2938,8 @@ class Accelerator:
         ...     ...
         ```
         """
+
+
+
+        
         return skip_first_batches(dataloader, num_batches=num_batches)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2938,5 +2938,4 @@ class Accelerator:
         ...     ...
         ```
         """
-
         return skip_first_batches(dataloader, num_batches=num_batches)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2939,7 +2939,4 @@ class Accelerator:
         ```
         """
 
-
-
-        
         return skip_first_batches(dataloader, num_batches=num_batches)


### PR DESCRIPTION
When quality checks fail, provides a clear error in the job summary, as seen here: https://github.com/huggingface/accelerate/actions/runs/5509213335

> Quality check failed. Please ensure the right dependency versions are installed with 'pip install -e .[quality]' and rerun 'make style; make quality;'

Many users have issues with knowing what to do or how to install with it, so this is one solution I have in mind, otherwise go as far as a github bot that points to the different job summaries and their statuses/errors that automatically gets updated each push. As github doesn't just let you go "Details" and automatically see the summary