### PR TITLE
Fix bnb import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras = {}
 extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 < 2.0.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
-extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm"]
+extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes"]
 extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["rich"] = ["rich"]
 

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -314,6 +314,7 @@ def _replace_with_bnb_layers(
 
     Returns the converted model and a boolean that indicates if the conversion has been successfull or not.
     """
+    # bitsandbytes will initialize CUDA on import, so it needs to be imported lazily
     import bitsandbytes as bnb
 
     has_been_replaced = False
@@ -422,6 +423,7 @@ def get_keys_to_not_convert(model):
 
 def has_4bit_bnb_layers(model):
     """Check if we have `bnb.nn.Linear4bit` or `bnb.nn.Linear8bitLt` layers inside our model"""
+    # bitsandbytes will initialize CUDA on import, so it needs to be imported lazily
     import bitsandbytes as bnb
 
     for m in model.modules():

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -21,7 +21,10 @@ from typing import Dict, List, Optional, Union
 import torch
 import torch.nn as nn
 
-from accelerate.utils.imports import is_4bit_bnb_available, is_8bit_bnb_available
+from accelerate.utils.imports import (
+    is_4bit_bnb_available,
+    is_8bit_bnb_available,
+)
 
 from ..big_modeling import dispatch_model, init_empty_weights
 from .dataclasses import BnbQuantizationConfig

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -15,16 +15,13 @@
 
 import logging
 import os
+from copy import deepcopy
 from typing import Dict, List, Optional, Union
 
 import torch
 import torch.nn as nn
 
-from accelerate.utils.imports import (
-    is_4bit_bnb_available,
-    is_8bit_bnb_available,
-    is_bnb_available,
-)
+from accelerate.utils.imports import is_4bit_bnb_available, is_8bit_bnb_available
 
 from ..big_modeling import dispatch_model, init_empty_weights
 from .dataclasses import BnbQuantizationConfig
@@ -36,12 +33,6 @@ from .modeling import (
     offload_weight,
     set_module_tensor_to_device,
 )
-
-
-if is_bnb_available():
-    import bitsandbytes as bnb
-
-from copy import deepcopy
 
 
 logger = logging.getLogger(__name__)
@@ -320,6 +311,8 @@ def _replace_with_bnb_layers(
 
     Returns the converted model and a boolean that indicates if the conversion has been successfull or not.
     """
+    import bitsandbytes as bnb
+
     has_been_replaced = False
     for name, module in model.named_children():
         if current_key_name is None:
@@ -426,6 +419,8 @@ def get_keys_to_not_convert(model):
 
 def has_4bit_bnb_layers(model):
     """Check if we have `bnb.nn.Linear4bit` or `bnb.nn.Linear8bitLt` layers inside our model"""
+    import bitsandbytes as bnb
+
     for m in model.modules():
         if isinstance(m, bnb.nn.Linear4bit):
             return True

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -329,3 +329,12 @@ class AcceleratorTester(AccelerateTestCase):
         sgd = torch.optim.SGD(model.parameters(), lr=0.01)
         accelerator = Accelerator(cpu=True)
         _ = accelerator.prepare(sgd)
+
+    @require_cuda
+    def test_a_cuda_initialization_on_import(self):
+        # Everything else is already initialized, now we just need to check that the cuda device is *not* initialized
+        initialized = torch.cuda.is_initialized()
+        self.assertFalse(
+            initialized,
+            "CUDA has been initialized somewhere after importing. Please see the imports in `test_accelerator.py` to try and locate the problem.",
+        )


### PR DESCRIPTION
`bitsandbytes` will always initialize CUDA on import as it's designed to be imported/ran from the CLI. As a result this makes it fully incompatible with the `notebook_launcher`. To try and mitigate this, I've moved all of the import statements to be inside the functions that require the items to use them. Not the cleanest solution, but as this behavior has been consistent in bnb for many versions I don't believe this is likely to change in the future, so we need to adapt for it as a result. 

Solves https://github.com/huggingface/accelerate/issues/1807