### PR TITLE
Fix check failure in Accelerator.save_state using multi-gpu

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2582,6 +2582,7 @@ class Accelerator:
                 raise ValueError(
                     f"Checkpoint directory {output_dir} ({self.save_iteration}) already exists. Please manually override `self.save_iteration` with what iteration to start with."
                 )
+            self.wait_for_everyone()
         os.makedirs(output_dir, exist_ok=True)
         logger.info(f"Saving current state to {output_dir}")
 


### PR DESCRIPTION
This happens occasionally when you run the merge test with multi-gpu. Here is the log of a failure ci-test link:
https://github.com/huggingface/accelerate/actions/runs/5601414096/job/15173828704#step:4:1472

The code caused failure is mainly from [https://github.com/huggingface/accelerate/blob/a2d8f540c3ab37c8f84d616be1300a0572b69cf8/src/accelerate/accelerator.py#L2580-L2585](https://github.com/huggingface/accelerate/blob/a2d8f540c3ab37c8f84d616be1300a0572b69cf8/src/accelerate/accelerator.py#L2580-L2585)

In some test (e.g. tests/test_state_checkpointing.py::CheckpointTest::test_map_location) and using multi-gpu environment, multi process would check whether output_dir is created. If one process A runs very fast and finishes making dir in L2585 above, another process B runs very slow and only finishes L2580, in case process B would raise error in L2582 above.

The solution is simple, add a barrier as this commit does. Please review whether this small change could affect other components.
