### PR TITLE
Check for misconfiguration of single node & single GPU

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -71,10 +71,6 @@ def get_cluster_input():
             int,
             default=1,
         )
-        if (distributed_type == DistributedType.MULTI_GPU) and (num_machines == 1) and (num_processes == 1):
-            raise ValueError(
-                f"Specified distributed type {distributed_type} but only using 1 GPU on a single machine. Please select `No distributed training` for the type of machine you are using."
-            )
 
         if num_machines > 1:
             machine_rank = _ask_options(
@@ -481,6 +477,11 @@ def get_cluster_input():
         )
     else:
         num_processes = 1
+
+    if (distributed_type == DistributedType.MULTI_GPU) and (num_machines == 1) and (num_processes == 1):
+        raise ValueError(
+            f"Specified distributed type {distributed_type} but only using 1 GPU on a single machine. Please select `No distributed training` for the type of machine you are using."
+        )
 
     if (
         distributed_type

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -71,7 +71,6 @@ def get_cluster_input():
             int,
             default=1,
         )
-
         if num_machines > 1:
             machine_rank = _ask_options(
                 "What is the rank of this machine?",

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -71,6 +71,11 @@ def get_cluster_input():
             int,
             default=1,
         )
+        if (distributed_type == DistributedType.MULTI_GPU) and (num_machines == 1) and (num_processes == 1):
+            raise ValueError(
+                f"Specified distributed type {distributed_type} but only using 1 GPU on a single machine. Please select `No distributed training` for the type of machine you are using."
+            )
+
         if num_machines > 1:
             machine_rank = _ask_options(
                 "What is the rank of this machine?",


### PR DESCRIPTION
It's possible to end up in a situation following the prompts where `num_machines == 1`, `num_processes == 1`, and `distributed_type == DistributedType.MULTI_GPU` if you select "multi-GPU" to the first question. This PR adds a check and raises the right error if done. Helps https://github.com/huggingface/accelerate/issues/1743

(Don't review until tomorrow 😉 )