### PR TITLE
fix check for train_micro_batch_size_per_gpu when preparing dataloader

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1499,7 +1499,10 @@ class Accelerator:
         deepspeed_plugin = self.state.deepspeed_plugin
 
         is_dataloader_present = any(isinstance(obj, torch.utils.data.DataLoader) for obj in args)
-        if deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"] == "auto" or is_dataloader_present:
+        if deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"] == "auto" or (
+            is_dataloader_present
+            and not isinstance(deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"], int)
+        ):
             result = [
                 self._prepare_one(obj, first_pass=True) if isinstance(obj, torch.utils.data.DataLoader) else obj
                 for obj in args


### PR DESCRIPTION
# What does this PR do?
When using deepspeed along with a custom batch sampler that doesn't use `batch_size`, accelerate will error with:
```
ValueError: At least one of the dataloaders passed to `accelerate.prepare()` has `None` as batch size.Please set an integer value in `train_micro_batch_size_per_gpu` in the deepspeed config fileor assign integer value to `AcceleratorState().deepspeed_plugin.deepspeed_config['train_micro_batch_size_per_gpu']`.
```

Despite setting this to an integer value, it continues to raise this error incorrectly. This fix adds a check and skips when it is set appropriately.

here's the reproducer I used and ran with `ACCELERATE_USE_DEEPSPEED=true accelerate launch repro.py`
```python
import accelerate
import numpy as np
from accelerate import Accelerator
from accelerate.state import AcceleratorState
from torch.utils.data import DataLoader, BatchSampler, SequentialSampler, Dataset

class MyDataset(Dataset):
    def __init__(self, data) -> None:
        super().__init__()
        self.data = data
    
    def __len__(self) -> int:
        return len(self.data)

    def __getitem__(self, index):
        return self.data[index]


class CustomBatchSampler(BatchSampler):
    def __init__(self, sampler, drop_last):
        self.sampler = sampler
        self.drop_last = drop_last
        self.batch_size = None

    def __iter__(self):
        sampler_iter = iter(self.sampler)
        while True:
            try:
                batch = [next(sampler_iter) for _ in range(4)]
                yield batch
            except StopIteration:
                break


accelerator = Accelerator()
accelerator.even_batches = False
dataset = MyDataset(np.arange(10000))
batch_sampler = CustomBatchSampler(SequentialSampler(dataset), drop_last=False)
dataloader = DataLoader(dataset, batch_sampler=batch_sampler)

for batch in dataloader:
    print(batch)
    break


accelerator.state.deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"] = 4
print(accelerator.state.deepspeed_plugin.deepspeed_config)
prepared_dataloader = accelerator.prepare(dataloader)
for batch in prepared_dataloader:
    print(batch)
    break
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@pacman100 
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->