### PR TITLE
Allow for ACCELERATE_SEED env var

### DIFF
--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -54,7 +54,6 @@ These are basic dataclasses used throughout 🤗 Accelerate and they can be pass
 
 These are environmental variables that can be enabled for different use cases
 
-* `ACCELERATE_SEED` (`int`): The seed to use for different internal random states not covered through the base cases. Also set during [`utils.set_seed`]
 * `ACCELERATE_DEBUG_MODE` (`str`): Whether to run accelerate in debug mode. More info available [here](../usage_guides/debug.md).
 
 ## Plugins

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -55,7 +55,7 @@ These are basic dataclasses used throughout 🤗 Accelerate and they can be pass
 These are environmental variables that can be enabled for different use cases
 
 * `ACCELERATE_SEED` (`int`): The seed to use for different internal random states not covered through the base cases. Also set during [`utils.set_seed`]
-* `ACCELERATE_DEBUG_MODE` (`str`, ["1","2"]): Whether to run accelerate in debug mode. More info available [here](../usage_guides/debug.md).
+* `ACCELERATE_DEBUG_MODE` (`str`): Whether to run accelerate in debug mode. More info available [here](../usage_guides/debug.md).
 
 ## Plugins
 

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -50,6 +50,13 @@ These are basic dataclasses used throughout 🤗 Accelerate and they can be pass
 
 [[autodoc]] utils.ProjectConfiguration
 
+## Environmental Variables
+
+These are environmental variables that can be enabled for different use cases
+
+* `ACCELERATE_SEED` (`int`): The seed to use for different internal random states not covered through the base cases. Also set during [`utils.set_seed`]
+* `ACCELERATE_DEBUG_MODE` (`str`, ["1","2"]): Whether to run accelerate in debug mode. More info available [here](../usage_guides/debug.md).
+
 ## Plugins
 
 These are plugins that can be passed to the [`Accelerator`] object. While they are defined elsewhere in the documentation, 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -73,8 +73,6 @@ class SeedableRandomSampler(RandomSampler):
 
     If a custom `generator` is passed, it will rely on its initial seed as well as the current iteration it is on
     (stored in `self.epoch`).
-
-    A manual seed can also be used by setting the `ACCELERATE_SEED` environmental variable.
     """
 
     def __init__(self, *args, **kwargs):
@@ -85,8 +83,10 @@ class SeedableRandomSampler(RandomSampler):
     def __iter__(self):
         if self.generator is None:
             self.generator = torch.Generator()
+        else:
+            self.seed = self.generator.initial_seed()
         # Allow `self.epoch` to modify the seed of the generator
-        seed = self.epoch + (self.seed if self.seed is not None else self.generator.initial_seed())
+        seed = self.epoch + self.seed
         self.generator.manual_seed(seed)
         yield from super().__iter__()
         self.set_epoch(self.epoch + 1)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -81,7 +81,7 @@ class SeedableRandomSampler(RandomSampler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.epoch = 0
-        self.seed = 0
+        self.seed = None
         if os.environ.get("ACCELERATE_SEED", False):
             self.seed = int(os.environ["ACCELERATE_SEED"])
 
@@ -89,7 +89,7 @@ class SeedableRandomSampler(RandomSampler):
         if self.generator is None:
             self.generator = torch.Generator()
         # Allow `self.epoch` to modify the seed of the generator
-        seed = self.epoch + (self.seed if self.seed != 0 else self.generator.initial_seed())
+        seed = self.epoch + (self.seed if self.seed is not None else self.generator.initial_seed())
         self.generator.manual_seed(seed)
         yield from super().__iter__()
         self.set_epoch(self.epoch + 1)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import os
 from contextlib import suppress
 from typing import Callable, List, Optional, Union
 
@@ -73,17 +74,22 @@ class SeedableRandomSampler(RandomSampler):
 
     If a custom `generator` is passed, it will rely on its initial seed as well as the current iteration it is on
     (stored in `self.epoch`).
+
+    A manual seed can also be used by setting the `ACCELERATE_SEED` environmental variable.
     """
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.epoch = 0
+        self.seed = 0
+        if os.environ.get("ACCELERATE_SEED", False):
+            self.seed = int(os.environ["ACCELERATE_SEED"])
 
     def __iter__(self):
         if self.generator is None:
             self.generator = torch.Generator()
         # Allow `self.epoch` to modify the seed of the generator
