### PR TITLE
FSDP enhancements and fixes

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -335,11 +335,18 @@ def get_cluster_input():
                 lambda x: FSDP_AUTO_WRAP_POLICY[int(x)],
             )
             if fsdp_config["fsdp_auto_wrap_policy"] == FSDP_AUTO_WRAP_POLICY[0]:
-                fsdp_config["fsdp_transformer_layer_cls_to_wrap"] = _ask_field(
-                    "Specify the comma-separated list of transformer layer class names (case-sensitive) to wrap ,e.g, :"
-                    "`BertLayer`, `GPTJBlock`, `T5Block`, `BertLayer,BertEmbeddings,BertSelfOutput` ...? : ",
-                    str,
+                use_no_split_modules = _ask_field(
+                    "Do you want to use the model's `_no_split_modules` to wrap. Only applicable for 🤗 Transformers [yes/NO]: ",
+                    _convert_yes_no_to_bool,
+                    default=False,
+                    error_message="Please enter yes or no.",
                 )
+                if not use_no_split_modules:
+                    fsdp_config["fsdp_transformer_layer_cls_to_wrap"] = _ask_field(
+                        "Specify the comma-separated list of transformer layer class names (case-sensitive) to wrap ,e.g, :"
+                        "`BertLayer`, `GPTJBlock`, `T5Block`, `BertLayer,BertEmbeddings,BertSelfOutput` ...? : ",
+                        str,
+                    )
             elif fsdp_config["fsdp_auto_wrap_policy"] == FSDP_AUTO_WRAP_POLICY[1]:
                 fsdp_config["fsdp_min_num_params"] = _ask_field(
                     "What should be your FSDP's minimum number of parameters for Default Auto Wrapping Policy? [1e8]: ",

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -936,7 +936,7 @@ class FullyShardedDataParallelPlugin:
         from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 
         default_transformer_cls_names_to_wrap = (
-            ",".join(model._no_split_modules) if hasattr(model, "_no_split_modules") else ""
+            ",".join(model._no_split_modules) if getattr(model, "_no_split_modules", None) is not None else ""
         )
         if self.auto_wrap_policy is None:
             auto_wrap_policy = os.environ.get("FSDP_AUTO_WRAP_POLICY", "NO_WRAP")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -935,10 +935,15 @@ class FullyShardedDataParallelPlugin:
     def set_auto_wrap_policy(self, model):
         from torch.distributed.fsdp.wrap import size_based_auto_wrap_policy, transformer_auto_wrap_policy
 
+        default_transformer_cls_names_to_wrap = (
+            ",".join(model._no_split_modules) if hasattr(model, "_no_split_modules") else ""
+        )
         if self.auto_wrap_policy is None:
             auto_wrap_policy = os.environ.get("FSDP_AUTO_WRAP_POLICY", "NO_WRAP")
             if auto_wrap_policy == FSDP_AUTO_WRAP_POLICY[0]:
-                transformer_cls_names_to_wrap = os.environ.get("FSDP_TRANSFORMER_CLS_TO_WRAP", "").split(",")
+                transformer_cls_names_to_wrap = os.environ.get(
+                    "FSDP_TRANSFORMER_CLS_TO_WRAP", default_transformer_cls_names_to_wrap
+                ).split(",")
                 transformer_cls_to_wrap = set()
                 for layer_class in transformer_cls_names_to_wrap:
                     transformer_cls = FullyShardedDataParallelPlugin.get_module_class_from_name(model, layer_class)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -20,6 +20,7 @@ import torch
 
 from ..commands.config.default import write_basic_config  # noqa: F401
 from ..state import PartialState
+from .constants import FSDP_PYTORCH_VERSION
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_tpu_available
 from .transformer_engine import convert_model
@@ -64,6 +65,11 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True):
 
     if is_deepspeed_available():
         options += (DeepSpeedEngine,)
+
+    if is_torch_version(">=", FSDP_PYTORCH_VERSION):
+        from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
+
+        options += (FSDP,)
 
     while isinstance(model, options):
         model = model.module


### PR DESCRIPTION
### What does this PR do?

1. If the model is already an instance of FSDP, bypass the warning and additional FSDP preparation logic. This is to enable PR https://github.com/huggingface/transformers/pull/24980 which Fixes https://github.com/huggingface/transformers/issues/24724
2. allow usage of _no_split_modules to simplify UX when using FSDP. Fixes https://github.com/huggingface/transformers/issues/24568 via https://github.com/huggingface/transformers/pull/24980
3. `extract_from_parallel` how unwraps FSDP models too but these will lead to FSDP issues if there are modules as part of the global FSDP unit as the parameters of those modules won't be gathered if one isn't calling global FSDP wrapper's forward call. This is wrt issue https://github.com/huggingface/diffusers/issues/4037