### PR TITLE
Fix safetensors contiguous

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -149,7 +149,7 @@ def clean_state_dict_for_safetensors(state_dict: dict):
         logger.warning(
             f"Removed shared tensor {warn_names} while saving. This should be OK, but check by verifying that you don't receive any warning while reloading",
         )
-    state_dict = {k: v.contiguous() for k, v in state_dict.items()}
+    state_dict = {k: v.contiguous() if isinstance(v, torch.Tensor) else v for k, v in state_dict.items()}
     return state_dict
 
 


### PR DESCRIPTION
# What does this PR do 

THis fixes the safetensors saving in case the `state_dict` contains other object (e.g. str). In that case, we can't use `.contiguous()` as it only works for `Tensor`