### PR TITLE
Apply DVC warning to Accelerate

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import logging
 import os
 
@@ -66,6 +67,17 @@ class MultiProcessAdapter(logging.LoggerAdapter):
                         msg, kwargs = self.process(msg, kwargs)
                         self.logger.log(level, msg, *args, **kwargs)
                     state.wait_for_everyone()
+
+    @functools.lru_cache(None)
+    def warning_once(self, *args, **kwargs):
+        """
+        This method is identical to `logger.warning()`, but will emit the warning with the same message only once
+
+        Note: The cache is for the function arguments, so 2 different callers using the same arguments will hit the
+        cache. The assumption here is that all warning messages are unique across the code. If they aren't then need to
+        switch to another type of cache that includes the caller frame information in the hashing function.
+        """
+        self.warning(*args, **kwargs)
 
 
 def get_logger(name: str, log_level: str = None):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -640,8 +640,8 @@ class MLflowTracker(GeneralTracker):
         for name, value in list(values.items()):
             # internally, all values are converted to str in MLflow
             if len(str(value)) > mlflow.utils.validation.MAX_PARAM_VAL_LENGTH:
-                logger.warning(
-                    f'Trainer is attempting to log a value of "{value}" for key "{name}" as a parameter. MLflow\'s'
+                logger.warning_once(
+                    f'Accelerate is attempting to log a value of "{value}" for key "{name}" as a parameter. MLflow\'s'
                     f" log_param() only accepts values no longer than {mlflow.utils.validation.MAX_PARAM_VAL_LENGTH} characters so we dropped this attribute."
                 )
                 del values[name]
@@ -670,7 +670,7 @@ class MLflowTracker(GeneralTracker):
             if isinstance(v, (int, float)):
                 metrics[k] = v
             else:
-                logger.warning(
+                logger.warning_once(
                     f'MLflowTracker is attempting to log a value of "{v}" of type {type(v)} for key "{k}" as a metric. '
                     "MLflow's log_metric() only accepts float and int types so we dropped this attribute."
                 )
@@ -755,7 +755,7 @@ class ClearMLTracker(GeneralTracker):
         clearml_logger = self.task.get_logger()
         for k, v in values.items():
             if not isinstance(v, (int, float)):
-                logger.warning(
+                logger.warning_once(
                     "Accelerator is attempting to log a value of "
                     f'"{v}" of type {type(v)} for key "{k}" as a scalar. '
                     "This invocation of ClearML logger's  report_scalar() "
@@ -902,13 +902,14 @@ class DVCLiveTracker(GeneralTracker):
                 Additional key word arguments passed along to `dvclive.Live.log_metric()`.
         """
         from dvclive.plots import Metric
+
         if step is not None:
             self.live.step = step
         for k, v in values.items():
             if Metric.could_log(v):
                 self.live.log_metric(k, v, **kwargs)
             else:
-                logger.warning(
+                logger.warning_once(
                     "Accelerator attempted to log a value of "
                     f'"{v}" of type {type(v)} for key "{k} as a scalar. '
                     "This invocation of DVCLive's Live.log_metric() "

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -901,7 +901,7 @@ class DVCLiveTracker(GeneralTracker):
             kwargs:
                 Additional key word arguments passed along to `dvclive.Live.log_metric()`.
         """
-        from dvclive import Metric
+        from dvclive.plots import Metric
         if step is not None:
             self.live.step = step
         for k, v in values.items():

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -911,7 +911,7 @@ class DVCLiveTracker(GeneralTracker):
             else:
                 logger.warning_once(
                     "Accelerator attempted to log a value of "
-                    f'"{v}" of type {type(v)} for key "{k} as a scalar. '
+                    f'"{v}" of type {type(v)} for key "{k}" as a scalar. '
                     "This invocation of DVCLive's Live.log_metric() "
                     "is incorrect so we dropped this attribute."
                 )

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -866,7 +866,7 @@ class DVCLiveTracker(GeneralTracker):
 
     @on_main_process
     def __init__(self, run_name: Optional[str] = None, live: Optional[Any] = None, **kwargs):
-        from dvclive import Live, Metric
+        from dvclive import Live
 
         super().__init__()
         self.live = live if live is not None else Live(**kwargs)
@@ -901,6 +901,7 @@ class DVCLiveTracker(GeneralTracker):
             kwargs:
                 Additional key word arguments passed along to `dvclive.Live.log_metric()`.
         """
+        from dvclive import Metric
         if step is not None:
             self.live.step = step
         for k, v in values.items():

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -866,7 +866,7 @@ class DVCLiveTracker(GeneralTracker):
 
     @on_main_process
     def __init__(self, run_name: Optional[str] = None, live: Optional[Any] = None, **kwargs):
-        from dvclive import Live
+        from dvclive import Live, Metric
 
         super().__init__()
         self.live = live if live is not None else Live(**kwargs)
@@ -904,7 +904,15 @@ class DVCLiveTracker(GeneralTracker):
         if step is not None:
             self.live.step = step
         for k, v in values.items():
-            self.live.log_metric(k, v, **kwargs)
+            if Metric.could_log(v):
+                self.live.log_metric(k, v, **kwargs)
+            else:
+                logger.warning(
+                    "Accelerator attempted to log a value of "
+                    f'"{v}" of type {type(v)} for key "{k} as a scalar. '
+                    "This invocation of DVCLive's Live.log_metric() "
+                    "is incorrect so we dropped this attribute."
+                )
 
     @on_main_process
     def finish(self):


### PR DESCRIPTION
# What does this PR do?

Same solution as https://github.com/huggingface/transformers/pull/27608, warn when failing trying to log non-scalars as metrics. Makes failing tests pass

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 