### PR TITLE
Introduce model memory estimator

### DIFF
--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -239,7 +239,7 @@ Estimates the total vRAM a particular model hosted on the Hub needs to perform B
 **Usage**: 
 
 ```bash
-accelerate estimate-memory --model_name {MODEL_NAME} --library_name {LIBRARY_NAME} --dtypes {dtype_1} {dtype_2} ...
+accelerate estimate-memory {MODEL_NAME} --library_name {LIBRARY_NAME} --dtypes {dtype_1} {dtype_2} ...
 ```
 
 **Required Arguments**:

--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -234,19 +234,23 @@ The following arguments are only useful when training in SageMaker
 
 `accelerate estimate-memory` or `accelerate-estimate-memory` or `python -m accelerate.commands.estimate`
 
-Estimates the total vRAM a particular model hosted on the Hub needs to perform Big Model Inference and training.
+Estimates the total vRAM a particular model hosted on the Hub needs to perform Big Model Inference and training. Requires that `huggingface_hub` be installed.
 
 **Usage**: 
 
 ```bash
-accelerate estimate-memory [arguments]
+accelerate estimate-memory --model_name {MODEL_NAME} --library_name {LIBRARY_NAME} --dtypes {dtype_1} {dtype_2} ...
 ```
+
+**Required Arguments**:
+
+* `MODEL_NAME` (`str`)-- The model name on the Hugging Face Hub
 
 **Optional Arguments**:
 
-* `--model_name MODEL_NAME` (`str`)-- The model name on the Hugging Face Hub
-* `--library_name LIBRARY_NAME` (`str`)-- The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub
+* `--library_name {timm,transformers}` (`str`)-- The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub
 * `--dtypes {float32,float16,int8,int4}` (`[{float32,float16,int8,int4} ...]`) --The dtypes to use for the model, must be one (or many) of `float32`, `float16`, `int8`, and `int4`
+* `--trust_remote_code` (`bool`) -- Whether or not to allow for custom models defined on the Hub in their own modeling files. This option should only be passed for repositories you trust and in which you have read the code, as it will execute code present on the Hub on your local machine.
 
 ## accelerate tpu-config
 

--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -228,6 +228,26 @@ The following arguments are only useful when training in SageMaker
 * `--aws_access_key_id AWS_ACCESS_KEY_ID` (`str`) -- The AWS_ACCESS_KEY_ID used to launch the Amazon SageMaker training job
 * `--aws_secret_access_key AWS_SECRET_ACCESS_KEY` (`str`) -- The AWS_SECRET_ACCESS_KEY used to launch the Amazon SageMaker training job
 
+## accelerate estimate-memory
+
+**Command**:
+
+`accelerate estimate-memory` or `accelerate-estimate-memory` or `python -m accelerate.commands.estimate`
+
+Estimates the total vRAM a particular model hosted on the Hub needs to perform Big Model Inference and training.
+
+**Usage**: 
+
+```bash
+accelerate estimate-memory [arguments]
+```
+
+**Optional Arguments**:
+
+* `--model_name MODEL_NAME` (`str`)-- The model name on the Hugging Face Hub
+* `--library_name LIBRARY_NAME` (`str`)-- The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub
+* `--dtypes {float32,float16,int8,int4}` (`[{float32,float16,int8,int4} ...]`) --The dtypes to use for the model, must be one (or many) of `float32`, `float16`, `int8`, and `int4`
+
 ## accelerate tpu-config
 
 `accelerate tpu-config`

--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -234,7 +234,7 @@ The following arguments are only useful when training in SageMaker
 
 `accelerate estimate-memory` or `accelerate-estimate-memory` or `python -m accelerate.commands.estimate`
 
-Estimates the total vRAM a particular model hosted on the Hub needs to perform Big Model Inference and training. Requires that `huggingface_hub` be installed.
+Estimates the total vRAM a particular model hosted on the Hub needs to perform inference and training. Requires that `huggingface_hub` be installed.
 
 **Usage**: 
 

