### PR TITLE
Introduce breakpoint API

### DIFF
--- a/docs/source/concept_guides/deferring_execution.md
+++ b/docs/source/concept_guides/deferring_execution.md
@@ -111,7 +111,7 @@ with accelerator.main_process_first():
 
 ## Applying checks such as Early Stopping
 
-To have a check that works with a flag set by a particular process, the `check` and `set` breakpoint API should be used. Useful examples
+To have a check that works with a flag set by a particular process, the `set_trigger` and `check_trigger` API should be used. Useful examples
 for doing so can include situations such as using early stopping and monitoring the loss (as each loss slightly differs on each process).
 
 Call [`Accelerator.set_trigger`] when your condition has been met, and [`Accelerator.check_trigger`] when checking if that condition has been met in any process:

--- a/docs/source/concept_guides/deferring_execution.md
+++ b/docs/source/concept_guides/deferring_execution.md
@@ -108,3 +108,19 @@ with accelerator.main_process_first():
         remove_columns=["idx", "sentence1", "sentence2"],
     )
 ```
+
+## Applying checks such as Early Stopping
+
+To have a check that works with a flag set by a particular process, the `check` and `set` breakpoint API should be used.
+
+Call [`Accelerator.set_breakpoint`] when your condition has been met, and [`Accelerator.check_breakpoint`] when checking if that condition has been met in any process:
+
+```python
+# Assume `should_do_breakpoint` is a custom defined function that returns a conditional
+if should_do_breakpoint(loss):
+    accelerator.set_breakpoint()
+
+# Later in the training script when we need to check for the breakpoint
+if accelerator.check_breakpoint():
+    break
+```

--- a/docs/source/concept_guides/deferring_execution.md
+++ b/docs/source/concept_guides/deferring_execution.md
@@ -111,16 +111,17 @@ with accelerator.main_process_first():
 
 ## Applying checks such as Early Stopping
 
-To have a check that works with a flag set by a particular process, the `check` and `set` breakpoint API should be used.
+To have a check that works with a flag set by a particular process, the `check` and `set` breakpoint API should be used. Useful examples
+for doing so can include situations such as using early stopping and monitoring the loss (as each loss slightly differs on each process).
 
-Call [`Accelerator.set_breakpoint`] when your condition has been met, and [`Accelerator.check_breakpoint`] when checking if that condition has been met in any process:
+Call [`Accelerator.set_trigger`] when your condition has been met, and [`Accelerator.check_trigger`] when checking if that condition has been met in any process:
 
 ```python
-# Assume `should_do_breakpoint` is a custom defined function that returns a conditional
-if should_do_breakpoint(loss):
-    accelerator.set_breakpoint()
+# Assume `should_do_early_stopping` is a custom defined function that returns a conditional
+if should_do_early_stopping(loss):
+    accelerator.set_trigger()
 
 # Later in the training script when we need to check for the breakpoint
-if accelerator.check_breakpoint():
+if accelerator.check_trigger():
     break
 ```

--- a/docs/source/concept_guides/deferring_execution.md
+++ b/docs/source/concept_guides/deferring_execution.md
@@ -117,11 +117,14 @@ for doing so can include situations such as using early stopping and monitoring 
 Call [`Accelerator.set_trigger`] when your condition has been met, and [`Accelerator.check_trigger`] when checking if that condition has been met in any process:
 
 ```python
-# Assume `should_do_early_stopping` is a custom defined function that returns a conditional
-if should_do_early_stopping(loss):
-    accelerator.set_trigger()
+for (x,y) in data_loader:
+    logits = model(x)
+    loss = loss_func(logits, y)
+    # Assume `should_do_early_stopping` is a custom defined function that returns a conditional
+    if should_do_early_stopping(loss):
+        accelerator.set_trigger()
 
