### PR TITLE
Integrate MS-AMP Support for FP8 as a seperate backend

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -65,7 +65,7 @@
     title: Executing and deferring jobs
   - local: concept_guides/gradient_synchronization
     title: Gradient synchronization
-  - local: usage_guides/low_precision_training
+  - local: concept_guides/low_precision_training
     title: How training in low-precision environments is possible (FP8)
   - local: concept_guides/training_tpu
     title: TPU best practices

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -41,6 +41,8 @@
     title: Using experiment trackers
   - local: usage_guides/mps
     title: How to use Apple Silicon M1 GPUs
+  - local: usage_guides/low_precision_training
+    title: How to train in low precision (FP8)
   - local: usage_guides/deepspeed
     title: How to use DeepSpeed
   - local: usage_guides/fsdp
@@ -63,6 +65,8 @@
     title: Executing and deferring jobs
   - local: concept_guides/gradient_synchronization
     title: Gradient synchronization
+  - local: usage_guides/low_precision_training
+    title: How training in low-precision environments is possible (FP8)
   - local: concept_guides/training_tpu
     title: TPU best practices
   title: Concepts and fundamentals

--- a/docs/source/concept_guides/low_precision_training.md
+++ b/docs/source/concept_guides/low_precision_training.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 # Low Precision Training Methods
 