--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -248,8 +248,8 @@ accelerate estimate-memory {MODEL_NAME} --library_name {LIBRARY_NAME} --dtypes {
 
 **Optional Arguments**:
 
-* `--library_name {timm,transformers}` (`str`)-- The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub
-* `--dtypes {float32,float16,int8,int4}` (`[{float32,float16,int8,int4} ...]`) --The dtypes to use for the model, must be one (or many) of `float32`, `float16`, `int8`, and `int4`
+* `--library_name {timm,transformers}` (`str`) -- The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub
+* `--dtypes {float32,float16,int8,int4}` (`[{float32,float16,int8,int4} ...]`) -- The dtypes to use for the model, must be one (or many) of `float32`, `float16`, `int8`, and `int4`
 * `--trust_remote_code` (`bool`) -- Whether or not to allow for custom models defined on the Hub in their own modeling files. This option should only be passed for repositories you trust and in which you have read the code, as it will execute code present on the Hub on your local machine.
 
 ## accelerate tpu-config

--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -234,7 +234,13 @@ The following arguments are only useful when training in SageMaker
 
 `accelerate estimate-memory` or `accelerate-estimate-memory` or `python -m accelerate.commands.estimate`
 
-Estimates the total vRAM a particular model hosted on the Hub needs to perform inference and training. Requires that `huggingface_hub` be installed.
+Estimates the total vRAM a particular model hosted on the Hub needs to be loaded in with an estimate for training. Requires that `huggingface_hub` be installed. 
+
+<Tip>
+
+    When performing inference, typically add ≤20% to the result as overall allocation [as referenced here](https://blog.eleuther.ai/transformer-math/). We will have more extensive estimations in the future that will automatically be included in the calculation.
+
+</Tip>
 
 **Usage**: 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras = {}
 extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 < 2.0.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
-extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes", "timm", "torchvision"]
+extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes", "timm", "torchvision", "einops"]
 extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["rich"] = ["rich"]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras = {}
 extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 < 2.0.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
-extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes", "timm", "torchvision", "einops"]
+extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes", "timm"]
 extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["rich"] = ["rich"]
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras = {}
 extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.0", "urllib3 < 2.0.0"]
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
-extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes"]
+extras["test_dev"] = ["datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes", "timm", "torchvision"]
 extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["rich"] = ["rich"]
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "console_scripts": [
             "accelerate=accelerate.commands.accelerate_cli:main",
             "accelerate-config=accelerate.commands.config:main",
+            "accelerate-estimate-memory=accelerate.commands.estimate:main",
             "accelerate-launch=accelerate.commands.launch:main",
         ]
     },

--- a/src/accelerate/commands/accelerate_cli.py
+++ b/src/accelerate/commands/accelerate_cli.py
@@ -18,6 +18,7 @@ from argparse import ArgumentParser
 
 from accelerate.commands.config import get_config_parser
 from accelerate.commands.env import env_command_parser
+from accelerate.commands.estimate import estimate_command_parser
 from accelerate.commands.launch import launch_command_parser
 from accelerate.commands.test import test_command_parser
 from accelerate.commands.tpu import tpu_command_parser
@@ -29,6 +30,7 @@ def main():
 
     # Register commands
     get_config_parser(subparsers=subparsers)
+    estimate_command_parser(subparsers=subparsers)
     env_command_parser(subparsers=subparsers)
     launch_command_parser(subparsers=subparsers)
     tpu_command_parser(subparsers=subparsers)

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -67,7 +67,7 @@ def check_has_model(error):
         return "unknown"
 
 
-def create_empty_model(model_name, library_name: str, trust_remote_code: bool = False):
+def create_empty_model(model_name: str, library_name: str, trust_remote_code: bool = False):
     """
     Creates an empty model from its parent library on the `Hub` to calculate the overall memory consumption.
 
@@ -81,6 +81,9 @@ def create_empty_model(model_name, library_name: str, trust_remote_code: bool = 
             Whether or not to allow for custom models defined on the Hub in their own modeling files. This option
             should only be set to `True` for repositories you trust and in which you have read the code, as it will
             execute code present on the Hub on your local machine.
+
+    Returns:
+        `torch.nn.Module`: The torch model that has been initialized on the `meta` device.
 
     """
     model_info = verify_on_hub(model_name)

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -175,7 +175,9 @@ def estimate_command_parser(subparsers=None):
     else:
         parser = argparse.ArgumentParser(description="Model size estimator")
 
-    parser.add_argument("model_name", type=str, help="The model name on the Hugging Face Hub.")
+    parser.add_argument(
+        "model_name", type=str, help="The model name on the Hugging Face Hub or local path to the model folder."
+    )
     parser.add_argument(
         "--library_name",
         type=str,

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+from requests.exceptions import HTTPError
+
+from accelerate import init_empty_weights
+from accelerate.utils import (
+    calculate_maximum_sizes,
+    convert_bytes,
+    is_huggingface_hub_available,
+    is_timm_available,
+    is_transformers_available,
+)
+
+
+if is_huggingface_hub_available():
+    from huggingface_hub import HfApi
+
+if is_transformers_available():
+    from transformers import AutoConfig, AutoModel
+
+if is_timm_available():
+    import timm
+
+
+def verify_on_hub(repo: str):
+    "Verifies that the model is on the hub and returns the model info."
+    api = HfApi()
+    try:
+        return api.model_info(repo)
+    except HTTPError:
+        return False
+
+
+def create_empty_model(model_name, library_name: str):
+    """
+    Creates an empty model from its parent library on the `Hub` to calculate the overall memory consumption.
+
+    Args:
+        model_name (`str`):
+            The model name on the Hub
+        library_name (`str`, *optional*, defaults to "auto"):
+            The library the model has an integration with, such as `transformers`. Will be used if `model_name` has no
+            metadata on the Hub to determine the library.
+    """
+    model_info = verify_on_hub(model_name)
+    if not model_info:
+        raise ValueError(f"Model `{model_name}` is not an available model on the Hub.")
+    if library_name is None and getattr(model_info, "library_name", False):
+        raise ValueError(
+            f"Model `{model_name}` does not have any library metadata on the Hub, please manually pass in a `--library_name` to use (such as `transformers`)"
+        )
+    if library_name == "transformers":
+        if not is_transformers_available():
+            raise ImportError(
+                f"To check `{model_name}`, `transformers` must be installed. Please install it via `pip install transformers`"
+            )
+        print(f"Loading pretrained config for `{model_name}` from `transformers`...")
+        config = AutoConfig.from_pretrained(model_name)
+        with init_empty_weights():
+            model = AutoModel.from_config(config)
+    elif library_name == "timm":
+        if not is_timm_available():
+            raise ImportError(
+                f"To check `{model_name}`, `timm` must be installed. Please install it via `pip install timm`"
+            )
+        print(f"Loading pretrained config for `{model_name}` from `timm`...")
+        with init_empty_weights():
+            model = timm.create_model(model_name, pretrained=False)
+    else:
+        raise ValueError(
+            f"Library `{library_name}` is not supported yet, please open an issue on GitHub for us to add support."
+        )
+    return model
+
+
+def create_ascii_table(headers: list, rows: list, title: str):
+    "Creates a pretty table from a list of rows, minimal version of `tabulate`."
+    sep_char, in_between = "│", "─"
+    column_widths = []
+    for i in range(len(headers)):
+        column_values = [row[i] for row in rows] + [headers[i]]
+        max_column_width = max(len(value) for value in column_values)
+        column_widths.append(max_column_width)
+
+    formats = [f"%{column_widths[i]}s" for i in range(len(rows[0]))]
+
+    pattern = f"{sep_char}{sep_char.join(formats)}{sep_char}"
+    separator = f'├{"┼".join([in_between * n for n in column_widths])}┤'
+    initial_rows = [
+        f"┌{in_between * (len(separator)-2)}┐",
+        f"{sep_char}{title.center(sum(column_widths) + len(column_widths)-1)}{sep_char}",
+        f'├{"┬".join([in_between * n for n in column_widths])}┤',
+    ]
+    table = "\n".join(initial_rows) + "\n"
+    centered_line = [text.center(column_widths[i]) for i, text in enumerate(headers)]
+    table += f"{pattern % tuple(centered_line)}\n{separator}\n"
+    for i, line in enumerate(rows):
+        centered_line = [t.center(column_widths[i]) for i, t in enumerate(line)]
+        table += f"{pattern % tuple(centered_line)}\n"
+    table += f'└{"┴".join([in_between * n for n in column_widths])}┘'
+
+    return table
+
+
+def estimate_command_parser(subparsers=None):
+    if subparsers is not None:
+        parser = subparsers.add_parser("estimate-memory")
+    else:
+        parser = argparse.ArgumentParser(description="Model size estimator")
+
+    parser.add_argument("--model_name", type=str, help="The model name on the Hugging Face Hub")
+    parser.add_argument(
+        "--library_name",
+        type=str,
+        help="The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub.",
+    )
+    parser.add_argument(
+        "--dtypes",
+        type=str,
+        nargs="+",
+        default=["float32"],
+        help="The dtypes to use for the model, must be one (or many) of `float32`, `float16`, `int8`, and `int4`",
+        choices=["float32", "float16", "int8", "int4"],
+    )
+
+    if subparsers is not None:
+        parser.set_defaults(func=estimate_command)
+    return parser
+
+
+def estimate_command(args):
+    model = create_empty_model(args.model_name, library_name=args.library_name)
+    total_size, largest_layer = calculate_maximum_sizes(model)
+
+    data = []
+
+    headers = ["dtype", "Largest Layer", "Total Size", "Training using Adam"]
+    for dtype in args.dtypes:
+        dtype_total_size = total_size
+        dtype_largest_layer = largest_layer[0]
+        if dtype == "float16":
+            dtype_total_size /= 2
+            dtype_largest_layer /= 2
+        elif dtype == "int8":
+            dtype_total_size /= 4
+            dtype_largest_layer /= 4
+        elif dtype == "int4":
+            dtype_total_size /= 8
+            dtype_largest_layer /= 8
+        dtype_training_size = convert_bytes(dtype_total_size * 4)
+        dtype_total_size = convert_bytes(dtype_total_size)
+        dtype_largest_layer = convert_bytes(dtype_largest_layer)
+        data.append([dtype, dtype_largest_layer, dtype_total_size, dtype_training_size])
+
+    title = f"Memory Usage for `{args.model_name}`"
+    table = create_ascii_table(headers, data, title)
+    print(table)
+
+
+def main():
+    parser = estimate_command_parser()
+    args = parser.parse_args()
+    estimate_command(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -53,17 +53,19 @@ def create_empty_model(model_name, library_name: str):
     Args:
         model_name (`str`):
             The model name on the Hub
-        library_name (`str`, *optional*, defaults to "auto"):
+        library_name (`str`):
             The library the model has an integration with, such as `transformers`. Will be used if `model_name` has no
             metadata on the Hub to determine the library.
     """
     model_info = verify_on_hub(model_name)
     if not model_info:
         raise ValueError(f"Model `{model_name}` is not an available model on the Hub.")
-    if library_name is None and getattr(model_info, "library_name", False):
-        raise ValueError(
-            f"Model `{model_name}` does not have any library metadata on the Hub, please manually pass in a `--library_name` to use (such as `transformers`)"
-        )
+    if library_name is None:
+        library_name = getattr(model_info, "library_name", False)
+        if not library_name:
+            raise ValueError(
+                f"Model `{model_name}` does not have any library metadata on the Hub, please manually pass in a `--library_name` to use (such as `transformers`)"
+            )
     if library_name == "transformers":
         if not is_transformers_available():
             raise ImportError(

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -104,8 +104,8 @@ def create_empty_model(model_name, library_name: str, trust_remote_code: bool = 
             )
         print(f"Loading pretrained config for `{model_name}` from `transformers`...")
         # As we just load in the `config` file and not the weights, we use `True`
-        remote_code = model_info.config.get("auto_map", False)
-        if remote_code and not trust_remote_code:
+        auto_map = model_info.config.get("auto_map", False)
+        if auto_map and not trust_remote_code:
             raise ValueError(
                 f"Loading {model_name} requires to execute some code in that repo, you can inspect the content of "
                 f"the repository at https://hf.co/{model_name}. You can bypass this by passing "
@@ -124,8 +124,8 @@ def create_empty_model(model_name, library_name: str, trust_remote_code: bool = 
             raise e
         with init_empty_weights():
             # remote code could specify a specific `AutoModel` class in the `auto_map`
-            if remote_code:
-                for key in remote_code.keys():
+            if isinstance(auto_map, dict):
+                for key in auto_map.keys():
                     if key.startswith("AutoModelFor"):
                         value = key
                         break

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -110,7 +110,16 @@ def create_empty_model(model_name, library_name: str, trust_remote_code: bool = 
                 f"the repository at https://hf.co/{model_name}. You can bypass this by passing "
                 "`--trust_remote_code`"
             )
-        config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+        try:
+            config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+        except ValueError as e:
+            if "trust_remote_code" in e.args[0]:
+                e.args = (
+                    f"Loading {model_name} requires to execute some code in that repo, you can inspect the content of "
+                    f"the repository at https://hf.co/{model_name}. You can bypass this by passing "
+                    "`--trust_remote_code`",
+                )
+            raise e
         with init_empty_weights():
             model = AutoModel.from_config(config, trust_remote_code=trust_remote_code)
     elif library_name == "timm":

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -169,7 +169,7 @@ def estimate_command_parser(subparsers=None):
     return parser
 
 
-def estimate_command(args):
+def estimate_command(args, debug=False):
     model = create_empty_model(
         args.model_name, library_name=args.library_name, trust_remote_code=args.trust_remote_code
     )
@@ -190,10 +190,15 @@ def estimate_command(args):
         elif dtype == "int4":
             dtype_total_size /= 8
             dtype_largest_layer /= 8
-        dtype_training_size = convert_bytes(dtype_total_size * 4)
-        dtype_total_size = convert_bytes(dtype_total_size)
-        dtype_largest_layer = convert_bytes(dtype_largest_layer)
+        dtype_training_size = dtype_total_size * 4
+        if not debug:
+            dtype_training_size = convert_bytes(dtype_training_size)
+            dtype_total_size = convert_bytes(dtype_total_size)
+            dtype_largest_layer = convert_bytes(dtype_largest_layer)
         data.append([dtype, dtype_largest_layer, dtype_total_size, dtype_training_size])
+
+    if debug:
+        return data
 
     title = f"Memory Usage for `{args.model_name}`"
     table = create_ascii_table(headers, data, title)

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -185,11 +185,9 @@ def estimate_command_parser(subparsers=None):
     if subparsers is not None:
         parser = subparsers.add_parser("estimate-memory")
     else:
-        parser = argparse.ArgumentParser(description="Model size estimator")
+        parser = argparse.ArgumentParser(description="Model size estimator for fitting a model onto CUDA memory.")
 
-    parser.add_argument(
-        "model_name", type=str, help="The model name on the Hugging Face Hub or local path to the model folder."
-    )
+    parser.add_argument("model_name", type=str, help="The model name on the Hugging Face Hub.")
     parser.add_argument(
         "--library_name",
         type=str,
@@ -261,7 +259,7 @@ def estimate_command(args):
 
     headers = ["dtype", "Largest Layer", "Total Size", "Training using Adam"]
 
-    title = f"Memory Usage for `{args.model_name}`"
+    title = f"Memory Usage for loading `{args.model_name}`\n"
     table = create_ascii_table(headers, data, title)
     print(table)
 

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -72,9 +72,10 @@ def create_empty_model(model_name, library_name: str):
                 f"To check `{model_name}`, `transformers` must be installed. Please install it via `pip install transformers`"
             )
         print(f"Loading pretrained config for `{model_name}` from `transformers`...")
-        config = AutoConfig.from_pretrained(model_name)
+        # As we just load in the `config` file and not the weights, we use `True`
+        config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
         with init_empty_weights():
-            model = AutoModel.from_config(config)
+            model = AutoModel.from_config(config, trust_remote_code=True)
     elif library_name == "timm":
         if not is_timm_available():
             raise ImportError(

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -152,13 +152,25 @@ def create_ascii_table(headers: list, rows: list, title: str):
     formats = [f"%{column_widths[i]}s" for i in range(len(rows[0]))]
 
     pattern = f"{sep_char}{sep_char.join(formats)}{sep_char}"
-    separator = f'├{"┼".join([in_between * n for n in column_widths])}┤'
+    diff = 0
+
+    def make_row(left_char, middle_char, right_char):
+        return f"{left_char}{middle_char.join([in_between * n for n in column_widths])}{in_between * diff}{right_char}"
+
+    separator = make_row("├", "┼", "┤")
+    if len(title) > sum(column_widths):
+        diff = abs(len(title) - len(separator))
+        column_widths[-1] += diff
+
+    # Update with diff
+    separator = make_row("├", "┼", "┤")
     initial_rows = [
-        f"┌{in_between * (len(separator)-2)}┐",
-        f"{sep_char}{title.center(sum(column_widths) + len(column_widths)-1)}{sep_char}",
-        f'├{"┬".join([in_between * n for n in column_widths])}┤',
+        make_row("┌", in_between, "┐"),
+        f"{sep_char}{title.center(len(separator) - 2)}{sep_char}",
+        make_row("├", "┬", "┤"),
     ]
     table = "\n".join(initial_rows) + "\n"
+    column_widths[-1] += diff
     centered_line = [text.center(column_widths[i]) for i, text in enumerate(headers)]
     table += f"{pattern % tuple(centered_line)}\n{separator}\n"
     for i, line in enumerate(rows):

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -106,25 +106,10 @@ def create_empty_model(model_name: str, library_name: str, trust_remote_code: bo
                 f"To check `{model_name}`, `transformers` must be installed. Please install it via `pip install transformers`"
             )
         print(f"Loading pretrained config for `{model_name}` from `transformers`...")
-        # As we just load in the `config` file and not the weights, we use `True`
-        auto_map = model_info.config.get("auto_map", False)
-        if auto_map and not trust_remote_code:
-            raise ValueError(
-                f"Loading {model_name} requires to execute some code in that repo, you can inspect the content of "
-                f"the repository at https://hf.co/{model_name}. You can bypass this by passing "
-                "`--trust_remote_code`"
-            )
 
-        try:
-            config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
-        except ValueError as e:
-            if "trust_remote_code" in e.args[0]:
-                e.args = (
-                    f"Loading {model_name} requires to execute some code in that repo, you can inspect the content of "
-                    f"the repository at https://hf.co/{model_name}. You can bypass this by passing "
-                    "`--trust_remote_code`",
-                )
-            raise e
+        auto_map = model_info.config.get("auto_map", False)
+        config = AutoConfig.from_pretrained(model_name, trust_remote_code=trust_remote_code)
+
         with init_empty_weights():
             # remote code could specify a specific `AutoModel` class in the `auto_map`
             constructor = AutoModel

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -127,14 +127,15 @@ def create_empty_model(model_name: str, library_name: str, trust_remote_code: bo
             raise e
         with init_empty_weights():
             # remote code could specify a specific `AutoModel` class in the `auto_map`
+            constructor = AutoModel
             if isinstance(auto_map, dict):
+                value = None
                 for key in auto_map.keys():
                     if key.startswith("AutoModelFor"):
                         value = key
                         break
-                constructor = getattr(transformers, value)
-            else:
-                constructor = AutoModel
+                if value is not None:
+                    constructor = getattr(transformers, value)
             model = constructor.from_config(config, trust_remote_code=trust_remote_code)
     elif library_name == "timm":
         if not is_timm_available():

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -89,10 +89,13 @@ def create_empty_model(model_name: str, library_name: str, trust_remote_code: bo
     model_info = verify_on_hub(model_name)
     # Simplified errors
     if model_info == "gated":
-        raise GatedRepoError(f"Repo for model `{model_name}` is gated. You must be authenticated to access it.")
+        raise GatedRepoError(
+            f"Repo for model `{model_name}` is gated. You must be authenticated to access it. Please run `huggingface-cli login`."
+        )
     elif model_info == "repo":
         raise RepositoryNotFoundError(
-            f"Repo for model `{model_name}` does not exist on the Hub. If you are trying to access a private repo, make sure you are authenticated."
+            f"Repo for model `{model_name}` does not exist on the Hub. If you are trying to access a private repo,"
+            " make sure you are authenticated via `huggingface-cli login` and have access."
         )
     if library_name is None:
         library_name = getattr(model_info, "library_name", False)

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -35,7 +35,6 @@ from ..utils import (
     is_comet_ml_available,
     is_datasets_available,
     is_deepspeed_available,
-    is_einops_available,
     is_huggingface_hub_available,
     is_mps_available,
     is_safetensors_available,
@@ -131,13 +130,6 @@ def require_transformers(test_case):
     Decorator marking a test that requires transformers. These tests are skipped when they are not.
     """
     return unittest.skipUnless(is_transformers_available(), "test requires the transformers library")(test_case)
-
-
-def require_einops(test_case):
-    """
-    Decorator marking a test that requires transformers. These tests are skipped when they are not.
-    """
-    return unittest.skipUnless(is_einops_available(), "test requires the einops library")(test_case)
 
 
 def require_timm(test_case):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -35,6 +35,7 @@ from ..utils import (
     is_comet_ml_available,
     is_datasets_available,
     is_deepspeed_available,
+    is_einops_available,
     is_huggingface_hub_available,
     is_mps_available,
     is_safetensors_available,
@@ -130,6 +131,13 @@ def require_transformers(test_case):
     Decorator marking a test that requires transformers. These tests are skipped when they are not.
     """
     return unittest.skipUnless(is_transformers_available(), "test requires the transformers library")(test_case)
+
+
+def require_einops(test_case):
+    """
+    Decorator marking a test that requires transformers. These tests are skipped when they are not.
+    """
+    return unittest.skipUnless(is_einops_available(), "test requires the einops library")(test_case)
 
 
 def require_timm(test_case):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -35,6 +35,7 @@ from ..utils import (
     is_comet_ml_available,
     is_datasets_available,
     is_deepspeed_available,
+    is_huggingface_hub_available,
     is_mps_available,
     is_safetensors_available,
     is_tensorboard_available,
@@ -115,6 +116,13 @@ def require_huggingface_suite(test_case):
     return unittest.skipUnless(
         is_transformers_available() and is_datasets_available(), "test requires the Hugging Face suite"
     )(test_case)
+
+
+def require_huggingface_hub(test_case):
+    """
+    Decorator marking a test that requires huggingface_hub. These tests are skipped when they are not.
+    """
+    return unittest.skipUnless(is_huggingface_hub_available(), "test requires the huggingface_hub library")(test_case)
 
 
 def require_transformers(test_case):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -38,6 +38,7 @@ from ..utils import (
     is_mps_available,
     is_safetensors_available,
     is_tensorboard_available,
+    is_timm_available,
     is_torch_version,
     is_tpu_available,
     is_transformers_available,
@@ -114,6 +115,20 @@ def require_huggingface_suite(test_case):
     return unittest.skipUnless(
         is_transformers_available() and is_datasets_available(), "test requires the Hugging Face suite"
     )(test_case)
+
+
+def require_transformers(test_case):
+    """
+    Decorator marking a test that requires transformers. These tests are skipped when they are not.
+    """
+    return unittest.skipUnless(is_transformers_available(), "test requires the transformers library")(test_case)
+
+
+def require_timm(test_case):
+    """
+    Decorator marking a test that requires transformers. These tests are skipped when they are not.
+    """
+    return unittest.skipUnless(is_timm_available(), "test requires the timm library")(test_case)
 
 
 def require_bnb(test_case):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -49,7 +49,6 @@ from .imports import (
     is_cuda_available,
     is_datasets_available,
     is_deepspeed_available,
-    is_einops_available,
     is_fp8_available,
     is_huggingface_hub_available,
     is_ipex_available,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -50,6 +50,7 @@ from .imports import (
     is_datasets_available,
     is_deepspeed_available,
     is_fp8_available,
+    is_huggingface_hub_available,
     is_ipex_available,
     is_megatron_lm_available,
     is_mlflow_available,
@@ -59,12 +60,14 @@ from .imports import (
     is_safetensors_available,
     is_sagemaker_available,
     is_tensorboard_available,
+    is_timm_available,
     is_tpu_available,
     is_transformers_available,
     is_wandb_available,
     is_xpu_available,
 )
 from .modeling import (
+    calculate_maximum_sizes,
     check_device_map,
     check_tied_parameters_in_config,
     check_tied_parameters_on_same_device,
@@ -163,6 +166,7 @@ from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
 from .memory import find_executable_batch_size, release_memory
 from .other import (
     clear_environment,
+    convert_bytes,
     extract_model_from_parallel,
     get_pretty_name,
     is_port_in_use,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -49,6 +49,7 @@ from .imports import (
     is_cuda_available,
     is_datasets_available,
     is_deepspeed_available,
+    is_einops_available,
     is_fp8_available,
     is_huggingface_hub_available,
     is_ipex_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -174,6 +174,10 @@ def is_timm_available():
     return _is_package_available("timm")
 
 
+def is_einops_available():
+    return _is_package_available("einops")
+
+
 def is_aim_available():
     package_exists = _is_package_available("aim")
     if package_exists:

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -174,10 +174,6 @@ def is_timm_available():
     return _is_package_available("timm")
 
 
-def is_einops_available():
-    return _is_package_available("einops")
-
-
 def is_aim_available():
     package_exists = _is_package_available("aim")
     if package_exists:

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -166,6 +166,14 @@ def is_datasets_available():
     return _is_package_available("datasets")
 
 
+def is_huggingface_hub_available():
+    return _is_package_available("huggingface_hub")
+
+
+def is_timm_available():
+    return _is_package_available("timm")
+
+
 def is_aim_available():
     package_exists = _is_package_available("aim")
     if package_exists:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -859,6 +859,7 @@ def get_balanced_memory(
 def calculate_maximum_sizes(model: torch.nn.Module):
     "Computes the total size of the model and its largest layer"
     sizes = compute_module_sizes(model)
+    # `transformers` models store this information for us
     no_split_modules = getattr(model, "_no_split_modules", [])
     modules_to_treat = (
         list(model.named_parameters(recurse=False))

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -860,7 +860,10 @@ def calculate_maximum_sizes(model: torch.nn.Module):
     "Computes the total size of the model and its largest layer"
     sizes = compute_module_sizes(model)
     # `transformers` models store this information for us
-    no_split_modules = getattr(model, "_no_split_modules", [])
+    no_split_modules = getattr(model, "_no_split_modules", None)
+    if no_split_modules is None:
+        no_split_modules = []
+
     modules_to_treat = (
         list(model.named_parameters(recurse=False))
         + list(model.named_children())

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -856,6 +856,19 @@ def get_balanced_memory(
     return max_memory
 
 
+def calculate_maximum_sizes(model: torch.nn.Module):
+    "Computes the total size of the model and its largest layer"
+    sizes = compute_module_sizes(model)
+    modules_to_treat = (
+        list(model.named_parameters(recurse=False))
+        + list(model.named_children())
+        + list(model.named_buffers(recurse=False))
+    )
+    largest_layer = get_max_layer_size(modules_to_treat, sizes, [])
+    total_size = sizes[""]
+    return total_size, largest_layer
+
+
 def infer_auto_device_map(
     model: nn.Module,
     max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -859,12 +859,13 @@ def get_balanced_memory(
 def calculate_maximum_sizes(model: torch.nn.Module):
     "Computes the total size of the model and its largest layer"
     sizes = compute_module_sizes(model)
+    no_split_modules = getattr(model, "_no_split_modules", [])
     modules_to_treat = (
         list(model.named_parameters(recurse=False))
         + list(model.named_children())
         + list(model.named_buffers(recurse=False))
     )
-    largest_layer = get_max_layer_size(modules_to_treat, sizes, [])
+    largest_layer = get_max_layer_size(modules_to_treat, sizes, no_split_modules)
     total_size = sizes[""]
     return total_size, largest_layer
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -222,3 +222,13 @@ def is_port_in_use(port: int = None) -> bool:
         port = 29500
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         return s.connect_ex(("localhost", port)) == 0
+
+
+def convert_bytes(size):
+    "Converts `size` from bytes to the largest possible unit"
+    for x in ["bytes", "KB", "MB", "GB", "TB"]:
+        if size < 1024.0:
+            return f"{round(size, 2)} {x}"
+        size /= 1024.0
+
+    return size

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,6 +249,7 @@ class ModelEstimatorTester(unittest.TestCase):
             + ["--dtypes", "float32", "float16", "int8", "int4"],
             return_stdout=True,
         )
+        print(f'Output:\n{output}')
         # The largest layer and total size of the model
         largest_layer, total_size = 84.95, 413.18
         # Check that full precision -> int4 is calculating correctly

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,16 +217,12 @@ class TpuConfigTester(unittest.TestCase):
 class ModelEstimatorTester(unittest.TestCase):
     """
     Test case for checking the output of `accelerate estimate-memory` is correct.
+
+    - Uses `estimate_command` when trying to catch raised errors
+    - Uses `gather_data` when just verifying the calculations are correct
     """
 
     parser = estimate_command_parser()
-    units = [" bytes", " KB", " MB", " GB", " TB"]
-
-    def remove_units(self, number):
-        "Removes the units from a number, such as `1.23 MB` to `1.23`"
-        for unit in self.units:
-            number = number.replace(unit, "")
-        return number
 
     def test_invalid_model_name(self):
         with self.assertRaises(ValueError, msg="Model `somebrokenname` is not an available model on the Hub"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -237,9 +237,9 @@ class ModelEstimatorTester(unittest.TestCase):
 
     def test_no_metadata(self):
         with self.assertRaises(
-            SubprocessCallException, msg="Model `bert-base-cased` does not have any library metadata on the Hub"
+            SubprocessCallException, msg="Model `meta-llama/Llama-2-7b` does not have any library metadata on the Hub"
         ):
-            run_command(self.base_cmd + ["--model_name", "bert-base-cased", "--dtypes", "float32"])
+            run_command(self.base_cmd + ["--model_name", "meta-llama/Llama-2-7b", "--dtypes", "float32"])
 
     @require_transformers
     def test_transformers_model(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,7 +249,7 @@ class ModelEstimatorTester(unittest.TestCase):
             + ["--dtypes", "float32", "float16", "int8", "int4"],
             return_stdout=True,
         )
-        print(f'Output:\n{output}')
+        print(f"Output:\n{output}")
         # The largest layer and total size of the model
         largest_layer, total_size = 84.95, 413.18
         # Check that full precision -> int4 is calculating correctly

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -314,37 +314,20 @@ class ModelEstimatorTester(unittest.TestCase):
 
     @require_transformers
     def test_transformers_model(self):
-        args = self.parser.parse_args(["bert-base-cased"])
+        args = self.parser.parse_args(["bert-base-cased", "--dtypes", "float32"])
         output = gather_data(args)
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 89075712, 433249280
-        # Check that full precision -> int4 is calculating correctly
-        self.assertEqual(len(output), 4, "Output was missing a precision")
-
-        for i, factor in enumerate([1, 2, 4, 8]):
-            precision = 32 // factor
-            precision_str = f"int{precision}" if precision < 16 else f"float{precision}"
-            largest_layer_estimate = largest_layer / factor
-            total_size_estimate = total_size / factor
-            total_training_size_estimate = total_size_estimate * 4
-
-            self.assertEqual(precision_str, output[i][0], f"Output is missing precision `{precision_str}`")
-            self.assertEqual(
-                largest_layer_estimate,
-                output[i][1],
-                f"Calculation for largest layer size in `{precision_str}` is incorrect.",
-            )
-
-            self.assertEqual(
-                total_size_estimate,
-                output[i][2],
-                msg=f"Calculation for total size in `{precision_str}` is incorrect.",
-            )
-            self.assertEqual(
-                total_training_size_estimate,
-                output[i][3],
-                msg=f"Calculation for total training size in `{precision_str}` is incorrect.",
-            )
+        self.assertEqual(
+            largest_layer,
+            output[0][1],
+            f"Calculation for largest layer size in `fp32` is incorrect, expected {largest_layer} but received {output[0][1]}",
+        )
+        self.assertEqual(
+            total_size,
+            output[0][2],
+            f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}",
+        )
 
     @require_transformers
     def test_no_split_modules(self):
@@ -364,30 +347,13 @@ class ModelEstimatorTester(unittest.TestCase):
         output = gather_data(args)
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 9437184, 102441032
-        # Check that full precision -> int4 is calculating correctly
-        self.assertEqual(len(output), 4, "Output was missing a precision")
-
-        for i, factor in enumerate([1, 2, 4, 8]):
-            precision = 32 // factor
-            precision_str = f"int{precision}" if precision < 16 else f"float{precision}"
-            largest_layer_estimate = largest_layer / factor
-            total_size_estimate = total_size / factor
-            total_training_size_estimate = total_size_estimate * 4
-
-            self.assertEqual(precision_str, output[i][0], f"Output is missing precision `{precision_str}`")
-            self.assertEqual(
-                largest_layer_estimate,
-                output[i][1],
-                f"Calculation for largest layer size in `{precision_str}` is incorrect.",
-            )
-
-            self.assertEqual(
-                total_size_estimate,
-                output[i][2],
-                msg=f"Calculation for total size in `{precision_str}` is incorrect.",
-            )
-            self.assertEqual(
-                total_training_size_estimate,
-                output[i][3],
-                msg=f"Calculation for total training size in `{precision_str}` is incorrect.",
-            )
+        self.assertEqual(
+            largest_layer,
+            output[0][1],
+            f"Calculation for largest layer size in `fp32` is incorrect, expected {largest_layer} but received {output[0][1]}",
+        )
+        self.assertEqual(
+            total_size,
+            output[0][2],
+            f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}",
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,6 +262,16 @@ class ModelEstimatorTester(unittest.TestCase):
                 estimate_command(args)
 
     @require_transformers
+    def test_remote_code(self):
+        args = self.parser.parse_args(["tiiuae/falcon-7b"])
+        with self.assertRaises(ValueError, msg="--trust_remote_code"):
+            gather_data(args)
+
+        # Verify it works with the flag
+        args = self.parser.parse_args(["tiiuae/falcon-7b", "--trust_remote_code"])
+        gather_data(args)
+
+    @require_transformers
     def test_explicit_dtypes(self):
         args = self.parser.parse_args(["bert-base-cased", "--dtypes", "float32", "float16"])
         output = gather_data(args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -353,6 +353,18 @@ class ModelEstimatorTester(unittest.TestCase):
                 msg=f"Calculation for total training size in `{precision_str}` is incorrect.",
             )
 
+    @require_transformers
+    def test_no_split_modules(self):
+        # idefics-80b-instruct has ["IdeficsDecoderLayer", "IdeficsGatedCrossAttentionLayer"]
+        args = self.parser.parse_args(["HuggingFaceM4/idefics-80b-instruct", "--dtypes", "float32"])
+        output = gather_data(args)
+        # without factoring in `no_split` modules, the largest layer is 721420288 bytes
+        self.assertNotEqual(
+            output[0][1], 721420288, "Largest layer calculation incorrect, did not factor in `no_split` modules."
+        )
+        # the real answer is 3240165632 bytes
+        self.assertEqual(output[0][1], 3240165632)
+
     @require_timm
     def test_timm_model(self):
         args = self.parser.parse_args(["timm/resnet50.a1_in1k", "--library_name", "timm"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ import torch
 import accelerate
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
-from accelerate.test_utils.testing import require_timm, require_transformers, run_command
+from accelerate.test_utils.testing import require_huggingface_hub, require_timm, require_transformers, run_command
 from accelerate.utils import is_huggingface_hub_available, patch_environment
 
 
@@ -219,6 +219,7 @@ class TpuConfigTester(unittest.TestCase):
         )
 
 
+@require_huggingface_hub
 class ModelEstimatorTester(unittest.TestCase):
     """
     Test case for checking the output of `accelerate estimate-memory` is correct.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -233,19 +233,19 @@ class ModelEstimatorTester(unittest.TestCase):
         with self.assertRaises(
             SubprocessCallException, msg="Model `somebrokenname` is not an available model on the Hub"
         ):
-            run_command(self.base_cmd + ["--model_name", "somebrokenname", "--dtypes", "float32"])
+            run_command(self.base_cmd + ["somebrokenname", "--dtypes", "float32"])
 
     def test_no_metadata(self):
         with self.assertRaises(
             SubprocessCallException, msg="Model `meta-llama/Llama-2-7b` does not have any library metadata on the Hub"
         ):
-            run_command(self.base_cmd + ["--model_name", "meta-llama/Llama-2-7b", "--dtypes", "float32"])
+            run_command(self.base_cmd + ["meta-llama/Llama-2-7b", "--dtypes", "float32"])
 
     @require_transformers
     def test_transformers_model(self):
         output = run_command(
             self.base_cmd
-            + ["--model_name", "bert-base-cased", "--library_name", "transformers"]
+            + ["bert-base-cased", "--library_name", "transformers"]
             + ["--dtypes", "float32", "float16", "int8", "int4"],
             return_stdout=True,
         )
@@ -293,7 +293,7 @@ class ModelEstimatorTester(unittest.TestCase):
     def test_timm_model(self):
         output = run_command(
             self.base_cmd
-            + ["--model_name", "timm/resnet50.a1_in1k", "--library_name", "timm"]
+            + ["timm/resnet50.a1_in1k", "--library_name", "timm"]
             + ["--dtypes", "float32", "float16", "int8", "int4"],
             return_stdout=True,
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,13 @@ import torch
 import accelerate
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
-from accelerate.test_utils.testing import require_huggingface_hub, require_timm, require_transformers, run_command
+from accelerate.test_utils.testing import (
+    require_einops,
+    require_huggingface_hub,
+    require_timm,
+    require_transformers,
+    run_command,
+)
 from accelerate.utils import is_huggingface_hub_available, patch_environment
 
 
@@ -262,6 +268,7 @@ class ModelEstimatorTester(unittest.TestCase):
             with patch_environment(hf_hub_disable_implicit_token="1"):
                 estimate_command(args)
 
+    @require_einops
     @require_transformers
     def test_remote_code(self):
         args = self.parser.parse_args(["tiiuae/falcon-7b"])
@@ -270,6 +277,12 @@ class ModelEstimatorTester(unittest.TestCase):
 
         # Verify it works with the flag
         args = self.parser.parse_args(["tiiuae/falcon-7b", "--trust_remote_code"])
+        gather_data(args)
+
+    @require_einops
+    @require_transformers
+    def test_custom_auto_class(self):
+        args = self.parser.parse_args(["tiiuae/falcon-7b-instruct", "--trust_remote_code"])
         gather_data(args)
 
     @require_transformers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,6 @@ import accelerate
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
 from accelerate.test_utils.testing import (
-    require_einops,
     require_huggingface_hub,
     require_timm,
     require_transformers,
@@ -268,21 +267,15 @@ class ModelEstimatorTester(unittest.TestCase):
             with patch_environment(hf_hub_disable_implicit_token="1"):
                 estimate_command(args)
 
-    @require_einops
     @require_transformers
     def test_remote_code(self):
-        args = self.parser.parse_args(["tiiuae/falcon-7b"])
+        # Also tests that custom `Auto` classes work
+        args = self.parser.parse_args(["hf-internal-testing/test_dynamic_model"])
         with self.assertRaises(ValueError, msg="--trust_remote_code"):
             gather_data(args)
 
         # Verify it works with the flag
-        args = self.parser.parse_args(["tiiuae/falcon-7b", "--trust_remote_code"])
-        gather_data(args)
-
-    @require_einops
-    @require_transformers
-    def test_custom_auto_class(self):
-        args = self.parser.parse_args(["tiiuae/falcon-7b-instruct", "--trust_remote_code"])
+        args = self.parser.parse_args(["hf-internal-testing/test_dynamic_model", "--trust_remote_code"])
         gather_data(args)
 
     @require_transformers

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import torch
 
 import accelerate
-from accelerate.commands.estimate import estimate_command, estimate_command_parser
+from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
 from accelerate.test_utils.testing import require_timm, require_transformers, run_command
 
@@ -243,7 +243,7 @@ class ModelEstimatorTester(unittest.TestCase):
     @require_transformers
     def test_transformers_model(self):
         args = self.parser.parse_args(["bert-base-cased", "--library_name", "transformers"])
-        output = estimate_command(args, debug=True)
+        output = gather_data(args)
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 89075712, 433249280
         # Check that full precision -> int4 is calculating correctly
@@ -277,7 +277,7 @@ class ModelEstimatorTester(unittest.TestCase):
     @require_timm
     def test_timm_model(self):
         args = self.parser.parse_args(["timm/resnet50.a1_in1k", "--library_name", "timm"])
-        output = estimate_command(args, debug=True)
+        output = gather_data(args)
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 9437184, 102441032
         # Check that full precision -> int4 is calculating correctly


### PR DESCRIPTION
# `accelerate estimate-memory`

## What does this add?

This PR introduces a new CLI command: `accelerate estimate-memory`, which will utilize the `meta` device to calculate the total vRAM needed for big model inference, the entire model, and training for a particular model and a variety of precision formats. This also does so *without needing to download model weights*.

## Who is it for?

Users of accelerate, and MLE's in general who want to know how big of a model they can fit on their system

## Why is it needed?

Many individuals have asked for a way to figure out just what size of a model they can perform big model inference on, the size of a model to fit on their system in general, and for training. As a result, this PR finally fulfills this, using much of the memory-calculating logic already existing in accelerate

Currently this supports `transformers` and `timm`, in the future it will support `diffusers`

## What parts of the API does this impact?

### User-facing:

A new `accelerate estimate-memory` command

### Internal structure:

A few utils were added for convenience to `big_modeling` and `other` in relation to this PR

## Basic Usage Example(s):

All from the CLI:

Using `transformers`:
```bash
accelerate estimate-memory  togethercomputer/LLaMA-2-7B-32K --dtypes float32 float16
Loading pretrained config for `togethercomputer/LLaMA-2-7B-32K` from `transformers`...
┌────────────────────────────────────────────────────┐
│ Memory Usage for `togethercomputer/LLaMA-2-7B-32K` │
├───────┬─────────────┬──────────┬───────────────────┤
│ dtype │Largest Layer│Total Size│Training using Adam│
├───────┼─────────────┼──────────┼───────────────────┤
│float32│   500.0 MB  │ 25.61 GB │     102.46 GB     │
│float16│   250.0 MB  │ 12.81 GB │      51.23 GB     │
└───────┴─────────────┴──────────┴───────────────────┘
```

Using `timm`:
```bash
accelerate estimate-memory timm/resnet50.a1_in1k --dtypes float32 float16
Loading pretrained config for `timm/resnet50.a1_in1k` from `timm`...
┌────────────────────────────────────────────────────┐
│      Memory Usage for `timm/resnet50.a1_in1k`      │
├───────┬─────────────┬──────────┬───────────────────┤
│ dtype │Largest Layer│Total Size│Training using Adam│
├───────┼─────────────┼──────────┼───────────────────┤
│float32│    9.0 MB   │ 97.7 MB  │     390.78 MB     │
│float16│    4.5 MB   │ 48.85 MB │     195.39 MB     │
└───────┴─────────────┴──────────┴───────────────────┘
```

## When would I use it, and when wouldn't I?

A user would want to use this feature if they wanted to know if a model will fit on their card or be inferenceable with big model inference before downloading the weights