### PR TITLE
Skip pypi transformers until release

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Add pypi back in after the next release!
         transformers-version: [
-          pypi,
           github
         ]
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Add pypi back in after the next release!
+        # TODO (@muellerzr, transformers v4.33) Add pypi back after the next release
         transformers-version: [
           github
         ]

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Add pypi back in after the next release!
+        # TODO (@muellerzr, transformers v4.33) Add pypi back after the next release
         transformers-version: [
           github
         ]

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -29,8 +29,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Add pypi back in after the next release!
         transformers-version: [
-          pypi,
           github
         ]
         cuda_visible_devices: [


### PR DESCRIPTION
# What does this PR do?

This PR in transformers (https://github.com/huggingface/transformers/pull/25077) makes the pypi version of transformers incompatible with the git-version of the tests. As a result, this PR skips their integration tests (but keeps github). Will be re-added in the next release.

Fixes # (issue)

Failing merge tests


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 