### PR TITLE
Add condition before using `check_tied_parameters_on_same_device`

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1366,8 +1366,8 @@ def load_checkpoint_in_model(
         logger.warn(
             "The model weights are not tied. Please use the `tie_weights` method before using the `infer_auto_device` function."
         )
-
-    check_tied_parameters_on_same_device(tied_params, device_map)
+    if device_map is not None:
+        check_tied_parameters_on_same_device(tied_params, device_map)
 
     if offload_folder is None and device_map is not None and "disk" in device_map.values():
         raise ValueError(


### PR DESCRIPTION
# What does this do ?
As pointed by @fxmarty [here](https://github.com/huggingface/accelerate/pull/2116#discussion_r1415338368), we need to check if the `device_map` is `None` or not before using `check_tied_parameters_on_same_device`. 