### PR TITLE
Detect device map auto and raise a helpful error when trying to not use model parallelism

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1325,6 +1325,12 @@ class Accelerator:
                 has_hf_device_map = True
                 break
 
+        if has_hf_device_map and self.distributed_type != DistributedType.NO:
+            raise ValueError(
+                "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
+                " Please rerun your script specifying `--num_processes=1` or by launching with `python {{myscript.py}}`."
+            )
+
         if (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)) and getattr(
             model, "hf_device_map", False
         ):

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -1,5 +1,6 @@
 from .testing import (
     are_the_same_tensors,
+    assert_exception,
     execute_subprocess_async,
     require_bnb,
     require_cpu,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -419,9 +419,11 @@ def run_command(command: List[str], return_stdout=False):
 
 
 @contextmanager
-def assert_exception(exception_class: Exception) -> bool:
+def assert_exception(exception_class: Exception, msg: str = None) -> bool:
     """
     Context manager to assert that the right `Exception` class was raised.
+
+    If `msg` is provided, will check that the message is contained in the raised exception.
     """
     was_ran = False
     try:
@@ -429,5 +431,7 @@ def assert_exception(exception_class: Exception) -> bool:
         was_ran = True
     except Exception as e:
         assert isinstance(e, exception_class), f"Expected exception of type {exception_class} but got {type(e)}"
+        if msg is not None:
+            assert msg in str(e), f"Expected message '{msg}' to be in exception but got '{str(e)}'"
     if was_ran:
         raise AssertionError(f"Expected exception of type {exception_class} but ran without issue.")

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -20,7 +20,8 @@ import torch
 
 import accelerate
 from accelerate import Accelerator
-from accelerate.test_utils import execute_subprocess_async, require_multi_gpu
+from accelerate.big_modeling import dispatch_model
+from accelerate.test_utils import assert_exception, execute_subprocess_async, require_multi_gpu
 from accelerate.utils import patch_environment
 
 
@@ -93,3 +94,22 @@ if __name__ == "__main__":
     # Raise error at the end to make sure we don't stop at the first failure.
     if len(error_msg) > 0:
         raise ValueError(error_msg)
+
+    # Check device_map
+    accelerator.print("Test `device_map` cannot be prepared.")
+
+    class ModelForTest(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = torch.nn.Linear(3, 4)
+            self.batchnorm = torch.nn.BatchNorm1d(4)
+            self.linear2 = torch.nn.Linear(4, 5)
+
+        def forward(self, x):
+            return self.linear2(self.batchnorm(self.linear1(x)))
+
+    device_map = {"linear1": 0, "batchnorm": "cpu", "linear2": 1}
+    model = ModelForTest()
+    dispatch_model(model, device_map=device_map)
+    with assert_exception(ValueError, "You can't train a model that has been loaded with"):
+        model = accelerator.prepare_model(model)


### PR DESCRIPTION
Solves https://github.com/huggingface/accelerate/issues/1802 by raising an error if a user tries doing `.prepare()` on a model that contains a device map and we are in something other than `Distributed.NO