### PR TITLE
Better control over DDP's `no_sync`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -866,31 +866,31 @@ class Accelerator:
     @contextmanager
     def trigger_sync_in_backward(model):
         """Trigger the sync of the gradients in the next backward pass of the model after multiple forward passes under
-`Accelerator.no_sync` (only applicable in multi-GPU scenarios).
+        `Accelerator.no_sync` (only applicable in multi-GPU scenarios).
 
-        If the script is not launched in distributed mode, this context manager does nothing.
+                If the script is not launched in distributed mode, this context manager does nothing.
 
-        Args:
-            model (`torch.nn.Module`):
-                The model for which to trigger the gradient synchronization.
+                Args:
+                    model (`torch.nn.Module`):
+                        The model for which to trigger the gradient synchronization.
 
-        Example:
+                Example:
 
-        ```python
-        >>> from accelerate import Accelerator
+                ```python
+                >>> from accelerate import Accelerator
 
-        >>> accelerator = Accelerator()
-        >>> dataloader, model, optimizer = accelerator.prepare(dataloader, model, optimizer)
+                >>> accelerator = Accelerator()
+                >>> dataloader, model, optimizer = accelerator.prepare(dataloader, model, optimizer)
 
-        >>> with accelerator.no_sync():
-        ...     loss_a = loss_func(model(input_a))  # first forward pass
-        ...     loss_b = loss_func(model(input_b))  # second forward pass
-        >>> accelerator.backward(loss_a)  # No synchronization across processes, only accumulate gradients
-        >>> with accelerator.trigger_sync_in_backward(model):
-        ...     accelerator.backward(loss_b)  # Synchronization across all processes
-        >>> optimizer.step()
-        >>> optimizer.zero_grad()
-        ```
+                >>> with accelerator.no_sync():
+                ...     loss_a = loss_func(model(input_a))  # first forward pass
+                ...     loss_b = loss_func(model(input_b))  # second forward pass
+                >>> accelerator.backward(loss_a)  # No synchronization across processes, only accumulate gradients
+                >>> with accelerator.trigger_sync_in_backward(model):
+                ...     accelerator.backward(loss_b)  # Synchronization across all processes
+                >>> optimizer.step()
+                >>> optimizer.zero_grad()
+                ```
         """
         if not isinstance(model, torch.nn.parallel.DistributedDataParallel):
             yield

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -868,10 +868,10 @@ class Accelerator:
         """Trigger the sync of the gradients in the next backward pass of DDP model.
 
         If `model` is not in DDP, this context manager does nothing
-        
+
         Args:
             model_ddp (`torch.nn.parallel.DistributedDataParallel`):
-                PyTorch Module wrapped in `DistributedDataParallel` 
+                PyTorch Module wrapped in `DistributedDataParallel`
 
         Example:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -865,7 +865,26 @@ class Accelerator:
     @staticmethod
     @contextmanager
     def ddp_trigger_sync_in_bwd(model_ddp):
-        """Trigger the sync of the gradients in the next backward pass of DDP model."""
+        """Trigger the sync of the gradients in the next backward pass of DDP model.
+
+        Example:
+
+        ```python
+        >>> from accelerate import Accelerator
+
+        >>> accelerator = Accelerator()
+        >>> dataloader, model, optimizer = accelerator.prepare(dataloader, model, optimizer)
+
+        >>> with accelerator.no_sync():
+        ...     loss_a = loss_func(model(input_a)) # first forward pass
+        ...     loss_b = loss_func(model(input_b)) # second forward pass
+        >>> accelerator.backward(loss_a) # No synchronization across processes, only accumulate gradients
+        >>> with accelerator.ddp_trigger_sync_in_bwd(model):
+        ...     accelerator.backward(loss_b) # Synchronization across all processes
+        >>> optimizer.step()
+        >>> optimizer.zero_grad()
+        ```
+        """
         assert isinstance(model_ddp, torch.nn.parallel.DistributedDataParallel), (
             f"model_ddp should be of type `torch.nn.parallel.DistributedDataParallel`, "
             f"got {type(model_ddp)} instead."

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -864,14 +864,14 @@ class Accelerator:
 
     @staticmethod
     @contextmanager
-    def ddp_trigger_sync_in_bwd(model_ddp):
-        """Trigger the sync of the gradients in the next backward pass of DDP model.
+    def trigger_sync_in_backward(model):
+        """Trigger the sync of the gradients in the next backward pass of the model (only applicable in distributed mode).
 
-        If `model` is not in DDP, this context manager does nothing
+        If the script is not launched in distributed mode, this context manager does nothing.
 
         Args:
-            model_ddp (`torch.nn.parallel.DistributedDataParallel`):
-                PyTorch Module wrapped in `DistributedDataParallel`
+            model (`torch.nn.Module`):
+                The model for which to trigger the gradient synchronization.
 
         Example:
 
@@ -885,7 +885,7 @@ class Accelerator:
         ...     loss_a = loss_func(model(input_a))  # first forward pass
         ...     loss_b = loss_func(model(input_b))  # second forward pass
         >>> accelerator.backward(loss_a)  # No synchronization across processes, only accumulate gradients
-        >>> with accelerator.ddp_trigger_sync_in_bwd(model):
+        >>> with accelerator.trigger_sync_in_backward(model):
         ...     accelerator.backward(loss_b)  # Synchronization across all processes
         >>> optimizer.step()
         >>> optimizer.zero_grad()

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -900,7 +900,7 @@ class Accelerator:
 
         model.require_backward_grad_sync = True
         model.require_forward_param_sync = True
-        # https://github.com/pytorch/pytorch/blob/master/torch/csrc/distributed/c10d/reducer.cpp#L1325-L1356
+        # https://github.com/pytorch/pytorch/blob/e1502c0cdbfd17548c612f25d5a65b1e4b86224d/torch/csrc/distributed/c10d/reducer.cpp#L1371-L1402
         model.reducer.prepare_for_backward([])
         try:
             yield

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -891,22 +891,22 @@ class Accelerator:
         >>> optimizer.zero_grad()
         ```
         """
