### PR TITLE
[`Big-Modeling`] Harmonize device check to handle corner cases

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -32,6 +32,7 @@ from .constants import SAFE_WEIGHTS_NAME, WEIGHTS_NAME
 from .dataclasses import AutocastKwargs, CustomDtype, DistributedType
 from .imports import is_mps_available, is_npu_available, is_xpu_available
 from .offload import load_offloaded_weight, offload_weight, save_offload_index
+from .other import check_device_same
 from .tqdm import is_tqdm_available, tqdm
 
 
@@ -324,7 +325,7 @@ def set_module_tensor_to_device(
             device = device_quantization
         if is_buffer:
             module._buffers[tensor_name] = new_value
-        elif value is not None or torch.device(device) != module._parameters[tensor_name].device:
+        elif value is not None or check_device_same(torch.device(device), module._parameters[tensor_name].device):
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
             if param_cls.__name__ in ["Int8Params", "FP4Params"]:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -325,7 +325,7 @@ def set_module_tensor_to_device(
             device = device_quantization
         if is_buffer:
             module._buffers[tensor_name] = new_value
-        elif value is not None or check_device_same(torch.device(device), module._parameters[tensor_name].device):
+        elif value is not None or not check_device_same(torch.device(device), module._parameters[tensor_name].device):
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
             if param_cls.__name__ in ["Int8Params", "FP4Params"]:

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -321,11 +321,11 @@ def check_os_kernel():
         )
         logger.warning(msg, main_process_only=True)
 
+
 def check_device_same(first_device, second_device):
     """
-    Utility method to check if two `torch` devices are similar.
-    When dealing with CUDA devices, torch throws `False` for `torch.device("cuda") == torch.device("cuda:0")`
-    whereas they should be the same
+    Utility method to check if two `torch` devices are similar. When dealing with CUDA devices, torch throws `False`
+    for `torch.device("cuda") == torch.device("cuda:0")` whereas they should be the same
 
     Args:
         first_device (`torch.device`):
@@ -335,14 +335,14 @@ def check_device_same(first_device, second_device):
     """
     if first_device.type != second_device.type:
         return False
-    
+
     if first_device.type == "cuda" and first_device.index is None:
-        # In case the first_device is a cuda device and have 
+        # In case the first_device is a cuda device and have
         # the index attribute set to `None`, default it to `0`
         first_device = torch.device("cuda", index=0)
 
     if second_device.type == "cuda" and second_device.index is None:
-        # In case the second_device is a cuda device and have 
+        # In case the second_device is a cuda device and have
         # the index attribute set to `None`, default it to `0`
         second_device = torch.device("cuda", index=0)
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -320,30 +320,3 @@ def check_os_kernel():
             "cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher."
         )
         logger.warning(msg, main_process_only=True)
-
-
-def check_device_same(first_device, second_device):
-    """
-    Utility method to check if two `torch` devices are similar. When dealing with CUDA devices, torch throws `False`
-    for `torch.device("cuda") == torch.device("cuda:0")` whereas they should be the same
-
-    Args:
-        first_device (`torch.device`):
-            First device to check
-        second_device (`torch.device`):
-            Second device to check
-    """
-    if first_device.type != second_device.type:
-        return False
-
-    if first_device.type == "cuda" and first_device.index is None:
-        # In case the first_device is a cuda device and have
-        # the index attribute set to `None`, default it to `0`
-        first_device = torch.device("cuda", index=0)
-
-    if second_device.type == "cuda" and second_device.index is None:
-        # In case the second_device is a cuda device and have
-        # the index attribute set to `None`, default it to `0`
-        second_device = torch.device("cuda", index=0)
-
-    return first_device == second_device

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -320,3 +320,30 @@ def check_os_kernel():
             "cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher."
         )
         logger.warning(msg, main_process_only=True)
+
+def check_device_same(first_device, second_device):
+    """
+    Utility method to check if two `torch` devices are similar.
+    When dealing with CUDA devices, torch throws `False` for `torch.device("cuda") == torch.device("cuda:0")`
+    whereas they should be the same
+
+    Args:
+        first_device (`torch.device`):
+            First device to check
+        second_device (`torch.device`):
+            Second device to check
+    """
+    if first_device.type != second_device.type:
+        return False
+    
+    if first_device.type == "cuda" and first_device.index is None:
+        # In case the first_device is a cuda device and have 
+        # the index attribute set to `None`, default it to `0`
+        first_device = torch.device("cuda", index=0)
+
+    if second_device.type == "cuda" and second_device.index is None:
+        # In case the second_device is a cuda device and have 
+        # the index attribute set to `None`, default it to `0`
+        second_device = torch.device("cuda", index=0)
+
+    return first_device == second_device


### PR DESCRIPTION
# What does this PR do?

This PR addresses the final issue raised by @poedator here: https://github.com/huggingface/transformers/pull/26037#issuecomment-1855421796 

In fact, there is a corner case when users pass `device_map="cuda"` since the device will be initialized without the index argument, leading the check `elif value is not None or torch.device(device) != module._parameters[tensor_name].device:` to pass whereas it should fail. 

I propose a simple approach where we define a new utils function `check_device_same` that effectively checks whether two devices are the same and deals with the corner case if one of the device that we want to check do not have the attribute `index`. 

cc @SunMarc @muellerzr 