### PR TITLE
Fix model copy after `dispatch_model`

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -156,16 +156,17 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False)
     module._hf_hook = hook
 
     @functools.wraps(old_forward)
-    def new_forward(*args, **kwargs):
-        args, kwargs = module._hf_hook.pre_forward(module, *args, **kwargs)
-        if module._hf_hook.no_grad:
+    def new_forward(self, *args, **kwargs):
+        args, kwargs = self._hf_hook.pre_forward(self, *args, **kwargs)
+        if self._hf_hook.no_grad:
             with torch.no_grad():
-                output = old_forward(*args, **kwargs)
+                output = self._old_forward(*args, **kwargs)
         else:
-            output = old_forward(*args, **kwargs)
-        return module._hf_hook.post_forward(module, output)
+            output = self._old_forward(*args, **kwargs)
+        return self._hf_hook.post_forward(self, output)
 
-    module.forward = new_forward
+    module.forward = new_forward.__get__(module)
+
     return module
 
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -155,7 +155,6 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False)
     module = hook.init_hook(module)
     module._hf_hook = hook
 
-    @functools.wraps(old_forward)
     def new_forward(self, *args, **kwargs):
         args, kwargs = self._hf_hook.pre_forward(self, *args, **kwargs)
         if self._hf_hook.no_grad:
@@ -165,7 +164,7 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False)
             output = self._old_forward(*args, **kwargs)
         return self._hf_hook.post_forward(self, output)
 
-    module.forward = new_forward.__get__(module)
+    module.forward = functools.update_wrapper(functools.partial(new_forward, module), old_forward)
 
     return module
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -155,14 +155,14 @@ def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False)
     module = hook.init_hook(module)
     module._hf_hook = hook
 
-    def new_forward(self, *args, **kwargs):
-        args, kwargs = self._hf_hook.pre_forward(self, *args, **kwargs)
-        if self._hf_hook.no_grad:
+    def new_forward(module, *args, **kwargs):
+        args, kwargs = module._hf_hook.pre_forward(module, *args, **kwargs)
+        if module._hf_hook.no_grad:
             with torch.no_grad():
-                output = self._old_forward(*args, **kwargs)
+                output = module._old_forward(*args, **kwargs)
         else:
-            output = self._old_forward(*args, **kwargs)
-        return self._hf_hook.post_forward(self, output)
+            output = module._old_forward(*args, **kwargs)
+        return module._hf_hook.post_forward(module, output)
 
     module.forward = functools.update_wrapper(functools.partial(new_forward, module), old_forward)
 

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+import copy
 import os
 import unittest
 from tempfile import TemporaryDirectory
@@ -43,6 +43,18 @@ class ModelForTest(nn.Module):
 
     def forward(self, x):
         return self.linear2(self.batchnorm(self.linear1(x)))
+
+
+class ModelForTestCopy(nn.Module):
+    def __init__(self, id: int):
+        super().__init__()
+        self.id = id
+        self.linear1 = nn.Linear(3, 4)
+        self.batchnorm = nn.BatchNorm1d(4)
+        self.linear2 = nn.Linear(4, 5)
+
+    def forward(self, x):
+        return self.linear2(self.batchnorm(self.linear1(x))), self.id
 
 
 class ModelForTestTiedWeights(nn.Module):
@@ -324,6 +336,24 @@ class BigModelingTester(unittest.TestCase):
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             output = model(x)
             self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+
+    @require_cuda
+    def test_dispatch_model_copy(self):
+        original_model = ModelForTestCopy(id=1)
+        device_map = {"linear1": 0, "batchnorm": "cpu", "linear2": 0}
+
+        x = torch.randn(2, 3)
+        expected, original_output_id = original_model(x)
+
+        dispatch_model(original_model, device_map)
+
+        copied_model = copy.deepcopy(original_model)
+        copied_model.id = 2
+        output, copied_output_id = copied_model(x)
+
+        self.assertEqual(original_model.id, original_output_id)
+        self.assertEqual(copied_model.id, copied_output_id)
+        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
     @require_cuda
     def test_dispatch_model_move_offloaded_model(self):

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -353,6 +353,7 @@ class BigModelingTester(unittest.TestCase):
 
         self.assertEqual(original_model.id, original_output_id)
         self.assertEqual(copied_model.id, copied_output_id)
+        self.assertFalse(copied_model.linear1.forward is original_model.linear1.forward)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
     @require_cuda


### PR DESCRIPTION
# What does this PR do?

Fixes #1835 where a model dispatched with `dispatch_model` was unable to be properly copied with `copy.deepcopy`. Specifically, the copied model would incorrectly still reference the align device hook forward function of the original model, rather than its own forward function. This PR includes a fix to this issue as well as a test to validate the fix.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @sgugger