-        if not isinstance(model_ddp, torch.nn.parallel.DistributedDataParallel):
+        if not isinstance(model, torch.nn.parallel.DistributedDataParallel):
             yield
             return
 
-        old_require_backward_grad_sync = model_ddp.require_backward_grad_sync
-        old_require_forward_param_sync = model_ddp.require_forward_param_sync
+        old_require_backward_grad_sync = model.require_backward_grad_sync
+        old_require_forward_param_sync = model.require_forward_param_sync
 
-        model_ddp.require_backward_grad_sync = True
-        model_ddp.require_forward_param_sync = True
+        model.require_backward_grad_sync = True
+        model.require_forward_param_sync = True
         # https://github.com/pytorch/pytorch/blob/master/torch/csrc/distributed/c10d/reducer.cpp#L1325-L1356
-        model_ddp.reducer.prepare_for_backward([])
+        model.reducer.prepare_for_backward([])
         try:
             yield
         finally:
-            model_ddp.require_backward_grad_sync = old_require_backward_grad_sync
-            model_ddp.require_forward_param_sync = old_require_forward_param_sync
+            model.require_backward_grad_sync = old_require_backward_grad_sync
+            model.require_forward_param_sync = old_require_forward_param_sync
 
     def _do_sync(self):
         "Sets the right `sync_gradients` context and either resets or increases `self.step`"

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -867,6 +867,12 @@ class Accelerator:
     def ddp_trigger_sync_in_bwd(model_ddp):
         """Trigger the sync of the gradients in the next backward pass of DDP model.
 
+        If `model` is not in DDP, this context manager does nothing
+        
+        Args:
+            model_ddp (`torch.nn.parallel.DistributedDataParallel`):
+                PyTorch Module wrapped in `DistributedDataParallel` 
+
         Example:
 
         ```python
@@ -885,10 +891,10 @@ class Accelerator:
         >>> optimizer.zero_grad()
         ```
         """
-        assert isinstance(model_ddp, torch.nn.parallel.DistributedDataParallel), (
-            f"model_ddp should be of type `torch.nn.parallel.DistributedDataParallel`, "
-            f"got {type(model_ddp)} instead."
-        )
+        if not isinstance(model_ddp, torch.nn.parallel.DistributedDataParallel):
+            yield
+            return
+
         old_require_backward_grad_sync = model_ddp.require_backward_grad_sync
         old_require_forward_param_sync = model_ddp.require_forward_param_sync
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -865,7 +865,8 @@ class Accelerator:
     @staticmethod
     @contextmanager
     def trigger_sync_in_backward(model):
-        """Trigger the sync of the gradients in the next backward pass of the model after multiple forward passes under `Accelerator.no_sync` (only applicable in multi-GPU scenarios).
+        """Trigger the sync of the gradients in the next backward pass of the model after multiple forward passes under
+`Accelerator.no_sync` (only applicable in multi-GPU scenarios).
 
         If the script is not launched in distributed mode, this context manager does nothing.
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -882,11 +882,11 @@ class Accelerator:
         >>> dataloader, model, optimizer = accelerator.prepare(dataloader, model, optimizer)
 
         >>> with accelerator.no_sync():
