### PR TITLE
Change assignment during sub-module device alignment

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -266,7 +266,7 @@ class AlignDevicesHook(ModelHook):
             for name, _ in named_module_tensors(
                 module, include_buffers=self.offload_buffers, recurse=self.place_submodules
             ):
-                set_module_tensor_to_device(module, name, "meta")
+                set_module_tensor_to_device(module, name, "cpu")
             if not self.offload_buffers and self.execution_device is not None:
                 for name, _ in module.named_buffers(recurse=self.place_submodules):
                     set_module_tensor_to_device(module, name, self.execution_device)


### PR DESCRIPTION
# What does this PR do?

Fixes`peft` issue #868, https://github.com/huggingface/peft/issues/868

This PR addresses what appears to be a bug in the loading and merging/unloading of PeftModels.  

Background: After loading the necessary libraries,

```
!pip install -q -U bitsandbytes
!pip install -q -U git+https://github.com/huggingface/transformers.git
!pip install -q -U git+https://github.com/huggingface/peft.git
!pip install -q -U git+https://github.com/huggingface/accelerate.git
!pip install -q datasets==2.13.1 pyarrow==8.0.0 tokenizers==0.14.0 sentencepiece==0.1.99
```

attempting to call `PeftModel.from_pretrained()` on a model loaded using `device_map='auto'` as follows

```python
model = AutoModelForCausalLM.from_pretrained("emozilla/LLongMA-2-7b-flash", device_map='auto') 
lora_checkpoint = '/path/to/lora' # add path
model = PeftModel.from_pretrained(model, lora_checkpoint) 
```

results in many parameters being loaded as meta tensors with no data.  

Attempting to perform merging and unloading escapes explicit errors, but attempting to then load the merged model results in the error message "Cannot copy out of meta tensor; no data!" (`peft` issue #868).  This does not occur if `device_map='cpu'` is specified.

The root of the problem appears to be the choice to send module tensors to the "meta" device when enforcing a device alignment via `AlignDevicesHook` which would explain why it is present during LoRA application but typically not during the loading (and dispatching) of merged pretrained models.  

This PR allows for the loading and merging of LoRA parameters using the "auto" device map by assigning offloaded tensors to the CPU rather than the "meta" device. Doing so sends all sub-module tensors to one device (CPU) and thus aligns them, while saving the GPU memory that was specified by choosing the "auto" device map. 

Note that there may be good reason to recast offloaded parameters as meta tensors during device alignment, and if so I would be happy to work on an alternative approach to the problem.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone!
@pacman100 

