### PR TITLE
[DRAFT] Support PipelineParallel

### DIFF
--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -1,0 +1,149 @@
+import math
+from functools import partial
+from typing import Literal
+
+import torch
+from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+from pippy.PipelineStage import PipelineStage
+from torch import nn
+
+from .big_modeling import dispatch_model
+from .state import PartialState
+from .utils import (
+    calculate_maximum_sizes,
+    convert_bytes,
+    infer_auto_device_map,
+)
+
+
+ParallelMode = Literal["sequential", "pipeline_parallel"]
+
+
+class InferenceHandler:
+    """
+    Base class for handling different backends for `device_map="auto"` inference.
+
+    Supports the native accelerate version as well as utilizing PiPPy.
+    """
+
+    def __init__(self, device_map: str = "auto", parallel_mode: ParallelMode = "sequential"):
+        self.model = None
+        self.device_map = device_map
+        self.state = PartialState()
+        self.parallel_mode = parallel_mode
+        # if parallel_mode == "pipeline_parallel" and not is_pippy_available():
+        #     raise RuntimeError("PiPPy is not installed, but is required for pipeline parallel inference.")
+
+        # Attrs for native pipeline parallelism
+        self.pipeline = None
+        self.scheduler = None
+
+    @staticmethod
+    def generate_device_map(model: nn.Module, parallel_mode: str, num_processes: int = 1):
+        if parallel_mode == "sequential":
+            # No change or adjustment is needed
+            return infer_auto_device_map(
+                model,
+                no_split_module_classes=model._no_split_modules,
+                clean_result=False,
+            )
+        elif parallel_mode == "pipeline_parallel":
+            # Calculate the maximum size of the model weights
+            model_size, shared = calculate_maximum_sizes(model)
+            # Split memory based on the number of devices
+            memory = (model_size + shared[0]) / num_processes
+            memory = convert_bytes(memory)
+            value, ending = memory.split(" ")
+
+            # Add a chunk to deal with placement issues on `pippy`
+            memory = math.ceil(float(value)) * 1.1
+            memory = f"{memory} {ending}"
+            # Create a device map based on the memory
+            max_memory = {i: memory for i in range(num_processes)}
+            return infer_auto_device_map(
+                model,
+                max_memory=max_memory,
+                no_split_module_classes=model._no_split_modules,
+                clean_result=False,
+            )
+        else:
+            raise ValueError(
+                f"Unknown parallel mode: {parallel_mode}. Expected either `sequential` or `pipeline_parallel`."
+            )
+
+    def prepare_pippy(self, model: nn.Module):
+        """
+        Prepares a model for inference based on `device_map` for pipeline parallelism.
+        """
+        if self.device_map == "auto":
+            self.device_map = self.generate_device_map(model, "pipeline_parallel", self.state.num_processes)
+        model._original_forward = model.forward
+        # get all the split points for each device
+        split_points = []
+        for i in range(1, self.state.num_processes):
+            split_points.append(next(k for k, v in self.device_map.items() if v == i))
+
+        # Annotate the model with the split points
+        for split_point in split_points:
+            annotate_split_points(model, {split_point: PipeSplitWrapper.SplitPoint.BEGINNING})
+
+        model._original_call = model.__call__
+        model._original_forward = model.forward
+        model.__call__ = partial(self.__call__, model=model)
+        return model
+
+    def prepare_native(self, model: nn.Module):
+        """
+        Prepares a model for inference based on `device_map` for sequential parallelism.
+        """
+        if self.device_map == "auto":
+            self.device_map = self.generate_device_map(model, "sequential", self.state.num_processes)
+
+        model = dispatch_model(model, self.device_map)
+        return model
+
+    def prepare(self, model: nn.Module):
+        """
+        Prepares a model for inference based on `device_map` and `parallel_mode`.
+        """
+        if self.parallel_mode == "sequential":
+            model = self.prepare_native(model)
+        elif self.parallel_mode == "pipeline_parallel":
+            # Send the model to the device for now
+            model.to(self.device)
+            model = self.prepare_pippy(model)
+        return model
+
+    @property
+    def device(self):
+        return self.state.device
+
+    def __call__(self, model, *args, **kwargs):
+        if model is None:
+            raise RuntimeError("Model must be prepared before inference is performed. Please call `prepare` first.")
+
+        with torch.inference_mode():
+            if self.parallel_mode == "sequential":
+                return model(*args, **kwargs)
+            elif self.parallel_mode == "pipeline_parallel":
+                if self.pipeline is None:
+                    # We need to do our first trace quickly over the model
+                    self.pipeline = Pipe.from_tracing(
+                        model,
+                        num_chunks=self.state.num_processes,
+                        example_args=args,
+                        example_kwargs=kwargs,
+                    )
+                if self.scheduler is None:
+                    # Create a schedule runtime
+                    self.scheduler = PipelineStage(
+                        self.pipeline,
+                        self.state.local_process_index,
+                        device=self.state.device,
+                    )
+                if self.state.is_local_main_process:
+                    # convert kwargs to a tuple, this has been fixed on main
+                    args = tuple(kwargs.values())
+                    return self.scheduler(*args)
+                else:
+                    return self.scheduler(*())

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -13,6 +13,7 @@ from .utils import (
     calculate_maximum_sizes,
     convert_bytes,
     infer_auto_device_map,
+    is_pippy_available,
 )
 
 
