### PR TITLE
Make SeedableRandomSampler the default always

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -93,6 +93,7 @@ class SeedableRandomSampler(RandomSampler):
                 yield from torch.randint(high=n, size=(32,), dtype=torch.int64, generator=g).tolist()
         else:
             yield from torch.randperm(n, generator=g).tolist()
+        self.set_epoch(self.epoch + 1)
 
     def set_epoch(self, epoch: int):
         "Sets the current iteration of the sampler."
@@ -836,7 +837,7 @@ def prepare_data_loader(
         sampler = getattr(dataloader.sampler, "sampler", None)
     else:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
-    if isinstance(sampler, RandomSampler) and num_processes > 1:
+    if isinstance(sampler, RandomSampler):
         # When iterating through the dataloader during distributed processes
         # we want to ensure that on each process we are iterating through the same
         # samples in the same order if a seed is set. This requires a tweak

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -339,17 +339,15 @@ def mock_training(length, batch_size, generator):
     set_seed(42)
     generator.manual_seed(42)
     train_set = RegressionDataset(length=length, seed=42)
-    if AcceleratorState().num_processes > 1:
-        # The SeedableRandomSampler is needed during distributed setups
-        # for full reproducability across processes with the `DataLoader`
-        sampler = SeedableRandomSampler(
-            generator=generator,
-            data_source=train_set,
-            num_samples=len(train_set),
-        )
-        train_dl = DataLoader(train_set, batch_size=batch_size, sampler=sampler)
-    else:
-        train_dl = DataLoader(train_set, batch_size=batch_size, shuffle=True, generator=generator)
+
+    # The SeedableRandomSampler is needed during distributed setups
+    # for full reproducability across processes with the `DataLoader`
+    sampler = SeedableRandomSampler(
+        generator=generator,
+        data_source=train_set,
+        num_samples=len(train_set),
+    )
+    train_dl = DataLoader(train_set, batch_size=batch_size, sampler=sampler)
     model = RegressionModel()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
     for epoch in range(3):


### PR DESCRIPTION
# What does this PR do?

Properly sets `SeedableRandomSampler` as the main sampler to be replaced if the user passed in `RandomSampler`. We need this always/should use it always.

Also fixes a missing `set_epoch` at the end of the `__iter__`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 