### PR TITLE
Safely end training even if trackers weren't initialized

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2496,6 +2496,8 @@ class Accelerator:
         >>> accelerator.end_training()
         ```
         """
+        if not hasattr(self, "trackers"):
+            return
         for tracker in self.trackers:
             tracker.finish()
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

If you create an instance of `Accelerator()` without logging to a tracker, and then call `end_training` (which would be common in development/debugging), the accelerator shouldn't crash if there aren't trackers. Since `self.trackers` isn't initialized in the `__init__` of the class, this is possible


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?

Tested by running the following
```
>>> a = Accelerator()
>>> a.end_training()
```

Made sure this wasn't thrown 
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ".venv/lib/python3.10/site-packages/accelerate/accelerator.py", line 615, in _inner
    return PartialState().on_main_process(function)(*args, **kwargs)
  File ".venv/lib/python3.10/site-packages/accelerate/accelerator.py", line 2499, in end_training
    for tracker in self.trackers:
AttributeError: 'Accelerator' object has no attribute 'trackers'
```

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->