### PR TITLE
Add examples to tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,4 +69,5 @@ jobs:
       run: |
         cd ../transformers/examples/pytorch
         pip install -r _tests_requirements.txt
-        pytest -sv test_accelerate_examples.py test_pytorch_examples.py
+        cd ../../
+        pytest -sv examples/pytorch/test_accelerate_examples.py examples/pytorch/test_pytorch_examples.py

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -62,3 +62,11 @@ jobs:
       run: |
         cd ../transformers
         pytest -sv tests/trainer
+
+    - name: Run transformers examples tests
+      env:
+        WANDB_DISABLED: true
+      run: |
+        cd examples/pytorch
+        pip install -r _test_requirements.txt
+        pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,4 +69,4 @@ jobs:
       run: |
         cd ../transformers/examples/pytorch
         pip install -r _tests_requirements.txt
-        pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py
+        pytest -sv test_accelerate_examples.py test_pytorch_examples.py

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -68,5 +68,5 @@ jobs:
         WANDB_DISABLED: true
       run: |
         cd ../transformers/examples/pytorch
-        pip install -r _test_requirements.txt
+        pip install -r _tests_requirements.txt
         pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -62,12 +62,3 @@ jobs:
       run: |
         cd ../transformers
         pytest -sv tests/trainer
-
-    - name: Run transformers examples tests
-      env:
-        WANDB_DISABLED: true
-      run: |
-        cd ../transformers/examples/pytorch
-        pip install -r _tests_requirements.txt
-        cd ../../
-        pytest -sv examples/pytorch/test_accelerate_examples.py examples/pytorch/test_pytorch_examples.py

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -67,6 +67,6 @@ jobs:
       env:
         WANDB_DISABLED: true
       run: |
-        cd examples/pytorch
+        cd ../transformers/examples/pytorch
         pip install -r _test_requirements.txt
         pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -88,7 +88,8 @@ jobs:
           WANDB_DISABLED: true
         run: |
           pip install -r _tests_requirements.txt
-          pytest -sv test_accelerate_examples.py test_pytorch_examples.py
+          cd ../../
+          pytest -sv examples/pytorch/test_accelerate_examples.py examples/pytorch/test_pytorch_examples.py
 
   run-skorch-tests:
     container:

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -87,7 +87,7 @@ jobs:
           CUDA_VISIBLE_DEVICES: ${{ matrix.cuda_visible_devices }}
           WANDB_DISABLED: true
         run: |
-          pip install -r _test_requirements.txt
+          pip install -r _tests_requirements.txt
           pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py
 
   run-skorch-tests:

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -88,7 +88,7 @@ jobs:
           WANDB_DISABLED: true
         run: |
           pip install -r _tests_requirements.txt
-          pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py
+          pytest -sv test_accelerate_examples.py test_pytorch_examples.py
 
   run-skorch-tests:
     container:

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -81,6 +81,15 @@ jobs:
           source activate accelerate;
           pytest -sv tests/deepspeed
 
+      - name: Run transformers examples tests
+        working-directory: transformers/examples/pytorch
+        env:
+          CUDA_VISIBLE_DEVICES: ${{ matrix.cuda_visible_devices }}
+          WANDB_DISABLED: true
+        run: |
+          pip install -r _test_requirements.txt
+          pytest -sv tests/test_accelerate_examples.py tests/test_pytorch_examples.py
+
   run-skorch-tests:
     container:
       image: huggingface/accelerate-gpu:latest


### PR DESCRIPTION
# What does this PR do?

Adds trainer integration tests (the examples) to our test suite since they test both the `Trainer` and the `Accelerator`