### PR TITLE
FIX: Bug with unwrap_model and keep_fp32_wrapper=False

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -15,6 +15,7 @@
 import os
 import socket
 from contextlib import contextmanager
+from types import MethodType
 
 import torch
 
@@ -82,7 +83,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True):
                 forward = forward.__wrapped__
                 if forward == original_forward:
                     break
-            model.forward = forward
+            model.forward = MethodType(forward, model)
         if getattr(model, "_converted_to_transformer_engine", False):
             convert_model(model, to_transformer_engine=False)
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -361,7 +361,7 @@ class AcceleratorTester(AccelerateTestCase):
 
     def test_can_unwrap_model(self):
         model = create_components()[0]
-        accelerator = Accelerator(mixed_precision="no")
+        accelerator = Accelerator(mixed_precision="no", cpu=True)
         inputs = torch.randn(10, 2)
         model = accelerator.prepare(model)
         model(inputs)  # sanity check that this works

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -362,7 +362,7 @@ class AcceleratorTester(AccelerateTestCase):
     def test_can_unwrap_model(self):
         model = create_components()[0]
         accelerator = Accelerator(mixed_precision="no")
-        inputs = torch.randn(10, 2).cuda()
+        inputs = torch.randn(10, 2)
         model = accelerator.prepare(model)
         model(inputs)  # sanity check that this works
 


### PR DESCRIPTION
Using `accelerator.unwrap_model(model, keep_fp32_wrapper=False)` results in a defective `forward` method. This bug was (probably) introduced in PR #872. I could reproduce it with current main, v0.21 and v0.20.

This PR provides a bugfix and tests for the regression.