### PR TITLE
Fix verify_device_map

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3060,6 +3060,9 @@ class Accelerator:
         Verifies that `model` has not been prepared with big model inference with a device-map resembling `auto`.
         """
         # Checks if any of the child module has the attribute `hf_device_map`.
-        has_hf_device_map = any(hasattr(m, "hf_device_map") for m in model.modules())
 
-        return has_hf_device_map
+        for m in model.modules():
+            if hasattr(m, "hf_device_map") and len(m.hf_device_map) > 1:
+                return True
+        
+        return False

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3063,6 +3063,5 @@ class Accelerator:
         for m in model.modules():
             if hasattr(m, "hf_device_map") and len(m.hf_device_map) > 1:
                 return True
-                
-        return False
 
+        return False

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3059,10 +3059,10 @@ class Accelerator:
         """
         Verifies that `model` has not been prepared with big model inference with a device-map resembling `auto`.
         """
-        # Checks if any of the child module has the attribute `hf_device_map`.
-
+        # Checks if any of the child modules has the attribute `hf_device_map` and this map has more than one entry.
         for m in model.modules():
             if hasattr(m, "hf_device_map") and len(m.hf_device_map) > 1:
                 return True
-        
+                
         return False
+


### PR DESCRIPTION
Currently `verify_device_map`, which is called during `Accelerator.prepare` only checks if there is an attribute `hf_device_map` in any of the submodules. However, it does not check the contents of the device map itself. In case of trivial device map with only one element this will prevent user from training a model in distributed mode, while the model would in fact work perfectly fine as it is not spread across many devices.

I've made a small change to the function, so now it will **only** return True if any of the child modules has `hf_device_map` **and** this map has more than one entry.