### PR TITLE
add warning when using to and cuda

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 from contextlib import contextmanager
 from typing import Dict, List, Optional, Union
@@ -38,6 +39,9 @@ from .utils import (
     offload_state_dict,
     retie_parameters,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -379,6 +383,21 @@ def dispatch_model(
         )
         # Attaching the hook may break tied weights, so we retie them
         retie_parameters(model, tied_params)
+
+        # add warning to cuda and to method
+        def add_warning(fn):
+            def wrapper(*args, **kwargs):
+                logger.warning(
+                    "You can't use the model anymore for training or inference as you moved the model."
+                    "You should not move the model when it is dispatched on multiples devices. "
+                )
+                return fn(*args, **kwargs)
+
+            return wrapper
+
+        model.to = add_warning(model.to)
+        model.cuda = add_warning(model.cuda)
+
     else:
         device = list(device_map.values())[0]
         if device != "disk":

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -389,10 +389,7 @@ def dispatch_model(
         def add_warning(fn):
             @wraps(fn)
             def wrapper(*args, **kwargs):
-                logger.warning(
-                    "You can't use the model anymore for training or inference as you moved the model."
-                    "You should not move the model when it is dispatched on multiples devices. "
-                )
+                logger.warning("You can't move a model when it is dispatched on multiple device.")
                 try:
                     return fn(*args, **kwargs)
                 except NotImplementedError as e:

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -389,7 +389,7 @@ def dispatch_model(
         def add_warning(fn):
             @wraps(fn)
             def wrapper(*args, **kwargs):
-                logger.warning("You can't move a model when it is dispatched on multiple device.")
+                logger.warning("You can't move a model when it is dispatched on multiple devices.")
                 try:
                     return fn(*args, **kwargs)
                 except NotImplementedError as e:

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -389,7 +389,7 @@ def dispatch_model(
         def add_warning(fn, model):
             @wraps(fn)
             def wrapper(*args, **kwargs):
-                logger.warning("You can't move a model when it is dispatched on multiple devices.")
+                logger.warning("You shouldn't move a model when it is dispatched on multiple devices.")
                 for param in model.parameters():
                     if param.device == torch.device("meta"):
                         raise RuntimeError("You can't move a model that has some modules offloaded to cpu or disk.")

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -319,6 +319,15 @@ class BigModelingTester(unittest.TestCase):
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
+    @require_cuda
+    def test_dispatch_model_move_offloaded_model(self):
+        model = ModelForTest()
+        device_map = {"linear1": "disk", "batchnorm": 'cpu', "linear2": 0}
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir)
+            with self.assertRaises(RuntimeError):
+                model.to(0)
+
     @require_multi_gpu
     def test_dispatch_model_move_model_warning(self):
         model = ModelForTest()

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -322,7 +322,7 @@ class BigModelingTester(unittest.TestCase):
     @require_cuda
     def test_dispatch_model_move_offloaded_model(self):
         model = ModelForTest()
-        device_map = {"linear1": "disk", "batchnorm": 'cpu', "linear2": 0}
+        device_map = {"linear1": "disk", "batchnorm": "cpu", "linear2": 0}
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             with self.assertRaises(RuntimeError):


### PR DESCRIPTION
# What does this PR do ? 
This PR wrap `to` and `cuda` method when we dispatch a model on multiple devices. We send a send a warning when these methods are called as they should not move the model for inference/training. We also give a better error message when the user tries to move a model that has some modules offloaded to cpu or disk. 