### PR TITLE
Add explicit error if empty batch received

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -234,6 +234,8 @@ def find_batch_size(data):
     if isinstance(data, (tuple, list)):
         return find_batch_size(data[0])
     elif isinstance(data, Mapping):
+        if len(data) == 0:
+            raise ValueError(f"Can't find the batch size from empty {type(data)}.")
         for k in data.keys():
             return find_batch_size(data[k])
     elif not isinstance(data, torch.Tensor):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -231,11 +231,12 @@ def find_batch_size(data):
     Returns:
         `int`: The batch size.
     """
+    if isinstance(data, (tuple, list, Mapping)) and (len(data) == 0):
+        raise ValueError(f"Cannot find the batch size from empty {type(data)}.")
+
     if isinstance(data, (tuple, list)):
         return find_batch_size(data[0])
     elif isinstance(data, Mapping):
-        if len(data) == 0:
-            raise ValueError(f"Can't find the batch size from empty {type(data)}.")
         for k in data.keys():
             return find_batch_size(data[k])
     elif not isinstance(data, torch.Tensor):


### PR DESCRIPTION
# Improve error message in find_batch_size() when dataset is empty

Add explicit error message in case of empty dictionary received. Details are in #2108.

Fixes #2108 