-# Later in the training script when we need to check for the breakpoint
-if accelerator.check_trigger():
-    break
+    # Later in the training script when we need to check for the breakpoint
+    if accelerator.check_trigger():
+        break
 ```

--- a/examples/by_feature/early_stopping.py
+++ b/examples/by_feature/early_stopping.py
@@ -1,0 +1,246 @@
+# coding=utf-8
+# Copyright 2021 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+import evaluate
+import torch
+from datasets import load_dataset
+from torch.optim import AdamW
+from torch.utils.data import DataLoader
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, get_linear_schedule_with_warmup, set_seed
+
+from accelerate import Accelerator, DistributedType
+
+
+########################################################################
+# This is a fully working simple example to use Accelerate
+# specifically showcasing how to perform early stopping,
+# and builds off the `nlp_example.py` script
+#
+# This example trains a Bert base model on GLUE MRPC
+# in any of the following settings (with the same script):
+#   - single CPU or single GPU
+#   - multi GPUS (using PyTorch distributed mode)
+#   - (multi) TPUs
+#   - fp16 (mixed-precision) or fp32 (normal precision)
+#
+# To run it in each of these various modes, follow the instructions
+# in the readme for examples:
+# https://github.com/huggingface/accelerate/tree/main/examples
+#
+########################################################################
+
+
+MAX_GPU_BATCH_SIZE = 16
+EVAL_BATCH_SIZE = 32
+
+
+def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
+    """
+    Creates a set of `DataLoader`s for the `glue` dataset,
+    using "bert-base-cased" as the tokenizer.
+
+    Args:
+        accelerator (`Accelerator`):
+            An `Accelerator` object
+        batch_size (`int`, *optional*):
+            The batch size for the train and validation DataLoaders.
+    """
+    tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
+    datasets = load_dataset("glue", "mrpc")
+
+    def tokenize_function(examples):
+        # max_length=None => use the model max length (it's actually the default)
+        outputs = tokenizer(examples["sentence1"], examples["sentence2"], truncation=True, max_length=None)
+        return outputs
+
+    # Apply the method we just defined to all the examples in all the splits of the dataset
+    # starting with the main process first:
+    with accelerator.main_process_first():
+        tokenized_datasets = datasets.map(
+            tokenize_function,
+            batched=True,
+            remove_columns=["idx", "sentence1", "sentence2"],
+        )
+
+    # We also rename the 'label' column to 'labels' which is the expected name for labels by the models of the
+    # transformers library
+    tokenized_datasets = tokenized_datasets.rename_column("label", "labels")
+
+    def collate_fn(examples):
+        # On TPU it's best to pad everything to the same length or training will be very slow.
+        max_length = 128 if accelerator.distributed_type == DistributedType.TPU else None
+        # When using mixed precision we want round multiples of 8/16
+        if accelerator.mixed_precision == "fp8":
+            pad_to_multiple_of = 16
+        elif accelerator.mixed_precision != "no":
+            pad_to_multiple_of = 8
+        else:
+            pad_to_multiple_of = None
+
+        return tokenizer.pad(
+            examples,
+            padding="longest",
+            max_length=max_length,
+            pad_to_multiple_of=pad_to_multiple_of,
+            return_tensors="pt",
+        )
+
+    # Instantiate dataloaders.
+    train_dataloader = DataLoader(
+        tokenized_datasets["train"], shuffle=True, collate_fn=collate_fn, batch_size=batch_size, drop_last=True
+    )
+    eval_dataloader = DataLoader(
+        tokenized_datasets["validation"],
+        shuffle=False,
+        collate_fn=collate_fn,
+        batch_size=EVAL_BATCH_SIZE,
+        drop_last=(accelerator.mixed_precision == "fp8"),
+    )
+
+    return train_dataloader, eval_dataloader
+
+
+# New code
+class EarlyStoppingCallback:
+    "A callback class that helps with early stopping"
+
+    def __init__(self, min_delta=0, patience=5):
+        self.min_delta = min_delta
+        self.patience = patience
+        self.counter = 0
+        self.lowest_loss = float("inf")
+
+    def check_early_stopping(self, eval_loss):
+        delta = self.lowest_loss - eval_loss
+        if delta >= self.min_delta:
+            self.lowest_loss = eval_loss
+            self.counter = 0
+        else:
+            self.counter += 1
+            if self.counter >= self.patience:
+                return True
+        return False
+
+
+callback = EarlyStoppingCallback()
+
+
+def training_function(config, args):
+    # Initialize accelerator
+    accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision)
+    # Sample hyper-parameters for learning rate, batch size, seed and a few other HPs
+    lr = config["lr"]
+    num_epochs = int(config["num_epochs"])
+    seed = int(config["seed"])
+    batch_size = int(config["batch_size"])
+
+    metric = evaluate.load("glue", "mrpc")
+
+    # If the batch size is too big we use gradient accumulation
+    gradient_accumulation_steps = 1
+    if batch_size > MAX_GPU_BATCH_SIZE and accelerator.distributed_type != DistributedType.TPU:
+        gradient_accumulation_steps = batch_size // MAX_GPU_BATCH_SIZE
+        batch_size = MAX_GPU_BATCH_SIZE
+
+    set_seed(seed)
+    train_dataloader, eval_dataloader = get_dataloaders(accelerator, batch_size)
+    # Instantiate the model (we build the model here so that the seed also control new weights initialization)
+    model = AutoModelForSequenceClassification.from_pretrained("bert-base-cased", return_dict=True)
+
+    # We could avoid this line since the accelerator is set with `device_placement=True` (default value).
+    # Note that if you are placing tensors on devices manually, this line absolutely needs to be before the optimizer
+    # creation otherwise training will not work on TPU (`accelerate` will kindly throw an error to make us aware of that).
+    model = model.to(accelerator.device)
+    # Instantiate optimizer
+    optimizer = AdamW(params=model.parameters(), lr=lr)
+
+    # Instantiate scheduler
+    lr_scheduler = get_linear_schedule_with_warmup(
+        optimizer=optimizer,
+        num_warmup_steps=100,
+        num_training_steps=(len(train_dataloader) * num_epochs) // gradient_accumulation_steps,
+    )
+
+    # Prepare everything
+    # There is no specific order to remember, we just need to unpack the objects in the same order we gave them to the
+    # prepare method.
+
+    model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
+        model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
+    )
+
+    # Now we train the model
+    for epoch in range(num_epochs):
+        model.train()
+        for step, batch in enumerate(train_dataloader):
+            # We could avoid this line since we set the accelerator with `device_placement=True`.
+            batch.to(accelerator.device)
+            outputs = model(**batch)
+            loss = outputs.loss
+            loss = loss / gradient_accumulation_steps
+            accelerator.backward(loss)
+            if step % gradient_accumulation_steps == 0:
+                optimizer.step()
+                lr_scheduler.step()
+                optimizer.zero_grad()
+
+        model.eval()
+        for step, batch in enumerate(eval_dataloader):
+            # We could avoid this line since we set the accelerator with `device_placement=True`.
+            batch.to(accelerator.device)
+            with torch.no_grad():
+                outputs = model(**batch)
+            predictions = outputs.logits.argmax(dim=-1)
+            predictions, references = accelerator.gather_for_metrics((predictions, batch["labels"]))
+            metric.add_batch(
+                predictions=predictions,
+                references=references,
+            )
+
+        eval_metric = metric.compute()
+
+        # New code
+        # Check if we should stop the training on any processes
+        if callback.check_early_stopping(outputs.loss.item()):
+            accelerator.set_breakpoint()
+
+        # If so, we break the loop
+        if accelerator.check_breakpoint():
+            break
+
+        # Use accelerator.print to print only on the main process.
+        accelerator.print(f"epoch {epoch}:", eval_metric)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple example of training script.")
+    parser.add_argument(
+        "--mixed_precision",
+        type=str,
+        default=None,
+        choices=["no", "fp16", "bf16", "fp8"],
+        help="Whether to use mixed precision. Choose"
+        "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
+        "and an Nvidia Ampere GPU.",
+    )
+    parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
+    args = parser.parse_args()
+    config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}
+    training_function(config, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2021,7 +2021,7 @@ class Accelerator:
             self.flag_tensor = torch.tensor(0, device=self.device)
         flag_tensor = self.reduce(self.flag_tensor)
         if flag_tensor.item() >= 1:
-            self.flag_tensor = None
+            self.flag_tensor = torch.tensor(0, device=self.device)
             return True
         return False
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2020,7 +2020,7 @@ class Accelerator:
         if self.flag_tensor is None:
             self.flag_tensor = torch.tensor(0, device=self.device)
         flag_tensor = self.reduce(self.flag_tensor)
-        if flag_tensor.item() == 1:
+        if flag_tensor.item() > 1:
             self.flag_tensor = None
             return True
         return False

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1966,10 +1966,10 @@ class Accelerator:
         else:
             loss.backward(**kwargs)
 
-    def set_breakpoint(self):
+    def set_trigger(self):
         """
-        Sets the internal flag tensor to 1 on the current process. A latter check of `Accelerator().check_breakpoint()`
-        should follow using this which will check across all processes.
+        Sets the internal trigger tensor to 1 on the current process. A latter check should follow using this which
+        will check across all processes.
 
         Note:
             Does not require `wait_for_everyone()`
@@ -1984,7 +1984,7 @@ class Accelerator:
         >>> # `should_do_breakpoint` is a custom function to monitor when to break,
         >>> # e.g. when the loss is NaN
         >>> if should_do_breakpoint(loss):
-        ...     accelerator.set_breakpoint()
+        ...     accelerator.set_trigger()
         >>> # Assume later in the training script
         >>> if accelerator.check_breakpoint():
         ...     break
@@ -1992,10 +1992,10 @@ class Accelerator:
         """
         self.flag_tensor = torch.tensor(1, device=self.device)
 
-    def check_breakpoint(self):
+    def check_trigger(self):
         """
-        Checks if `self.flag_tensor` has been set to 1 in any of the processes. If so, will return `True` and reset the
-        flag tensor to 0.
+        Checks if the internal trigger tensor has been set to 1 in any of the processes. If so, will return `True` and
+        reset the trigger tensor to 0.
 
         Note:
             Does not require `wait_for_everyone()`
@@ -2010,9 +2010,9 @@ class Accelerator:
         >>> # `should_do_breakpoint` is a custom function to monitor when to break,
         >>> # e.g. when the loss is NaN
         >>> if should_do_breakpoint(loss):
-        ...     accelerator.set_breakpoint()
+        ...     accelerator.set_trigger()
         >>> # Assume later in the training script
-        >>> if accelerator.check_breakpoint():
+        >>> if accelerator.check_trigger():
         ...     break
         ```
         """

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2020,7 +2020,7 @@ class Accelerator:
         if self.flag_tensor is None:
             self.flag_tensor = torch.tensor(0, device=self.device)
         flag_tensor = self.reduce(self.flag_tensor)
-        if flag_tensor.item() > 1:
+        if flag_tensor.item() >= 1:
             self.flag_tensor = None
             return True
         return False

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -544,15 +544,15 @@ def test_split_between_processes_tensor():
 def test_breakpoint():
     accelerator = Accelerator()
     # should start with being false
-    assert accelerator.check_breakpoint() is False
+    assert accelerator.set_trigger() is False
 
     # set a breakpoint on the main process
     if accelerator.is_main_process:
-        accelerator.set_breakpoint()
+        accelerator.set_trigger()
 
     # check it's been activated across all processes
     # calls `all_reduce` and triggers a sync
-    assert accelerator.check_breakpoint() is True
+    assert accelerator.check_trigger() is True
 
 
 def main():

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -554,6 +554,9 @@ def test_trigger():
     # calls `all_reduce` and triggers a sync
     assert accelerator.check_trigger() is True
 
+    # check it's been reset after the sync
+    assert accelerator.check_trigger() is False
+
 
 def main():
     accelerator = Accelerator()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -541,7 +541,7 @@ def test_split_between_processes_tensor():
     state.wait_for_everyone()
 
 
-def test_breakpoint():
+def test_trigger():
     accelerator = Accelerator()
     # should start with being false
     assert accelerator.check_trigger() is False
@@ -605,8 +605,8 @@ def main():
     training_check()
 
     if state.local_process_index == 0:
-        print("\n**Breakpoint test**")
-    test_breakpoint()
+        print("\n**Breakpoint trigger test**")
+    test_trigger()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -544,7 +544,7 @@ def test_split_between_processes_tensor():
 def test_breakpoint():
     accelerator = Accelerator()
     # should start with being false
-    assert accelerator.set_trigger() is False
+    assert accelerator.check_trigger() is False
 
     # set a breakpoint on the main process
     if accelerator.is_main_process:

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -608,8 +608,6 @@ def main():
         print("\n**Breakpoint test**")
     test_breakpoint()
 
-    AcceleratorState()._reset_state()
-
 
 if __name__ == "__main__":
     main()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -558,51 +558,51 @@ def test_breakpoint():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
-    # state.wait_for_everyone()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
+    state.wait_for_everyone()
 
-    # if state.distributed_type == DistributedType.MULTI_GPU:
-    #     num_processes_per_node = torch.cuda.device_count()
-    # else:
-    #     num_processes_per_node = state.num_processes
+    if state.distributed_type == DistributedType.MULTI_GPU:
+        num_processes_per_node = torch.cuda.device_count()
+    else:
+        num_processes_per_node = state.num_processes
 
-    # # We only run this test on non-multinode
-    # if num_processes_per_node == state.num_processes:
-    #     if state.process_index == 0:
-    #         print("\n**Test process execution**")
-    #     process_execution_check()
+    # We only run this test on non-multinode
+    if num_processes_per_node == state.num_processes:
+        if state.process_index == 0:
+            print("\n**Test process execution**")
+        process_execution_check()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a list**")
-    #     test_split_between_processes_list()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a list**")
+        test_split_between_processes_list()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a dict**")
-    #     test_split_between_processes_nested_dict()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a dict**")
+        test_split_between_processes_nested_dict()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a tensor**")
-    #     test_split_between_processes_tensor()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a tensor**")
+        test_split_between_processes_tensor()
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    if state.local_process_index == 0:
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.TPU:
-    #     central_dl_preparation_check()
+    if state.local_process_index == 0:
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.TPU:
+        central_dl_preparation_check()
 
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check()
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check()
 
     if state.local_process_index == 0:
         print("\n**Breakpoint test**")

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -558,55 +558,57 @@ def test_breakpoint():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
-    state.wait_for_everyone()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
+    # state.wait_for_everyone()
 
-    if state.distributed_type == DistributedType.MULTI_GPU:
-        num_processes_per_node = torch.cuda.device_count()
-    else:
-        num_processes_per_node = state.num_processes
+    # if state.distributed_type == DistributedType.MULTI_GPU:
+    #     num_processes_per_node = torch.cuda.device_count()
+    # else:
+    #     num_processes_per_node = state.num_processes
 
-    # We only run this test on non-multinode
-    if num_processes_per_node == state.num_processes:
-        if state.process_index == 0:
-            print("\n**Test process execution**")
-        process_execution_check()
+    # # We only run this test on non-multinode
+    # if num_processes_per_node == state.num_processes:
+    #     if state.process_index == 0:
+    #         print("\n**Test process execution**")
+    #     process_execution_check()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a list**")
-        test_split_between_processes_list()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a list**")
+    #     test_split_between_processes_list()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a dict**")
-        test_split_between_processes_nested_dict()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a dict**")
+    #     test_split_between_processes_nested_dict()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a tensor**")
-        test_split_between_processes_tensor()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a tensor**")
+    #     test_split_between_processes_tensor()
 
-    if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.TPU:
-        central_dl_preparation_check()
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.TPU:
+    #     central_dl_preparation_check()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check()
 
     if state.local_process_index == 0:
         print("\n**Breakpoint test**")
     test_breakpoint()
+
+    AcceleratorState()._reset_state()
 
 
 if __name__ == "__main__":

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -541,6 +541,20 @@ def test_split_between_processes_tensor():
     state.wait_for_everyone()
 
 
+def test_breakpoint():
+    accelerator = Accelerator()
+    # should start with being false
+    assert accelerator.check_breakpoint() is False
+
+    # set a breakpoint on the main process
+    if accelerator.is_main_process:
+        accelerator.set_breakpoint()
+
+    # check it's been activated across all processes
+    # calls `all_reduce` and triggers a sync
+    assert accelerator.check_breakpoint() is True
+
+
 def main():
     accelerator = Accelerator()
     state = accelerator.state
@@ -589,6 +603,10 @@ def main():
     if state.local_process_index == 0:
         print("\n**Training integration test**")
     training_check()
+
+    if state.local_process_index == 0:
+        print("\n**Breakpoint test**")
+    test_breakpoint()
 
 
 if __name__ == "__main__":

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -41,6 +41,7 @@ EXCLUDE_EXAMPLES = [
     "fsdp_with_peak_mem_tracking.py",
     "deepspeed_with_config_support.py",
     "megatron_lm_gpt_pretraining.py",
+    "early_stopping.py",
 ]
 
 
@@ -221,4 +222,8 @@ class FeatureExamplesTests(TempDirTestCase):
 
     def test_local_sgd(self):
         testargs = ["examples/by_feature/local_sgd.py"]
+        run_command(self._launch_args + testargs)
+
+    def test_early_stopping(self):
+        testargs = ["examples/by_feature/early_stopping.py"]
         run_command(self._launch_args + testargs)


### PR DESCRIPTION
# Introduce breakpoint API

## What does this add?

This PR adds two new functions to `Accelerator`: `set_breakpoint` and `check_breakpoint` based on https://discuss.pytorch.org/t/how-to-use-break-in-distributeddataparallel-training/88296/7

## Who is it for?

https://discuss.huggingface.co/t/early-stopping-for-eval-loss-causes-timeout/51349

## Why is it needed?

When doing early stopping in DDP, if each process has a specific conditional that it can check, where it may not be synchronized across all of them, a `break` can happen on process 0 but not on process 1. As a result this will cause the code to hang indefinitely until a timeout occurs. 

To address that this PR introduces a new `set` and `check` breakpoint API, which should be used in-tandem with such conditionals to ensure that the breakpoint will be reached. This API can be used on any distributed type, not just DDP/multi-gpu

## What parts of the API does this impact?

### User-facing:

`Accelerator.set_breakpoint` and `Accelerator.check_breakpoint`

### Internal structure:

The `Accelerator` object now keeps track of a tensor at `self.flag_tensor`

## Basic Usage Example(s):

```python
# Assume `should_do_breakpoint` is a custom defined function that returns a conditional, 
# and that conditional might be true only on process 1
if should_do_breakpoint(loss):
    accelerator.set_breakpoint()

# Later in the training script when we need to check for the breakpoint
if accelerator.check_breakpoint():
    break
```

## When would I use it, and when wouldn't I?

A prime example would be triggering early stopping, where stopping on process 0 should trigger stopping the process across all of them. 