### PR TITLE
auto_wrap_policy for PEFT with FSDP

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -993,11 +993,16 @@ class FullyShardedDataParallelPlugin:
                     transformer_layer_cls=transformer_cls_to_wrap,
                 )
 
-                # In an FSDP setting PEFT models require individually wrapping unfrozen parameters 
-                
+                # In an FSDP setting PEFT models require individually wrapping unfrozen parameters
+
                 if isinstance(model, PeftModel):
                     print("PEFT wrapping")
-                    from torch.distributed.fsdp.wrap import _or_policy, lambda_auto_wrap_policy, transformer_auto_wrap_policy
+                    from torch.distributed.fsdp.wrap import (
+                        _or_policy,
+                        lambda_auto_wrap_policy,
+                        transformer_auto_wrap_policy,
+                    )
+
                     def lambda_policy_fn(module):
                         if (
                             len(list(module.named_children())) == 0
@@ -1009,9 +1014,9 @@ class FullyShardedDataParallelPlugin:
 
                     lambda_policy = functools.partial(lambda_auto_wrap_policy, lambda_fn=lambda_policy_fn)
                     auto_wrap_policy = functools.partial(_or_policy, policies=[lambda_policy, auto_wrap_policy])
-                    
+
                 self.auto_wrap_policy = auto_wrap_policy
-                
+
             elif auto_wrap_policy == FSDP_AUTO_WRAP_POLICY[1]:
                 min_num_params = int(os.environ.get("FSDP_MIN_NUM_PARAMS", 0))
                 if min_num_params > 0:

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -50,6 +50,7 @@ FP16 = "fp16"
 BF16 = "bf16"
 dtypes = [FP16, BF16]
 
+
 @require_fsdp
 @require_cuda
 class FSDPPluginIntegration(AccelerateTestCase):
@@ -103,20 +104,21 @@ class FSDPPluginIntegration(AccelerateTestCase):
                     self.assertTrue(fsdp_plugin.state_dict_config.rank0_only)
 
     def test_auto_wrap_policy_peft(self):
-        from peft import LoraConfig, get_peft_model, TaskType
+        from peft import LoraConfig, TaskType, get_peft_model
         from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
+
         peft_config = LoraConfig(
             task_type=TaskType.SEQ_2_SEQ_LM, inference_mode=False, r=8, lora_alpha=32, lora_dropout=0.1
         )
         model = AutoModel.from_pretrained(BERT_BASE_CASED)
         model = get_peft_model(model, peft_config)
-        
+
         env = self.dist_env.copy()
         env["FSDP_AUTO_WRAP_POLICY"] = "TRANSFORMER_BASED_WRAP"
         env["FSDP_TRANSFORMER_CLS_TO_WRAP"] = "BertLayer"
         env["FSDP_USE_ORIG_PARAMS"] = "false"
         env["RANK"] = "0"
-        with mockenv_context(**env):#
+        with mockenv_context(**env):  #
             fsdp_plugin = FullyShardedDataParallelPlugin()
             fsdp_plugin.set_auto_wrap_policy(model)
             kwargs = {
@@ -126,7 +128,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
             }
             torch.distributed.init_process_group(backend="nccl")
             model = FSDP(model, **kwargs)
-            
+
     def test_auto_wrap_policy(self):
         model = AutoModel.from_pretrained(BERT_BASE_CASED)
         for policy in FSDP_AUTO_WRAP_POLICY:
@@ -191,6 +193,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
             with mockenv_context(**env):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
                 self.assertEqual(fsdp_plugin.cpu_offload, CPUOffload(offload_params=flag))
+
 
 @require_fsdp
 @require_multi_gpu

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -50,7 +50,6 @@ FP16 = "fp16"
 BF16 = "bf16"
 dtypes = [FP16, BF16]
 
-import logging
 @require_fsdp
 @require_cuda
 class FSDPPluginIntegration(AccelerateTestCase):


### PR DESCRIPTION
# What does this PR do?

While doing finetuning with a PEFT model and FSDP I noticed excessive memory usage caused by the parameter use_orig_params which leads to additional memory usage for frozen parameters. When trying to disable use_orig_params the following error was thrown by FSDP

> ValueError: Must flatten tensors with uniform `requires_grad` when `use_orig_params=False`

The reason for this is documented in the torch library.

> FSDP has some constraints on freezing parameters (i.e. setting param.requires_grad=False). For use_orig_params=False, each FSDP instance must manage parameters that are all frozen or all non-frozen. For use_orig_params=True, FSDP supports mixing frozen and non-frozen, but we recommend not doing so since then the gradient memory usage will be higher than expected (namely, equivalent to not freezing those parameters). This means that ideally, frozen parameters should be isolated into their own nn.Module s and wrapped separately with FSDP.

I implemented a check in the auto_wrap_policy function of the FullyShardedDataParallelPlugin and wrapped the unfrozen parameters individually if necessary.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?
I wrote an additional test called `test_auto_wrap_policy_peft`which tests if FSDP fails when using PEFT and use_orig_params=False.

## Who can review?

@pacman100
@muellerzr