### PR TITLE
Ipex bug fix for device properties in modelling

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -776,7 +776,10 @@ def get_balanced_memory(
             [
                 d
                 for d in max_memory
-                if (torch.device(d).type == "xpu" or torch.xpu.get_device_properties(d).dev_type == "gpu")
+                if (
+                    d != "cpu"
+                    and (torch.device(d).type == "xpu" or torch.xpu.get_device_properties(d).dev_type == "gpu")
+                )
                 and max_memory[d] > 0
             ]
         )


### PR DESCRIPTION
For our arc intel gpus, there is an issue where if cpu is present in the device map (which it is by default from get_max_memory)  , it will flag an error in ipex (during device_map =balanced or auto) as ipex expects no 'cpu' type in its arc gpu memory initialization. This fix  is exclusively for our gpus .
@sgugger @muellerzr 