### PR TITLE
Add FSDP activation checkpointing feature

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1447,10 +1447,15 @@ class Accelerator:
                             CheckpointImpl,
                             apply_activation_checkpointing,
                         )
+
                         apply_activation_checkpointing(
                             model,
-                            checkpoint_wrapper_fn=functools.partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT,),
-                            auto_wrap_policy=fsdp_plugin.auto_wrap_policy,)
+                            checkpoint_wrapper_fn=functools.partial(
+                                checkpoint_wrapper,
+                                checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+                            ),
+                            auto_wrap_policy=fsdp_plugin.auto_wrap_policy,
+                        )
 
                 self._models[-1] = model
             elif self.distributed_type == DistributedType.MULTI_CPU:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import collections
 import contextlib
+import functools
 import json
 import math
 import os
@@ -1440,6 +1441,17 @@ class Accelerator:
                         "device_id": self.device,
                     }
                     model = FSDP(model, **kwargs)
+                    if fsdp_plugin.activation_checkpointing:
+                        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+                            checkpoint_wrapper,
+                            CheckpointImpl,
+                            apply_activation_checkpointing,
+                        )
+                        apply_activation_checkpointing(
+                            model,
+                            checkpoint_wrapper_fn=functools.partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT,),
+                            auto_wrap_policy=fsdp_plugin.auto_wrap_policy,)
+
                 self._models[-1] = model
             elif self.distributed_type == DistributedType.MULTI_CPU:
                 kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1443,9 +1443,9 @@ class Accelerator:
                     model = FSDP(model, **kwargs)
                     if fsdp_plugin.activation_checkpointing:
                         from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-                            checkpoint_wrapper,
                             CheckpointImpl,
                             apply_activation_checkpointing,
+                            checkpoint_wrapper,
                         )
 
                         apply_activation_checkpointing(

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -872,6 +872,14 @@ class FullyShardedDataParallelPlugin:
             "all-gather while executing in the forward pass. only use with Static graphs."
         },
     )
+    activation_checkpointing: bool = field(
+        default=False,
+        metadata={
+            "help": "If True, activation checkpointing is a technique to reduce memory usage by clearing activations of "
+            "certain layers and recomputing them during a backward pass. Effectively, this trades extra computation time "
+            "for reduced memory usage."
+        },
+    )
 
     def __post_init__(self):
         from torch.distributed.fsdp.fully_sharded_data_parallel import BackwardPrefetch, CPUOffload, ShardingStrategy
@@ -897,6 +905,7 @@ class FullyShardedDataParallelPlugin:
         self.use_orig_params = strtobool(os.environ.get(prefix + "USE_ORIG_PARAMS", "False")) == 1
         self.sync_module_states = strtobool(os.environ.get(prefix + "SYNC_MODULE_STATES", "True")) == 1
         self.forward_prefetch = strtobool(os.environ.get(prefix + "FORWARD_PREFETCH", "False")) == 1
+        self.activation_checkpointing = strtobool(os.environ.get(prefix + "ACTIVATION_CHECKPOINTING", "False")) == 1
 
         if self.sync_module_states:
             self.param_init_fn = lambda x: x.to_empty(device=torch.cuda.current_device(), recurse=False)


### PR DESCRIPTION
Add FSDP `activation_checkpointing` option. It's already well supported in the native pytorch training code. 
Please see the details about the FSDP activation chekpointing [here](https://pytorch.org/blog/scaling-multimodal-foundation-models-in-torchmultimodal-with-pytorch-distributed/#activation-checkpointing).

Also, I observed the improvement in training performance for the large LLM models (e.g., LLAMA 70B) as compared to  existing `gradient_checkpointing` option.
