### PR TITLE
Better guards for slow imports

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -99,8 +99,6 @@ from .utils.constants import FSDP_PYTORCH_VERSION
 
 
 if is_deepspeed_available():
-    import deepspeed
-
     from .utils import (
         DeepSpeedEngineWrapper,
         DeepSpeedOptimizerWrapper,
@@ -1471,6 +1469,7 @@ class Accelerator:
         return model
 
     def _prepare_deepspeed(self, *args):
+        import deepspeed
         deepspeed_plugin = self.state.deepspeed_plugin
 
         is_dataloader_present = any(isinstance(obj, torch.utils.data.DataLoader) for obj in args)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1470,6 +1470,7 @@ class Accelerator:
 
     def _prepare_deepspeed(self, *args):
         import deepspeed
+
         deepspeed_plugin = self.state.deepspeed_plugin
 
         is_dataloader_present = any(isinstance(obj, torch.utils.data.DataLoader) for obj in args)

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -284,8 +284,9 @@ class WandBTracker(GeneralTracker):
     def __init__(self, run_name: str, **kwargs):
         super().__init__()
         self.run_name = run_name
-       
+
         import wandb
+
         self.run = wandb.init(project=self.run_name, **kwargs)
         logger.debug(f"Initialized WandB project {self.run_name}")
         logger.debug(
@@ -307,6 +308,7 @@ class WandBTracker(GeneralTracker):
                 `str`, `float`, `int`, or `None`.
         """
         import wandb
+
         wandb.config.update(values, allow_val_change=True)
         logger.debug("Stored initial configuration hyperparameters to WandB")
 
@@ -341,6 +343,7 @@ class WandBTracker(GeneralTracker):
                 Additional key word arguments passed along to the `wandb.log` method.
         """
         import wandb
+
         for k, v in values.items():
             self.log({k: [wandb.Image(image) for image in v]}, step=step, **kwargs)
         logger.debug("Successfully logged images to WandB")
@@ -372,6 +375,7 @@ class WandBTracker(GeneralTracker):
                 The run step. If included, the log will be affiliated with this step.
         """
         import wandb
+
         values = {table_name: wandb.Table(columns=columns, data=data, dataframe=dataframe)}
         self.log(values, step=step, **kwargs)
 
@@ -406,6 +410,7 @@ class CometMLTracker(GeneralTracker):
         self.run_name = run_name
 
         from comet_ml import Experiment
+
         self.writer = Experiment(project_name=run_name, **kwargs)
         logger.debug(f"Initialized CometML project {self.run_name}")
         logger.debug(
@@ -483,6 +488,7 @@ class AimTracker(GeneralTracker):
         self.run_name = run_name
 
         from aim import Run
+
         self.writer = Run(repo=logging_dir, **kwargs)
         self.writer.name = self.run_name
         logger.debug(f"Initialized Aim project {self.run_name}")
@@ -581,6 +587,7 @@ class MLflowTracker(GeneralTracker):
         nested_run = os.getenv("MLFLOW_NESTED_RUN", nested_run)
 
         import mlflow
+
         exps = mlflow.search_experiments(filter_string=f"name = '{experiment_name}'")
         if len(exps) > 0:
             if len(exps) > 1:
@@ -621,6 +628,7 @@ class MLflowTracker(GeneralTracker):
                 Values to be stored as initial hyperparameters as key-value pairs.
         """
         import mlflow
+
         for name, value in list(values.items()):
             # internally, all values are converted to str in MLflow
             if len(str(value)) > mlflow.utils.validation.MAX_PARAM_VAL_LENGTH:
@@ -659,6 +667,7 @@ class MLflowTracker(GeneralTracker):
                     "MLflow's log_metric() only accepts float and int types so we dropped this attribute."
                 )
         import mlflow
+
         mlflow.log_metrics(metrics, step=step)
         logger.debug("Successfully logged to mlflow")
 
@@ -668,6 +677,7 @@ class MLflowTracker(GeneralTracker):
         End the active MLflow run.
         """
         import mlflow
+
         mlflow.end_run()
 
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -42,23 +42,15 @@ if is_tensorboard_available():
     _available_trackers.append(LoggerType.TENSORBOARD)
 
 if is_wandb_available():
-    import wandb
-
     _available_trackers.append(LoggerType.WANDB)
 
 if is_comet_ml_available():
-    from comet_ml import Experiment
-
     _available_trackers.append(LoggerType.COMETML)
 
 if is_aim_available():
-    from aim import Run
-
     _available_trackers.append(LoggerType.AIM)
 
 if is_mlflow_available():
-    import mlflow
-
     _available_trackers.append(LoggerType.MLFLOW)
 
 logger = get_logger(__name__)
@@ -180,11 +172,10 @@ class TensorBoardTracker(GeneralTracker):
 
     @on_main_process
     def __init__(self, run_name: str, logging_dir: Union[str, os.PathLike], **kwargs):
-        if is_tensorboard_available():
-            try:
-                from torch.utils import tensorboard
-            except ModuleNotFoundError:
-                import tensorboardX as tensorboard
+        try:
+            from torch.utils import tensorboard
+        except ModuleNotFoundError:
+            import tensorboardX as tensorboard
         super().__init__()
         self.run_name = run_name
         self.logging_dir = os.path.join(logging_dir, run_name)
@@ -293,6 +284,8 @@ class WandBTracker(GeneralTracker):
     def __init__(self, run_name: str, **kwargs):
         super().__init__()
         self.run_name = run_name
+       
+        import wandb
         self.run = wandb.init(project=self.run_name, **kwargs)
         logger.debug(f"Initialized WandB project {self.run_name}")
         logger.debug(
@@ -313,6 +306,7 @@ class WandBTracker(GeneralTracker):
                 Values to be stored as initial hyperparameters as key-value pairs. The values need to have type `bool`,
                 `str`, `float`, `int`, or `None`.
         """
+        import wandb
         wandb.config.update(values, allow_val_change=True)
         logger.debug("Stored initial configuration hyperparameters to WandB")
 
@@ -346,6 +340,7 @@ class WandBTracker(GeneralTracker):
             kwargs:
                 Additional key word arguments passed along to the `wandb.log` method.
         """
+        import wandb
         for k, v in values.items():
             self.log({k: [wandb.Image(image) for image in v]}, step=step, **kwargs)
         logger.debug("Successfully logged images to WandB")
@@ -376,7 +371,7 @@ class WandBTracker(GeneralTracker):
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
         """
-
+        import wandb
         values = {table_name: wandb.Table(columns=columns, data=data, dataframe=dataframe)}
         self.log(values, step=step, **kwargs)
 
@@ -409,6 +404,8 @@ class CometMLTracker(GeneralTracker):
     def __init__(self, run_name: str, **kwargs):
         super().__init__()
         self.run_name = run_name
+
+        from comet_ml import Experiment
         self.writer = Experiment(project_name=run_name, **kwargs)
         logger.debug(f"Initialized CometML project {self.run_name}")
         logger.debug(
@@ -484,6 +481,8 @@ class AimTracker(GeneralTracker):
     @on_main_process
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
         self.run_name = run_name
+
+        from aim import Run
         self.writer = Run(repo=logging_dir, **kwargs)
         self.writer.name = self.run_name
         logger.debug(f"Initialized Aim project {self.run_name}")
@@ -581,6 +580,7 @@ class MLflowTracker(GeneralTracker):
 
         nested_run = os.getenv("MLFLOW_NESTED_RUN", nested_run)
 
+        import mlflow
         exps = mlflow.search_experiments(filter_string=f"name = '{experiment_name}'")
         if len(exps) > 0:
             if len(exps) > 1:
@@ -620,7 +620,7 @@ class MLflowTracker(GeneralTracker):
             values (`dict`):
                 Values to be stored as initial hyperparameters as key-value pairs.
         """
-
+        import mlflow
         for name, value in list(values.items()):
             # internally, all values are converted to str in MLflow
             if len(str(value)) > mlflow.utils.validation.MAX_PARAM_VAL_LENGTH:
@@ -658,7 +658,7 @@ class MLflowTracker(GeneralTracker):
                     f'MLflowTracker is attempting to log a value of "{v}" of type {type(v)} for key "{k}" as a metric. '
                     "MLflow's log_metric() only accepts float and int types so we dropped this attribute."
                 )
-
+        import mlflow
         mlflow.log_metrics(metrics, step=step)
         logger.debug("Successfully logged to mlflow")
 
@@ -667,6 +667,7 @@ class MLflowTracker(GeneralTracker):
         """
         End the active MLflow run.
         """
+        import mlflow
         mlflow.end_run()
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -27,10 +27,6 @@ from .imports import is_deepspeed_available, is_safetensors_available, is_tpu_av
 from .transformer_engine import convert_model
 from .versions import is_torch_version
 
-
-if is_deepspeed_available():
-    from deepspeed import DeepSpeedEngine
-
 if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
@@ -68,6 +64,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True):
         model = model._orig_mod
 
     if is_deepspeed_available():
+        from deepspeed import DeepSpeedEngine
         options += (DeepSpeedEngine,)
 
     if is_torch_version(">=", FSDP_PYTORCH_VERSION):

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -27,6 +27,7 @@ from .imports import is_deepspeed_available, is_safetensors_available, is_tpu_av
 from .transformer_engine import convert_model
 from .versions import is_torch_version
 
+
 if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
@@ -65,6 +66,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True):
 
     if is_deepspeed_available():
         from deepspeed import DeepSpeedEngine
+
         options += (DeepSpeedEngine,)
 
     if is_torch_version(">=", FSDP_PYTORCH_VERSION):


### PR DESCRIPTION
# What does this PR do?

This PR guards slower imports better, namely the trackers and especially `deepspeed` across the framework.

Alternative to https://github.com/huggingface/accelerate/pull/1961, unless we decide that it's getting too repetitive and we want a wrapper 

Fixes # (issue)

Resolves https://github.com/huggingface/accelerate/issues/1952

## Speedup

Before, with DeepSpeed installed too:

![image](https://github.com/huggingface/accelerate/assets/7831895/f8c28d67-55f0-4eae-85a3-f060a427ceab)

After: 
![image](https://github.com/huggingface/accelerate/assets/7831895/6e66dc37-de2e-4314-87c6-df4c2ce62cae)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @BenjaminBossan 