### PR TITLE
[docs] project_dir parameter update

### DIFF
--- a/docs/source/usage_guides/tracking.md
+++ b/docs/source/usage_guides/tracking.md
@@ -86,11 +86,15 @@ for iteration in config["num_iterations"]:
 accelerator.end_training()
 ```
 
-If a tracker requires a directory to save data to such as `TensorBoard` then a `logging_dir` or `project_dir` can be passed in. `project_dir` is useful 
-if there are other further configurations such as those which can be combined with the [`~utils.ProjectConfiguration`] dataclass.
+If a tracker requires a directory to save data to, such as `TensorBoard`, then pass the directory path to `project_dir`. The `project_dir` parameter is useful 
+when there are other configurations to be combined with in the [`~utils.ProjectConfiguration`] data class. For example, you can save the TensorBoard data to `project_dir` and everything else can be logged in the `logging_dir` parameter of [`~utils.ProjectConfiguration`: 
 
 ```python
-accelerator = Accelerator(log_with="tensorboard", logging_dir=".")
+accelerator = Accelerator(log_with="tensorboard", project_dir=".")
+
+# use with ProjectConfiguration
+config = ProjectConfiguration(project_dir=".", logging_dir="another/directory")
+accelerator = Accelerator(log_with="tensorboard", project_config=config)
 ```
 
 ## Implementing Custom Trackers


### PR DESCRIPTION
Updates the Tracking doc to use `project_dir` instead of the deprecated `logging_dir` parameter as mentioned [here](https://github.com/huggingface/diffusers/pull/3924#issuecomment-1617703691). Let me know if I've interpreted this correctly! 🤗 