### PR TITLE
Always use SeedableRandomSampler

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -478,6 +478,8 @@ class DataLoaderShard(DataLoader, DataLoaderStateMixin):
             self.iteration = epoch
         if hasattr(self.batch_sampler, "sampler") and hasattr(self.batch_sampler.sampler, "set_epoch"):
             self.batch_sampler.sampler.set_epoch(epoch)
+        elif hasattr(self.batch_sampler, "set_epoch"):
+            self.batch_sampler.set_epoch(epoch)
         # We support if a custom `Dataset` implementation has `set_epoch`
         # or in general HF datasets `Datasets`
         elif hasattr(self.dataset, "set_epoch"):
@@ -836,7 +838,7 @@ def prepare_data_loader(
         sampler = getattr(dataloader.sampler, "sampler", None)
     else:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
-    if isinstance(sampler, RandomSampler) and num_processes > 1:
+    if isinstance(sampler, RandomSampler):
         # When iterating through the dataloader during distributed processes
         # we want to ensure that on each process we are iterating through the same
         # samples in the same order if a seed is set. This requires a tweak

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -841,7 +841,7 @@ def prepare_data_loader(
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(sampler, RandomSampler):
         # CPU's specifically do not require this workaround
-        if (AcceleratorState().distributed_type == DistributedType.NO) and (AcceleratorState().device.type == "cpu"):
+        if (AcceleratorState().distributed_type == DistributedType.NO) and (device.type == "cpu"):
             pass
         else:
             # When iterating through the dataloader we want to ensure that

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -841,9 +841,7 @@ def prepare_data_loader(
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(sampler, RandomSampler):
         # CPU's specifically do not require this workaround
-        if num_processes == 1 and (device.type == "cpu"):
-            pass
-        else:
+        if not ((num_processes == 1) and (device.type == "cpu")):
             # When iterating through the dataloader we want to ensure that
             # on each process we are iterating through the same
             # samples in the same order if a seed is set. This requires a tweak

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -840,7 +840,7 @@ def prepare_data_loader(
     else:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(sampler, RandomSampler):
-        # When iterating through the dataloader we want to ensure that 
+        # When iterating through the dataloader we want to ensure that
         # on each process we are iterating through the same
         # samples in the same order if a seed is set. This requires a tweak
         # to the `torch.utils.data.RandomSampler` class (if used).

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -839,8 +839,8 @@ def prepare_data_loader(
     else:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(sampler, RandomSampler):
-        # When iterating through the dataloader during distributed processes
-        # we want to ensure that on each process we are iterating through the same
+        # When iterating through the dataloader we want to ensure that 
+        # on each process we are iterating through the same
         # samples in the same order if a seed is set. This requires a tweak
         # to the `torch.utils.data.RandomSampler` class (if used).
         sampler = SeedableRandomSampler(

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -476,10 +476,11 @@ class DataLoaderShard(DataLoader, DataLoaderStateMixin):
         # In case it is manually passed in, the user can set it to what they like
         if self.iteration != epoch:
             self.iteration = epoch
-        if hasattr(self.batch_sampler, "sampler") and hasattr(self.batch_sampler.sampler, "set_epoch"):
-            self.batch_sampler.sampler.set_epoch(epoch)
-        elif hasattr(self.batch_sampler, "set_epoch"):
+        if hasattr(self.batch_sampler, "set_epoch"):
+            # Case: `SkipBatchSampler`
             self.batch_sampler.set_epoch(epoch)
+        elif hasattr(self.batch_sampler, "sampler") and hasattr(self.batch_sampler.sampler, "set_epoch"):
+            self.batch_sampler.sampler.set_epoch(epoch)
         # We support if a custom `Dataset` implementation has `set_epoch`
         # or in general HF datasets `Datasets`
         elif hasattr(self.dataset, "set_epoch"):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -841,7 +841,7 @@ def prepare_data_loader(
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(sampler, RandomSampler):
         # CPU's specifically do not require this workaround
-        if (AcceleratorState().distributed_type == DistributedType.NO) and (device.type == "cpu"):
+        if num_processes == 1 and (device.type == "cpu"):
             pass
         else:
             # When iterating through the dataloader we want to ensure that


### PR DESCRIPTION
# What does this PR do?

Because at the end of the day the trainer will always use a `DispatchDataLoader` (even in the case of num_gpus == 1), it needs to be able to set the random seed properly for the sampler. The solution is to just always use the `SeedableRandomSampler`. While our tests (in accelerate)do not fail, they don't account for if the base case is `DispatchDataLoader` (`Trainer` tests).

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 