### PR TITLE
Ignore torch.autocast for mixed precision when FSDP is used

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1382,7 +1382,7 @@ class Accelerator:
         elif device_placement and not self.verify_device_map(model):
             model = model.to(self.device)
 
-        if self.native_amp:
+        if self.native_amp and self.distributed_type != DistributedType.FSDP:
             model._original_forward = model.forward
             model_forward_func = model.forward.__func__ if hasattr(model.forward, "__func__") else model.forward
             autocast_context = get_mixed_precision_context_manager(self.native_amp, self.autocast_handler)


### PR DESCRIPTION
# What does this PR do?

FSDP supports mixed precision using [MixedPrecision](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision) class, it does not need to wrap forward function with `torch.autocast`.

The code statement of ignoring this wrapping was added at accelerate v0.22.0, but now removed at v0.23.0

Related PRs are:
- #1777 (Added)
- #1919 (Removed)

I can't find any information about why it is added or removed.

In fact, mixed precision works well even without `torch.autocast`, and even if it is needed, it does not work properly in the current version.

So, I think it need to apply one of the following two options:

1. Add `self.distributed_type != DistributedType.FSDP` in [condition](https://github.com/huggingface/accelerate/blob/main/src/accelerate/accelerator.py#L1385) not to use `torch.autocast`
2. Add `DistributedType.FSDP` in [this file](https://github.com/huggingface/accelerate/blob/main/src/accelerate/utils/modeling.py#L1455-L1461)

The reason for 2 is that when FSDP is used, the `distributed_type` field is replaced with `DistribytedType.FSDP` in [this line](https://github.com/huggingface/accelerate/blob/main/src/accelerate/state.py#L767), so I think it needs to be added to support FSDP as well.

As a related issue, the MPT posted on Huggingface Hub uses the [LPNorm class](https://huggingface.co/mosaicml/mpt-7b/blob/main/norm.py#L14), but when learning with FSDP + bfloat16, the dtype changes before and after norm. It is occurred in version v0.23.0.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->