### PR TITLE
Final nits on model util

### DIFF
--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -48,7 +48,7 @@ it will use:
 
 ```
 ┌────────────────────────────────────────────────────┐
-│    Memory Usage for loading `bert-base-cased`      │
+│     Memory Usage for loading `bert-base-cased`     │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -71,16 +71,16 @@ accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name tra
 ```
 
 ```
-┌────────────────────────────────────────────────────────────────────┐
-│   Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`    |
-├───────┬─────────────┬──────────┬───────────────────────────────────┤
-│ dtype │Largest Layer│Total Size│        Training using Adam        │
-├───────┼─────────────┼──────────┼───────────────────────────────────┤
-│float32│   3.02 GB   │297.12 GB │              1.16 TB              │
-│float16│   1.51 GB   │148.56 GB │             594.24 GB             │
-│  int8 │  772.52 MB  │ 74.28 GB │             297.12 GB             │
-│  int4 │  386.26 MB  │ 37.14 GB │             148.56 GB             │
-└───────┴─────────────┴──────────┴───────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────┐
+│  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`   │
+├───────┬─────────────┬──────────┬─────────────────────────────────┤
+│ dtype │Largest Layer│Total Size│       Training using Adam       │
+├───────┼─────────────┼──────────┼─────────────────────────────────┤
+│float32│   3.02 GB   │297.12 GB │             1.16 TB             │
+│float16│   1.51 GB   │148.56 GB │            594.24 GB            │
+│  int8 │  772.52 MB  │ 74.28 GB │            297.12 GB            │
+│  int4 │  386.26 MB  │ 37.14 GB │            148.56 GB            │
+└───────┴─────────────┴──────────┴─────────────────────────────────┘
 ```
 
 ```bash
@@ -89,7 +89,7 @@ accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 
 ```
 ┌────────────────────────────────────────────────────┐
-│ Memory Usage for loading `timm/resnet50.a1_in1k`   │
+│  Memory Usage for loading `timm/resnet50.a1_in1k`  │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -112,7 +112,7 @@ accelerate estimate-memory bert-base-cased --dtypes float32 float16
 
 ```
 ┌────────────────────────────────────────────────────┐
-│    Memory Usage for loading `bert-base-cased`      │
+│     Memory Usage for loading `bert-base-cased`     │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -123,9 +123,11 @@ accelerate estimate-memory bert-base-cased --dtypes float32 float16
 
 ## Caveats with this calculator
 
-This calculator will tell you exactly how much memory is needed to purely load the model in, *not* to perform inference.
+This calculator will tell you how much memory is needed to purely load the model in, *not* to perform inference.
 
-When performing inference however, you can expect to add up to an additional 20% as found by [EleutherAI](https://blog.eleuther.ai/transformer-math/). We'll be conducting research into finding a more accurate estimate to these values, and will update 
+This calculation is accurate within a few % of the actual value, so it is a very good view of just how much memory it will take. For instance loading `bert-base-cased` actually takes `413.68 MB` when loaded on CUDA in full precision, and the calculator estimates `413.18 MB`.
+
+When performing inference you can expect to add up to an additional 20% as found by [EleutherAI](https://blog.eleuther.ai/transformer-math/). We'll be conducting research into finding a more accurate estimate to these values, and will update 
 this calculator once done.
 
 ## Live Gradio Demo

--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -48,7 +48,7 @@ it will use:
 
 ```
 ┌────────────────────────────────────────────────────┐
-│    Memory Usage for loading `bert-base-cased`      │
+│    Memory Usage for loading bert-base-cased      │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -72,7 +72,7 @@ accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name tra
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`   │
+│  Memory Usage for loading HuggingFaceM4/idefics-80b-instruct   │
 ├───────┬─────────────┬──────────┬─────────────────────────────────┤
 │ dtype │Largest Layer│Total Size│       Training using Adam       │
 ├───────┼─────────────┼──────────┼─────────────────────────────────┤
@@ -89,7 +89,7 @@ accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 
 ```
 ┌────────────────────────────────────────────────────┐
