### PR TITLE
Make balanced memory able to work with non continguous GPUs ids

### DIFF
--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -527,6 +527,10 @@ class ModelingUtilsTester(unittest.TestCase):
         max_memory = get_balanced_memory(model, max_memory={0: 200, 1: 200})
         self.assertDictEqual({0: 200, 1: 200}, max_memory)
 
+        # We should be able to set models on a non-contiguous sub-set of
+        max_memory = get_balanced_memory(model, max_memory={0: 200, 2: 200})
+        self.assertDictEqual({0: 200, 2: 200}, max_memory)
+
         max_memory = get_balanced_memory(model, max_memory={0: 300, 1: 300})
         self.assertDictEqual({0: 215, 1: 300}, max_memory)
 


### PR DESCRIPTION
This small PR allow one to use both DP and PP for fast inference of large models on larger nodes.

Here is how this can be done on a 8 GPUs with a model which requires 2 GPUs to be loaded:
- run accelerate with 4 processes => GPU 0, 1, 2, 3 will have a process with DP
- setup max_memory on each process to use the first GPU + a second GPU in the remaining four GPUs (4, 5, 6, 7)

To be able to do that with the current transformers/accelerate we only need to make sure `get_balanced_memory` can handle non contiguous list of GPUs which this PR does.

Here is a working examples of doing DP=4 + PP=2 for Falcon 40B on a node with 8 A100 for instance:
[Not shown: start accelerate on the node with 4 processes - could also with done with 2 process and we'd get DP=2 + PP=4]
```
from accelerate import Accelerator
from accelerate.utils import get_max_memory
from transformers import AutoModelForCausalLM

accelerator = Accelerator()

max_memory_all_gpus = get_max_memory()  # A dict of the max memory for all the gpus
if "cpu" in max_memory_all_gpus:
    del max_memory_all_gpus["cpu"]  # Keep only the GPUs (can tweak this to use also CPU)

# Keep only the subset of GPUs we want for this process
max_mem_this_process = {
    k: v
    for k, v in max_memory_all_gpus.items()
    if k % accelerator.num_processes == accelerator.process_index
}

model = AutoModelForCausalLM.from_pretrained("tiiuae/falcon-40b",
    trust_remote_code=True,
    max_memory=max_mem_this_process,
    device_map="auto")
```

Added a test for this as well

(Note that while this is working and rather easy to do in the end, importing a method from `accelerate.utils` is maybe a non trivial step for the user so possibly you can do a simpler and larger change in API at some point - up to you for now this doesn't touch any functionality)