### PR TITLE
Add offload for 8-bit model

### DIFF
--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -114,13 +114,14 @@ For 4-bit quantization, the selected modules will be kept in `torch_dtype` that 
  You just need to pass a custom `device_map` in order to offload modules on cpu/disk. The offload modules will be dispatched on the GPU when needed. Here's an example :
 
 ```py
-device_map = {'transformer.wte': 0,
-              'transformer.wpe': 0,
-              'transformer.drop': 0,
-              'transformer.h':'cpu',
-              'transformer.ln_f': 'disk', 
-              'lm_head': 'disk'
-              }
+device_map = {
+    "transformer.wte": 0,
+    "transformer.wpe": 0,
+    "transformer.drop": 0,
+    "transformer.h": "cpu",
+    "transformer.ln_f": "disk",
+    "lm_head": "disk",
+}
 ```
 ### Fine-tune a quantized model
 

--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -102,6 +102,26 @@ quantized_model_from_saved = load_and_quantize_model(empty_model, weights_locati
 
 Note that 4-bit model serialization is currently not supported.
 
+### Offload modules to cpu and disk 
+
+You can offload some modules to cpu/disk if you don't have enough space on the GPU to store the entire model on your GPUs.
+This uses big model inference under the hood. Check this [documentation](https://huggingface.co/docs/accelerate/usage_guides/big_modeling) for more details. 
+
+For 8-bit quantization, the selected modules will be converted to 8-bit precision. 
+
+For 4-bit quantization, the selected modules will be kept in `torch_dtype` that the user passed in `BnbQuantizationConfig`.  We will add support to convert these offloaded modules in 4-bit when 4-bit serialization will be possible. 
+
+ You just need to pass a custom `device_map` in order to offload modules on cpu/disk. The offload modules will be dispatched on the GPU when needed. Here's an example :
+
+```py
+device_map = {'transformer.wte': 0,
+              'transformer.wpe': 0,
+              'transformer.drop': 0,
+              'transformer.h':'cpu',
+              'transformer.ln_f': 'disk', 
+              'lm_head': 'disk'
+              }
+```
 ### Fine-tune a quantized model
 
 With the official support of adapters in the Hugging Face ecosystem, you can fine-tune quantized models. Please have a look at [peft](https://github.com/huggingface/peft) library for more details.

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -446,26 +446,32 @@ def get_parameter_device(parameter: nn.Module):
     return next(parameter.parameters()).device
 
 
-def quantize_and_offload_8bit(model, param, param_name, new_dtype, offload_folder, offload_index):
-    set_module_tensor_to_device(model, param_name, 0, dtype=new_dtype, value=param)
-    tensor_name = param_name
-    module = model
-    if "." in tensor_name:
-        splits = tensor_name.split(".")
-        for split in splits[:-1]:
-            new_module = getattr(module, split)
-            if new_module is None:
-                raise ValueError(f"{module} has no attribute {split}.")
-            module = new_module
-        tensor_name = splits[-1]
-    # offload weights
-    module._parameters[tensor_name].requires_grad = False
-    offload_weight(module._parameters[tensor_name], param_name, offload_folder, index=offload_index)
-    if hasattr(module._parameters[tensor_name], "SCB"):
-        offload_weight(
-            module._parameters[tensor_name].SCB,
-            param_name.replace("weight", "SCB"),
-            offload_folder,
-            index=offload_index,
-        )
+def quantize_and_offload_8bit(model, param, param_name, new_dtype, offload_folder, offload_index, fp16_statistics):
+    # if it is not quantized, we quantize and offload the quantized weights and the SCB stats
+    if fp16_statistics is None:
+        set_module_tensor_to_device(model, param_name, 0, dtype=new_dtype, value=param)
+        tensor_name = param_name
+        module = model
+        if "." in tensor_name:
+            splits = tensor_name.split(".")
+            for split in splits[:-1]:
+                new_module = getattr(module, split)
+                if new_module is None:
+                    raise ValueError(f"{module} has no attribute {split}.")
+                module = new_module
+            tensor_name = splits[-1]
+        # offload weights
+        module._parameters[tensor_name].requires_grad = False
+        offload_weight(module._parameters[tensor_name], param_name, offload_folder, index=offload_index)
+        if hasattr(module._parameters[tensor_name], "SCB"):
+            offload_weight(
+                module._parameters[tensor_name].SCB,
+                param_name.replace("weight", "SCB"),
+                offload_folder,
+                index=offload_index,
+            )
+    else:
+        offload_weight(param, param_name, offload_folder, index=offload_index)
+        offload_weight(fp16_statistics, param_name.replace("weight", "SCB"), offload_folder, index=offload_index)
+
     set_module_tensor_to_device(model, param_name, "meta", dtype=new_dtype, value=torch.empty(*param.size()))

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1378,14 +1378,6 @@ class BnbQuantizationConfig:
         metadata={"help": "an explicit list of the modules that we don't quantize. We keep them in `torch.float32`."},
     )
 
-    enable_offload: bool = field(
-        default=False,
-        metadata={
-            "help": "enable offload on cpu/disk. For 8-bit conversion, offloaded modules will be converted in 8-bit. "
-            "For 4-bit conversion, offloaded modules will be kept in `torch_dtype`"
-        },
-    )
-
     def __post_init__(self):
         """
         Safety checker that arguments are correct - also replaces some NoneType arguments with their default values.
@@ -1404,9 +1396,6 @@ class BnbQuantizationConfig:
 
         if not isinstance(self.llm_int8_threshold, (int, float)):
             raise ValueError("llm_int8_threshold must be a float or an int")
-
-        if not isinstance(self.enable_offload, bool):
-            raise ValueError("enable_offload must be a boolean")
 
         if not isinstance(self.bnb_4bit_quant_type, str):
             raise ValueError("bnb_4bit_quant_type must be a string")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1378,14 +1378,11 @@ class BnbQuantizationConfig:
         metadata={"help": "an explicit list of the modules that we don't quantize. We keep them in `torch.float32`."},
     )
 
-    # we will see if it will be useful
-    enable_fp32_cpu_offload: bool = field(
+    enable_offload: bool = field(
         default=False,
         metadata={
-            "help": """ this flag is used for advanced use cases and users that are aware of this feature. If you want to split
-            your model in different parts and run some parts in int8 on GPU and some parts in fp32 on CPU, you can use
-            this flag. This is useful for offloading large models such as `google/flan-t5-xxl`. Note that the int8
-            operations will not be run on CPU."""
+            "help": "enable offload on cpu/disk. For 8-bit conversion, offloaded modules will be converted in 8-bit. "
+            "For 4-bit conversion, offloaded modules will be kept in `torch_dtype`"
         },
     )
 
@@ -1408,8 +1405,8 @@ class BnbQuantizationConfig:
         if not isinstance(self.llm_int8_threshold, (int, float)):
             raise ValueError("llm_int8_threshold must be a float or an int")
 
-        if not isinstance(self.enable_fp32_cpu_offload, bool):
-            raise ValueError("enable_fp32_cpu_offload must be a boolean")
+        if not isinstance(self.enable_offload, bool):
+            raise ValueError("enable_offload must be a boolean")
 
         if not isinstance(self.bnb_4bit_quant_type, str):
             raise ValueError("bnb_4bit_quant_type must be a string")
@@ -1438,9 +1435,6 @@ class BnbQuantizationConfig:
 
         if self.keep_in_fp32_modules is not None and not isinstance(self.keep_in_fp32_modules, list):
             raise ValueError("keep_in_fp_32_modules must be a list of strings")
-
-        if not isinstance(self.enable_fp32_cpu_offload, bool):
-            raise ValueError("enable_fp32_cpu_offload must be a boolean")
 
         if self.load_in_4bit:
             self.target_dtype = CustomDtype.INT4

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1305,7 +1305,7 @@ def load_checkpoint_in_model(
                             new_dtype = param.dtype
                         if offload_8bit_bnb:
                             quantize_and_offload_8bit(
-                                model, param, param_name, new_dtype, offload_folder, offload_index
+                                model, param, param_name, new_dtype, offload_folder, offload_index, fp16_statistics
                             )
                             continue
                         else:
@@ -1316,7 +1316,7 @@ def load_checkpoint_in_model(
                         new_dtype = param.dtype
                     if offload_8bit_bnb:
                         quantize_and_offload_8bit(
-                            model, param, param_name, new_dtype, state_dict_folder, state_dict_index
+                            model, param, param_name, new_dtype, state_dict_folder, state_dict_index, fp16_statistics
                         )
                     else:
                         set_module_tensor_to_device(model, param_name, "meta", dtype=new_dtype)

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1198,7 +1198,7 @@ def load_checkpoint_in_model(
         keep_in_fp32_modules(`List[str]`, *optional*):
             A list of the modules that we keep in `torch.float32` dtype.
         offload_8bit_bnb(`bool`, *optional*):
-            Enable offload of 8-bit modules on cpu/disk
+            Whether or not to enable offload of 8-bit modules on cpu/disk.
 
     """
     if offload_8bit_bnb:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1197,7 +1197,7 @@ def load_checkpoint_in_model(
             Whether or not to include the buffers in the weights offloaded to disk.
         keep_in_fp32_modules(`List[str]`, *optional*):
             A list of the modules that we keep in `torch.float32` dtype.
-        offload_8bit_bnb(`bool`, *optional*):
+        offload_8bit_bnb (`bool`, *optional*):
             Whether or not to enable offload of 8-bit modules on cpu/disk.
 
     """

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -228,7 +228,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             "transformer.h.23": 0,
             "transformer.ln_f": 1,
         }
-        bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True, enable_offload=True)
+        bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True)
 
         with init_empty_weights():
             model_8bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))
@@ -284,7 +284,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             "transformer.ln_f": 1,
         }
 
-        bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True, enable_offload=True)
+        bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True)
 
         with init_empty_weights():
             model_8bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))
@@ -341,7 +341,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             "transformer.h.23": 0,
             "transformer.ln_f": 1,
         }
-        bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True, enable_offload=True)
+        bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True)
 
         with init_empty_weights():
             model_8bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))
@@ -409,7 +409,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
                 # let's suppose that we can get the right config
                 model_8bit_from_saved = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))
             model_8bit_from_saved.tie_weights()
-            bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True, enable_offload=True)
+            bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True)
             device_map = {
                 "transformer.word_embeddings": "cpu",
                 "transformer.word_embeddings_layernorm": 0,
@@ -763,7 +763,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
             "transformer.ln_f": 1,
         }
 
-        bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True, enable_offload=True)
+        bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True)
 
         with init_empty_weights():
             model_4bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))
@@ -793,7 +793,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
             "transformer.ln_f": 1,
         }
 
-        bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True, enable_offload=True)
+        bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True)
 
         with init_empty_weights():
             model_4bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))
@@ -823,7 +823,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
             "transformer.h": 1,
             "transformer.ln_f": "cpu",
         }
-        bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True, enable_offload=True)
+        bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True)
 
         with init_empty_weights():
             model_4bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(self.model_name))


### PR DESCRIPTION
# What does this PR do ? 
This PR makes offload on cpu/disk possible with 8-bit models, thus saving even more memory. Previously, we did not quantize the modules on cpu/disk and the modules weights stayed at full precision. With cpu/disk offlaod, we offload the quantized weight to cpu/disk and move them back to gpu when needed using hooks. This should work out of the box with `device_map="auto"` but we make the user specify `enable_offload=True` to be sure that he knows what he's doing. Furthermore, no modification is needed on `bitsandbytes` library. 

The input weights (`weights_location`) can be quantized or not. If the weights are not quantized, we will first quantize them before offloading them to the cpu/disk. If we don't want to quantize a module, the user should add it in `skip_modules` arg. 

PS: 4-bit model offload will be added when we will be able to serialize them.

```python
input_text =  "Hello my name is"
tokenizer =  AutoTokenizer.from_pretrained("bigscience/bloom-1b7")
encoded_input = tokenizer(input_text, return_tensors="pt")

model_name = "marcsun13/bloom-1b7_with_lm_head"
weights_location = hf_hub_download(model_name, "pytorch_model.bin")

with init_empty_weights():
    model_8bit = AutoModelForCausalLM.from_config(AutoConfig.from_pretrained(model_name))
model_8bit.tie_weights()

device_map = {'transformer.word_embeddings': 'cpu',
              'transformer.word_embeddings_layernorm': 'cpu',
              'transformer.h.0': 0,
              'transformer.h.1': 0,
              'transformer.h.2': 0,
              'transformer.h.3': 0,
              'transformer.h.4': 0,
              'transformer.h.5': 0,
              'transformer.h.6': 0,
              'transformer.h.7': 0,
              'transformer.h.8': 0,
              'transformer.h.9': 0,
              'transformer.h.10': 0,
              'transformer.h.11': 0,
              'transformer.h.12': 0, 
              'transformer.h.13': 'cpu', 
              'transformer.h.14': 'cpu',
              'transformer.h.15': 'cpu', 
              'transformer.h.16': 'cpu',
              'transformer.h.17': 'cpu',
              'transformer.h.18': 'cpu',
              'transformer.h.19': 'cpu',
              'transformer.h.20': 'cpu', 
              'transformer.h.21': 'cpu', 
              'transformer.h.22': 'cpu',
              'transformer.h.23': 'disk', 
              'transformer.ln_f': 'cpu',
              'lm_head':"cpu"}

bnb_quantization_config = BnbQuantizationConfig(load_in_8bit=True, enable_offload=True)

model_8bit = load_and_quantize_model(model_8bit,
                            bnb_quantization_config,
                            weights_location=weights_location,
                            device_map = device_map,
                            no_split_module_classes=["BloomBlock"],
                            offload_state_dict=True,
                            offload_folder="tmp"
                            )
output_parallel = model_8bit.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
output_text = tokenizer.decode(output_parallel[0], skip_special_tokens=True)
```