-        ...     loss_a = loss_func(model(input_a)) # first forward pass
-        ...     loss_b = loss_func(model(input_b)) # second forward pass
-        >>> accelerator.backward(loss_a) # No synchronization across processes, only accumulate gradients
+        ...     loss_a = loss_func(model(input_a))  # first forward pass
+        ...     loss_b = loss_func(model(input_b))  # second forward pass
+        >>> accelerator.backward(loss_a)  # No synchronization across processes, only accumulate gradients
         >>> with accelerator.ddp_trigger_sync_in_bwd(model):
-        ...     accelerator.backward(loss_b) # Synchronization across all processes
+        ...     accelerator.backward(loss_b)  # Synchronization across all processes
         >>> optimizer.step()
         >>> optimizer.zero_grad()
         ```

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -898,6 +898,8 @@ class Accelerator:
         old_require_backward_grad_sync = model.require_backward_grad_sync
         old_require_forward_param_sync = model.require_forward_param_sync
 
+        # EXPERIMENTAL: While I'm sure this forces grad sync in backward, I don't know if it breaks other DDP features.
+        # https://github.com/pytorch/pytorch/blob/e1502c0cdbfd17548c612f25d5a65b1e4b86224d/torch/nn/parallel/distributed.py#L1453-L1466
         model.require_backward_grad_sync = True
         model.require_forward_param_sync = True
         # https://github.com/pytorch/pytorch/blob/e1502c0cdbfd17548c612f25d5a65b1e4b86224d/torch/csrc/distributed/c10d/reducer.cpp#L1371-L1402

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -899,7 +899,7 @@ class Accelerator:
         old_require_backward_grad_sync = model.require_backward_grad_sync
         old_require_forward_param_sync = model.require_forward_param_sync
 
-        # EXPERIMENTAL: While I'm sure this forces grad sync in backward, I don't know if it breaks other DDP features.
+        # EXPERIMENTAL: This will force grad sync during `backward()`, but it is unknown if it breaks other DDP features.
         # https://github.com/pytorch/pytorch/blob/e1502c0cdbfd17548c612f25d5a65b1e4b86224d/torch/nn/parallel/distributed.py#L1453-L1466
         model.require_backward_grad_sync = True
         model.require_forward_param_sync = True

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -865,7 +865,7 @@ class Accelerator:
     @staticmethod
     @contextmanager
     def trigger_sync_in_backward(model):
-        """Trigger the sync of the gradients in the next backward pass of the model (only applicable in distributed mode).
+        """Trigger the sync of the gradients in the next backward pass of the model after multiple forward passes under `Accelerator.no_sync` (only applicable in multi-GPU scenarios).
 
         If the script is not launched in distributed mode, this context manager does nothing.
 

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -149,6 +149,7 @@ def test_distributed_sync(accelerator):
         torch.manual_seed(1337 + iteration)
         ddp_input = ddp_input[torch.randperm(len(ddp_input))]
 
+
 def test_distributed_sync_multiple_fwd(accelerator):
     # Test on distributed setup that context manager behaves properly when used with multiple forwards followed by multiple backwards
     model, ddp_model, dataloader = get_training_setup(accelerator)

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -191,7 +191,7 @@ def test_distributed_sync_multiple_fwd(accelerator):
 
         else:
             # Sync grads if last backward
-            with accelerator.ddp_trigger_sync_in_bwd(ddp_model):
+            with accelerator.trigger_sync_in_bwd(ddp_model):
                 accelerator.backward(loss)
 
             # DDP model and model should only be in sync after last backward

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -191,7 +191,7 @@ def test_distributed_sync_multiple_fwd(accelerator):
 
         else:
             # Sync grads if last backward
-            with accelerator.trigger_sync_in_bwd(ddp_model):
+            with accelerator.trigger_sync_in_backward(ddp_model):
                 accelerator.backward(loss)
 
             # DDP model and model should only be in sync after last backward

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -149,6 +149,59 @@ def test_distributed_sync(accelerator):
         torch.manual_seed(1337 + iteration)
         ddp_input = ddp_input[torch.randperm(len(ddp_input))]
 
+def test_distributed_sync_multiple_fwd(accelerator):
+    # Test on distributed setup that context manager behaves properly when used with multiple forwards followed by multiple backwards
+    model, ddp_model, dataloader = get_training_setup(accelerator)
+    # Do multiple forwards
+    losses = []
+    num_iterations = 3
+    for iteration in range(num_iterations):
+        ddp_input, ddp_target = next(iter(dataloader)).values()
+
+        # Gather the distributed inputs and targs for the base model
+        input, target = accelerator.gather((ddp_input, ddp_target))
+        input, target = input.to(accelerator.device), target.to(accelerator.device)
+
+        # Perform our initial ground truth step in non "DDP"
+        step_model(model, input, target, accelerator)
+
+        # Accumulate grads locally
+        with accelerator.no_sync(ddp_model):
+            ddp_output = ddp_model(ddp_input)
+            loss = F.mse_loss(ddp_output, ddp_target.to(ddp_output.device))
+            losses.append(loss)
+
+    # Do multiple backwards and sync only at the last backward
+    for iteration in range(num_iterations):
+        loss = losses[iteration]
+
+        if iteration < num_iterations - 1:
+            # Accumulate grads locally
+            accelerator.backward(loss)
+
+            # DDP model and model should only be in sync after last backward
+            for param, ddp_param in zip(model.parameters(), ddp_model.parameters()):
+                if not param.requires_grad:
+                    continue
+                # Grads should not be in sync
+                assert (
+                    torch.allclose(param.grad, ddp_param.grad) is False
+                ), f"Gradients in sync when they should not be:\nModel grad ({param.grad}) == DDP grad ({ddp_param.grad})"
+
+        else:
+            # Sync grads if last backward
+            with accelerator.ddp_trigger_sync_in_bwd(ddp_model):
+                accelerator.backward(loss)
+
+            # DDP model and model should only be in sync after last backward
+            for param, ddp_param in zip(model.parameters(), ddp_model.parameters()):
+                if not param.requires_grad:
+                    continue
+                # Grads should be in sync
+                assert (
+                    torch.allclose(param.grad, ddp_param.grad) is True
+                ), f"Gradients not in sync when they should be:\nModel grad ({param.grad}) != DDP grad ({ddp_param.grad})"
+
 
 def test_gradient_accumulation(split_batches=False, dispatch_batches=False):
     accelerator = Accelerator(
@@ -270,6 +323,9 @@ def main():
         if state.local_process_index == 0:
             print("**Test Distributed `no_sync` context manager**")
         test_distributed_sync(accelerator)
+        if state.local_process_index == 0:
+            print("**Test Distributed `no_sync` context manager with multiple forwards**")
+        test_distributed_sync_multiple_fwd(accelerator)
     if state.distributed_type == DistributedType.MULTI_GPU:
         for split_batch in [True, False]:
             for dispatch_batches in [True, False]:


### PR DESCRIPTION
This PR is a suggestion for a solution for the following observation regarding torch's DDP behaviour using `no_sync`:

Here’s the example from the docs (uses forward-backward)
```python
ddp = torch.nn.parallel.DistributedDataParallel(model, pg)
with ddp.no_sync():
    ddp(input).backward()  # no synchronization, accumulate grads
