### PR TITLE
Support wrapping multiple models in Accelerator.accumulate()

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -885,7 +885,7 @@ class Accelerator:
         self.gradient_state.plugin_kwargs.update({"num_steps": gradient_accumulation_steps})
 
     @contextmanager
-    def accumulate(self, *model):
+    def accumulate(self, *models):
         """
         A context manager that will lightly wrap around and perform gradient accumulation automatically
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -914,7 +914,7 @@ class Accelerator:
         """
         self._do_sync()
         with contextlib.ExitStack() as cm_stack:
-            for m in model:
+            for m in models:
                 cm_stack.enter_context(contextlib.nullcontext() if self.sync_gradients else self.no_sync(m))
             yield
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -891,8 +891,8 @@ class Accelerator:
 
         Args:
             *model (`torch.nn.Module`):
-                PyTorch Modules that was prepared with `Accelerator.prepare`. Models passed to `accumulate()`
-                will skip gradient syncing during backward pass in distributed training
+                PyTorch Modules that was prepared with `Accelerator.prepare`. Models passed to `accumulate()` will skip
+                gradient syncing during backward pass in distributed training
 
         Example:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -890,7 +890,7 @@ class Accelerator:
         A context manager that will lightly wrap around and perform gradient accumulation automatically
 
         Args:
-            *model (`torch.nn.Module`):
+            *models (list of `torch.nn.Module`):
                 PyTorch Modules that was prepared with `Accelerator.prepare`. Models passed to `accumulate()` will skip
                 gradient syncing during backward pass in distributed training
 


### PR DESCRIPTION
This PR updates ``Accelerator.accumulate()`` so that users can pass in multiple models into the context manager for skipping gradient sync (by calling ``no_sync()``)