### PR TITLE
More specific logging in `gather_for_metrics`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2060,19 +2060,25 @@ class Accelerator:
         ```
         """
         tensor = self.gather(tensor)
-        if self.gradient_state.remainder == -1:
-            logger.info(
-                "The used dataset had no length, returning gathered tensors. You should drop the remainder yourself."
-            )
-            return tensor
-        try:
-            # Then see if we're on the last batch of our eval dataloader
-            if self.gradient_state.end_of_dataloader and self.gradient_state.remainder > 0:
-                # Last batch needs to be truncated on distributed systems as it contains additional samples
-                def _adjust_samples(tensor):
-                    return tensor[: self.gradient_state.remainder]
 
-                return recursively_apply(_adjust_samples, tensor)
+        try:
+            if self.gradient_state.end_of_dataloader:
+                # at the end of a dataloader, `gather_for_metrics` regresses to
+                # `gather` unless the dataset has a remainder so log.
+                if self.gradient_state.remainder == -1:
+                    logger.info(
+                        "The used dataset had no length, returning gathered tensors. You should drop the remainder yourself."
+                    )
+                    return tensor
+                elif self.gradient_state.remainder > 0:
+                    # Last batch needs to be truncated on distributed systems as it contains additional samples
+                    def _adjust_samples(tensor):
+                        return tensor[: self.gradient_state.remainder]
+
+                    return recursively_apply(_adjust_samples, tensor)
+                else: # remainder is 0
+                    # no remainder even though at end of dataloader, so nothing to do.
+                    return tensor
             else:
                 # Not at the end of the dataloader, no need to adjust the tensors
                 return tensor

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -102,7 +102,7 @@ def test_gather_for_metrics_with_iterable_dataset(state):
             for element in self.data:
                 yield element
 
-    iterable_dataset = DummyIterableDataset(torch.as_tensor(range(15)))
+    iterable_dataset = DummyIterableDataset(torch.as_tensor(range(30)))
     dataloader = DataLoader(iterable_dataset, batch_size=4)
 
     accelerator = Accelerator()
@@ -116,16 +116,16 @@ def test_gather_for_metrics_with_iterable_dataset(state):
         logger.addHandler(list_handler)
 
     batches_for_metrics = []
-    for _, batch in enumerate(prepared_dataloader):
-        print(accelerator.gradient_state.remainder)
+    for batch in prepared_dataloader:
         batches_for_metrics.append(accelerator.gather_for_metrics(batch))
 
-    assert torch.cat(batches_for_metrics).size(0) == 15
+    assert torch.cat(batches_for_metrics).size(0) == 30
 
     if state.is_main_process:
+        assert len(list_handler.logs) == 0
         # inverse assertion
-        assert len(list_handler.logs) == 1
-        assert "The used dataset had no length, returning gathered tensors." in list_handler.logs[0].msg
+        # assert len(list_handler.logs) == 3
+        # assert "The used dataset had no length, returning gathered tensors." in list_handler.logs[0].msg
 
         logger.removeHandler(list_handler)
 

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -123,9 +123,6 @@ def test_gather_for_metrics_with_iterable_dataset(state):
 
     if state.is_main_process:
         assert len(list_handler.logs) == 0
-        # inverse assertion
-        # assert len(list_handler.logs) == 3
-        # assert "The used dataset had no length, returning gathered tensors." in list_handler.logs[0].msg
 
         logger.removeHandler(list_handler)
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -397,28 +397,3 @@ class DataLoaderTester(unittest.TestCase):
         # Test it also works on the second iteration
         for idx, _ in enumerate(dataloader):
             self.assertEqual(dataloader.end_of_dataloader, idx == 3)
-
-    def test_data_loader_dispatcher_gather_for_metrics(self):
-        class DummyIterableDataset(IterableDataset):
-            def __init__(self, data):
-                self.data = data
-
-            def __iter__(self):
-                for element in self.data:
-                    yield element
-
-        iterable_dataset = DummyIterableDataset(torch.as_tensor(range(10)))
-        dataloader = DataLoader(iterable_dataset, batch_size=4)
-
-        accelerator = Accelerator()
-        prepared_dataloader = accelerator.prepare(dataloader)
-
-        assert type(prepared_dataloader) == DataLoaderDispatcher
-
-        batch_shapes = []
-        for _, batch in enumerate(prepared_dataloader):
-            gathered = accelerator.gather_for_metrics(batch)
-            batch_shapes.append(gathered.size(0))
-        
-        assert batch_shapes == []
-

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -14,7 +14,6 @@
 
 import random
 import unittest
-import torch
 
 from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -65,7 +65,6 @@ class MultiGPUTester(unittest.TestCase):
         with patch_environment(omp_num_threads=1, cuda_visible_devices="0,1"):
             execute_subprocess_async(cmd, env=os.environ.copy())
 
-
 if __name__ == "__main__":
     accelerator = Accelerator()
     shape = (accelerator.state.process_index + 2, 10)

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -45,7 +45,7 @@ class MultiGPUTester(unittest.TestCase):
         print(f"Found {torch.cuda.device_count()} devices.")
         cmd = ["torchrun", f"--nproc_per_node={torch.cuda.device_count()}", self.operation_file_path]
         print(f"Command: {cmd}")
-        with patch_environment(omp_num_threads=1):
+        with patch_environment(omp_num_threads=1, ACCELERATE_LOG_LEVEL="INFO"):
             execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_multi_gpu


### PR DESCRIPTION
## Problem

When `accelerate.prepare()`-ing a `DataLoader` for an `IterableDataset`, the prepared dataloader is a `DataLoaderDispatcher`. A `DataLoaderDispatcher` only knows its remainder when it is at the end of its iteration. As the current behavior of `gather_for_metrics` is to log whenever there's a remainder not set (and has the default value of -1), this means that there will be a ton of log messages from `gather_for_metrics` about a remainder not being set, even when not at the end of the dataloader.

## Solution

* Update `gather_for_metrics` to only check for a unset remainder when we're at the end of the dataloader
* Add test case to test_ops that captures this case (fails without this change) by asserting on the number of log messages