ddp(another_input).backward()  # synchronize grads
```

Let’s separate forward from backward. It seems like `no_sync` doesn't affect backward(), it must wrap the forward() call instead.
```python
ddp = torch.nn.parallel.DistributedDataParallel(model, pg)
with ddp.no_sync(): # forward under no_sync -> works
    loss = ddp(input) 
loss.backward() # no synchronization, accumulate grads
ddp(another_input).backward()  # synchronize grads
```

```python
ddp = torch.nn.parallel.DistributedDataParallel(model, pg)
loss = ddp(input) 
with ddp.no_sync(): # backward under no_sync -> doesn't work
    loss.backward() # synchronize grads
ddp(another_input).backward()  # synchronize grads
# This means that no_sync doesn't affect backward() calls, only forward() calls
```

This PR aims at solving the following: How to do multiple forwards then multiple backwards, and only sync on the last backward
```python
ddp = torch.nn.parallel.DistributedDataParallel(model, pg)
with ddp.no_sync():
    loss_1 = ddp(input) 
loss_2 = ddp(another_input)
loss_1.backward() # synchronizes grad, but I expect it to no sync (how to do this?)
loss_2.backward()  # synchronize grads
```

My hacky solution was to have a trigger mechanism, that triggers a sync on the last backward:
```python
def ddp_trigger_sync_in_bwd(model_ddp):
    """Trigger the sync of the gradients in the next backward pass of DDP model."""
    assert isinstance(model_ddp, torch.nn.parallel.DistributedDataParallel)
    model_ddp.require_backward_grad_sync = True
    model_ddp.require_forward_param_sync = True
    model_ddp.reducer.prepare_for_backward([])
```

```python
ddp = torch.nn.parallel.DistributedDataParallel(model, pg)
with ddp.no_sync():
    loss_1 = ddp(input) 
    loss_2 = ddp(another_input)
loss_1.backward() # doesn't sync
ddp_trigger_sync_in_bwd(ddp)
loss_2.backward()  # synchronize grads
```

Also as this gives better control over which model to sync grads for, and exactly on which bwd pass. I think it should unlock much more usecases for grad accumulation than the example I gave 🚀
cc @muellerzr 