-As new hardware has been released, new training paradigms to better utilize them ahve come out as a result. Currently this is in the form of training
+As new hardware has been released, new training paradigms to better utilize them have come out as a result. Currently this is in the form of training
 in 8-bit precision using packages such as [TranformersEngine](https://github.com/NVIDIA/TransformerEngine) (TE) or [MS-AMP](https://github.com/Azure/MS-AMP/tree/main).
 
 For an introduction to the topics discussed today, it's recommended to review the low precision usage documentation available [here](../usage_guides/low_precision_training.md) as this documentation will reference it regularly. 
@@ -43,7 +43,7 @@ Specifically, 🤗 Accelerate will find and replace the following layers with th
 
 As a result we wind up with a model that has most of its layers in BF16, while some layers are in FP8 reducing some of the memory. 
 
-Anecdotally, we have noticied that profmance gains don't really start showing when using `TransformerEngine` until a large majority of the layers
+Anecdotally, we have noticed that performance gains don't really start showing when using `TransformerEngine` until a large majority of the layers
 in the model are made up of those two layers to replace. As a result only larger models have been seen to show performance improvements when the number of parameters is around and upwards of a few billion. 
 
 There are many different arguments that can be passed to the `TransformerEngine` that customize how FP8 calculations are performed and what they do. A full list of the arguments is available below:
@@ -57,7 +57,7 @@ There are many different arguments that can be passed to the `TransformerEngine`
 
 Each of these can be customized as part of the [`utils.FP8RecipeKwargs`] and tweaked to help optimize performance of your models.
 
-If we notice in the chart mentioned earlier, TE simply casts the computation layers into FP8, while everything else is in FP32. As a result this winds up utilizing the most memory but does so with the benefit of guarenting the least amount of loss in end accuracy during training. 
+If we notice in the chart mentioned earlier, TE simply casts the computation layers into FP8, while everything else is in FP32. As a result this winds up utilizing the most memory but does so with the benefit of guaranteeing the least amount of loss in end accuracy during training. 
 
 ## `MS-AMP`
 

--- a/docs/source/concept_guides/low_precision_training.md
+++ b/docs/source/concept_guides/low_precision_training.md
@@ -1,0 +1,74 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Low Precision Training Methods
+
+As new hardware has been released, new training paradigms to better utilize them ahve come out as a result. Currently this is in the form of training
+in 8-bit precision using packages such as [TranformersEngine](https://github.com/NVIDIA/TransformerEngine) (TE) or [MS-AMP](https://github.com/Azure/MS-AMP/tree/main).
+
+For an introduction to the topics discussed today, it's recommended to review the low precision usage documentation available [here](../usage_guides/low_precision_training.md) as this documentation will reference it regularly. 
+
+## A Quick Chart
+
+Below is a quick chart from the MS-AMP documentation showing the different bit-precisions for each solution during training:
+
+Optimization Level | Computation(GEMM) | Comm | Weight | Master Weight | Weight Gradient | Optimizer States
+-- | -- | -- | -- | -- | -- | --
+FP16 AMP | FP16 | FP32 | FP32 | N/A | FP32 | FP32+FP32
+Nvidia TE | FP8 | FP32 | FP32 | N/A | FP32 | FP32+FP32
+MS-AMP O1 | FP8 | FP8 | FP16 | N/A | FP8 | FP32+FP32
+MS-AMP O2 | FP8 | FP8 | FP16 | N/A | FP8 | FP8+FP16
+MS-AMP O3 | FP8 | FP8 | FP8 | FP16 | FP8 | FP8+FP16
+
+## `TransformersEngine`
+
+`TranformersEngine` is the first solution to trying to train in 8-bit floating point. It operates by changing layers inside the model to ones that utilize 8-bit accelerated ones that should not degrade the final accuracy of the model upon convergence. 
+
+Specifically, 🤗 Accelerate will find and replace the following layers with their own versions:
+
+* `nn.LayerNorm` for `te.LayerNorm`
+* `nn.Linear` for `te.Linear`
+
+As a result we wind up with a model that has most of its layers in BF16, while some layers are in FP8 reducing some of the memory. 
+
+Anecdotally, we have noticied that profmance gains don't really start showing when using `TransformerEngine` until a large majority of the layers
+in the model are made up of those two layers to replace. As a result only larger models have been seen to show performance improvements when the number of parameters is around and upwards of a few billion. 
+
+There are many different arguments that can be passed to the `TransformerEngine` that customize how FP8 calculations are performed and what they do. A full list of the arguments is available below:
+
+* `margin`: The margin to use for the gradient scaling.
+* `interval`: The interval to use for how often the scaling factor is recomputed.
+* `fp8_format``: The format to use for the FP8 recipe. Must be one of `E4M3` or `HYBRID`.
+* `amax_history_len`: The length of the history to use for the scaling factor computation
+* `amax_compute_algo`: The algorithm to use for the scaling factor computation. Must be one of `max` or `most_recent`.
+* `override_linear_precision`: Whether or not to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision.
+
+Each of these can be customized as part of the [`utils.FP8RecipeKwargs`] and tweaked to help optimize performance of your models.
+
+If we notice in the chart mentioned earlier, TE simply casts the computation layers into FP8, while everything else is in FP32. As a result this winds up utilizing the most memory but does so with the benefit of guarenting the least amount of loss in end accuracy during training. 
+
+## `MS-AMP`
+
+MS-AMP takes a different approach to `TransformersEngine` by providing three different optimization levels to convert more operations in FP8 or FP16.
+
+* The base optimization level (`O1`), will also pass communications of the weights (such as in DDP) in FP8, stores the weights of the model in FP16, and leaves the optimizer states in FP32. The main benefit of this optimization level is we can reduce the communication bandwidth by essentially half and more GPU memory is saved due to 1/2 of everything being cast in FP8, and the weights are cast to FP16. Notably both the optimizer states remain in FP32.
+
+* The second optimization level (`O2`) improves upon this by also reducing the precision of the optimizer states. One is in FP8 while the other is in FP16. Generally it's been shown that this will only provide a net-gain of no degredated end accuracy, increased training speed, and reduced memory as now every state is either in FP16 or FP8. 
+
+* Finally, MS-AMP has a third optimization level (`O3`) which helps during DDP scenarios such as DeepSpeed. The weights of the model in memory is fully cast to FP8 and the master weights are now stored in FP16. This fully reduces memory by the highest factor as now not only is almost everything in FP8, only two states are left in FP16. Currently only DeepSpeed versions up through 0.9.2 are supported, so this capability is not included in the 🤗 Accelerate integration
+
+## Combining the two
+
+More experiments need to be performed but it's been noted that combining both MS-AMP and TransformersEngine can lead to the highest throughput by relying on NVIDIA's optimized FP8 operators and utilizing how MS-AMP reduces the memory overhead.

--- a/docs/source/concept_guides/low_precision_training.md
+++ b/docs/source/concept_guides/low_precision_training.md
@@ -34,7 +34,7 @@ MS-AMP O3 | FP8 | FP8 | FP8 | FP16 | FP8 | FP8+FP16
 
 ## `TransformersEngine`
 
-`TranformersEngine` is the first solution to trying to train in 8-bit floating point. It operates by changing layers inside the model to ones that utilize 8-bit accelerated ones that should not degrade the final accuracy of the model upon convergence. 
+`TranformersEngine` is the first solution to trying to train in 8-bit floating point. It works by using drop-in replacement layers for certain ones in a model that utilize their FP8-engine to reduce the number of bits (such as 32 to 8) without degrading the final accuracy of the model. 
 
 Specifically, 🤗 Accelerate will find and replace the following layers with `TranformersEngine` versions:
 
@@ -46,7 +46,7 @@ As a result we wind up with a model that has most of its layers in BF16, while s
 Anecdotally, we have noticed that performance gains don't really start showing when using `TransformerEngine` until a large majority of the layers
 in the model are made up of those two layers to replace. As a result, only larger models have shown performance improvements when the number of parameters is around and upwards of a few billion. 
 
-There are many different arguments that can be passed to the `TransformerEngine` that customize how FP8 calculations are performed and what they do. A full list of the arguments is available below:
+The `TransformerEngine` can receive many different arguments that customize how it performs FP8 calculations and what they do. A full list of the arguments is available below:
 
 * `margin`: The margin to use for the gradient scaling.
 * `interval`: The interval to use for how often the scaling factor is recomputed.
@@ -55,7 +55,7 @@ There are many different arguments that can be passed to the `TransformerEngine`
 * `amax_compute_algo`: The algorithm to use for the scaling factor computation. Must be one of `max` or `most_recent`.
 * `override_linear_precision`: Whether or not to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision.
 
-Each of these can be customized as part of the [`utils.FP8RecipeKwargs`] and tweaked to help optimize performance of your models.
+You can customize each of these as part of [`utils.FP8RecipeKwargs`] to help optimize performance of your models.
 
 If we notice in the chart mentioned earlier, TE simply casts the computation layers into FP8, while everything else is in FP32. As a result this winds up utilizing the most memory but does so with the benefit of guaranteeing the least amount of loss in end accuracy during training. 
 

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -48,6 +48,8 @@ These are basic dataclasses used throughout 🤗 Accelerate and they can be pass
 
 [[autodoc]] utils.PrecisionType
 
+[[autodoc]] utils.FP8RecipeKwargs
+
 [[autodoc]] utils.ProjectConfiguration
 
 ## Environmental Variables

--- a/docs/source/usage_guides/low_precision_training.md
+++ b/docs/source/usage_guides/low_precision_training.md
@@ -54,7 +54,7 @@ accelerator = Accelerator(mixed_precision="fp8", kwarg_handlers=kwargs)
 
 Of the two, `MS-AMP` is traditionally the easier one to configure as there is only a single argument: the optimization level. 
 
-Currently we support one of two different levels, `"O1"` and `"O2"` (using the letter 'o', not zero). 
+Currently two levels of optimization are supported in the 🤗 Accelerate integration, `"O1"` and `"O2"` (using the letter 'o', not zero). 
 
 * `"O1"` will cast the weight gradients and `all_reduce` communications to happen in 8-bit, while the rest are done in 16 bit. This reduces the general GPU memory usage and speeds up communication bandwidths.
 * `"O2"` will also cast first-order optimizer states into 8 bit, while the second order states are in FP16. (Currently just the `Adam` optimizer is supported). This tries it's best to minimize final accuracy degredation and will save the highest potential memory.

--- a/docs/source/usage_guides/low_precision_training.md
+++ b/docs/source/usage_guides/low_precision_training.md
@@ -1,0 +1,92 @@
+<!--Copyright 2023 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Low Precision Training Methods
+
+🤗 Accelerate provides integrations to train on lower precision methods using specified supported hardware through the `TransformersEngine` and `MS-AMP` packages. This documentation will help guide you through what hardware is supported, how to configure your [`Accelerator`] to do so, and what you can expect when training. 
+
+## What training on FP8 means
+
+To explore more of the nitty-gritty in traninig in FP8 with PyTorch and 🤗 Accelerate, check out the [concept_guide](../concept_guides/low_precision_training.md) on why this can be difficult. But essentially rather than training in BF16, some (or all) aspects of training a model can be performed using 8 bits instead of 16. The challenge is doing so without degrading final performance. 
+
+This is only enabled on specific NVIDIA hardware, namely:
+
+* Anything after the 3000 series consumer graphics cards (such as the 4090)
+* Hopper-based GPU architectures (such as the `H100` and `H200`)
+
+What this will result in is some gain in the memory used (as we've cut the needed memory in half for some parts of training) and an increase in throughput *should* be seen as well for larger models that can replace certain layers with FP8-enabled ones.
+
+## Configuring the Accelerator
+
+Currently two different backends for FP8 are supported (`TransformersEngine` and `MS-AMP`), each with different capabilities and configurations. 
+
+To use either, the same core API is used. Just pass `mixed_precision="fp8"` to either the [`Accelerator`], during `accelerate config` when prompted about mixed precision, or as part of your `config.yaml` file in the `mixed_precision` key:
+
+```{python}
+from accelerate import Accelerator
+accelerator = Accelerator(mixed_precision="fp8")
+```
+
+By default if `MS-AMP` is available in your environment, 🤗 Accelerate will automatically utilize it as a backend. To specify it yourself however (and customize other parts of the FP8 mixed precision setup), you can utilize the [`utils.FP8RecipeKwargs`] to configure it:
+
+```{python}
+from accelerate import Accelerator
+from accelerate.utils import FP8RecipeKwargs
+kwargs = [FP8RecipeKwargs(backend="msamp")]
+# Or to specify the backend as `TransformersEngine` even if MS-AMP is installed
+# kwargs = [FP8RecipeKwargs(backend="te")]
+accelerator = Accelerator(mixed_precision="fp8", kwarg_handlers=kwargs)
+```
+
+## Configuring MS-AMP
+
+Of the two, `MS-AMP` is traditionally the easier one to configure as there is only a single argument: the optimization level. 
+
+Currently we support one of two different levels, `"O1"` and `"O2"` (using the letter 'o', not zero). 
+
+* `"O1"` will cast the weight gradients and `all_reduce` communications to happen in 8-bit, while the rest are done in 16 bit. This reduces the general GPU memory usage and speeds up communication bandwidths.
+* `"O2"` will also cast first-order optimizer states into 8 bit, while the second order states are in FP16. (Currently just the `Adam` optimizer is supported). This tries it's best to minimize final accuracy degredation and will save the highest potential memory.
+
+To specify an optimization level, pass it to the `FP8KwargsHandler` by setting the `optimization_level` argument:
+
+```{python}
+from accelerate import Accelerator
+from accelerate.utils import FP8RecipeKwargs
+kwargs = [FP8RecipeKwargs(backend="msamp", optimization_level="O2")]
+accelerator = Accelerator(mixed_precision="fp8", kwarg_handlers=kwargs)
+```
+
+## Configuring TransformersEngine
+
+TransformersEngine has much more available for customizing how and what FP8 calculations are performed. A full list of supported arguments and what they mean are available in [NVIDIA's documentation](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html), however they are restated as part of [`FP8KwargsHandler`]'s docstring for your convience. 
+
+🤗 Accelerate tries to set sensible defaults, but exploring and tweaking the various parameters yourself can lead to better performance potentially.
+
+To use it, specify `backend="msamp"` and modify any of the arguments you want as part of your kwarg handler:
+
+```{python}
+from accelerate import Accelerator
+from accelerate.utils import FP8RecipeKwargs
+kwargs = [FP8RecipeKwargs(backend="te", ...)]
+accelerator = Accelerator(mixed_precision="fp8", kwarg_handlers=kwargs)
+```
+
+## Futher Reading
+
+To learn more about training in FP8 please check out the following resources:
+
+* [Our concept guide](../concept_guides/low_precision_training.md) detailing into more about both TransformersEngine and MS-AMP
+* [The `transformers-engine` documentation](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html)
+* [The `MS-AMP` documentation](https://azure.github.io/MS-AMP/docs/)

--- a/docs/source/usage_guides/low_precision_training.md
+++ b/docs/source/usage_guides/low_precision_training.md
@@ -74,7 +74,7 @@ TransformersEngine has much more available for customizing how and what FP8 calc
 
 🤗 Accelerate tries to set sensible defaults, but exploring and tweaking the various parameters yourself can lead to better performance potentially.
 
-To use it, specify `backend="msamp"` and modify any of the arguments you want as part of your kwarg handler:
+To use it, specify `backend="te"` and modify any of the arguments you want as part of your kwarg handler:
 
 ```{python}
 from accelerate import Accelerator

--- a/docs/source/usage_guides/low_precision_training.md
+++ b/docs/source/usage_guides/low_precision_training.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 # Low Precision Training Methods
 
-🤗 Accelerate provides integrations to train on lower precision methods using specified supported hardware through the `TransformersEngine` and `MS-AMP` packages. This documentation will help guide you through what hardware is supported, how to configure your [`Accelerator`] to do so, and what you can expect when training. 
+🤗 Accelerate provides integrations to train on lower precision methods using specified supported hardware through the `TransformersEngine` and `MS-AMP` packages. This documentation will help guide you through what hardware is supported, how to configure your [`Accelerator`] to leverage the low precision methods, and what you can expect when training. 
 
 ## What training on FP8 means
 
@@ -39,7 +39,7 @@ from accelerate import Accelerator
 accelerator = Accelerator(mixed_precision="fp8")
 ```
 
-By default if `MS-AMP` is available in your environment, 🤗 Accelerate will automatically utilize it as a backend. To specify it yourself however (and customize other parts of the FP8 mixed precision setup), you can utilize the [`utils.FP8RecipeKwargs`] to configure it:
+By default, if `MS-AMP` is available in your environment, 🤗 Accelerate will automatically utilize it as a backend. To specify it yourself (and customize other parts of the FP8 mixed precision setup), you can utilize the [`utils.FP8RecipeKwargs`]:
 
 ```{python}
 from accelerate import Accelerator

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -19,12 +19,9 @@ import torch
 from datasets import load_dataset
 from torch.optim import AdamW
 from torch.utils.data import DataLoader
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, get_linear_schedule_with_warmup, set_seed, logging
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, get_linear_schedule_with_warmup, set_seed
 
 from accelerate import Accelerator, DistributedType
-from accelerate.utils import FP8RecipeKwargs
-
-logging.set_verbosity_error()
 
 
 ########################################################################
@@ -116,11 +113,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
 
 def training_function(config, args):
     # Initialize accelerator
-    if args.mixed_precision == "fp8":
-        kwargs = [FP8RecipeKwargs(backend="te")]
-    else:
-        kwargs = None
-    accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision, kwargs_handlers=kwargs)
+    accelerator = Accelerator(cpu=args.cpu, mixed_precision=args.mixed_precision)
     # Sample hyper-parameters for learning rate, batch size, seed and a few other HPs
     lr = config["lr"]
     num_epochs = int(config["num_epochs"])

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1759,7 +1759,8 @@ class Accelerator:
     def _prepare_msamp(self, *args):
         if not is_msamp_available():
             raise ImportError(
-                "MS-AMP was not found on your system. Please ensure that MS-AMP is available or choose `'te'` as the backend for FP8 mixed precision training."
+                "MS-AMP was not found on your system. Please ensure that MS-AMP is available "
+                " or choose `'te'` as the backend for FP8 mixed precision training."
             )
         else:
             import msamp

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1302,15 +1302,7 @@ class Accelerator:
             if "fp8_format" in kwargs:
                 kwargs["fp8_format"] = getattr(te_recipe.Format, kwargs["fp8_format"])
             fp8_recipe = te_recipe.DelayedScaling(**kwargs)
-            cuda_device_capacity = torch.cuda.get_device_capability()
-            fp8_enabled = cuda_device_capacity >= (8, 9)
-            if not fp8_enabled:
-                logger.warn(
-                    f"The current device has compute capability of {cuda_device_capacity} which is "
-                    "insufficient for FP8 mixed precision training (requires a GPU Hopper/Ada Lovelace "
-                    "or higher, compute capability of 8.9 or higher). Will use FP16 instead."
-                )
-            model.forward = fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe)(model.forward)
+            model.forward = fp8_autocast(enabled=True, fp8_recipe=fp8_recipe)(model.forward)
 
         if (getattr(model, "is_loaded_in_8bit", False) or getattr(model, "is_loaded_in_4bit", False)) and getattr(
             model, "hf_device_map", False

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1767,8 +1767,10 @@ class Accelerator:
             elif isinstance(obj, (torch.optim.Optimizer)):
                 optimizer = obj
                 num_optimizers += 1
-        if optimizer is None and model is None:
-            raise ValueError("You must pass a model and an optimizer to `accelerate.prepare()` when using MS-AMP.")
+        if optimizer is None or model is None:
+            raise ValueError(
+                "You must pass a model and an optimizer together to `accelerate.prepare()` when using MS-AMP."
+            )
         elif num_models > 1 or num_optimizers > 1:
             raise ValueError(
                 f"You can't use multiple models ({num_models}) or optimizers {num_optimizers} with MS-AMP."

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1286,7 +1286,7 @@ class Accelerator:
                 model.forward = MethodType(convert_outputs_to_fp32(model.forward.__func__), model)
             else:
                 model.forward = convert_outputs_to_fp32(new_forward)
-        elif self.mixed_precision == "fp8" and self.fp8_recipe_handler.backend == "transformer_engine":
+        elif self.mixed_precision == "fp8" and self.fp8_recipe_handler.backend == "TE":
             if not has_transformer_engine_layers(model):
                 with torch.no_grad():
                     convert_model(model)

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -65,6 +65,7 @@ from .imports import (
     is_megatron_lm_available,
     is_mlflow_available,
     is_mps_available,
+    is_msamp_available,
     is_npu_available,
     is_pandas_available,
     is_rich_available,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -40,6 +40,7 @@ from .dataclasses import (
 from .environment import (
     are_libraries_initialized,
     check_cuda_p2p_ib_support,
+    check_fp8_capability,
     get_int_from_env,
     parse_choice_from_env,
     parse_flag_from_env,
@@ -73,6 +74,7 @@ from .imports import (
     is_tensorboard_available,
     is_timm_available,
     is_tpu_available,
+    is_transformer_engine_available,
     is_transformers_available,
     is_wandb_available,
     is_xpu_available,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -171,21 +171,8 @@ class InitProcessGroupKwargs(KwargsHandler):
 
 @dataclass
 class FP8RecipeKwargs(KwargsHandler):
-    """
-    Use this object in your [`Accelerator`] to customize the initialization of the recipe for FP8 mixed precision
-    training. Please refer to the documentation of this
-    [class](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html#transformer_engine.common.recipe.DelayedScaling)
-    for more information on each argument.
-
-    ```python
-    from accelerate import Accelerator
-    from accelerate.utils import FP8RecipeKwargs
-
-    kwargs = FP8RecipeKwargs(fp8_format="HYBRID")
-    accelerator = Accelerator(mixed_precision="fp8", kwargs_handlers=[kwargs])
-    ```
-    """
-
+    backend: str = "msamp"
+    opt_level: str = "O2"
     margin: int = 0
     interval: int = 1
     fp8_format: str = "E4M3"
@@ -194,6 +181,9 @@ class FP8RecipeKwargs(KwargsHandler):
     override_linear_precision: Tuple[bool, bool, bool] = (False, False, False)
 
     def __post_init__(self):
+        self.backend = self.backend.upper()
+        if self.backend not in ["MSAMP", "TE"]:
+            raise ValueError("`backend` must be 'MSAMP' or 'TE' (TransformerEngine).")
         self.fp8_format = self.fp8_format.upper()
         if self.fp8_format not in ["E4M3", "HYBRID"]:
             raise ValueError("`fp8_format` must be 'E4M3' or 'HYBRID'.")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -231,13 +231,16 @@ class FP8RecipeKwargs(KwargsHandler):
         self.backend = self.backend.upper()
         if self.backend not in ["MSAMP", "TE"]:
             raise ValueError("`backend` must be 'MSAMP' or 'TE' (TransformerEngine).")
-        if self.opt_level not in ["O1", "O2"]:
-            raise NotImplementedError("MS-AMP with Accelerate is only supported for `optimization_level` '01' or '02'")
-        self.fp8_format = self.fp8_format.upper()
-        if self.fp8_format not in ["E4M3", "HYBRID"]:
-            raise ValueError("`fp8_format` must be 'E4M3' or 'HYBRID'.")
-        if self.amax_compute_algo not in ["max", "most_recent"]:
-            raise ValueError("`amax_compute_algo` must be 'max' or 'most_recent'")
+        # Check TE args
+        if self.backend == "TE":
+            self.fp8_format = self.fp8_format.upper()
+            if self.fp8_format not in ["E4M3", "HYBRID"]:
+                raise ValueError("`fp8_format` must be 'E4M3' or 'HYBRID'.")
+            if self.amax_compute_algo not in ["max", "most_recent"]:
+                raise ValueError("`amax_compute_algo` must be 'max' or 'most_recent'")
+        elif self.backend == "MSAMP":
+            if self.opt_level not in ["O1", "O2"]:
+                raise NotImplementedError("MS-AMP with Accelerate is only supported for `optimization_level` '01' or '02'")
 
 
 class EnumWithContains(enum.EnumMeta):

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -26,7 +26,7 @@ import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple
 
 import torch
 
@@ -173,9 +173,15 @@ class InitProcessGroupKwargs(KwargsHandler):
 class FP8RecipeKwargs(KwargsHandler):
     """
     Use this object in your [`Accelerator`] to customize the initialization of the recipe for FP8 mixed precision
-    training with `transformers-engine`. Please refer to the documentation of this
-    [class](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html#transformer_engine.common.recipe.DelayedScaling)
-    for more information on each argument.
+    training with `transformer-engine` or `ms-amp`.
+
+    <Tip>
+        For more information on `transformer-engine` args, please refer to the API
+        [documentation](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html).
+
+        For more information on the `ms-amp` args, please refer to the Optimization Level
+        [documentation](https://azure.github.io/MS-AMP/docs/user-tutorial/optimization-level).
+    </Tip>
 
     ```python
     from accelerate import Accelerator
@@ -218,13 +224,13 @@ class FP8RecipeKwargs(KwargsHandler):
                     available currently).
     """
 
-    backend: str = "msamp"
-    opt_level: str = "O2"
+    backend: Literal["msamp", "te"] = "msamp"
+    opt_level: Literal["O1", "O2"] = "O2"
     margin: int = 0
     interval: int = 1
-    fp8_format: str = "E4M3"
+    fp8_format: Literal["E4M3", "HYBRID"] = "E4M3"
     amax_history_len: int = 1
-    amax_compute_algo: str = "most_recent"
+    amax_compute_algo: Literal["max", "most_recent"] = "most_recent"
     override_linear_precision: Tuple[bool, bool, bool] = (False, False, False)
 
     def __post_init__(self):

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -240,7 +240,9 @@ class FP8RecipeKwargs(KwargsHandler):
                 raise ValueError("`amax_compute_algo` must be 'max' or 'most_recent'")
         elif self.backend == "MSAMP":
             if self.opt_level not in ["O1", "O2"]:
-                raise NotImplementedError("MS-AMP with Accelerate is only supported for `optimization_level` '01' or '02'")
+                raise NotImplementedError(
+                    "MS-AMP with Accelerate is only supported for `optimization_level` '01' or '02'"
+                )
 
 
 class EnumWithContains(enum.EnumMeta):

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -176,11 +176,13 @@ class FP8RecipeKwargs(KwargsHandler):
     training with `transformer-engine` or `ms-amp`.
 
     <Tip>
+
         For more information on `transformer-engine` args, please refer to the API
         [documentation](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/common.html).
 
         For more information on the `ms-amp` args, please refer to the Optimization Level
         [documentation](https://azure.github.io/MS-AMP/docs/user-tutorial/optimization-level).
+
     </Tip>
 
     ```python

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -231,6 +231,8 @@ class FP8RecipeKwargs(KwargsHandler):
         self.backend = self.backend.upper()
         if self.backend not in ["MSAMP", "TE"]:
             raise ValueError("`backend` must be 'MSAMP' or 'TE' (TransformerEngine).")
+        if self.opt_level not in ["O1", "O2"]:
+            raise NotImplementedError("MS-AMP with Accelerate is only supported for `optimization_level` '01' or '02'")
         self.fp8_format = self.fp8_format.upper()
         if self.fp8_format not in ["E4M3", "HYBRID"]:
             raise ValueError("`fp8_format` must be 'E4M3' or 'HYBRID'.")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -185,7 +185,7 @@ class FP8RecipeKwargs(KwargsHandler):
     accelerator = Accelerator(mixed_precision="fp8", kwargs_handlers=[kwargs])
     ```
 
-    To use with MS-AMP, use `backend="msamp"` and pass the `optimization_level`:
+    To use MS-AMP as an engine, pass `backend="msamp"` and the `optimization_level`:
 
     ```python
     kwargs = FP8RecipeKwargs(backend="msamp", optimization_level="02")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -222,9 +222,9 @@ class FP8RecipeKwargs(KwargsHandler):
     opt_level: str = "O2"
     margin: int = 0
     interval: int = 1
-    fp8_format: str = "HYBRID"
-    amax_history_len: int = 1024
-    amax_compute_algo: str = "max"
+    fp8_format: str = "E4M3"
+    amax_history_len: int = 1
+    amax_compute_algo: str = "most_recent"
     override_linear_precision: Tuple[bool, bool, bool] = (False, False, False)
 
     def __post_init__(self):

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -19,6 +19,8 @@ import sys
 from distutils import spawn
 from typing import Dict
 
+import torch
+
 
 def str_to_bool(value) -> int:
     """
@@ -108,3 +110,13 @@ def check_cuda_p2p_ib_support():
     except Exception:
         pass
     return True
+
+
+def check_fp8_capability():
+    """
+    Checks if all the current GPUs available support FP8.
+
+    Notably must initialize `torch.cuda` to check.
+    """
+    cuda_device_capacity = torch.cuda.get_device_capability()
+    return cuda_device_capacity >= (8, 9)

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -214,6 +214,18 @@ def is_pandas_available():
     return _is_package_available("pandas")
 
 
+def is_msamp_available():
+    package_exists = importlib.util.find_spec("msamp") is not None
+    if package_exists:
+        try:
+            # MS-AMP has a different metadata name
+            _ = importlib.metadata.metadata("ms-amp")
+            return True
+        except importlib.metadata.PackageNotFoundError:
+            return False
+    return False
+
+
 def is_mlflow_available():
     if _is_package_available("mlflow"):
         return True

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -72,8 +72,24 @@ def get_ccl_version():
     return importlib.metadata.version("oneccl_bind_pt")
 
 
-def is_fp8_available():
+def is_msamp_available():
+    package_exists = importlib.util.find_spec("msamp") is not None
+    if package_exists:
+        try:
+            # MS-AMP has a different metadata name
+            _ = importlib.metadata.metadata("ms-amp")
+            return True
+        except importlib.metadata.PackageNotFoundError:
+            return False
+    return False
+
+
+def is_transformer_engine_available():
     return _is_package_available("transformer_engine")
+
+
+def is_fp8_available():
+    return is_msamp_available() or is_transformer_engine_available()
 
 
 def is_cuda_available():
@@ -212,18 +228,6 @@ def is_clearml_available():
 
 def is_pandas_available():
     return _is_package_available("pandas")
-
-
-def is_msamp_available():
-    package_exists = importlib.util.find_spec("msamp") is not None
-    if package_exists:
-        try:
-            # MS-AMP has a different metadata name
-            _ = importlib.metadata.metadata("ms-amp")
-            return True
-        except importlib.metadata.PackageNotFoundError:
-            return False
-    return False
 
 
 def is_mlflow_available():


### PR DESCRIPTION
# Integrate MS-AMP to the `Accelerator` (round 2)

## What does this add?

This PR introduces an additional backend for FP8 support through [MS-AMP](https://github.com/Azure/MS-AMP/tree/main) which has shown to decrease memory when using FP8 precision while maintaining accuracy

## Who is it for?

Individuals training with FP8 (H100/4090's, etc)

## Issues linked to

https://github.com/Azure/MS-AMP/issues/128

## What parts of the API does this impact?

### User-facing:

Two new arguments were added to the `FP8RecipeKwargs`:
* `backend` (`str`): Whether a user should use MS-AMP or TE (transformerengine). Uses `MS-AMP` by default.
* `optimization_level` (`str`), should be one of `"O1"` or `"O2"`. `"O3"` is for DeepSpeed and we need to wait for them to update to v0.9.3 of deepspeed to match what Accelerate supports

General guideline to optimization levels:
  * O1: Weight gradients and `all_reduce` communications are done in fp8, reducing GPU
      memory usage and communication bandwidth
  * O2: First-order optimizer states are in 8-bit, and second order states are in FP16.
      Only available when using Adam or AdamW. This maintains accuracy and can potentially save the highest
      memory.
  * 03: Specifically for DeepSpeed, implements capabilities so weights and master weights of models
      are stored in FP8. If `fp8` is selected and deepspeed is enabled, will be used by default.
      (Not available currently).
      
As a result, `"O2"` is the default. Here is an overview of each optimization level and what it does, taken from their [docs](https://azure.github.io/MS-AMP/docs/user-tutorial/optimization-level):

Optimization Level | Computation(GEMM) | Comm | Weight | Master Weight | Weight Gradient | Optimizer States
-- | -- | -- | -- | -- | -- | --
FP16 AMP | FP16 | FP32 | FP32 | N/A | FP32 | FP32+FP32
Nvidia TE | FP8 | FP32 | FP32 | N/A | FP32 | FP32+FP32
MS-AMP O1 | FP8 | FP8 | FP16 | N/A | FP8 | FP32+FP32
MS-AMP O2 | FP8 | FP8 | FP16 | N/A | FP8 | FP8+FP16
MS-AMP O3 | FP8 | FP8 | FP8 | FP16 | FP8 | FP8+FP16

## Basic Usage Example(s):

A user can either do:

```python
accelerator = Accelerator(mixed_precision="fp8")
```
Or use the `FP8RecipeKwargs`:

```python
# To use TransformerEngine instead
kwarg_handlers = [FP8RecipeKwargs(backend="TE")]

# To change the optimization level
kwarg_handlers = [FP8RecipeKwargs(optimization_level="O1")]

accelerator = Accelerator(
    mixed_precision="fp8",
    kwargs_handlers=kwarg_handlers,
)
```

### Benchmarks

When running on bloomz-560m I saw a memory decrease of ~1/3. 

More experiments need to be conducted on the behavior between TE x MS-AMP wrt performance. For instance, when running my sample script I use here for speed ([here](https://github.com/muellerzr/h100-performance-tests/blob/main/bloomz-560m/accelerate_script.py)) running on the first 100 batches, I saw a stark contrast in the ending training loss between TE and MS-AMP:

BF16 (baseline): 2.4867
TE: *11.3125*
MS-AMP: **2.89**

I also found overall there wasn't much of a time save with MS-AMP, as it actually added time instead (BF16 was ~0.139s/batch, while MS-AMP was 0.169s/batch). I want to run some more tests to verify but these were some local results. 

This performance difference isn't much in the case of BF16 vs MS-AMP, but it is *starkly contrast* when compared to TE. More work is needed to investigate why, so as a result I've opted to make MS-AMP just an entirely separate backend to use, rather than combine the two. 

### What went wrong in the last PR

While the training speed results looked *very good*, I quickly noticed issues with the losses that didn't make sense. Models just simply weren't training or converging, which was surprising. For now taking this more staged approach to the integration while we discover behaviors (both with TE and MS-AMP) through longer training runs. 