### PR TITLE
Add support for deepspeed optimizer and custom scheduler

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1557,10 +1557,6 @@ class Accelerator:
                     "Please remove the scheduler from the config file or "
                     "create `accelerate.utils.DummyScheduler` in the code."
                 )
-            elif "scheduler" not in deepspeed_plugin.deepspeed_config and isinstance(scheduler, (DummyScheduler)):
-                raise ValueError(
-                    "You cannot create a `DummyScheduler` without specifying a scheduler in the config file."
-                )
 
         if optimizer is not None and scheduler is not None:
             if isinstance(optimizer, (DummyOptim)) and not isinstance(scheduler, (DummyScheduler)):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1557,6 +1557,15 @@ class Accelerator:
                     "Please remove the scheduler from the config file or "
                     "create `accelerate.utils.DummyScheduler` in the code."
                 )
+            elif (
+                "scheduler" not in deepspeed_plugin.deepspeed_config
+                and isinstance(scheduler, (DummyScheduler))
+                and scheduler.lr_scheduler_callable is None
+            ):
+                raise ValueError(
+                    "Either specify a scheduler in the config file or "
+                    "pass in the `lr_scheduler_callable` parameter when using `accelerate.utils.DummyScheduler`."
+                )
 
         if optimizer is not None and scheduler is not None:
             if isinstance(optimizer, (DummyOptim)) and not isinstance(scheduler, (DummyScheduler)):

--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -258,12 +258,15 @@ class DummyScheduler:
             Total number of steps.
         warmup_num_steps (int):
             Number of steps for warmup.
+        lr_scheduler_callable (callable):
+            A callable function that creates an LR Scheduler. It accepts only one argument `optimizer`.
         **kwargs:
             Other arguments.
     """
 
-    def __init__(self, optimizer, total_num_steps=None, warmup_num_steps=0, **kwargs):
+    def __init__(self, optimizer, total_num_steps=None, warmup_num_steps=0, lr_scheduler_callable=None, **kwargs):
         self.optimizer = optimizer
         self.total_num_steps = total_num_steps
         self.warmup_num_steps = warmup_num_steps
+        self.lr_scheduler_callable = lr_scheduler_callable
         self.kwargs = kwargs

--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -254,11 +254,11 @@ class DummyScheduler:
     Args:
         optimizer (`torch.optim.optimizer.Optimizer`):
             The optimizer to wrap.
-        total_num_steps (int):
+        total_num_steps (int, *optional*):
             Total number of steps.
-        warmup_num_steps (int):
+        warmup_num_steps (int, *optional*):
             Number of steps for warmup.
-        lr_scheduler_callable (callable):
+        lr_scheduler_callable (callable, *optional*):
             A callable function that creates an LR Scheduler. It accepts only one argument `optimizer`.
         **kwargs:
             Other arguments.

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -494,7 +494,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     in str(cm.exception)
                 )
 
-                # passing `lr_scheduler_callable` to DUmmyScheduler should enable DS Optim + Custom Scheduler
+                # passing `lr_scheduler_callable` to DummyScheduler should enable DS Optim + Custom Scheduler
                 def _lr_scheduler_callable(optimizer):
                     return get_scheduler(
                         name="linear",

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -353,7 +353,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 self.assertTrue(accelerator.deepspeed_config["train_batch_size"], 16)
                 self.assertEqual(type(model), DeepSpeedEngine)
                 self.assertEqual(type(optimizer), DeepSpeedOptimizerWrapper)
-                self.assertEqual(type(lr_scheduler), AcceleratedScheduler)
+                self.assertEqual(type(lr_scheduler), DeepSpeedSchedulerWrapper)
                 self.assertEqual(type(accelerator.deepspeed_engine_wrapped), DeepSpeedEngineWrapper)
 
         elif optim_type == DS_OPTIMIZER and scheduler_type == DS_SCHEDULER:
@@ -505,10 +505,9 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     )
 
                 dummy_lr_scheduler = DummyScheduler(dummy_optimizer, lr_scheduler_callable=_lr_scheduler_callable)
-                with self.assertRaises(ValueError) as cm:
-                    model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
-                        model, dummy_optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
-                    )
+                model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
+                    model, dummy_optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
+                )
 
     def test_save_checkpoints(self):
         deepspeed_plugin = DeepSpeedPlugin(

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -31,7 +31,6 @@ from transformers.utils import is_torch_bf16_available
 
 import accelerate
 from accelerate.accelerator import Accelerator
-from accelerate.scheduler import AcceleratedScheduler
 from accelerate.state import AcceleratorState
 from accelerate.test_utils.testing import (
     AccelerateTestCase,


### PR DESCRIPTION
# What does this PR do?
1. Add support for deepspeed optimizer and custom scheduler
2. Fixing the lr scheduler not being saved by passing them to the DeepSpeed engineer for all schedulers that are instances of LRScheduler.
3. Added related tests