### PR TITLE
simplify and correct the deepspeed example

### DIFF
--- a/examples/by_feature/deepspeed_with_config_support.py
+++ b/examples/by_feature/deepspeed_with_config_support.py
@@ -649,7 +649,7 @@ def main():
                 {
                     "perplexity": perplexity,
                     "eval_loss": eval_loss,
-                    "train_loss": total_loss.item() / len(train_dataloader),
+                    "train_loss": total_loss / len(train_dataloader),
                     "epoch": epoch,
                     "step": completed_steps,
                 },


### PR DESCRIPTION
### What does this PR do?

1. Fixes https://github.com/huggingface/accelerate/issues/1767 and https://github.com/huggingface/accelerate/issues/1773
2. Simplifies the example by removing the redundant saving/loading utils for DeepSpeed as they are supported via `accelerator.save_state()` and `accelerator.load_state()`.