### PR TITLE
[data_loader] expand the error message

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -152,7 +152,8 @@ class BatchSamplerShard(BatchSampler):
         self.batch_size = getattr(batch_sampler, "batch_size", None)
         self.drop_last = getattr(batch_sampler, "drop_last", False)
         if self.batch_size is None and self.even_batches:
-            raise ValueError("You need to use `even_batches=False` when the batch sampler has no batch size.")
+            raise ValueError("You need to use `even_batches=False` when the batch sampler has no batch size. If you "
+                            "are not calling this method directly, set `accelerator.even_batches=False` instead.")
 
     @property
     def total_length(self):


### PR DESCRIPTION
# What does this PR do?

When using deepspeed with a DL that doesn't have a `.batch_size` (e.g. due to using a batch sampler) it fails with:

```
[:0]:    ) = self.accelerator.prepare(
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/accelerator.py", line 1209, in prepare
[:0]:    result = self._prepare_deepspeed(*args)
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/accelerator.py", line 1419, in _prepare_deepspeed
[:0]:    result = [
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/accelerator.py", line 1420, in <listcomp>
[:0]:    self._prepare_one(obj, first_pass=True) if isinstance(obj, torch.utils.data.DataLoader) else obj
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/accelerator.py", line 1092, in _prepare_one
[:0]:    return self.prepare_data_loader(obj, device_placement=device_placement)
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/accelerator.py", line 1791, in prepare_data_loader
[:0]:    prepared_data_loader = prepare_data_loader(
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/data_loader.py", line 863, in prepare_data_loader
[:0]:    new_batch_sampler = BatchSamplerShard(
[:0]:  File "/mnt/nvme0/code/huggingface/accelerate-ds-bs-auto/src/accelerate/data_loader.py", line 155, in __init__
[:0]:    raise ValueError("You need to use `even_batches=False` when the batch sampler has no batch size.")
[:0]:ValueError: You need to use `even_batches=False` when the batch sampler has no batch size.
```
It's impossible to act on the error message's suggestion, since the deepspeed plugin doesn't expose this parameter to the user. But instead it uses `accelerator.even_batches`.

So I expanded the error message to suggest to do that.

Of course @pacman100 may consider to do the work for the user and if `.batch_size` isn't available then to set the correct flag automatically.

## Who can review?

- DeepSpeed: @pacman100
- Core parts of the library: @muellerzr @BenjaminBossan
