### PR TITLE
Protect tensorflow dependency

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -39,11 +39,6 @@ from .utils import (
 _available_trackers = []
 
 if is_tensorboard_available():
-    try:
-        from torch.utils import tensorboard
-    except ModuleNotFoundError:
-        import tensorboardX as tensorboard
-
     _available_trackers.append(LoggerType.TENSORBOARD)
 
 if is_wandb_available():
@@ -185,6 +180,11 @@ class TensorBoardTracker(GeneralTracker):
 
     @on_main_process
     def __init__(self, run_name: str, logging_dir: Union[str, os.PathLike], **kwargs):
+        if is_tensorboard_available():
+            try:
+                from torch.utils import tensorboard
+            except ModuleNotFoundError:
+                import tensorboardX as tensorboard
         super().__init__()
         self.run_name = run_name
         self.logging_dir = os.path.join(logging_dir, run_name)


### PR DESCRIPTION
# What does this PR do ? 
This PR protect the tensorflow dependency, so that we import tensorflow only when it is needed ! This should speed-up the import by ~2s. See similar PR for [transformers](https://github.com/huggingface/transformers/pull/26106#issuecomment-1715318226). 

To get the dashboard : 
```py
pip install tuna
python -X importtime -c "import accelerate" 2> accelerate-import-profile.log
tuna accelerate-import-profile.log
```

cc @younesbelkada

<img width="1438" alt="Screenshot 2023-09-12 at 11 38 46 AM" src="https://github.com/huggingface/accelerate/assets/57196510/93938233-3fe3-4935-84ac-ba1372437723">