-│  Memory Usage for loading `timm/resnet50.a1_in1k`  │
+│  Memory Usage for loading timm/resnet50.a1_in1k  │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -112,7 +112,7 @@ accelerate estimate-memory bert-base-cased --dtypes float32 float16
 
 ```
 ┌────────────────────────────────────────────────────┐
-│     Memory Usage for loading `bert-base-cased`    │
+│     Memory Usage for loading bert-base-cased    │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤

--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -46,7 +46,7 @@ accelerate estimate-memory bert-base-cased
 This will download the `config.json` for `bert-based-cased`, load the model on the `meta` device, and report back how much space
 it will use:
 
-
+```
 ┌────────────────────────────────────────────────────┐
 │    Memory Usage for loading `bert-base-cased`      │
 ├───────┬─────────────┬──────────┬───────────────────┤
@@ -57,7 +57,7 @@ it will use:
 │  int8 │   21.24 MB  │103.29 MB │     413.18 MB     │
 │  int4 │   10.62 MB  │ 51.65 MB │     206.59 MB     │
 └───────┴─────────────┴──────────┴───────────────────┘
-
+```
 
 By default it will return all the supported dtypes (`int4` through `float32`), but if you are interested in specific ones these can be filtered.
 
@@ -70,7 +70,7 @@ be passed in.
 accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name transformers
 ```
 
-
+```
 ┌──────────────────────────────────────────────────────────────────┐
 │  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`   │
 ├───────┬─────────────┬──────────┬─────────────────────────────────┤
@@ -81,13 +81,13 @@ accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name tra
 │  int8 │  772.52 MB  │ 74.28 GB │            297.12 GB            │
 │  int4 │  386.26 MB  │ 37.14 GB │            148.56 GB            │
 └───────┴─────────────┴──────────┴─────────────────────────────────┘
-
+```
 
 ```bash
 accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 ```
 
-
+```
 ┌────────────────────────────────────────────────────┐
 │  Memory Usage for loading `timm/resnet50.a1_in1k`  │
 ├───────┬─────────────┬──────────┬───────────────────┤
@@ -98,7 +98,7 @@ accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 │  int8 │   2.25 MB   │ 24.42 MB │      97.7 MB      │
 │  int4 │   1.12 MB   │ 12.21 MB │      48.85 MB     │
 └───────┴─────────────┴──────────┴───────────────────┘
-
+```
 
 ### Specific dtypes
 

--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -48,7 +48,7 @@ it will use:
 
 ```
 ┌────────────────────────────────────────────────────┐
-│     Memory Usage for loading `bert-base-cased`     │
+│  Memory Usage for loading `bert-base-cased`   │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -72,7 +72,7 @@ accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name tra
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`   │
+│Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`│
 ├───────┬─────────────┬──────────┬─────────────────────────────────┤
 │ dtype │Largest Layer│Total Size│       Training using Adam       │
 ├───────┼─────────────┼──────────┼─────────────────────────────────┤
@@ -89,7 +89,7 @@ accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 
 ```
 ┌────────────────────────────────────────────────────┐
-│  Memory Usage for loading `timm/resnet50.a1_in1k`  │
+│Memory Usage for loading `timm/resnet50.a1_in1k`│
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -112,7 +112,7 @@ accelerate estimate-memory bert-base-cased --dtypes float32 float16
 
 ```
 ┌────────────────────────────────────────────────────┐
-│     Memory Usage for loading `bert-base-cased`     │
+│  Memory Usage for loading `bert-base-cased`  │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤

--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -46,18 +46,14 @@ accelerate estimate-memory bert-base-cased
 This will download the `config.json` for `bert-based-cased`, load the model on the `meta` device, and report back how much space
 it will use:
 
-```
-┌────────────────────────────────────────────────────┐
-│    Memory Usage for loading bert-base-cased      │
-├───────┬─────────────┬──────────┬───────────────────┤
-│ dtype │Largest Layer│Total Size│Training using Adam│
-├───────┼─────────────┼──────────┼───────────────────┤
-│float32│   84.95 MB  │413.18 MB │      1.61 GB      │
-│float16│   42.47 MB  │206.59 MB │     826.36 MB     │
-│  int8 │   21.24 MB  │103.29 MB │     413.18 MB     │
-│  int4 │   10.62 MB  │ 51.65 MB │     206.59 MB     │
-└───────┴─────────────┴──────────┴───────────────────┘
-```
+Memory Usage for loading `bert-base-cased`:
+
+| dtype   | Largest Layer | Total Size | Training using Adam |
+|---------|---------------|------------|---------------------|
+| float32 | 84.95 MB      | 418.18 MB  | 1.61 GB             |
+| float16 | 42.47 MB      | 206.59 MB  | 826.36 MB           |
+| int8    | 21.24 MB      | 103.29 MB  | 413.18 MB           |
+| int4    | 10.62 MB      | 51.65 MB   | 206.59 MB           |
 
 By default it will return all the supported dtypes (`int4` through `float32`), but if you are interested in specific ones these can be filtered.
 
