### PR TITLE
Leave native `save` as `False`

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -263,7 +263,7 @@ def save_custom_state(obj, path, index: int = 0, save_on_each_node: bool = False
     # Should this be the right way to get a qual_name type value from `obj`?
     save_location = Path(path) / f"custom_checkpoint_{index}.pkl"
     logger.info(f"Saving the state of {get_pretty_name(obj)} to {save_location}")
-    save(obj.state_dict(), save_location, save_on_each_node=save_on_each_node)
+    save(obj.state_dict(), save_location, save_on_each_node=save_on_each_node, safe_serialization=False)
 
 
 def load_custom_state(obj, path, index: int = 0):

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -263,7 +263,7 @@ def save_custom_state(obj, path, index: int = 0, save_on_each_node: bool = False
     # Should this be the right way to get a qual_name type value from `obj`?
     save_location = Path(path) / f"custom_checkpoint_{index}.pkl"
     logger.info(f"Saving the state of {get_pretty_name(obj)} to {save_location}")
-    save(obj.state_dict(), save_location, save_on_each_node=save_on_each_node, safe_serialization=False)
+    save(obj.state_dict(), save_location, save_on_each_node=save_on_each_node)
 
 
 def load_custom_state(obj, path, index: int = 0):

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -115,7 +115,7 @@ def wait_for_everyone():
     PartialState().wait_for_everyone()
 
 
-def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = True):
+def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = False):
     """
     Save the data to disk. Use in place of `torch.save()`.
 
@@ -126,8 +126,8 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Tru
             The file (or file-like object) to use to save the data
         save_on_each_node (`bool`, *optional*, defaults to `False`):
             Whether to only save on the global main process
-        safe_serialization (`bool`, *optional*, defaults to `True`):
-            Whether to save the model using `safetensors` or the traditional PyTorch way (that uses `pickle`).
+        safe_serialization (`bool`, *optional*, defaults to `False`):
+            Whether to save `obj` using `safetensors` or the traditional PyTorch way (that uses `pickle`).
     """
     save_func = torch.save if not safe_serialization else partial(safe_save_file, metadata={"format": "pt"})
     if PartialState().distributed_type == DistributedType.TPU:


### PR DESCRIPTION
# What does this PR do?

We only care if the model is saved in `safetensors`, general objects should never be if registered.. As a result makes `save` follow the same notion as `Accelerator.save` where `safe_serialization` is `False` by default. It can remain true for `save_model` and `save_state` however. 

Fixes https://github.com/huggingface/accelerate/issues/2135

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 