### PR TITLE
Reduce memory by using `all_gather_into_tensor`

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -299,7 +299,7 @@ def _gpu_gather(tensor):
             # differs from `all_gather` for better efficiency,
             # and we rely on the number of items in the tensor
             # rather than its direct shape
-            output_tensors = torch.zeros(
+            output_tensors = torch.empty(
                 state.num_processes * tensor.numel(),
                 dtype=tensor.dtype,
                 device=state.device,

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -280,6 +280,8 @@ def _tpu_gather(tensor):
 
 
 def _gpu_gather(tensor):
+    state = PartialState()
+
     def _gpu_gather_one(tensor):
         if tensor.ndim == 0:
             tensor = tensor.clone()[None]
@@ -288,7 +290,6 @@ def _gpu_gather(tensor):
         if not tensor.is_contiguous():
             tensor = tensor.contiguous()
 
-        state = PartialState()
         if state.backend is not None and state.backend != "gloo":
             output_tensors = torch.zeros(
                 state.num_processes * tensor.numel(),

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -295,7 +295,7 @@ def _gpu_gather(tensor):
             tensor = tensor.contiguous()
 
         if state.backend is not None and state.backend != "gloo":
-            # We use `zeros` as `all_gather_into_tensor` slightly
+            # We use `empty` as `all_gather_into_tensor` slightly
             # differs from `all_gather` for better efficiency,
             # and we rely on the number of items in the tensor
             # rather than its direct shape

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -296,9 +296,6 @@ def _gpu_gather(tensor):
         )
         torch.distributed.all_gather_into_tensor(output_tensors, tensor)
         return output_tensors.view(-1, *tensor.size()[1:])
-        # output_tensors = [torch.empty_like(tensor) for _ in range(torch.distributed.get_world_size())]
-        # torch.distributed.all_gather(output_tensors, tensor)
-        # return torch.cat(output_tensors, dim=0)
 
     return recursively_apply(_gpu_gather_one, tensor, error_on_other_type=True)
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -296,7 +296,9 @@ def _gpu_gather(tensor):
 
         if state.backend is not None and state.backend != "gloo":
             # We use `zeros` as `all_gather_into_tensor` slightly
-            # differs from `all_gather` for better efficiency
+            # differs from `all_gather` for better efficiency,
+            # and we rely on the number of items in the tensor
+            # rather than its direct shape
             output_tensors = torch.zeros(
                 state.num_processes * tensor.numel(),
                 dtype=tensor.dtype,

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -287,9 +287,18 @@ def _gpu_gather(tensor):
         # Can only gather contiguous tensors
         if not tensor.is_contiguous():
             tensor = tensor.contiguous()
-        output_tensors = [torch.empty_like(tensor) for _ in range(torch.distributed.get_world_size())]
-        torch.distributed.all_gather(output_tensors, tensor)
-        return torch.cat(output_tensors, dim=0)
+
+        state = PartialState()
+        output_tensors = torch.zeros(
+            state.num_processes * tensor.numel(),
+            dtype=tensor.dtype,
+            device=state.device,
+        )
+        torch.distributed.all_gather_into_tensor(output_tensors, tensor)
+        return output_tensors.view(-1, *tensor.size()[1:])
+        # output_tensors = [torch.empty_like(tensor) for _ in range(torch.distributed.get_world_size())]
+        # torch.distributed.all_gather(output_tensors, tensor)
+        # return torch.cat(output_tensors, dim=0)
 
     return recursively_apply(_gpu_gather_one, tensor, error_on_other_type=True)
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -290,7 +290,7 @@ def _gpu_gather(tensor):
 
         state = PartialState()
 
-        if state.backend != "gloo":
+        if state.backend is not None and state.backend != "gloo":
             output_tensors = torch.zeros(
                 state.num_processes * tensor.numel(),
                 dtype=tensor.dtype,

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -295,6 +295,8 @@ def _gpu_gather(tensor):
             tensor = tensor.contiguous()
 
         if state.backend is not None and state.backend != "gloo":
+            # We use `zeros` as `all_gather_into_tensor` slightly
+            # differs from `all_gather` for better efficiency
             output_tensors = torch.zeros(
                 state.num_processes * tensor.numel(),
                 dtype=tensor.dtype,


### PR DESCRIPTION
# What does this PR do?

torch 1.13 introduced publicly `all_gather_into_tensor` (before this was `_all_gather_base`) which is a much more memory efficient version of gather. One thing to note mentioned in the PR [here](https://github.com/pytorch/pytorch/pull/85686) is they did not have this be the base of `gather`, since it handles uneven inputs automatically. Since Accelerate does this separately and checks, we can safely use this API. [Original DeepSpeed PR I discovered showing this](https://github.com/microsoft/DeepSpeed/pull/4282)

For a general idea of just how much memory can be stored, I ran a small simple test:

```python
import time
import torch
from accelerate import PartialState
from accelerate.utils import gather

def convert_bytes(size):
    "Converts `size` from bytes to the largest possible unit"
    for x in ["bytes", "KB", "MB", "GB", "TB"]:
        if size < 1024.0:
            return f"{round(size, 2)} {x}"
        size /= 1024.0

    return f"{round(size, 2)} PB"

state = PartialState()
tensor = torch.rand((64, 224, 224, 64), device=state.device)

# Using `PartialState`
start_time = time.time()
tensor = gather(tensor)
end_time = time.time()

with state.main_process_first():
    print(f"Process {state.process_index} memory allocated after: {convert_bytes(torch.cuda.max_memory_allocated(state.device))}")
    print(f"Process {state.process_index} time: {end_time - start_time}")
```

The results can be summarized as such:

**Before**:
 Total CUDA memory allocated: 3.83gb

**After**:
Total CUDA memory allocated: *_2.3gb_*


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @LysandreJik 