### PR TITLE
Skip tests when bnb isn't available

### DIFF
--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -9,7 +9,7 @@ from torch.utils.data import DataLoader, TensorDataset
 from accelerate import DistributedType, infer_auto_device_map, init_empty_weights
 from accelerate.accelerator import Accelerator
 from accelerate.state import GradientState, PartialState
-from accelerate.test_utils import require_multi_gpu, slow
+from accelerate.test_utils import require_bnb, require_multi_gpu, slow
 from accelerate.test_utils.testing import AccelerateTestCase, require_cuda
 from accelerate.utils import patch_environment
 
@@ -229,6 +229,7 @@ class AcceleratorTester(AccelerateTestCase):
         )
 
     @slow
+    @require_bnb
     def test_accelerator_bnb(self):
         """Tests that the accelerator can be used with the BNB library."""
         from transformers import AutoModelForCausalLM
@@ -244,6 +245,7 @@ class AcceleratorTester(AccelerateTestCase):
         model = accelerator.prepare(model)
 
     @slow
+    @require_bnb
     def test_accelerator_bnb_cpu_error(self):
         """Tests that the accelerator can be used with the BNB library. This should fail as we are trying to load a model
         that is loaded between cpu and gpu"""
@@ -268,6 +270,7 @@ class AcceleratorTester(AccelerateTestCase):
             model = accelerator.prepare(model)
 
     @slow
+    @require_bnb
     @require_multi_gpu
     def test_accelerator_bnb_multi_gpu(self):
         """Tests that the accelerator can be used with the BNB library."""
@@ -297,6 +300,7 @@ class AcceleratorTester(AccelerateTestCase):
         PartialState._reset_state()
 
     @slow
+    @require_bnb
     @require_multi_gpu
     def test_accelerator_bnb_multi_gpu_no_distributed(self):
         """Tests that the accelerator can be used with the BNB library."""

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -30,7 +30,7 @@ from accelerate.big_modeling import (
     load_checkpoint_and_dispatch,
 )
 from accelerate.hooks import remove_hook_from_submodules
-from accelerate.test_utils import require_cuda, require_mps, require_multi_gpu, slow
+from accelerate.test_utils import require_bnb, require_cuda, require_mps, require_multi_gpu, slow
 from accelerate.utils import offload_state_dict
 
 
@@ -598,6 +598,7 @@ class BigModelingTester(unittest.TestCase):
         self.assertEqual(model2.weight.device, torch.device("cpu"))
 
     @slow
+    @require_bnb
     @require_multi_gpu
     def test_dispatch_model_bnb(self):
         """Tests that `dispatch_model` quantizes int8 layers"""
@@ -634,6 +635,7 @@ class BigModelingTester(unittest.TestCase):
         self.assertTrue(model.h[-1].self_attention.query_key_value.weight.device.index == 1)
 
     @slow
+    @require_bnb
     def test_dispatch_model_int8_simple(self):
         """Tests that `dispatch_model` quantizes int8 layers"""
         from huggingface_hub import hf_hub_download
@@ -709,6 +711,7 @@ class BigModelingTester(unittest.TestCase):
         self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
 
     @slow
+    @require_bnb
     @unittest.skip("Un-skip in the next transformers release")
     def test_dipatch_model_fp4_simple(self):
         """Tests that `dispatch_model` quantizes fp4 layers"""


### PR DESCRIPTION
Noticed some tests in Accelerator that fail when bnb isn't available, rather than use the conditional check for if it is when running the slow tests locally