### PR TITLE
Create lazy-style import decorator

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -23,6 +23,8 @@ from typing import Any, Dict, List, Optional, Union
 
 import yaml
 
+import accelerate.utils.imports as imports
+
 from .logging import get_logger
 from .state import PartialState
 from .utils import (
@@ -35,8 +37,6 @@ from .utils import (
     listify,
     require_import,
 )
-
-import accelerate.utils.imports as imports
 
 
 _available_trackers = []
@@ -265,6 +265,7 @@ class TensorBoardTracker(GeneralTracker):
         """
         self.writer.close()
         logger.debug("TensorBoard writer closed")
+
 
 class WandBTracker(GeneralTracker):
     """
@@ -531,6 +532,7 @@ class AimTracker(GeneralTracker):
         """
         self.writer.close()
 
+
 class MLflowTracker(GeneralTracker):
     """
     A `Tracker` class that supports `mlflow`. Should be initialized at the start of your script.
@@ -561,7 +563,6 @@ class MLflowTracker(GeneralTracker):
 
     name = "mlflow"
     requires_logging_directory = False
-
 
     @on_main_process
     @require_import("mlflow")

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -485,7 +485,6 @@ class AimTracker(GeneralTracker):
     @on_main_process
     @require_import("from aim import Run")
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
-        super().__init__()
         global Run
         Run = imports.Run
 
@@ -580,7 +579,6 @@ class MLflowTracker(GeneralTracker):
         run_name: Optional[str] = None,
         description: Optional[str] = None,
     ):
-        super().__init__()
         global mlflow
         mlflow = imports.mlflow
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -177,10 +177,11 @@ class TensorBoardTracker(GeneralTracker):
     @require_import("import torch.utils.tensorboard as tensorboard", "import tensorboardX as tensorboard")
     def __init__(self, run_name: str, logging_dir: Union[str, os.PathLike], **kwargs):
         super().__init__()
-        self.run_name = run_name
-        self.logging_dir = os.path.join(logging_dir, run_name)
         global tensorboard
         tensorboard = imports.tensorboard
