### PR TITLE
[`Tests`] Finish all todos

### DIFF
--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -638,22 +638,16 @@ class BigModelingTester(unittest.TestCase):
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
-        # TODO: @younesbelkada remove the positional arg on the next `transformers` release
         quantization_config = BitsAndBytesConfig(load_in_8bit=True)
         model = replace_with_bnb_linear(
             model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
         )
-
-        # TODO: @younesbelkada remove this block on the next `transformers` release
-        for p in model.parameters():
-            p.requires_grad = False
 
         model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")
 
         model = load_checkpoint_and_dispatch(
             model,
             checkpoint=model_path,
-            # device_map="auto",
             device_map="balanced",
         )
 
@@ -674,15 +668,10 @@ class BigModelingTester(unittest.TestCase):
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
-        # TODO: @younesbelkada remove the positional arg on the next `transformers` release
         quantization_config = BitsAndBytesConfig(load_in_8bit=True)
         model = replace_with_bnb_linear(
             model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
         )
-
-        # TODO: @younesbelkada remove this block on the next `transformers` release
-        for p in model.parameters():
-            p.requires_grad = False
 
         model_path = hf_hub_download("bigscience/bloom-560m", "pytorch_model.bin")
 
@@ -699,13 +688,9 @@ class BigModelingTester(unittest.TestCase):
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
-        # TODO: @younesbelkada remove the positional arg on the next `transformers` release
         model = replace_with_bnb_linear(
             model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
         )
-
-        for p in model.parameters():
-            p.requires_grad = False
 
         # test with str device map
         model = load_checkpoint_and_dispatch(
@@ -720,14 +705,9 @@ class BigModelingTester(unittest.TestCase):
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
 
-        # TODO: @younesbelkada remove the positional arg on the next `transformers` release
         model = replace_with_bnb_linear(
             model, modules_to_not_convert=["lm_head"], quantization_config=quantization_config
         )
-
-        # TODO: @younesbelkada remove this block on the next `transformers` release
-        for p in model.parameters():
-            p.requires_grad = False
 
         # test with torch.device device map
         model = load_checkpoint_and_dispatch(
@@ -741,7 +721,6 @@ class BigModelingTester(unittest.TestCase):
 
     @slow
     @require_bnb
-    @unittest.skip("Un-skip in the next transformers release")
     def test_dipatch_model_fp4_simple(self):
         """Tests that `dispatch_model` quantizes fp4 layers"""
         from huggingface_hub import hf_hub_download


### PR DESCRIPTION
# What does this PR do?

As per title ! 
Some TODOs were left for the next transformers release, this PR fixes them

note for the

```bash
remove the positional arg on the next `transformers` release
```

task it is irrelevant, we still need to use positional arguments for `replace_with_bnb_linear` method, check the signature of that method: https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/bitsandbytes.py#L184

cc @muellerzr 