### PR TITLE
fix failing test on 8GPU

### DIFF
--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -480,7 +480,7 @@ def test_split_between_processes_list():
             len(results) == 2
         ), f"Each process did not have two items. Process index: {state.process_index}; Length: {len(results)}"
 
-    data = list(range(0, (2 * state.num_processes) + 3))
+    data = list(range(0, (3 * state.num_processes) - 1))
     with state.split_between_processes(data, apply_padding=True) as results:
         if state.is_last_process:
             # Test that the last process gets the extra item(s)


### PR DESCRIPTION
Solves #1722 by changing the test to：
- Properly give us an extra remainder/odd one

Verified on (2, 4, 8)xA100