+
+        self.run_name = run_name
+        self.logging_dir = os.path.join(logging_dir, run_name)
         self.writer = tensorboard.SummaryWriter(self.logging_dir, **kwargs)
         logger.debug(f"Initialized TensorBoard project {self.run_name} logging to {self.logging_dir}")
         logger.debug(
@@ -286,9 +287,10 @@ class WandBTracker(GeneralTracker):
     @require_import("wandb")
     def __init__(self, run_name: str, **kwargs):
         super().__init__()
-        self.run_name = run_name
         global wandb
         wandb = imports.wandb
+
+        self.run_name = run_name
         self.run = wandb.init(project=self.run_name, **kwargs)
         logger.debug(f"Initialized WandB project {self.run_name}")
         logger.debug(
@@ -309,6 +311,7 @@ class WandBTracker(GeneralTracker):
                 Values to be stored as initial hyperparameters as key-value pairs. The values need to have type `bool`,
                 `str`, `float`, `int`, or `None`.
         """
+        wandb.config.update(values, allow_val_change=True)
         logger.debug("Stored initial configuration hyperparameters to WandB")
 
     @on_main_process
@@ -403,11 +406,10 @@ class CometMLTracker(GeneralTracker):
     @require_import("from comet_ml import Experiment")
     def __init__(self, run_name: str, **kwargs):
         super().__init__()
-        self.run_name = run_name
-
         global Experiment
         Experiment = imports.Experiment
 
+        self.run_name = run_name
         self.writer = Experiment(project_name=run_name, **kwargs)
         logger.debug(f"Initialized CometML project {self.run_name}")
         logger.debug(
@@ -483,9 +485,11 @@ class AimTracker(GeneralTracker):
     @on_main_process
     @require_import("from aim import Run")
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
-        self.run_name = run_name
+        super().__init__()
         global Run
         Run = imports.Run
+
+        self.run_name = run_name
         self.writer = Run(repo=logging_dir, **kwargs)
         self.writer.name = self.run_name
         logger.debug(f"Initialized Aim project {self.run_name}")
@@ -576,8 +580,10 @@ class MLflowTracker(GeneralTracker):
         run_name: Optional[str] = None,
         description: Optional[str] = None,
     ):
+        super().__init__()
         global mlflow
         mlflow = imports.mlflow
+
         experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME", experiment_name)
         run_id = os.getenv("MLFLOW_RUN_ID", run_id)
         tags = os.getenv("MLFLOW_TAGS", tags)

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -64,6 +64,7 @@ from .imports import (
     is_transformers_available,
     is_wandb_available,
     is_xpu_available,
+    require_import,
 )
 from .modeling import (
     calculate_maximum_sizes,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -330,14 +330,17 @@ def require_import(import_str: str, secondary_import_str: str = None):
             nonlocal import_str, secondary_import_str
             if len(import_str.split(" ")) == 1:
                 import_str = f"import {import_str}"
-            if len(secondary_import_str.split(" ")) == 1:
+            if secondary_import_str is not None and len(secondary_import_str.split(" ")) == 1:
                 secondary_import_str = f"import {secondary_import_str}"
             try:
                 parsed_import = ast.parse(import_str).body[0]
                 _import_module(parsed_import)
             except ModuleNotFoundError:
-                parsed_import = ast.parse(secondary_import_str).body[0]
-                _import_module(parsed_import)
+                if secondary_import_str is not None:
+                    parsed_import = ast.parse(secondary_import_str).body[0]
+                    _import_module(parsed_import)
+                else:
+                    raise
 
             function(*args, **kwargs)
 

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -298,19 +298,19 @@ def is_xpu_available(check_device=False):
             return False
     return hasattr(torch, "xpu") and torch.xpu.is_available()
 
-def require_import(import_str:str, secondary_import_str:str=None):
+
+def require_import(import_str: str, secondary_import_str: str = None):
     """
-    Decorator which checks that the module in `import_str`
-    is available, and then imports it, making it 
-    available on the global scope.
+    Decorator which checks that the module in `import_str` is available, and then imports it, making it available on
+    the global scope.
 
     Args:
-        import_str (`str`): 
+        import_str (`str`):
             The import statement to check and execute.
-        secondary_import_str (`str`, *optional*): 
-            A secondary import statement to check and execute if `import_str` fails
-            via `ModuleNotFoundError`.
+        secondary_import_str (`str`, *optional*):
+            A secondary import statement to check and execute if `import_str` fails via `ModuleNotFoundError`.
     """
+
     def _import_module(parsed_import):
         name = parsed_import.names[0]
         # First check `import x` syntax
@@ -319,20 +319,19 @@ def require_import(import_str:str, secondary_import_str:str=None):
                 globals()[name.name] = importlib.import_module(name.name)
             else:
                 globals()[name.asname] = importlib.import_module(name.name)
-        
+
         # Then check for `from x import y` syntax
         elif isinstance(parsed_import, ast.ImportFrom):
             globals()[name.name] = importlib.import_module(parsed_import.module)
-            
-    
+
     def decorator(function):
         @wraps(function)
         def inner(*args, **kwargs):
             nonlocal import_str, secondary_import_str
             if len(import_str.split(" ")) == 1:
-                import_str = f'import {import_str}'
+                import_str = f"import {import_str}"
             if len(secondary_import_str.split(" ")) == 1:
-                secondary_import_str = f'import {secondary_import_str}'
+                secondary_import_str = f"import {secondary_import_str}"
             # try:
             parsed_import = ast.parse(import_str).body[0]
             _import_module(parsed_import)
@@ -341,5 +340,7 @@ def require_import(import_str:str, secondary_import_str:str=None):
             # except ModuleNotFoundError:
             #     parsed_import = ast.parse(secondary_import_str).body[0]
             #     _import_module(parsed_import)
+
         return inner
+
     return decorator

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -332,14 +332,14 @@ def require_import(import_str: str, secondary_import_str: str = None):
                 import_str = f"import {import_str}"
             if len(secondary_import_str.split(" ")) == 1:
                 secondary_import_str = f"import {secondary_import_str}"
-            # try:
-            parsed_import = ast.parse(import_str).body[0]
-            _import_module(parsed_import)
+            try:
+                parsed_import = ast.parse(import_str).body[0]
+                _import_module(parsed_import)
+            except ModuleNotFoundError:
+                parsed_import = ast.parse(secondary_import_str).body[0]
+                _import_module(parsed_import)
 
             function(*args, **kwargs)
-            # except ModuleNotFoundError:
-            #     parsed_import = ast.parse(secondary_import_str).body[0]
-            #     _import_module(parsed_import)
 
         return inner
 


### PR DESCRIPTION
# What does this PR do?

This PR creates a lazy-esq style import decorator designed to be used with integrations that can optionally be there and require certain imports globally. This further improves on https://github.com/huggingface/accelerate/pull/1959, with a speed difference shown below (tl;dr 45% speedup):

### Before change, with all tracking modules available:

![image](https://github.com/huggingface/accelerate/assets/7831895/80e4421e-30d9-49e9-8218-de06310841aa)

### After change:

![image](https://github.com/huggingface/accelerate/assets/7831895/f585dcb5-531c-4006-ad71-5bd1befc0827)

## How does it work?

This operates by writing a decorator with the exact module to be imported later. In the same function that is decorated, `global {mymodule}` should be declared and assigned to `accelerate.utils.imports.{mymodule}`, where it'll be imported from.

The main con here is we lose static checking, however the argument here is immense speedup and flexibility, while reserving this *just* for integrations.

## Fixes # (issue)

Lays foundation to solve https://github.com/huggingface/accelerate/issues/1952

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @SunMarc 