### PR TITLE
Warn when kernel version is too low on Linux

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -63,6 +63,7 @@ from .utils import (
     ProjectConfiguration,
     RNGType,
     TorchDynamoPlugin,
+    check_os_kernel,
     compare_versions,
     convert_model,
     convert_outputs_to_fp32,
@@ -469,6 +470,8 @@ class Accelerator:
 
         # Set a flag tensor for early stopping and other breakpoints
         self.flag_tensor = None
+
+        check_os_kernel()
 
     @property
     def use_distributed(self):

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -85,6 +85,9 @@ def get_logger(name: str, log_level: str = None):
 
     ```python
     >>> from accelerate.logging import get_logger
+    >>> from accelerate import Accelerator
+
+    >>> accelerator = Accelerator()
 
     >>> logger = get_logger(__name__)
 
@@ -95,9 +98,6 @@ def get_logger(name: str, log_level: str = None):
     >>> logger.info("My log")
     >>> logger.debug("My second log")
 
-    >>> from accelerate import Accelerator
-
-    >>> accelerator = Accelerator()
     >>> array = ["a", "b", "c", "d"]
     >>> letter_at_rank = array[accelerator.process_index]
     >>> logger.info(letter_at_rank, in_order=True)

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -87,10 +87,9 @@ def get_logger(name: str, log_level: str = None):
     >>> from accelerate.logging import get_logger
     >>> from accelerate import Accelerator
 
-    >>> accelerator = Accelerator()
-
     >>> logger = get_logger(__name__)
 
+    >>> accelerator = Accelerator()
     >>> logger.info("My log", main_process_only=False)
     >>> logger.debug("My log", main_process_only=True)
 

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -164,6 +164,7 @@ from .megatron_lm import prepare_optimizer as megatron_lm_prepare_optimizer
 from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
 from .memory import find_executable_batch_size, release_memory
 from .other import (
+    check_os_kernel,
     clear_environment,
     convert_bytes,
     extract_model_from_parallel,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -13,20 +13,27 @@
 # limitations under the License.
 
 import os
+import platform
+import re
 import socket
 from contextlib import contextmanager
 from functools import partial
 from types import MethodType
 
 import torch
+from packaging.version import Version
 
 from ..commands.config.default import write_basic_config  # noqa: F401
+from ..logging import get_logger
 from ..state import PartialState
 from .constants import FSDP_PYTORCH_VERSION
 from .dataclasses import DistributedType
 from .imports import is_deepspeed_available, is_safetensors_available, is_tpu_available
 from .transformer_engine import convert_model
 from .versions import is_torch_version
+
+
+logger = get_logger(__name__)
 
 
 if is_tpu_available(check_device=False):
@@ -252,3 +259,21 @@ def convert_bytes(size):
         size /= 1024.0
 
     return f"{round(size, 2)} PB"
+
+
+def check_os_kernel():
+    """Warns if the kernel version is below the recommended minimum on Linux."""
+    # see issue #1929
+    info = platform.uname()
+    system = info.system
+    if system != "Linux":
+        return
+
+    _, version, *_ = re.split(r"(\d+\.\d+\.\d+)", info.release)
+    min_version = "5.5.0"
+    if Version(version) < Version(min_version):
+        msg = (
+            f"Detected kernel version {version}, which is below the recommended minimum of {min_version}; this can "
+            "cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher."
+        )
+        logger.warning(msg, main_process_only=True)


### PR DESCRIPTION
# What does this PR do?

See #1929

On Linux with kernel version < 5.5, issues with hanging processes have been reported. It is not clear how to fix the issue, so instead we warn the user that they may encounter problems.

### Notes

As logging requires an initialized `PartialState`, the actual check happens at the end of `Accelerator.__init__`.

In a similar vein, the docstring of `get_logger` has been adjusted to first initialize the `Accelerator`, as it is not working as currently shown.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

@muellerzr 