-        seed = self.epoch + self.generator.initial_seed()
+        seed = self.epoch + (self.seed if self.seed != 0 else self.generator.initial_seed())
         self.generator.manual_seed(seed)
         yield from super().__iter__()
         self.set_epoch(self.epoch + 1)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import os
 from contextlib import suppress
 from typing import Callable, List, Optional, Union
 
@@ -81,9 +80,7 @@ class SeedableRandomSampler(RandomSampler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.epoch = 0
-        self.seed = None
-        if os.environ.get("ACCELERATE_SEED", False):
-            self.seed = int(os.environ["ACCELERATE_SEED"])
+        self.seed = torch.random.initial_seed()
 
     def __iter__(self):
         if self.generator is None:

--- a/src/accelerate/utils/random.py
+++ b/src/accelerate/utils/random.py
@@ -30,8 +30,7 @@ if is_tpu_available(check_device=False):
 
 def set_seed(seed: int, device_specific: bool = False):
     """
-    Helper function for reproducible behavior to set the seed in `random`, `numpy`, `torch`. Also will set the random
-    seed for `SeedableRandomSampler` through the `ACCELERATE_SEED` environment variable.
+    Helper function for reproducible behavior to set the seed in `random`, `numpy`, `torch`.
 
     Args:
         seed (`int`):

--- a/src/accelerate/utils/random.py
+++ b/src/accelerate/utils/random.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import random
 from typing import List, Optional, Union
 
@@ -30,7 +31,8 @@ if is_tpu_available(check_device=False):
 
 def set_seed(seed: int, device_specific: bool = False):
     """
-    Helper function for reproducible behavior to set the seed in `random`, `numpy`, `torch`.
+    Helper function for reproducible behavior to set the seed in `random`, `numpy`, `torch`. Also will set the random
+    seed for `SeedableRandomSampler` through the `ACCELERATE_SEED` environment variable.
 
     Args:
         seed (`int`):
@@ -52,6 +54,8 @@ def set_seed(seed: int, device_specific: bool = False):
     # ^^ safe to call this function even if cuda is not available
     if is_tpu_available():
         xm.set_rng_state(seed)
+    # For `SeedableRandomSampler` samplers
+    os.environ["ACCELERATE_SEED"] = str(seed)
 
 
 def synchronize_rng_state(rng_type: Optional[RNGType] = None, generator: Optional[torch.Generator] = None):

--- a/src/accelerate/utils/random.py
+++ b/src/accelerate/utils/random.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import random
 from typing import List, Optional, Union
 
@@ -54,8 +53,6 @@ def set_seed(seed: int, device_specific: bool = False):
     # ^^ safe to call this function even if cuda is not available
     if is_tpu_available():
         xm.set_rng_state(seed)
-    # For `SeedableRandomSampler` samplers
-    os.environ["ACCELERATE_SEED"] = str(seed)
 
 
 def synchronize_rng_state(rng_type: Optional[RNGType] = None, generator: Optional[torch.Generator] = None):


### PR DESCRIPTION
# What does this PR do?

This PR introduces `ACCELERATE_SEED` as part of `set_seed`. Doing so will allow for the custom random samplers to rely on it for setting the seed, rather than the generator (as this can lead to imperfect issues). Solves related trainer test failures.

Fixes # (issue)

[Internal slack thread](https://huggingface.slack.com/archives/C01NE71C4F7/p1699294942410279)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@LysandreJik @BenjaminBossan 