@@ -70,35 +66,28 @@ be passed in.
 accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name transformers
 ```
 
-```
-┌──────────────────────────────────────────────────────────────────┐
-│  Memory Usage for loading HuggingFaceM4/idefics-80b-instruct   │
-├───────┬─────────────┬──────────┬─────────────────────────────────┤
-│ dtype │Largest Layer│Total Size│       Training using Adam       │
-├───────┼─────────────┼──────────┼─────────────────────────────────┤
-│float32│   3.02 GB   │297.12 GB │             1.16 TB             │
-│float16│   1.51 GB   │148.56 GB │            594.24 GB            │
-│  int8 │  772.52 MB  │ 74.28 GB │            297.12 GB            │
-│  int4 │  386.26 MB  │ 37.14 GB │            148.56 GB            │
-└───────┴─────────────┴──────────┴─────────────────────────────────┘
-```
+Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`:
+
+| dtype   | Largest Layer | Total Size | Training using Adam |
+|---------|---------------|------------|---------------------|
+| float32 | 3.02 GB       | 297.12 GB  | 1.16 TB             |
+| float16 | 1.51 GB       | 148.56 GB  | 594.24 GB           |
+| int8    | 772.52 MB     | 74.28 GB   | 297.12 GB           |
+| int4    | 386.26 MB     | 37.14 GB   | 148.56 GB           |
+
 
 ```bash
 accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 ```
 
-```
-┌────────────────────────────────────────────────────┐
-│  Memory Usage for loading timm/resnet50.a1_in1k  │
-├───────┬─────────────┬──────────┬───────────────────┤
-│ dtype │Largest Layer│Total Size│Training using Adam│
-├───────┼─────────────┼──────────┼───────────────────┤
-│float32│    9.0 MB   │ 97.7 MB  │     390.78 MB     │
-│float16│    4.5 MB   │ 48.85 MB │     195.39 MB     │
-│  int8 │   2.25 MB   │ 24.42 MB │      97.7 MB      │
-│  int4 │   1.12 MB   │ 12.21 MB │      48.85 MB     │
-└───────┴─────────────┴──────────┴───────────────────┘
-```
+Memory Usage for loading `timm/resnet50.a1_in1k`:
+
+| dtype   | Largest Layer | Total Size | Training using Adam |
+|---------|---------------|------------|---------------------|
+| float32 | 9.0 MB        | 97.7 MB    | 390.78 MB           |
+| float16 | 4.5 MB        | 48.85 MB   | 195.39 MB           |
+| int8    | 2.25 MB       | 24.42 MB   | 97.7 MB             |
+| int4    | 1.12 MB       | 12.21 MB   | 48.85 MB            |
 
 ### Specific dtypes
 
@@ -110,16 +99,12 @@ To do so, pass them in after specifying `--dtypes`:
 accelerate estimate-memory bert-base-cased --dtypes float32 float16
 ```
 
-```
-┌────────────────────────────────────────────────────┐
-│     Memory Usage for loading bert-base-cased    │
-├───────┬─────────────┬──────────┬───────────────────┤
-│ dtype │Largest Layer│Total Size│Training using Adam│
-├───────┼─────────────┼──────────┼───────────────────┤
-│float32│   84.95 MB  │413.18 MB │      1.61 GB      │
-│float16│   42.47 MB  │206.59 MB │     826.36 MB     │
-└───────┴─────────────┴──────────┴───────────────────┘
-```
+Memory Usage for loading `bert-base-cased`:
+
+| dtype   | Largest Layer | Total Size | Training using Adam |
+|---------|---------------|------------|---------------------|
+| float32 | 84.95 MB      | 413.18 MB  | 1.61 GB             |
+| float16 | 42.47 MB      | 206.59 MB  | 826.36 MB           |
 
 ## Caveats with this calculator
 

--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -48,7 +48,7 @@ it will use:
 
 ```
 ┌────────────────────────────────────────────────────┐
