### PR TITLE
Add hub as core dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ]
     },
     python_requires=">=3.8.0",
-    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.10.0"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.10.0", "huggingface_hub"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -15,19 +15,17 @@
 # limitations under the License.
 import argparse
 
+from huggingface_hub import model_info
+from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+
 from accelerate import init_empty_weights
 from accelerate.utils import (
     calculate_maximum_sizes,
     convert_bytes,
-    is_huggingface_hub_available,
     is_timm_available,
     is_transformers_available,
 )
 
-
-if is_huggingface_hub_available():
-    from huggingface_hub import model_info
-    from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 
 if is_transformers_available():
     import transformers
@@ -39,10 +37,6 @@ if is_timm_available():
 
 def verify_on_hub(repo: str):
     "Verifies that the model is on the hub and returns the model info."
-    if not is_huggingface_hub_available():
-        raise ImportError(
-            "To use `accelerate estimate-memory`, the `huggingface_hub` library must be installed. Please run `pip install huggingface_hub` and try again."
-        )
     try:
         return model_info(repo)
     except GatedRepoError:

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -35,7 +35,6 @@ from ..utils import (
     is_comet_ml_available,
     is_datasets_available,
     is_deepspeed_available,
-    is_huggingface_hub_available,
     is_mps_available,
     is_safetensors_available,
     is_tensorboard_available,
@@ -116,13 +115,6 @@ def require_huggingface_suite(test_case):
     return unittest.skipUnless(
         is_transformers_available() and is_datasets_available(), "test requires the Hugging Face suite"
     )(test_case)
-
-
-def require_huggingface_hub(test_case):
-    """
-    Decorator marking a test that requires huggingface_hub. These tests are skipped when they are not.
-    """
-    return unittest.skipUnless(is_huggingface_hub_available(), "test requires the huggingface_hub library")(test_case)
 
 
 def require_transformers(test_case):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -50,7 +50,6 @@ from .imports import (
     is_datasets_available,
     is_deepspeed_available,
     is_fp8_available,
-    is_huggingface_hub_available,
     is_ipex_available,
     is_megatron_lm_available,
     is_mlflow_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -166,10 +166,6 @@ def is_datasets_available():
     return _is_package_available("datasets")
 
 
-def is_huggingface_hub_available():
-    return _is_package_available("huggingface_hub")
-
-
 def is_timm_available():
     return _is_package_available("timm")
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,6 @@ import accelerate
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
 from accelerate.test_utils.testing import (
-    require_huggingface_hub,
     require_timm,
     require_transformers,
     run_command,
@@ -224,7 +223,6 @@ class TpuConfigTester(unittest.TestCase):
         )
 
 
-@require_huggingface_hub
 class ModelEstimatorTester(unittest.TestCase):
     """
     Test case for checking the output of `accelerate estimate-memory` is correct.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ import unittest
 from pathlib import Path
 
 import torch
+from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 
 import accelerate
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
@@ -27,11 +28,7 @@ from accelerate.test_utils.testing import (
     require_transformers,
     run_command,
 )
-from accelerate.utils import is_huggingface_hub_available, patch_environment
-
-
-if is_huggingface_hub_available():
-    from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+from accelerate.utils import patch_environment
 
 
 class AccelerateLauncherTester(unittest.TestCase):


### PR DESCRIPTION
As the hub is meant to be the foundational library for every lib in the hf ecosystem, adds `huggingface_hub` as a core dep on Accelerate since we have need for it now with the model estimation tool. 