### PR TITLE
add compatibility with peft

### DIFF
--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -125,7 +125,9 @@ device_map = {
 ```
 ### Fine-tune a quantized model
 
-With the official support of adapters in the Hugging Face ecosystem, you can fine-tune quantized models. Please have a look at [peft](https://github.com/huggingface/peft) library for more details.
+It is not possible to perform pure 8bit or 4bit training on these models. However, you can train these models by leveraging parameter efficient fine tuning methods (PEFT) and train for example adapters on top of them. Please have a look at [peft](https://github.com/huggingface/peft) library for more details.
+
+Currently, you can't add adapters on top of any quantized model. However, with the official support of adapters with 🤗 Transformers models, you can fine-tune quantized models. If you want to finetune a 🤗 Transformers model , follow this [documentation](https://huggingface.co/docs/transformers/main_classes/quantization) instead. Check out this [demo](https://colab.research.google.com/drive/1VoYNfYDKcKRQRor98Zbf2-9VQTtGJ24k?usp=sharing) on how to fine-tune a 4-bit 🤗 Transformers model. 
 
 Note that you don’t need to pass `device_map` when loading the model for training. It will automatically load your model on your GPU. Please note that `device_map=auto` should be used for inference only.
 

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -124,7 +124,7 @@ def load_and_quantize_model(
         bnb_quantization_config.keep_in_fp32_modules = []
     keep_in_fp32_modules = bnb_quantization_config.keep_in_fp32_modules
     modules_to_not_convert.extend(keep_in_fp32_modules)
-    
+
     # compatibility with peft
     model.is_loaded_in_4bit = load_in_4bit
     model.is_loaded_in_8bit = load_in_8bit

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -124,6 +124,10 @@ def load_and_quantize_model(
         bnb_quantization_config.keep_in_fp32_modules = []
     keep_in_fp32_modules = bnb_quantization_config.keep_in_fp32_modules
     modules_to_not_convert.extend(keep_in_fp32_modules)
+    
+    # compatibility with peft
+    model.is_loaded_in_4bit = load_in_4bit
+    model.is_loaded_in_8bit = load_in_8bit
 
     model_device = get_parameter_device(model)
     if model_device.type != "meta":


### PR DESCRIPTION
# What does this PR do  ?
This PR fixes an issue when people quantize transformers model with the quantization api from accelerate and convert them into peft model for training. In order to fix this issue, we need to add the attributes  `model.is_loaded_in_4bit` and `model.is_loaded_in_8bit`. However, as indicated by the docs, the user should use the transformers integration of bnb when using transformers model. I've also updated the training section of the doc. 

related issue #1713 