### PR TITLE
allocate 80% for cpu is unset in `max_memory`

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -664,8 +664,8 @@ def get_max_layer_size(
 
 def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None):
     """
-    Get the maximum memory available if nothing is passed.
-    Otherwise, we convert string to int and we allocate 80% of the cpu memory if cpu is not passed in max_memory.
+    Get the maximum memory available if nothing is passed. Otherwise, we convert string to int and we allocate 80% of
+    the cpu memory if cpu is not passed in max_memory.
     """
     import psutil
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -697,7 +697,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
         max_memory["cpu"] = psutil.virtual_memory().available * 0.8
         logger.info(
             "We will use 80% of the memory on cpu for storing the model."
-            "You can set `max_memory["cpu"]` in to a higher value to use more memory (at your own risk)."
+            "You can set `max_memory['cpu']` in to a higher value to use more memory (at your own risk)."
         )
 
     # Need to sort the device by type to make sure that we allocate the gpu first.

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -697,7 +697,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
         max_memory["cpu"] = psutil.virtual_memory().available * 0.8
         logger.info(
             "We will use 80% of the memory on cpu for storing the model."
-            "You can set `max_memory` in to a higher value to use more memory (at your own risk)."
+            "You can set `max_memory["cpu"]` in to a higher value to use more memory (at your own risk)."
         )
 
     # Need to sort the device by type to make sure that we allocate the gpu first.

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -664,7 +664,8 @@ def get_max_layer_size(
 
 def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None):
     """
-    Get the maximum memory available if nothing is passed, converts string to int otherwise.
+    Get the maximum memory available if nothing is passed.
+    Otherwise, we convert string to int and we allocate 80% of the cpu memory if cpu is not passed in max_memory.
     """
     import psutil
 
@@ -692,6 +693,12 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     for key in max_memory:
         if isinstance(max_memory[key], str):
             max_memory[key] = convert_file_size_to_int(max_memory[key])
+    if "cpu" not in max_memory:
+        max_memory["cpu"] = psutil.virtual_memory().available * 0.8
+        logger.info(
+            "We will use 80% of the memory on cpu for storing the model."
+            "You can set `max_memory` in to a higher value to use more memory (at your own risk)."
+        )
 
     # Need to sort the device by type to make sure that we allocate the gpu first.
     # As gpu/xpu are represented by int, we need to sort them first.


### PR DESCRIPTION
# What does this PR do ?
This PR modifies `max_memory` by allocating 80% of cpu memory of "cpu" is not passed in `max_memory`. The idea was in case the user did not specify the cpu allocation using `max_memory` arg, we should just infer from the current system available memory minus some reserved pool for the OS to continue to work. Otherwise, we will move directly to disk offload.  
cc @mfuntowicz as you suggested.

Before this PR: 
```py
max_memory = {"0:"15GiB"}
get_max_memory(max_memory)
# returns {0: 16106127360}
```
After this PR
```py
max_memory = {"0:"15GiB"}
get_max_memory(max_memory)
# returns {0: 16106127360,  'cpu': 384541448601.60004}
```

TODO: 
- [ ] check accelerate tests 
- [ ] check transformers tests
