### PR TITLE
Fix integration CI

### DIFF
--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -53,7 +53,7 @@ jobs:
           git config --global --add safe.directory '*'
           git checkout main && git pull
           if [[ ${{ matrix.transformers-version }} = pypi ]]; then 
-            git checkout $(git describe --tags `git rev-list --tags --max-count=1`)
+            git checkout $(git tag --sort=taggerdate | tail -1)
           fi
           pip install .[torch,deepspeed-testing]
       

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           source activate accelerate
           git config --global --add safe.directory '*'
-          git checkout main && git pull
+          git checkout main && git pull && git fetch --tags
           if [[ ${{ matrix.transformers-version }} = pypi ]]; then 
             git checkout $(git tag --sort=taggerdate | tail -1)
           fi


### PR DESCRIPTION
# What does this PR do?

Fixes issue finding the last latest release from github for transformers, need a better way to search for it in case what happened last time happens again, where a release was made but not a *release branch*. This method will grab all actual existing tags and search for the latest one made/release.

Fixes # (issue)

Failing pypi integration tests on main. See [here](https://github.com/huggingface/accelerate/actions/runs/6484993725) for an example completed run


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 