### PR TITLE
fix KwargsHandler.to_kwargs not working with os.environ initialization in __post_init__

### DIFF
--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -104,6 +104,8 @@ These functionalities check the state of the current working environment includi
 
 [[autodoc]] utils.patch_environment
 
+[[autodoc]] utils.clear_environment
+
 [[autodoc]] utils.write_basic_config
 
 When setting up 🤗 Accelerate for the first time, rather than running `accelerate config` [~utils.write_basic_config] can be used as an alternative for quick configuration.

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -163,6 +163,7 @@ from .other import (
     get_pretty_name,
     is_port_in_use,
     merge_dicts,
+    clear_environment,
     patch_environment,
     save,
     wait_for_everyone,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -159,11 +159,11 @@ from .megatron_lm import prepare_optimizer as megatron_lm_prepare_optimizer
 from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
 from .memory import find_executable_batch_size, release_memory
 from .other import (
+    clear_environment,
     extract_model_from_parallel,
     get_pretty_name,
     is_port_in_use,
     merge_dicts,
-    clear_environment,
     patch_environment,
     save,
     wait_for_everyone,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -48,6 +48,7 @@ class KwargsHandler:
         """
         # import clear_environment here to avoid circular import problem
         from .other import clear_environment
+
         with clear_environment():
             default_dict = self.__class__().to_dict()
         this_dict = self.to_dict()

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -34,6 +34,14 @@ import torch
 from .constants import FSDP_AUTO_WRAP_POLICY, FSDP_BACKWARD_PREFETCH, FSDP_STATE_DICT_TYPE
 
 
+@contextmanager
+def clear_os_environ():
+    _old_os_environ = os.environ
+    os.environ = dict()
+    yield
+    os.environ = _old_os_environ
+
+
 class KwargsHandler:
     """
     Internal mixin that implements a `to_kwargs()` method for a dataclass.
@@ -46,7 +54,8 @@ class KwargsHandler:
         """
         Returns a dictionary containing the attributes with values different from the default of this class.
         """
-        default_dict = self.__class__().to_dict()
+        with clear_os_environ():
+            default_dict = self.__class__().to_dict()
         this_dict = self.to_dict()
         return {k: v for k, v in this_dict.items() if default_dict[k] != v}
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -34,14 +34,6 @@ import torch
 from .constants import FSDP_AUTO_WRAP_POLICY, FSDP_BACKWARD_PREFETCH, FSDP_STATE_DICT_TYPE
 
 
-@contextmanager
-def clear_os_environ():
-    _old_os_environ = os.environ
-    os.environ = dict()
-    yield
-    os.environ = _old_os_environ
-
-
 class KwargsHandler:
     """
     Internal mixin that implements a `to_kwargs()` method for a dataclass.
@@ -54,7 +46,9 @@ class KwargsHandler:
         """
         Returns a dictionary containing the attributes with values different from the default of this class.
         """
-        with clear_os_environ():
+        # import clear_environment here to avoid circular import problem
+        from .other import clear_environment
+        with clear_environment():
             default_dict = self.__class__().to_dict()
         this_dict = self.to_dict()
         return {k: v for k, v in this_dict.items() if default_dict[k] != v}

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -129,7 +129,7 @@ def clear_environment():
 
     >>> os.environ["FOO"] = "bar"
     >>> with clear_environment():
-    ...     print(os.environ) # prints "{}"
+    ...     print(os.environ)  # prints "{}"
     ...     os.environ["FOO"] = "new_bar"
     ...     print(os.environ.get("FOO", None))  # prints "new_bar"
     >>> print(os.environ["FOO"])  # prints "bar"

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -115,6 +115,35 @@ def save(obj, f):
 
 
 @contextmanager
+def clear_environment():
+    """
+    A context manager that will cache origin `os.environ` and replace it with a empty dictionary in this context.
+
+    When this context exits, the cached `os.environ` will be back.
+
+    Example:
+
+    ```python
+    >>> import os
+    >>> from accelerate.utils import clear_environment
+
+    >>> os.environ["FOO"] = "bar"
+    >>> with clear_environment():
+    ...     print(os.environ) # prints "{}"
+    ...     os.environ["FOO"] = "new_bar"
+    ...     print(os.environ.get("FOO", None))  # prints "new_bar"
+    >>> print(os.environ["FOO"])  # prints "bar"
+    ```
+    """
+    _old_os_environ = os.environ
+    os.environ = dict()
+
+    yield
+
+    os.environ = _old_os_environ
+
+
+@contextmanager
 def patch_environment(**kwargs):
     """
     A context manager that will add each keyword argument passed to `os.environ` and remove them when exiting.

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -129,10 +129,14 @@ def clear_environment():
 
     >>> os.environ["FOO"] = "bar"
     >>> with clear_environment():
-    ...     print(os.environ)  # prints "{}"
+    ...     print(os.environ)
     ...     os.environ["FOO"] = "new_bar"
-    ...     print(os.environ.get("FOO", None))  # prints "new_bar"
-    >>> print(os.environ["FOO"])  # prints "bar"
+    ...     print(os.environ["FOO"])
+    {}
+    new_bar
+
+    >>> print(os.environ["FOO"])
+    bar
     ```
     """
     _old_os_environ = os.environ

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -22,8 +22,7 @@ import torch
 from accelerate import Accelerator, DistributedDataParallelKwargs, GradScalerKwargs
 from accelerate.state import AcceleratorState
 from accelerate.test_utils import execute_subprocess_async, require_cuda, require_multi_gpu
-from accelerate.utils import KwargsHandler, TorchDynamoPlugin
-from accelerate.utils.dataclasses import clear_os_environ
+from accelerate.utils import KwargsHandler, TorchDynamoPlugin, clear_environment
 
 
 @dataclass
@@ -65,7 +64,7 @@ class KwargsHandlerTester(unittest.TestCase):
         execute_subprocess_async(cmd, env=os.environ.copy())
 
     def test_torch_dynamo_plugin(self):
-        with clear_os_environ():
+        with clear_environment():
             prefix = "ACCELERATE_DYNAMO_"
             # nvfuser's dynamo backend name is "nvprims_nvfuser"
             # use "nvfuser" here to cause exception if this test causes os.environ changed permanently


### PR DESCRIPTION
[https://github.com/huggingface/accelerate/blob/653ba110d31c86d3527bb88bf6209441c176ce11/src/accelerate/accelerator.py#L1423-L1427](https://github.com/huggingface/accelerate/blob/653ba110d31c86d3527bb88bf6209441c176ce11/src/accelerate/accelerator.py#L1423-L1427)
Before this patch, `self.state.dynamo_plugin.to_kwargs()` in above code always results in `{}` if torch.compile kwargs are set through environment variables. This behaviour is used by transformers:
[https://github.com/huggingface/transformers/blob/66fd3a8d626a32989f4569260db32785c6cbf42a/src/transformers/training_args.py#L1375-L1382](https://github.com/huggingface/transformers/blob/66fd3a8d626a32989f4569260db32785c6cbf42a/src/transformers/training_args.py#L1375-L1382)

In this patch, we fix it by unset all data in os.environ when default_dict is evaluated.