### PR TITLE
Expose a bit of args/docstring fixup

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -159,9 +159,8 @@ class Accelerator:
         mixed_precision (`str`, *optional*):
             Whether or not to use mixed precision training. Choose from 'no','fp16','bf16 or 'fp8'. Will default to the
             value in the environment variable `ACCELERATE_MIXED_PRECISION`, which will use the default value in the
-            accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp16'
-            requires pytorch 1.6 or higher. 'bf16' requires pytorch 1.10 or higher. 'fp8' requires the installation of
-            transformers-engine.
+            accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp8'
+            requires the installation of transformers-engine.
         gradient_accumulation_steps (`int`, *optional*, default to 1):
             The number of steps that should pass before gradients are accumulated. A number > 1 should be combined with
             `Accelerator.accumulate`. If not passed, will default to the value in the environment variable

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -106,7 +106,7 @@ class PartialState:
           in use.
         - **local_process_index** (`int`) -- The index of the current process on the current server.
         - **mixed_precision** (`str`) -- Whether or not the current script will use mixed precision, and if so the type
-          of mixed precision being performed.
+          of mixed precision being performed. (One of `"fp16"`, `"bf16"`, or `"fp8"`).
         - **num_processes** (`int`) -- The number of processes currently launched in parallel.
         - **process_index** (`int`) -- The index of the current process.
         - **is_last_process** (`bool`) -- Whether or not the current process is the last one.
@@ -695,7 +695,7 @@ class AcceleratorState:
         - **initialized** (`bool`) -- Whether or not the `AcceleratorState` has been initialized from `Accelerator`.
         - **local_process_index** (`int`) -- The index of the current process on the current server.
         - **mixed_precision** (`str`) -- Whether or not the current script will use mixed precision, and if so the type
-          of mixed precision being performed.
+          of mixed precision being performed. (One of `"no`", `"fp16"`, `"bf16"`, or `"fp8"`).
         - **num_processes** (`int`) -- The number of processes currently launched in parallel.
         - **process_index** (`int`) -- The index of the current process.
         - **is_last_process** (`bool`) -- Whether or not the current process is the last one.


### PR DESCRIPTION
Applies some feedback from an in-depth doc review, and removes chunks about minimal torch requirements since we now require torch 1.10+