### PR TITLE
fix bnb version

### DIFF
--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -28,7 +28,7 @@ You will need to install the following requirements:
 
 - Install `bitsandbytes` library
 ```bash
-pip install bitsandbytes==0.39.0
+pip install bitsandbytes
 ```
 - Install latest `accelerate` from source
 ```bash


### PR DESCRIPTION
# What does this PR do ? 
This PR updates the version of bitsandbytes required for the tutorial since we fixed the [issue](https://github.com/huggingface/accelerate/pull/1679) with the serialization of 8bit model. 