@@ -31,8 +32,8 @@ class InferenceHandler:
         self.device_map = device_map
         self.state = PartialState()
         self.parallel_mode = parallel_mode
-        # if parallel_mode == "pipeline_parallel" and not is_pippy_available():
-        #     raise RuntimeError("PiPPy is not installed, but is required for pipeline parallel inference.")
+        if parallel_mode == "pipeline_parallel" and not is_pippy_available():
+            raise RuntimeError("PiPPy is not installed, but is required for pipeline parallel inference.")
 
         # Attrs for native pipeline parallelism
         self.pipeline = None

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -67,6 +67,7 @@ from .imports import (
     is_mps_available,
     is_npu_available,
     is_pandas_available,
+    is_pippy_available,
     is_rich_available,
     is_sagemaker_available,
     is_tensorboard_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -110,6 +110,10 @@ def is_deepspeed_available():
     return _is_package_available("deepspeed")
 
 
+def is_pippy_available():
+    return _is_package_available("pippy")
+
+
 def is_bf16_available(ignore_tpu=False):
     "Checks if bf16 is supported, optionally ignoring the TPU"
     if is_tpu_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -111,7 +111,7 @@ def is_deepspeed_available():
 
 
 def is_pippy_available():
-    return _is_package_available("pippy")
+    return _is_package_available("torchpippy")
 
 
 def is_bf16_available(ignore_tpu=False):

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -922,7 +922,7 @@ def infer_auto_device_map(
     no_split_module_classes: Optional[List[str]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     special_dtypes: Optional[Dict[str, Union[str, torch.dtype]]] = None,
-    clean_result: Optional[bool] = True,
+    clean_result: bool = True,
     verbose: bool = False,
 ):
     """
@@ -955,7 +955,7 @@ def infer_auto_device_map(
         special_dtypes (`Dict[str, Union[str, torch.device]]`, *optional*):
             If provided, special dtypes to consider for some specific weights (will override dtype used as default for
             all weights).
-        clean_result (`bool` *optional*):
+        clean_result (`bool`, *optional*, defaults to True):
             Clean the resulting device_map by grouping all submodules that go on the same device together. 
         verbose (`bool`, *optional*, defaults to `False`):
             Whether or not to provide debugging statements as the function builds the device_map.

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -957,7 +957,7 @@ def infer_auto_device_map(
             all weights).
         verbose (`bool`, *optional*, defaults to `False`):
             Whether or not to provide debugging statements as the function builds the device_map.
-        clean_result (`bool`, *optional*, defaults to True):
+        clean_result (`bool`, *optional*, defaults to `True`):
             Clean the resulting device_map by grouping all submodules that go on the same device together.
     """
     # Get default / clean up max_memory

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -21,7 +21,7 @@ import os
 import re
 import shutil
 import tempfile
-from collections import defaultdict, OrderedDict
+from collections import OrderedDict, defaultdict
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
@@ -922,8 +922,8 @@ def infer_auto_device_map(
     no_split_module_classes: Optional[List[str]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     special_dtypes: Optional[Dict[str, Union[str, torch.dtype]]] = None,
-    clean_result: bool = True,
     verbose: bool = False,
+    clean_result: bool = True,
 ):
     """
     Compute a device map for a given model giving priority to GPUs, then offload on CPU and finally offload to disk,
@@ -955,10 +955,10 @@ def infer_auto_device_map(
         special_dtypes (`Dict[str, Union[str, torch.device]]`, *optional*):
             If provided, special dtypes to consider for some specific weights (will override dtype used as default for
             all weights).
-        clean_result (`bool`, *optional*, defaults to True):
-            Clean the resulting device_map by grouping all submodules that go on the same device together. 
         verbose (`bool`, *optional*, defaults to `False`):
             Whether or not to provide debugging statements as the function builds the device_map.
+        clean_result (`bool`, *optional*, defaults to True):
+            Clean the resulting device_map by grouping all submodules that go on the same device together.
     """
     # Get default / clean up max_memory
     max_memory = get_max_memory(max_memory)


### PR DESCRIPTION
## TODO:

* [ ] Look at how we can make this as part of the existing API, probably at `dispatch_model`?
* [ ] Efficient loading of the weights, currently requires entire model to fit on the device. Waiting for the torch team for a fix

## Example use:

```python
import torch
from accelerate.utils import set_seed
from accelerate.inference import InferenceHandler
from transformers import T5ForConditionalGeneration, T5Config

set_seed(42)
config = T5Config()
model = T5ForConditionalGeneration(config)
model.eval()

handler = InferenceHandler(parallel_mode="pipeline_parallel")
model = handler.prepare(model)

input = torch.randint(
    low=0,
    high=config.vocab_size,
    size=(2, 1024),  # bs x seq_len
    device="cuda",
    dtype=torch.int64,
    requires_grad=False,
)

input = {"input_ids": input, "decoder_input_ids": input}
with torch.no_grad():
    output = model(**input)

if output is not None:
    print(f'Output: {output}')
```