### PR TITLE
Include a note to the forums in the bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,11 +1,11 @@
 name: "\U0001F41B Bug Report"
 description: Submit a bug report to help us improve Accelerate
 body:
-  - type: textarea
-    id: faq
-    attributes:
-      label: Post on the forum first
-      description: If this is not a bug related to the Accelerate library directly, but instead is a general question about your code or the library specifically, please use the [forums](https://discuss.huggingface.co/c/accelerate/18).
+  - type: markdown
+    attributes: 
+      value: | 
+        Thanks for taking the time to submit a bug report! 🐛 
+        If this is not a bug related to the Accelerate library directly, but instead a general question about your code or the library specifically please use the [forums](https://discuss.huggingface.co/c/accelerate/18).
 
   - type: textarea
     id: system-info

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -2,6 +2,12 @@ name: "\U0001F41B Bug Report"
 description: Submit a bug report to help us improve Accelerate
 body:
   - type: textarea
+    id: faq
+    attributes:
+      label: Post on the forum first
+      description: If this is not a bug related to the Accelerate library directly, but instead is a general question about your code or the library specifically, please use the [forums](https://discuss.huggingface.co/c/accelerate/18).
+
+  - type: textarea
     id: system-info
     attributes:
       label: System Info


### PR DESCRIPTION
As noted in https://github.com/huggingface/accelerate/issues/1870, this PR adds a link to the forums for users choosing the bug report template, enticing them to post there first: 
![image](https://github.com/huggingface/accelerate/assets/7831895/bb249135-076c-47f4-8c35-1b18fdd9d250)
