### PR TITLE
Fix docker images

### DIFF
--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -35,11 +35,9 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push CPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-cpu
-          push: true
-          tags: huggingface/accelerate-cpu:${{needs.get-version.outputs.version}}
+        run: |
+          docker build -t huggingface/accelerate-cpu -f ./docker/accelerate-cpu/Dockerfile .
+          docker push huggingface/accelerate-cpu::${{needs.get-version.outputs.version}}
 
   version-cuda:
     name: "Latest Accelerate GPU [version]"
@@ -57,8 +55,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push GPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-gpu
-          push: true
-          tags: huggingface/accelerate-gpu:${{needs.get-version.outputs.version}}
+        run: |
+          docker build -t huggingface/accelerate-gpu -f ./docker/accelerate-gpu/Dockerfile .
+          docker push huggingface/accelerate-gpu::${{needs.get-version.outputs.version}}

--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build and Push CPU
         run: |
           docker build -t huggingface/accelerate-cpu -f ./docker/accelerate-cpu/Dockerfile .
-          docker push huggingface/accelerate-cpu::${{needs.get-version.outputs.version}}
+          docker push huggingface/accelerate-cpu:${{needs.get-version.outputs.version}}
 
   version-cuda:
     name: "Latest Accelerate GPU [version]"
@@ -57,4 +57,4 @@ jobs:
       - name: Build and Push GPU
         run: |
           docker build -t huggingface/accelerate-gpu -f ./docker/accelerate-gpu/Dockerfile .
-          docker push huggingface/accelerate-gpu::${{needs.get-version.outputs.version}}
+          docker push huggingface/accelerate-gpu:${{needs.get-version.outputs.version}}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -31,6 +31,7 @@ jobs:
           context: ./docker/accelerate-cpu
           push: true
           tags: huggingface/accelerate-cpu
+          driver: docker
 
   latest-cuda:
     name: "Latest Accelerate GPU [dev]"
@@ -52,3 +53,4 @@ jobs:
           context: ./docker/accelerate-gpu
           push: true
           tags: huggingface/accelerate-gpu
+          driver: docker

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -24,14 +24,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Build and Push CPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-cpu
-          push: true
-          tags: huggingface/accelerate-cpu
-          driver: docker
+        run: |
+          docker build -t huggingface/accelerate-cpu -f ./docker/accelerate-cpu/Dockerfile .
+          docker push huggingface/accelerate-cpu:latest
 
   latest-cuda:
     name: "Latest Accelerate GPU [dev]"
@@ -48,9 +44,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and Push GPU
-        uses: docker/build-push-action@v2
-        with:
-          context: ./docker/accelerate-gpu
-          push: true
-          tags: huggingface/accelerate-gpu
-          driver: docker
+        run: |
+          docker build -t huggingface/accelerate-gpu -f ./docker/accelerate-gpu/Dockerfile .
+          docker push huggingface/accelerate-gpu:latest

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           source activate accelerate
           git config --global --add safe.directory '*'
-          git checkout main && git pull
+          git checkout master && git pull
           if [[ ${{ matrix.skorch-version }} = pypi ]]; then 
             git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
           fi

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    git+https://github.com/huggingface/accelerate#egg=accelerate[testing,test_trackers] \
+    git+https://github.com/huggingface/accelerate#egg=accelerate \
     --extra-index-url https://download.pytorch.org/whl/cu117
 
 RUN python3 -m pip install --no-cache-dir bitsandbytes

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -25,7 +25,7 @@ RUN source activate accelerate && \
     git+https://github.com/huggingface/accelerate#egg=accelerate \
     --extra-index-url https://download.pytorch.org/whl/cu117
 
-RUN python3 -m pip install --no-cache-dir bitsandbytes
+# RUN python3 -m pip install --no-cache-dir bitsandbytes
 
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists*
 
 # Create our conda env
-RUN conda create --name accelerate python=${PYTHON_VERSION} pip
+RUN conda create --name accelerate python=${PYTHON_VERSION} ipython jupyter pip
 # We don't install pytorch here yet since CUDA isn't available
 # instead we use the direct torch wheel
 ENV PATH /opt/conda/envs/accelerate/bin:$PATH
@@ -22,10 +22,10 @@ SHELL ["/bin/bash", "-c"]
 # Activate the conda env and install torch + accelerate
 RUN source activate accelerate && \
     python3 -m pip install --no-cache-dir \
-    git+https://github.com/huggingface/accelerate#egg=accelerate \
+    git+https://github.com/huggingface/accelerate#egg=accelerate[testing,test_trackers] \
     --extra-index-url https://download.pytorch.org/whl/cu117
 
-# RUN python3 -m pip install --no-cache-dir bitsandbytes
+RUN python3 -m pip install --no-cache-dir bitsandbytes
 
 # Stage 2
 FROM nvidia/cuda:11.2.2-cudnn8-devel-ubuntu20.04 AS build-image

--- a/docker/accelerate-gpu/Dockerfile
+++ b/docker/accelerate-gpu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists*
 
 # Create our conda env
-RUN conda create --name accelerate python=${PYTHON_VERSION} ipython jupyter pip
+RUN conda create --name accelerate python=${PYTHON_VERSION} pip
 # We don't install pytorch here yet since CUDA isn't available
 # instead we use the direct torch wheel
 ENV PATH /opt/conda/envs/accelerate/bin:$PATH


### PR DESCRIPTION
# What does this PR do?

Docker image workflows have been broken for the last few months silently, it comes from the workflow we use for it. Instead now we just manually upload it using the repository secrets, and I've confirmed this works and runs without issue. 

cc @LysandreJik @BenjaminBossan 