### PR TITLE
Contigous on gather

### DIFF
--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -36,12 +36,13 @@ def test_gather_object(state):
     assert len(gathered_obj) == state.num_processes, f"{gathered_obj}, {len(gathered_obj)} != {state.num_processes}"
     assert gathered_obj == list(range(state.num_processes)), f"{gathered_obj} != {list(range(state.num_processes))}"
 
+
 def test_gather_non_contigous(state):
     # Create a non-contiguous tensor
     tensor = torch.arange(12).view(4, 3).t().to(state.device)
     assert not tensor.is_contiguous()
-    gathered_tensor = gather(tensor)
-    assert gathered_tensor.shape == torch.Size([state.num_processes, 3, 4])
+    # Shouldn't error out
+    _ = gather(tensor)
 
 
 def test_broadcast(state):
@@ -91,21 +92,21 @@ def _mp_fn(index):
 
 def main():
     state = PartialState()
-    # state.print(f"State: {state}")
-    # state.print("testing gather")
-    # test_gather(state)
-    # state.print("testing gather_object")
-    # test_gather_object(state)
+    state.print(f"State: {state}")
+    state.print("testing gather")
+    test_gather(state)
+    state.print("testing gather_object")
+    test_gather_object(state)
     state.print("testing gather non-contigous")
     test_gather_non_contigous(state)
-    # state.print("testing broadcast")
-    # test_broadcast(state)
-    # state.print("testing pad_across_processes")
-    # test_pad_across_processes(state)
-    # state.print("testing reduce_sum")
-    # test_reduce_sum(state)
-    # state.print("testing reduce_mean")
-    # test_reduce_mean(state)
+    state.print("testing broadcast")
+    test_broadcast(state)
+    state.print("testing pad_across_processes")
+    test_pad_across_processes(state)
+    state.print("testing reduce_sum")
+    test_reduce_sum(state)
+    state.print("testing reduce_mean")
+    test_reduce_mean(state)
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -36,6 +36,13 @@ def test_gather_object(state):
     assert len(gathered_obj) == state.num_processes, f"{gathered_obj}, {len(gathered_obj)} != {state.num_processes}"
     assert gathered_obj == list(range(state.num_processes)), f"{gathered_obj} != {list(range(state.num_processes))}"
 
+def test_gather_non_contigous(state):
+    # Create a non-contiguous tensor
+    tensor = torch.arange(12).view(4, 3).t().to(state.device)
+    assert not tensor.is_contiguous()
+    gathered_tensor = gather(tensor)
+    assert gathered_tensor.shape == torch.Size([state.num_processes, 3, 4])
+
 
 def test_broadcast(state):
     tensor = create_tensor(state)
@@ -84,19 +91,21 @@ def _mp_fn(index):
 
 def main():
     state = PartialState()
-    state.print(f"State: {state}")
-    state.print("testing gather")
-    test_gather(state)
-    state.print("testing gather_object")
-    test_gather_object(state)
-    state.print("testing broadcast")
-    test_broadcast(state)
-    state.print("testing pad_across_processes")
-    test_pad_across_processes(state)
-    state.print("testing reduce_sum")
-    test_reduce_sum(state)
-    state.print("testing reduce_mean")
-    test_reduce_mean(state)
+    # state.print(f"State: {state}")
+    # state.print("testing gather")
+    # test_gather(state)
+    # state.print("testing gather_object")
+    # test_gather_object(state)
+    state.print("testing gather non-contigous")
+    test_gather_non_contigous(state)
+    # state.print("testing broadcast")
+    # test_broadcast(state)
+    # state.print("testing pad_across_processes")
+    # test_pad_across_processes(state)
+    # state.print("testing reduce_sum")
+    # test_reduce_sum(state)
+    # state.print("testing reduce_mean")
+    # test_reduce_mean(state)
 
 
 if __name__ == "__main__":

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -251,6 +251,9 @@ def _tpu_gather(tensor):
         if tensor.ndim == 0:
             tensor = tensor.clone()[None]
 
+        # Can only gather contiguous tensors
+        if not tensor.is_contiguous():
+            tensor = tensor.contiguous()
         return xm.all_gather(tensor)
 
     res = recursively_apply(_tpu_gather_one, tensor, error_on_other_type=True)
@@ -262,6 +265,10 @@ def _gpu_gather(tensor):
     def _gpu_gather_one(tensor):
         if tensor.ndim == 0:
             tensor = tensor.clone()[None]
+
+        # Can only gather contiguous tensors
+        if not tensor.is_contiguous():
+            tensor = tensor.contiguous()
         output_tensors = [torch.empty_like(tensor) for _ in range(torch.distributed.get_world_size())]
         torch.distributed.all_gather(output_tensors, tensor)
         return torch.cat(output_tensors, dim=0)


### PR DESCRIPTION
Solves https://github.com/huggingface/transformers/issues/25076
Solves https://github.com/huggingface/accelerate/issues/1764

We need to ensure tensors are `contiguous` before gathering, else torch will raise an error. 