### PR TITLE
[deepspeed plugin] fails when DL uses batch_sampler

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1421,16 +1421,19 @@ class Accelerator:
                 for obj in args
             ]
 
-            batch_sizes = [obj.batch_size for obj in args if hasattr(obj, "batch_size")]
-            if self.split_batches:
-                batch_sizes = [batch_size // self.num_processes for batch_size in batch_sizes]
+            if deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"] == "auto":
+                batch_sizes = [obj.batch_size for obj in args if hasattr(obj, "batch_size")]
+                if self.split_batches:
+                    batch_sizes = [batch_size // self.num_processes for batch_size in batch_sizes]
+                if any(bs is None for bs in batch_sizes):
+                    raise ValueError(
+                        "At least one of the dataloaders passed to `accelerate.prepare()` has `None` as batch size."
+                        "Please set an integer value in `train_micro_batch_size_per_gpu` in the deepspeed config file"
+                        "or assign integer value to `AcceleratorState().deepspeed_plugin.deepspeed_config['train_micro_batch_size_per_gpu']`."
+                    )
+            else:
+                batch_sizes = [deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"]]
 
-            if any(bs is None for bs in batch_sizes):
-                raise ValueError(
-                    "At least one of the dataloaders passed to `accelerate.prepare()` has `None` as batch size."
-                    "Please set an integer value in `train_micro_batch_size_per_gpu` in the deepspeed config file"
-                    "or assign integer value to `AcceleratorState().deepspeed_plugin.deepspeed_config['train_micro_batch_size_per_gpu']`."
-                )
             if len(batch_sizes) == 0:
                 raise ValueError(
                     "When using DeepSpeed `accelerate.prepare()` requires you to pass at least one of training or evaluation dataloaders "


### PR DESCRIPTION
currently if the DL doesn't have `batch_size` set, because it uses `batch_sampler` the deepspeed plugin code fails to work.

The problem comes from here:

https://github.com/huggingface/accelerate/blob/77628ec6033b47e489054b383953378288526391/src/accelerate/accelerator.py#L1418

so even if the user acted on the exception and set `AcceleratorState().deepspeed_plugin.deepspeed_config['train_micro_batch_size_per_gpu']` this code still fails. 

Here is a possible quick fix that overcomes this problem.

But I suspect that the original logic is a bit off. Wouldn't it be better if it did this check instead:

```
if deepspeed_plugin.deepspeed_config["train_micro_batch_size_per_gpu"] == "auto":
    if is_dataloader_present:
        current logic
    else:
        raise ValueError("can't derive train_micro_batch_size_per_gpu - either use a DL with batch_size attribute returning an int or set train_micro_batch_size_per_gpu manually")
```

@pacman100, @muellerzr
