### PR TITLE
Do not override traceback to rich-style by default, on init.

### DIFF
--- a/src/accelerate/__init__.py
+++ b/src/accelerate/__init__.py
@@ -27,7 +27,3 @@ from .utils import (
     load_checkpoint_in_model,
     synchronize_rng_states,
 )
-
-
-if is_rich_available():
-    from .utils import rich


### PR DESCRIPTION
This is a super bad practice to force the traceback formatting style without user consent, as a side-effect of importing accelerate. If somebody wants rich traceback formatting they will configure it themselves - for everybody else it is just super annoying.

The chances that accelerate is being transitively imported is pretty high, and if the rich package is installed too, the user ends up with some annoying error formatting.

This PR removes import side-effect.