### PR TITLE
Fix launcher validation 

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -111,7 +111,6 @@ def get_cluster_input():
             error_message="Please enter yes or no.",
         )
     if not use_cpu and is_xpu_available() and distributed_type not in [DistributedType.MULTI_GPU, DistributedType.TPU]:
-
         ipex_config["use_xpu"] = _ask_field(
             "Do you want to use XPU plugin to speed up training on XPU? [yes/NO]:",
             _convert_yes_no_to_bool,

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -111,6 +111,7 @@ def get_cluster_input():
             error_message="Please enter yes or no.",
         )
     if not use_cpu and is_xpu_available() and distributed_type not in [DistributedType.MULTI_GPU, DistributedType.TPU]:
+
         ipex_config["use_xpu"] = _ask_field(
             "Do you want to use XPU plugin to speed up training on XPU? [yes/NO]:",
             _convert_yes_no_to_bool,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -886,7 +886,7 @@ def _validate_launch_command(args):
                 native_amp = is_torch_version(">=", "1.10")
             else:
                 native_amp = is_bf16_available(True)
-            if args.mixed_precision == "bf16" and not native_amp and not is_tpu_available():
+            if args.mixed_precision == "bf16" and not native_amp and not (args.tpu and is_tpu_available()):
                 raise ValueError(err.format(mode="bf16", requirement="PyTorch >= 1.10 and a supported device."))
 
         # Silently set the default here

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -38,6 +38,7 @@ from accelerate.utils import (
     is_deepspeed_available,
     is_rich_available,
     is_sagemaker_available,
+    is_torch_version,
     is_tpu_available,
     is_xpu_available,
     patch_environment,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -34,9 +34,11 @@ from accelerate.utils import (
     DistributedType,
     PrepareForLaunch,
     _filter_args,
+    is_bf16_available,
     is_deepspeed_available,
     is_rich_available,
     is_sagemaker_available,
+    is_tpu_available,
     is_xpu_available,
     patch_environment,
     prepare_deepspeed_cmd_env,
@@ -876,6 +878,15 @@ def _validate_launch_command(args):
             else:
                 args.mixed_precision = defaults.mixed_precision
                 mp_from_config_flag = True
+        else:
+            native_amp = False
+            err = "{mode} mixed precision requires {requirement}"
+            if args.use_cpu or (args.use_xpu and torch.xpu.is_available()):
+                native_amp = is_torch_version(">=", "1.10")
+            else:
+                native_amp = is_bf16_available(True)
+            if args.mixed_precision == "bf16" and not native_amp and not is_tpu_available():
+                raise ValueError(err.format(mode="bf16", requirement="PyTorch >= 1.10 and a supported device."))
 
         # Silently set the default here
         if args.dynamo_backend is None:


### PR DESCRIPTION
Possible fix for #1693  (bf16 silent error ignorance) . 
There might be  a  better design than throwing a value error, but resorted to default accelerator code for throwing the error.
@muellerzr could you take a look ?  