### PR TITLE
Fix error when max_memory argument is in unexpected order

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -660,7 +660,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     for k in max_memory.keys():
         if k not in all_devices:
             raise ValueError(
-                f"Device {k} is not recognized, avaiable device are integers(for GPU/XPU), 'mps', 'cpu' and 'disk'"
+                f"Device {k} is not recognized, available device are integers(for GPU/XPU), 'mps', 'cpu' and 'disk'"
             )
     max_memory = {k: max_memory[k] for k in all_devices}
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -647,20 +647,18 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     # As gpu/xpu are represented by int, we need to sort them first.
     gpu_devices = [k for k in max_memory.keys() if isinstance(k, int)]
     gpu_devices.sort()
-    # check if gpu/xgpu device are available and if not, throw a warning
+    # check if gpu/xgpu devices are available and if not, throw a warning
     num_devices = torch.xpu.device_count() if is_xpu_available() else torch.cuda.device_count()
     for device in gpu_devices:
         if device >= num_devices or device < 0:
-            logger.warning(
-                f"Device {device} is not available, available device are {list(range(num_devices))}"
-            )
+            logger.warning(f"Device {device} is not available, available devices are {list(range(num_devices))}")
     # Add the other devices in the preset order if they are available
     all_devices = gpu_devices + [k for k in ["mps", "cpu", "disk"] if k in max_memory.keys()]
     # Raise an error if a device is not recognized
     for k in max_memory.keys():
         if k not in all_devices:
             raise ValueError(
-                f"Device {k} is not recognized, available device are integers(for GPU/XPU), 'mps', 'cpu' and 'disk'"
+                f"Device {k} is not recognized, available devices are integers(for GPU/XPU), 'mps', 'cpu' and 'disk'"
             )
     max_memory = {k: max_memory[k] for k in all_devices}
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -642,6 +642,15 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     for key in max_memory:
         if isinstance(max_memory[key], str):
             max_memory[key] = convert_file_size_to_int(max_memory[key])
+
+    # Need to sort the device by type to make sure that we allocate the gpu first.
+    # As gpu/xpu are represented by int, we need to sort them first.
+    gpu_devices = [k for k in max_memory.keys() if isinstance(k, int)]
+    gpu_devices.sort()
+    # Add the other devices in the preset order if they are available
+    all_devices = gpu_devices + [k for k in ["mps", "cpu", "disk"] if k in max_memory.keys()]
+    max_memory = {k: max_memory[k] for k in all_devices}
+
     return max_memory
 
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -652,7 +652,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     for device in gpu_devices:
         if device >= num_deivces or device < 0:
             logger.warning(
-                f"Device {max(gpu_devices)} is not available, available device are {list(range(num_deivces))}"
+                f"Device {device} is not available, available device are {list(range(num_devices))}"
             )
     # Add the other devices in the preset order if they are available
     all_devices = gpu_devices + [k for k in ["mps", "cpu", "disk"] if k in max_memory.keys()]

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -650,7 +650,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     # check if gpu/xgpu device are available and if not, throw a warning
     num_deivces = torch.xpu.device_count() if is_xpu_available() else torch.cuda.device_count()
     for device in gpu_devices:
-        if device >= num_deivces or device < 0:
+        if device >= num_devices or device < 0:
             logger.warning(
                 f"Device {device} is not available, available device are {list(range(num_devices))}"
             )

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -648,7 +648,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     gpu_devices = [k for k in max_memory.keys() if isinstance(k, int)]
     gpu_devices.sort()
     # check if gpu/xgpu device are available and if not, throw a warning
-    num_deivces = torch.xpu.device_count() if is_xpu_available() else torch.cuda.device_count()
+    num_devices = torch.xpu.device_count() if is_xpu_available() else torch.cuda.device_count()
     for device in gpu_devices:
         if device >= num_devices or device < 0:
             logger.warning(

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -870,9 +870,9 @@ def infer_auto_device_map(
         no_split_module_classes = [no_split_module_classes]
 
     devices = list(max_memory.keys())
-    gpus = [device for device in devices if device != "cpu"]
     if "disk" not in devices:
         devices.append("disk")
+    gpus = [device for device in devices if device not in ["cpu", "disk"]]
 
     # Devices that need to keep space for a potential offloaded layer.
     if "mps" in gpus:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -647,8 +647,21 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     # As gpu/xpu are represented by int, we need to sort them first.
     gpu_devices = [k for k in max_memory.keys() if isinstance(k, int)]
     gpu_devices.sort()
+    # check if gpu/xgpu device are available and if not, throw a warning
+    num_deivces = torch.xpu.device_count() if is_xpu_available() else torch.cuda.device_count()
+    for device in gpu_devices:
+        if device >= num_deivces or device < 0:
+            logger.warning(
+                f"Device {max(gpu_devices)} is not available, available device are {list(range(num_deivces))}"
+            )
     # Add the other devices in the preset order if they are available
     all_devices = gpu_devices + [k for k in ["mps", "cpu", "disk"] if k in max_memory.keys()]
+    # Raise an error if a device is not recognized
+    for k in max_memory.keys():
+        if k not in all_devices:
+            raise ValueError(
+                f"Device {k} is not recognized, avaiable device are integers(for GPU/XPU), 'mps', 'cpu' and 'disk'"
+            )
     max_memory = {k: max_memory[k] for k in all_devices}
 
     return max_memory


### PR DESCRIPTION
# What does this PR do?
This PR fixes some errors when user-provided `max_memory` argument in `infer_auto_device_map` is not in expected order or contains unexpected devices. 
- [Add argument-checking for max_memory](https://github.com/huggingface/accelerate/commit/301c034ac935509b2b6c706fa47de997c0aab20a)
- [Sort the user-provided max_memory keys in gpu-cpu-disk order](https://github.com/huggingface/accelerate/commit/f84ac36bcda4525f6bbc1596770453e34923ee29)
- [Fixed the bug that adds "disk" to gpus if it is provided in max_memory argument](https://github.com/huggingface/accelerate/commit/394d937fc344bae9e7a370cd4b200948a22736cd)

For some large models that I tested,  using device_map="auto" might still lead to OOM problem( and I'd like to look into it soon). So we need to explicitly call `infer_auto_device_map`  and specify `max_memory` argument to get a device_map. This PR makes the function more user-friendly and less error-prune. 