### PR TITLE
Deal with shared memory scenarios

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -168,6 +168,7 @@ from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
 from .memory import find_executable_batch_size, release_memory
 from .other import (
     check_os_kernel,
+    clean_state_dict_for_safetensors,
     clear_environment,
     convert_bytes,
     extract_model_from_parallel,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -152,6 +152,7 @@ def clean_state_dict_for_safetensors(state_dict: dict):
     state_dict = {k: v.contiguous() for k, v in state_dict.items()}
     return state_dict
 
+
 def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = False):
     """
     Save the data to disk. Use in place of `torch.save()`.

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -152,7 +152,7 @@ def clean_state_dict_for_safetensors(state_dict: dict):
     state_dict = {k: v.contiguous() for k, v in state_dict.items()}
     return state_dict
 
-def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = True):
+def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = False):
     """
     Save the data to disk. Use in place of `torch.save()`.
 
@@ -163,7 +163,7 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Tru
             The file (or file-like object) to use to save the data
         save_on_each_node (`bool`, *optional*, defaults to `False`):
             Whether to only save on the global main process
-        safe_serialization (`bool`, *optional*, defaults to `True`):
+        safe_serialization (`bool`, *optional*, defaults to `False`):
             Whether to save `obj` using `safetensors` or the traditional PyTorch way (that uses `pickle`).
     """
     # Check if it's a model and remove duplicates

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -222,4 +222,7 @@ class UtilsTester(unittest.TestCase):
         model = Model()
         with tempfile.TemporaryDirectory() as tmp_dir:
             save_path = os.path.join(tmp_dir, "model.safetensors")
-            save(model.state_dict(), save_path, safe_serialization=True)
+            with self.assertLogs(level="WARNING") as log:
+                save(model.state_dict(), save_path, safe_serialization=True)
+                self.assertEqual(len(log.records), 1)
+                self.assertIn("Removed shared tensor", log.output[0])


### PR DESCRIPTION
# What does this PR do?

We need to deal with shared memory scenarios when saving with `safetensors` and a model. Since the `safetensor` version relies on passing the *entire model* instead of the state dict directly, [see here](https://github.com/huggingface/safetensors/blob/main/bindings/python/py_src/safetensors/torch.py#L130), to deal with this, for now a raw copy/paste of the code is done instead to remove duplicate names.

(All `state_dict` in torch are `OrderedDict`, hence the check)

Fixes # (issue)
Two failures on the transformers CI

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 