### PR TITLE
Allow users to resume from previous wandb runs with allow_val_change 

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -313,7 +313,7 @@ class WandBTracker(GeneralTracker):
                 Values to be stored as initial hyperparameters as key-value pairs. The values need to have type `bool`,
                 `str`, `float`, `int`, or `None`.
         """
-        wandb.config.update(values)
+        wandb.config.update(values, allow_val_change=True)
         logger.debug("Stored initial configuration hyperparameters to WandB")
 
     @on_main_process


### PR DESCRIPTION
Minor fix to allow users to resume from a previous run on wandb. Example use case: if one uses a custom `config` with  `wandb` for tracking as follows:

`accelerator.init_trackers(project_name=args.wandb_project, config=args, init_kwargs=wandb_init_kwargs)`

I might want to resume from the same `wandb` run using the `resume`  argument 
(Docs: https://docs.wandb.ai/guides/runs/resuming) 

Resuming by just passing the `resume` argument with `wandb_init_kwargs` as `{"wandb": {"resume": True, "allow_val_change": True}}` does not work if I have changed the `config` parameter above (Say a "checkpoint_path" key).  leading to the following error:

`ConfigError: Attempted to change value of key "checkpoint_path" from None to test_ckpt_path If you really want to do this, pass allow_val_change=True to config.update()`
