### PR TITLE
Fix bnb test by adding multi_gpu decorator

### DIFF
--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -393,6 +393,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
 
             self.check_inference_correctness(model_8bit_from_saved)
 
+    @require_multi_gpu
     def test_int8_serialization_offload(self):
         r"""
         Test whether it is possible to serialize a model in 8-bit and offload weights to cpu/disk


### PR DESCRIPTION
# What does this PR do ? 
This PR adds a decorator to a test that should require multi gpu. Otherwise, it will fail during the nightly single_gpu test. 