### PR TITLE
[FSDP] Fix `load_fsdp_optimizer`

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -187,5 +187,5 @@ def load_fsdp_optimizer(fsdp_plugin, accelerator, optimizer, model, input_dir, o
             )
             optim_state = optim_state["optimizer"]
             logger.info(f"Optimizer loaded from {ckpt_dir}")
-        flattened_osd = FSDP.optim_state_dict_to_load(optim_state, model, optimizer)
+        flattened_osd = FSDP.optim_state_dict_to_load(model=model, optim=optimizer, optim_state_dict=optim_state)
         optimizer.load_state_dict(flattened_osd)


### PR DESCRIPTION
**Overview**
This PR fixes `load_fsdp_optimizer` and passes `test_checkpointing` in the FSDP unit tests.
```
@staticmethod
def optim_state_dict_to_load(
    model: torch.nn.Module,
    optim: torch.optim.Optimizer,
    optim_state_dict: Dict[str, Any],
    is_named_optimizer: bool = False,
    load_directly: bool = False,
    group: Optional[dist.ProcessGroup] = None,
) -> Dict[str, Any]:
```
[code pointer](https://github.com/pytorch/pytorch/blob/29f856e3e02cea6b608167555719c907a80fb135/torch/distributed/fsdp/fully_sharded_data_parallel.py#L1810-L1818)

To support both the old and new arg orders, this passes to `optim_state_dict_to_load()` using kwargs. (See [here](https://github.com/pytorch/pytorch/commit/580b4702bc862dbce386312900db985df58428c0#diff-ffc1ad1876fbf03d814108f6f2f5950a99281b47e0fd77597745f10dc99add86R1822-R1827) for PR that changed the order.)

**Test Plan**
```
export RUN_SLOW="yes"
export WANDB_DISABLED="true"
python -m pytest tests/fsdp/test_fsdp.py -k test_checkpointing -sv
```