### PR TITLE
fix warmup lr when using deepspeed

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1646,6 +1646,9 @@ class Accelerator:
                     kwargs["model_parameters"] = optimizer.params
                     if isinstance(scheduler, (DummyScheduler)) and scheduler.lr_scheduler_callable is not None:
                         kwargs["lr_scheduler"] = scheduler.lr_scheduler_callable
+                    if isinstance(scheduler, (DummyScheduler)) and 'warmup' in kwargs['config_params']['scheduler']['type'].lower():
+                        # if using warmup, set inintial optimizer learning rate as min lr.
+                        kwargs['config_params']['optimizer']['params']['lr'] = kwargs['config_params']['scheduler']['params']['warmup_min_lr']
                 else:
                     if self.deepspeed_config["zero_optimization"].get("offload_optimizer", {}).get(
                         "device", "none"


### PR DESCRIPTION
# What does this PR do?

Fixes #2124 
Current DeepSpeedEngineWrapper.backwards() calls [DeepSpeedEngine._take_model_step()](https://github.com/microsoft/DeepSpeed/blob/de96e18ad5c6c58b21b906249296ca45ff46a24f/deepspeed/runtime/engine.py#L2026), which performs optimizer step first, followed by lr_scheduler step. https://github.com/huggingface/accelerate/blob/4f100318f499cff48b62555ca7d96ad97d7cb9be/src/accelerate/utils/deepspeed.py#L176  

However, the DS optimizer will be initialized with the maximum learning rate in the prepare function, the optimizer will update model parameters with the maximum learning rate at the first step, which will cause an unexpected behavior. https://github.com/huggingface/accelerate/blob/4f100318f499cff48b62555ca7d96ad97d7cb9be/src/accelerate/accelerator.py#L1665 

This PR solves this problem by initializing the optimizer with warmup_min_lr if the warmup lr scheduler is activated.

@pacman100
