### PR TITLE
fix detach_hook

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -311,6 +311,7 @@ class AlignDevicesHook(ModelHook):
             for name, device in self.original_devices.items():
                 if device != torch.device("meta"):
                     set_module_tensor_to_device(module, name, device, value=self.weights_map.get(name, None))
+        return module
 
 
 def attach_execution_device_hook(


### PR DESCRIPTION
# What does this PR do ? 
Fixes #1869. This PR fixes the `detach_hook` function from `AlignDevicesHook` class so that we can call `.detach_hook()` on a `SequentialHook` object where one of the hooks is an `AlignDevicesHook` object. 