### PR TITLE
Remove explicit copy of `model.forward()` and instead check/store the `id` to unwrap

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1357,8 +1357,8 @@ class Accelerator:
                 " Please rerun your script specifying `--num_processes=1` or by launching with `python {{myscript.py}}`."
             )
 
+        model._accelerate_original_forward_id = id(model.forward)
         if self.native_amp:
-            model._original_forward = model.forward
             model_forward_func = model.forward.__func__ if hasattr(model.forward, "__func__") else model.forward
             autocast_context = get_mixed_precision_context_manager(self.native_amp, self.autocast_handler)
             new_forward = autocast_context(model_forward_func)
@@ -1372,7 +1372,6 @@ class Accelerator:
                 with torch.no_grad():
                     convert_model(model)
                 model._converted_to_transformer_engine = True
-            model._original_forward = model.forward
 
             kwargs = self.fp8_recipe_handler.to_kwargs() if self.fp8_recipe_handler is not None else {}
             if "fp8_format" in kwargs:

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -95,10 +95,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True):
                 forward_func = getattr(forward, "__func__", None)
                 if id(forward) == original_forward_id or id(forward_func) == original_forward_id:
                     break
-            if forward_func is not None:
-                model.forward = MethodType(forward_func, model)
-            else:
-                model.forward = MethodType(forward, model)
+            model.forward = MethodType(forward_func if forward_func is not None else forward, model)
         if getattr(model, "_converted_to_transformer_engine", False):
             convert_model(model, to_transformer_engine=False)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,7 +132,7 @@ class UtilsTester(unittest.TestCase):
 
     def test_can_undo_convert_outputs(self):
         model = RegressionModel()
-        model._original_forward = model.forward
+        model._accelerate_original_forward_id = id(model.forward)
         model.forward = convert_outputs_to_fp32(model.forward)
         model = extract_model_from_parallel(model, keep_fp32_wrapper=False)
         _ = pickle.dumps(model)
@@ -140,7 +140,7 @@ class UtilsTester(unittest.TestCase):
     @require_cuda
     def test_can_undo_fp16_conversion(self):
         model = RegressionModel()
-        model._original_forward = model.forward
+        model._accelerate_original_forward_id = id(model.forward)
         model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
         model.forward = convert_outputs_to_fp32(model.forward)
         model = extract_model_from_parallel(model, keep_fp32_wrapper=False)
@@ -150,7 +150,7 @@ class UtilsTester(unittest.TestCase):
     @require_torch_min_version(version="2.0")
     def test_dynamo(self):
         model = RegressionModel()
-        model._original_forward = model.forward
+        model._accelerate_original_forward_id = id(model.forward)
         model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
         model.forward = convert_outputs_to_fp32(model.forward)
         model.forward = torch.compile(model.forward, backend="inductor")


### PR DESCRIPTION
# What does this PR do?

This PR solves another bug with fp8 where having a link to the original forward in the model would cause yet another memory spike:

(From the NVIDIA team):
> we still experience OOM in fp8, but in model function call. In fp8, the forward step takes 15 GB of memory, while in bf16, it is 3GB.

The solution is to get rid of `_original_forward_func` (which was shown to be the issue) and to instead rely on the `id` of the function and don't make copies of it/copies of references. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @SunMarc 