### PR TITLE
Modify loading checkpoint behavior

### DIFF
--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -72,6 +72,7 @@ def load_and_quantize_model(
             - a path to a file containing a whole model state dict
             - a path to a `.json` file containing the index to a sharded checkpoint
             - a path to a folder containing a unique `.index.json` file and the shards of a checkpoint.
+            - a path to a folder containing a unique pytorch_model.bin file.
         device_map (`Dict[str, Union[int, str, torch.device]]`, *optional*):
             A map that specifies where each submodule should go. It doesn't need to be refined to each parameter/buffer
             name, once a given module name is inside, every submodule of it will be sent to the same device.

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -382,7 +382,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             model_8bit_from_saved = load_and_quantize_model(
                 model_8bit_from_saved,
                 bnb_quantization_config,
-                weights_location=tmpdirname + "/pytorch_model.bin",
+                weights_location=tmpdirname,
                 device_map="auto",
                 no_split_module_classes=["BloomBlock"],
             )


### PR DESCRIPTION
# What does this PR do ? 
This PR adds the possibility to load the state dict by just passing the folder containing the state dict when the user used `Accelerator.save_model` to save the model. The model will be saved as a unique pytorch_model.bin file if there is no sharding. If the user saved the model under a custom name, he will need to specify the path to the file.

Solves #1713 