-│  Memory Usage for loading `bert-base-cased`   │
+│    Memory Usage for loading `bert-base-cased`     │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -72,7 +72,7 @@ accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name tra
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`│
+│  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`  │
 ├───────┬─────────────┬──────────┬─────────────────────────────────┤
 │ dtype │Largest Layer│Total Size│       Training using Adam       │
 ├───────┼─────────────┼──────────┼─────────────────────────────────┤
@@ -89,7 +89,7 @@ accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 
 ```
 ┌────────────────────────────────────────────────────┐
-│Memory Usage for loading `timm/resnet50.a1_in1k`│
+│  Memory Usage for loading `timm/resnet50.a1_in1k` │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -112,7 +112,7 @@ accelerate estimate-memory bert-base-cased --dtypes float32 float16
 
 ```
 ┌────────────────────────────────────────────────────┐
-│  Memory Usage for loading `bert-base-cased`  │
+│     Memory Usage for loading `bert-base-cased`    │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤

--- a/docs/source/usage_guides/model_size_estimator.md
+++ b/docs/source/usage_guides/model_size_estimator.md
@@ -46,9 +46,9 @@ accelerate estimate-memory bert-base-cased
 This will download the `config.json` for `bert-based-cased`, load the model on the `meta` device, and report back how much space
 it will use:
 
-```
+
 ┌────────────────────────────────────────────────────┐
-│    Memory Usage for loading `bert-base-cased`     │
+│    Memory Usage for loading `bert-base-cased`      │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -57,7 +57,7 @@ it will use:
 │  int8 │   21.24 MB  │103.29 MB │     413.18 MB     │
 │  int4 │   10.62 MB  │ 51.65 MB │     206.59 MB     │
 └───────┴─────────────┴──────────┴───────────────────┘
-```
+
 
 By default it will return all the supported dtypes (`int4` through `float32`), but if you are interested in specific ones these can be filtered.
 
@@ -70,9 +70,9 @@ be passed in.
 accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name transformers
 ```
 
-```
+
 ┌──────────────────────────────────────────────────────────────────┐
-│  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`  │
+│  Memory Usage for loading `HuggingFaceM4/idefics-80b-instruct`   │
 ├───────┬─────────────┬──────────┬─────────────────────────────────┤
 │ dtype │Largest Layer│Total Size│       Training using Adam       │
 ├───────┼─────────────┼──────────┼─────────────────────────────────┤
@@ -81,15 +81,15 @@ accelerate estimate-memory HuggingFaceM4/idefics-80b-instruct --library_name tra
 │  int8 │  772.52 MB  │ 74.28 GB │            297.12 GB            │
 │  int4 │  386.26 MB  │ 37.14 GB │            148.56 GB            │
 └───────┴─────────────┴──────────┴─────────────────────────────────┘
-```
+
 
 ```bash
 accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 ```
 
-```
+
 ┌────────────────────────────────────────────────────┐
-│  Memory Usage for loading `timm/resnet50.a1_in1k` │
+│  Memory Usage for loading `timm/resnet50.a1_in1k`  │
 ├───────┬─────────────┬──────────┬───────────────────┤
 │ dtype │Largest Layer│Total Size│Training using Adam│
 ├───────┼─────────────┼──────────┼───────────────────┤
@@ -98,7 +98,7 @@ accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm
 │  int8 │   2.25 MB   │ 24.42 MB │      97.7 MB      │
 │  int4 │   1.12 MB   │ 12.21 MB │      48.85 MB     │
 └───────┴─────────────┴──────────┴───────────────────┘
-```
+
 
 ### Specific dtypes
 

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -255,7 +255,7 @@ def estimate_command(args):
 
     headers = ["dtype", "Largest Layer", "Total Size", "Training using Adam"]
 
-    title = f"Memory Usage for loading `{args.model_name}`\n"
+    title = f"Memory Usage for loading `{args.model_name}`"
     table = create_ascii_table(headers, data, title)
     print(table)
 


### PR DESCRIPTION
Just some final nits and cleaning on the model util and doc, specifying that after testing the real vs estimated values, we're off by at most a few % (further tests to be done on this), showing `bert-base-cased` as an example of this. 