### PR TITLE
Fix memory leak in fp8 causing OOM (and potentially 3x vRAM usage)

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1372,7 +1372,7 @@ class Accelerator:
                 with torch.no_grad():
                     convert_model(model)
                 model._converted_to_transformer_engine = True
-            model._original_forward = model.forward
+            #model._original_forward = model.forward
 
             kwargs = self.fp8_recipe_handler.to_kwargs() if self.fp8_recipe_handler is not None else {}
             if "fp8_format" in kwargs:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1406,7 +1406,6 @@ class Accelerator:
                 if (self.device.index is not None) or (current_device_index != 0):
                     raise ValueError(
                         "You can't train a model that has been loaded in 8-bit precision on a different device than the one "
-                        "you're training on. Make sure you loaded the model on the correct device using for example `device_map={'':torch.cuda.current_device()}"
                         "you're training on. Make sure you loaded the model on the correct device using for example `device_map={'':torch.cuda.current_device() or device_map={'':torch.xpu.current_device()}"
                     )
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1372,7 +1372,7 @@ class Accelerator:
                 with torch.no_grad():
                     convert_model(model)
                 model._converted_to_transformer_engine = True
-            #model._original_forward = model.forward
+            model._original_forward = model.forward
 
             kwargs = self.fp8_recipe_handler.to_kwargs() if self.fp8_recipe_handler is not None else {}
             if "fp8_format" in kwargs:

--- a/src/accelerate/utils/transformer_engine.py
+++ b/src/accelerate/utils/transformer_engine.py
@@ -36,15 +36,15 @@ def convert_model(model, to_transformer_engine=True, _convert_linear=True, _conv
             te_module = te.Linear(
                 module.in_features, module.out_features, bias=has_bias, params_dtype=module.weight.dtype
             )
-            te_module.weight.data = module.weight.data.clone()
+            module.weight.copy_(te_module.weight)
             if has_bias:
-                te_module.bias.data = module.bias.data.clone()
+                module.bias.copy_(te_module.bias)
 
             setattr(model, name, te_module)
         elif isinstance(module, nn.LayerNorm) and to_transformer_engine and _convert_ln:
             te_module = te.LayerNorm(module.normalized_shape[0], eps=module.eps, params_dtype=module.weight.dtype)
-            te_module.weight.data = module.weight.data.clone()
-            te_module.bias.data = module.bias.data.clone()
+            module.weight.copy_(te_module.weight)
+            module.bias.copy_(te_module.bias)
 
             setattr(model, name, te_module)
         elif isinstance(module, te.Linear) and not to_transformer_engine and _convert_linear:
@@ -52,15 +52,15 @@ def convert_model(model, to_transformer_engine=True, _convert_linear=True, _conv
             new_module = nn.Linear(
                 module.in_features, module.out_features, bias=has_bias, params_dtype=module.weight.dtype
             )
-            new_module.weight.data = module.weight.data.clone()
+            module.weight.copy_(new_module.weight)
             if has_bias:
-                new_module.bias.data = module.bias.data.clone()
+                module.bias.copy_(new_module.bias)
 
             setattr(model, name, new_module)
         elif isinstance(module, te.LayerNorm) and not to_transformer_engine and _convert_ln:
             new_module = nn.LayerNorm(module.normalized_shape[0], eps=module.eps, params_dtype=module.weight.dtype)
-            new_module.weight.data = module.weight.data.clone()
-            new_module.bias.data = module.bias.data.clone()
+            module.weight.copy_(new_module.weight)
+            module.bias.copy_(new_module.bias)
 
             setattr(model, name, new_module)
         else:


### PR DESCRIPTION
# What does this PR do?

Doing `.copy()` like we were before leads to a *huge* memory leak during `fp8`, and also putting the model on CUDA *after* converting the layers can reduce some memory.

Example benchmark:
Model: `"meta-llama/Llama-2-7b-hf"`
Note: on FP8 weights are in bf16 beforehand
**Before fix**:
Memory in FP32: 25.23 GB
Memory on BF16: 12.61 GB
Memory on FP8: **37.23 GB** <- Warning sign that something is amiss!

**After fix**:
Memory on FP8:
1. Doing `.cuda()` before (current implementation in `.prepare()`): **12.87 GB**
2. Doing `.cuda()` after: **12.61 GB**

Fixes # (issue)

(Finally) fixes https://github.com/huggingface/accelerate/issues/1430

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @LysandreJik 