### PR TITLE
Check for invalid keys

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -60,7 +60,7 @@ def load_config_from_file(config_file):
                 config_class = ClusterConfig
             else:
                 config_class = SageMakerConfig
-            return config_class.from_json_file(json_file=config_file)
+                return config_class.from_json_file(json_file=config_file)
         else:
             if (
                 yaml.safe_load(f).get("compute_environment", ComputeEnvironment.LOCAL_MACHINE)
@@ -69,6 +69,7 @@ def load_config_from_file(config_file):
                 config_class = ClusterConfig
             else:
                 config_class = SageMakerConfig
+
             return config_class.from_yaml_file(yaml_file=config_file)
 
 
@@ -109,6 +110,12 @@ class BaseConfig:
             config_dict["use_cpu"] = False
         if "debug" not in config_dict:
             config_dict["debug"] = False
+        extra_keys = set(config_dict.keys()) - set(cls.__dataclass_fields__.keys())
+        if len(extra_keys) > 0:
+            raise ValueError(
+                f"Unknown keys in the config file: {list(extra_keys)}, please try upgrading your `accelerate` version or remove them."
+            )
+
         return cls(**config_dict)
 
     def to_json_file(self, json_file):
@@ -123,7 +130,6 @@ class BaseConfig:
             config_dict = yaml.safe_load(f)
         if "compute_environment" not in config_dict:
             config_dict["compute_environment"] = ComputeEnvironment.LOCAL_MACHINE
-
         if "mixed_precision" not in config_dict:
             config_dict["mixed_precision"] = "fp16" if ("fp16" in config_dict and config_dict["fp16"]) else None
         if isinstance(config_dict["mixed_precision"], bool) and not config_dict["mixed_precision"]:
@@ -137,6 +143,11 @@ class BaseConfig:
             config_dict["use_cpu"] = False
         if "debug" not in config_dict:
             config_dict["debug"] = False
+        extra_keys = set(config_dict.keys()) - set(cls.__dataclass_fields__.keys())
+        if len(extra_keys) > 0:
+            raise ValueError(
+                f"Unknown keys in the config file: {list(extra_keys)}, please try upgrading your `accelerate` version or remove them."
+            )
         return cls(**config_dict)
 
     def to_yaml_file(self, yaml_file):

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -60,7 +60,7 @@ def load_config_from_file(config_file):
                 config_class = ClusterConfig
             else:
                 config_class = SageMakerConfig
-                return config_class.from_json_file(json_file=config_file)
+            return config_class.from_json_file(json_file=config_file)
         else:
             if (
                 yaml.safe_load(f).get("compute_environment", ComputeEnvironment.LOCAL_MACHINE)

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -110,10 +110,11 @@ class BaseConfig:
             config_dict["use_cpu"] = False
         if "debug" not in config_dict:
             config_dict["debug"] = False
-        extra_keys = set(config_dict.keys()) - set(cls.__dataclass_fields__.keys())
+        extra_keys = sorted(set(config_dict.keys()) - set(cls.__dataclass_fields__.keys()))
         if len(extra_keys) > 0:
             raise ValueError(
-                f"Unknown keys in the config file: {list(extra_keys)}, please try upgrading your `accelerate` version or remove them."
+                f"The config file at {json_file} had unknown keys ({extra_keys}), please try upgrading your `accelerate`"
+                " version or fix (and potentially remove) these keys from your config file."
             )
 
         return cls(**config_dict)
@@ -143,10 +144,11 @@ class BaseConfig:
             config_dict["use_cpu"] = False
         if "debug" not in config_dict:
             config_dict["debug"] = False
-        extra_keys = set(config_dict.keys()) - set(cls.__dataclass_fields__.keys())
+        extra_keys = sorted(set(config_dict.keys()) - set(cls.__dataclass_fields__.keys()))
         if len(extra_keys) > 0:
             raise ValueError(
-                f"Unknown keys in the config file: {list(extra_keys)}, please try upgrading your `accelerate` version or remove them."
+                f"The config file at {yaml_file} had unknown keys ({extra_keys}), please try upgrading your `accelerate`"
+                " version or fix (and potentially remove) these keys from your config file."
             )
         return cls(**config_dict)
 

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -69,7 +69,6 @@ def load_config_from_file(config_file):
                 config_class = ClusterConfig
             else:
                 config_class = SageMakerConfig
-
             return config_class.from_yaml_file(yaml_file=config_file)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -67,10 +67,21 @@ class AccelerateLauncherTester(unittest.TestCase):
 
     def test_config_compatibility(self):
         for config in sorted(self.test_config_path.glob("**/*.yaml")):
-            with self.subTest(config_file=config):
-                execute_subprocess_async(
-                    self.base_cmd + ["--config_file", str(config), self.test_file_path], env=os.environ.copy()
-                )
+            if "invalid" not in str(config):
+                with self.subTest(config_file=config):
+                    execute_subprocess_async(
+                        self.base_cmd + ["--config_file", str(config), self.test_file_path], env=os.environ.copy()
+                    )
+
+    def test_invalid_keys(self):
+        with self.assertRaises(
+            RuntimeError, msg="Unknown keys in the config file: ['another_invalid_key', 'invalid_key']"
+        ):
+            execute_subprocess_async(
+                self.base_cmd
+                + ["--config_file", str(self.test_config_path / "invalid_keys.yaml"), self.test_file_path],
+                env=os.environ.copy(),
+            )
 
     def test_accelerate_test(self):
         execute_subprocess_async(["accelerate", "test"], env=os.environ.copy())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,7 +75,8 @@ class AccelerateLauncherTester(unittest.TestCase):
 
     def test_invalid_keys(self):
         with self.assertRaises(
-            RuntimeError, msg="Unknown keys in the config file: ['another_invalid_key', 'invalid_key']"
+            RuntimeError,
+            msg="The config file at 'invalid_keys.yaml' had unknown keys ('another_invalid_key', 'invalid_key')",
         ):
             execute_subprocess_async(
                 self.base_cmd

--- a/tests/test_configs/invalid_keys.yaml
+++ b/tests/test_configs/invalid_keys.yaml
@@ -1,0 +1,15 @@
+compute_environment: LOCAL_MACHINE
+deepspeed_config: {}
+distributed_type: 'NO'
+downcast_bf16: 'no'
+fsdp_config: {}
+machine_rank: 0
+main_process_ip: null
+main_process_port: null
+main_training_function: main
+mixed_precision: 'no'
+num_machines: 1
+num_processes: 1
+use_cpu: false
+invalid_key: "invalid_value"
+another_invalid_key: "another_invalid_value"


### PR DESCRIPTION
# What does this PR do?

This PR introduces a better error when loading the YAML file in by letting the user know what errors were actually present. 

Fixes # (issue)

Helps relieve the confusion when getting errors such as:

```python
ClusterConfig.__init__() got an unexpected keyword argument 'myargument'
```

And instead results with:
```python
Unknown keys in the config file: ['myargument'], please try upgrading your `accelerate` version or remove them.
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 