### PR TITLE
reserve 10% GPU in `get_balanced_memory` to avoid OOM

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -779,7 +779,7 @@ def get_balanced_memory(
             for key in max_memory.keys():
                 if isinstance(key, int):
                     max_memory[key] *= 0.9  # 90% is a good compromise
-                    logger.warning(
+                    logger.info(
                         f"We will use 90% of the memory on device {key} for storing the model, and 10% for the buffer to avoid OOM. "
                         "You can set `max_memory` in to a higher value to use more memory (at your own risk)."
                     )

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -896,8 +896,6 @@ def infer_auto_device_map(
         devices.append("disk")
     gpus = [device for device in devices if device not in ["cpu", "disk"]]
 
-    # find the lowest cardinal of gpus, lower
-
     # Devices that need to keep space for a potential offloaded layer.
     if "mps" in gpus:
         main_devices = ["mps"]

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -781,7 +781,7 @@ def get_balanced_memory(
                     max_memory[key] *= 0.9  # 90% is a good compromise
                     logger.warning(
                         f"We will use 90% of the memory on device {key} for storing the model, and 10% for the buffer to avoid OOM. "
-                        "You can set `max_memory` in to a higher value to use more memory."
+                        "You can set `max_memory` in to a higher value to use more memory (at your own risk)."
                     )
                     break  # only one device
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -753,6 +753,7 @@ def get_balanced_memory(
             Transformers generate function).
     """
     # Get default / clean up max_memory
+    user_not_set_max_memory = max_memory is None
     max_memory = get_max_memory(max_memory)
 
     if not (torch.cuda.is_available() or is_xpu_available()) or is_mps_available():
@@ -771,8 +772,18 @@ def get_balanced_memory(
         )
 
     if num_devices == 1:
-        # We cannot do low_zero on just one GPU
+        # We cannot do low_zero on just one GPU, but we will still reserve some memory for the buffer
         low_zero = False
+        # If user just asked us to handle memory usage, we should avoid OOM
+        if user_not_set_max_memory:
+            for key in max_memory.keys():
+                if isinstance(key, int):
+                    max_memory[key] *= 0.9  # 90% is a good compromise
+                    logger.warning(
+                        f"We will use 90% of the memory on device {key} for storing the model, and 10% for the buffer to avoid OOM. "
+                        "You can set `max_memory` in to a higher value to use more memory."
+                    )
+                    break  # only one device
 
     module_sizes = compute_module_sizes(model, dtype=dtype, special_dtypes=special_dtypes)
     per_gpu = module_sizes[""] // (num_devices - 1 if low_zero else num_devices)
@@ -884,6 +895,8 @@ def infer_auto_device_map(
     if "disk" not in devices:
         devices.append("disk")
     gpus = [device for device in devices if device not in ["cpu", "disk"]]
+
+    # find the lowest cardinal of gpus, lower
 
     # Devices that need to keep space for a potential offloaded layer.
     if "mps" in gpus:


### PR DESCRIPTION
# What does this PR do?
This PR fixes OOM problem in the case of 1 GPU and device_map="auto", by reserving 10% memory for buffer(e.g. , storing the text embeddings). Manually setting max_memory or device_map will override this change. 

This is a patch to `get_balanced_memory()` in the case of `num_devices==1`.

The OOM problem happens for some LLMs, such as chatglm, llama, etc. 

Hope it's acceptable. 
