### PR TITLE
Let drop_last modify `gather_for_metrics`

### DIFF
--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -221,16 +221,21 @@ def test_gather_for_metrics_with_iterable_dataset():
 
 def test_gather_for_metrics_drop_last():
     accelerator = Accelerator()
-    dataloader = DataLoader(range((10 * accelerator.num_processes) + 1), batch_size=5, drop_last=True)
+    per_device_batch_size = 5
+    num_items = (10 * accelerator.num_processes) + 1
+    dataloader = DataLoader(range(num_items), batch_size=per_device_batch_size, drop_last=True)
     dataloader = accelerator.prepare(dataloader)
 
     iterator = iter(dataloader)
     next(iterator)  # Skip first batch tensor([0, 1, 2, 3, 4], device='cuda:0')
     batch = next(iterator)
     gathered_items = accelerator.gather_for_metrics(batch)
+
+    # Should return a full set of complete batches from each GPU
+    num_expected_items = per_device_batch_size * accelerator.num_processes
     assert gathered_items.size(0) == (
-        5 * accelerator.num_processes
-    ), f"Expected number of items: {5*accelerator.num_processes}, Actual: {gathered_items.size(0)}"
+        num_expected_items
+    ), f"Expected number of items: {num_expected_items}, Actual: {gathered_items.size(0)}"
 
 
 def main():

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -230,7 +230,7 @@ def test_gather_for_metrics_drop_last():
     gathered_items = accelerator.gather_for_metrics(batch)
     assert gathered_items.size(0) == (
         5 * accelerator.num_processes
-    ), f"Expected number of items: {(5*accelerator.num_processes)}, Actual: {gathered_items.size(0)}"
+    ), f"Expected number of items: {5*accelerator.num_processes}, Actual: {gathered_items.size(0)}"
 
 
 def main():

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -28,7 +28,7 @@ from transformers import AutoModelForSequenceClassification, AutoTokenizer
 from accelerate import Accelerator
 from accelerate.data_loader import DataLoaderDispatcher
 from accelerate.test_utils import RegressionDataset, RegressionModel
-from accelerate.utils import set_seed
+from accelerate.utils import is_tpu_available, set_seed
 
 
 os.environ["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "true"
@@ -241,34 +241,34 @@ def main():
     else:
         datasets.utils.logging.set_verbosity_error()
         transformers.utils.logging.set_verbosity_error()
-    # # These are a bit slower so they should only be ran on the GPU or TPU
-    # if torch.cuda.is_available() or is_tpu_available():
-    #     if accelerator.is_local_main_process:
-    #         print("**Testing gather_for_metrics**")
-    #     for split_batches in [True, False]:
-    #         for dispatch_batches in [True, False]:
-    #             if accelerator.is_local_main_process:
-    #                 print(f"With: `split_batches={split_batches}`, `dispatch_batches={dispatch_batches}`")
-    #             test_mrpc(dispatch_batches, split_batches)
-    #             accelerator.state._reset_state()
-    #     print("test_gather_for_metrics_with_iterable_dataset")
-    #     test_gather_for_metrics_with_iterable_dataset()
-    #     print("test gather_for_metrics_with_non_tensor_objects_iterable_dataset")
-    #     test_gather_for_metrics_with_non_tensor_objects_iterable_dataset()
-    # if accelerator.is_local_main_process:
-    #     print("**Test torch metrics**")
-    # for split_batches in [True, False]:
-    #     for dispatch_batches in [True, False]:
-    #         accelerator = Accelerator(split_batches=split_batches, dispatch_batches=dispatch_batches)
-    #         if accelerator.is_local_main_process:
-    #             print(f"With: `split_batches={split_batches}`, `dispatch_batches={dispatch_batches}`, length=99")
-    #         test_torch_metrics(accelerator, 99)
-    #         accelerator.state._reset_state()
-    # if accelerator.is_local_main_process:
-    #     print("**Test last batch is not dropped when perfectly divisible**")
+    # These are a bit slower so they should only be ran on the GPU or TPU
+    if torch.cuda.is_available() or is_tpu_available():
+        if accelerator.is_local_main_process:
+            print("**Testing gather_for_metrics**")
+        for split_batches in [True, False]:
+            for dispatch_batches in [True, False]:
+                if accelerator.is_local_main_process:
+                    print(f"With: `split_batches={split_batches}`, `dispatch_batches={dispatch_batches}`")
+                test_mrpc(dispatch_batches, split_batches)
+                accelerator.state._reset_state()
+        print("test_gather_for_metrics_with_iterable_dataset")
+        test_gather_for_metrics_with_iterable_dataset()
+        print("test gather_for_metrics_with_non_tensor_objects_iterable_dataset")
+        test_gather_for_metrics_with_non_tensor_objects_iterable_dataset()
+    if accelerator.is_local_main_process:
+        print("**Test torch metrics**")
+    for split_batches in [True, False]:
+        for dispatch_batches in [True, False]:
+            accelerator = Accelerator(split_batches=split_batches, dispatch_batches=dispatch_batches)
+            if accelerator.is_local_main_process:
+                print(f"With: `split_batches={split_batches}`, `dispatch_batches={dispatch_batches}`, length=99")
+            test_torch_metrics(accelerator, 99)
+            accelerator.state._reset_state()
+    if accelerator.is_local_main_process:
+        print("**Test last batch is not dropped when perfectly divisible**")
     accelerator = Accelerator()
-    # test_torch_metrics(accelerator, 512)
-    # accelerator.state._reset_state()
+    test_torch_metrics(accelerator, 512)
+    accelerator.state._reset_state()
     if accelerator.is_local_main_process:
         print("**Test that `drop_last` is taken into account**")
     test_gather_for_metrics_drop_last()


### PR DESCRIPTION
# What does this PR do?

Ensures that if `drop_last=True`, the default remainder for the `GradientState` is utilized since we are just dropping the non-fitting batch anyways instead.

Fixes # (issue)

closes https://github.com/huggingface/accelerate/issues/2007

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @LysandreJik 