### PR TITLE
Enable power users to bypass device_map="auto" training block

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1409,10 +1409,10 @@ class Accelerator:
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
                     # TODO: Look at enabling native TP training directly with a proper config
-                    if os.environ.get("ACCELERATE_BYPASS_AUTO", "false") == "true":
-                        device_ids, output_device = None, None
-                    else:
+                    if os.environ.get("ACCELERATE_BYPASS_AUTO", "false") != "true":
                         device_ids, output_device = [self.local_process_index], self.local_process_index
+                    else:
+                        device_ids, output_device = None, None
 
                     model = torch.nn.parallel.DistributedDataParallel(
                         model, device_ids=device_ids, output_device=output_device, **kwargs

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,7 @@ class Accelerator:
                 isinstance(obj, torch.nn.Module)
                 and self.verify_device_map(obj)
                 and self.distributed_type != DistributedType.NO
-                and not os.environ.get("ACCELERATE_BYPASS_AUTO", "false")
+                and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") == "false"
             ):
                 raise ValueError(
                     "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1334,7 +1334,7 @@ class Accelerator:
         if (
             self.verify_device_map(model)
             and self.distributed_type != DistributedType.NO
-            and not os.environ.get("ACCELERATE_BYPASS_AUTO", "false")
+            and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") == "false"
         ):
             raise ValueError(
                 "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1409,10 +1409,10 @@ class Accelerator:
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
                     # TODO: Look at enabling native TP training directly with a proper config
-                    if not os.environ.get("ACCELERATE_BYPASS_AUTO", "false"):
-                        device_ids, output_device = [self.local_process_index], self.local_process_index
-                    else:
+                    if os.environ.get("ACCELERATE_BYPASS_AUTO", "false") == "true":
                         device_ids, output_device = None, None
+                    else:
+                        device_ids, output_device = [self.local_process_index], self.local_process_index
 
                     model = torch.nn.parallel.DistributedDataParallel(
                         model, device_ids=device_ids, output_device=output_device, **kwargs

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,7 @@ class Accelerator:
                 isinstance(obj, torch.nn.Module)
                 and self.verify_device_map(obj)
                 and self.distributed_type != DistributedType.NO
-                and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") == "false"
+                and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") != "true"
             ):
                 raise ValueError(
                     "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1334,7 +1334,7 @@ class Accelerator:
         if (
             self.verify_device_map(model)
             and self.distributed_type != DistributedType.NO
-            and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") == "false"
+            and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") != "true"
         ):
             raise ValueError(
                 "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1193,10 +1193,12 @@ class Accelerator:
             )
 
         for obj in args:
+            # TODO: Look at enabling native TP training directly with a proper config
             if (
                 isinstance(obj, torch.nn.Module)
                 and self.verify_device_map(obj)
                 and self.distributed_type != DistributedType.NO
+                and not os.environ.get("ACCELERATE_BYPASS_AUTO", "false")
             ):
                 raise ValueError(
                     "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1328,7 +1330,12 @@ class Accelerator:
             device_placement = self.device_placement and self.distributed_type != DistributedType.FSDP
         self._models.append(model)
 
-        if self.verify_device_map(model) and self.distributed_type != DistributedType.NO:
+        # TODO: Look at enabling native TP training directly with a proper config
+        if (
+            self.verify_device_map(model)
+            and self.distributed_type != DistributedType.NO
+            and not os.environ.get("ACCELERATE_BYPASS_AUTO", "false")
+        ):
             raise ValueError(
                 "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
                 " Please rerun your script specifying `--num_processes=1` or by launching with `python {{myscript.py}}`."
@@ -1401,8 +1408,14 @@ class Accelerator:
             ):
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
+                    # TODO: Look at enabling native TP training directly with a proper config
+                    if not os.environ.get("ACCELERATE_BYPASS_AUTO", "false"):
+                        device_ids, output_device = [self.local_process_index], self.local_process_index
+                    else:
+                        device_ids, output_device = None, None
+
                     model = torch.nn.parallel.DistributedDataParallel(
-                        model, device_ids=[self.local_process_index], output_device=self.local_process_index, **kwargs
+                        model, device_ids=device_ids, output_device=output_device, **kwargs
                     )
             elif self.distributed_type == DistributedType.FSDP:
                 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1198,7 +1198,7 @@ class Accelerator:
                 isinstance(obj, torch.nn.Module)
                 and self.verify_device_map(obj)
                 and self.distributed_type != DistributedType.NO
-                and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") != "true"
+                and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true"
             ):
                 raise ValueError(
                     "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1334,7 +1334,7 @@ class Accelerator:
         if (
             self.verify_device_map(model)
             and self.distributed_type != DistributedType.NO
-            and os.environ.get("ACCELERATE_BYPASS_AUTO", "false") != "true"
+            and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true"
         ):
             raise ValueError(
                 "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1409,7 +1409,7 @@ class Accelerator:
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
                     # TODO: Look at enabling native TP training directly with a proper config
-                    if os.environ.get("ACCELERATE_BYPASS_AUTO", "false") != "true":
+                    if os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true":
                         device_ids, output_device = [self.local_process_index], self.local_process_index
                     else:
                         device_ids, output_device = None, None


### PR DESCRIPTION
This PR fulfills https://github.com/huggingface/accelerate/issues/1368#issuecomment-1689817806 by letting users set `ACCELERATE_BYPASS_DEVICE_MAP="true"` as an environmental variable so that if users wish to try an experimental approach at TP as described in the issue thread, they can. 