### PR TITLE
Minor idiomatic change for fp8 check.

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1385,9 +1385,7 @@ class Accelerator:
                 kwargs["fp8_format"] = getattr(te_recipe.Format, kwargs["fp8_format"])
             fp8_recipe = te_recipe.DelayedScaling(**kwargs)
             cuda_device_capacity = torch.cuda.get_device_capability()
-            fp8_enabled = cuda_device_capacity[0] >= 9 or (
-                cuda_device_capacity[0] == 8 and cuda_device_capacity[1] >= 9
-            )
+            fp8_enabled = cuda_device_capacity >= (8, 9)
             if not fp8_enabled:
                 logger.warn(
                     f"The current device has compute capability of {cuda_device_capacity} which is "


### PR DESCRIPTION
Tuple comparison in Python is a slightly cleaner way to check that the major/minor is >= 8.9.