### PR TITLE
Support `log_images` for aim tracker

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -495,9 +495,8 @@ class AimTracker(GeneralTracker):
     def __init__(self, run_name: str, logging_dir: Optional[Union[str, os.PathLike]] = ".", **kwargs):
         self.run_name = run_name
 
-        from aim import Image, Run
+        from aim import Run
 
-        self.aim_image_callable = Image
         self.writer = Run(repo=logging_dir, **kwargs)
         self.writer.name = self.run_name
         logger.debug(f"Initialized Aim project {self.run_name}")
@@ -552,6 +551,7 @@ class AimTracker(GeneralTracker):
                 Additional key word arguments passed along to the `Run.Image` and `Run.track` method specified by the
                 keys `aim_image` and `track`, respectively.
         """
+        from aim import Image
 
         aim_image_kw = {}
         track_kw = {}
@@ -565,7 +565,7 @@ class AimTracker(GeneralTracker):
                 img, caption = value
             else:
                 img, caption = value, ""
-            aim_image = self.aim_image_callable(img, caption=caption, **aim_image_kw)
+            aim_image = Image(img, caption=caption, **aim_image_kw)
             self.writer.track(aim_image, name=key, step=step, **track_kw)
 
     @on_main_process

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -538,9 +538,7 @@ class AimTracker(GeneralTracker):
             self.writer.track(value, name=key, step=step, **kwargs)
 
     @on_main_process
-    def log_images(
-        self, values: dict, step: Optional[int] = None, kwargs: Dict[str, dict] = {"aim_image": {}, "track": {}}
-    ):
+    def log_images(self, values: dict, step: Optional[int] = None, kwargs: Optional[Dict[str, dict]] = None):
         """
         Logs `images` to the current run.
 
@@ -554,13 +552,21 @@ class AimTracker(GeneralTracker):
                 Additional key word arguments passed along to the `Run.Image` and `Run.track` method specified by the
                 keys `aim_image` and `track`, respectively.
         """
+
+        aim_image_kw = {}
+        track_kw = {}
+
+        if kwargs is not None:
+            aim_image_kw = kwargs.get("aim_image", {})
+            track_kw = kwargs.get("track", {})
+
         for key, value in values.items():
             if isinstance(value, tuple):
                 img, caption = value
             else:
                 img, caption = value, ""
-            aim_image = self.aim_image_callable(img, caption=caption, **kwargs["aim_image"])
-            self.writer.track(aim_image, name=key, step=step, **kwargs["track"])
+            aim_image = self.aim_image_callable(img, caption=caption, **aim_image_kw)
+            self.writer.track(aim_image, name=key, step=step, **track_kw)
 
     @on_main_process
     def finish(self):
@@ -962,7 +968,8 @@ LOGGER_TYPE_TO_CLASS = {
 
 
 def filter_trackers(
-    log_with: List[Union[str, LoggerType, GeneralTracker]], logging_dir: Union[str, os.PathLike] = None
+    log_with: List[Union[str, LoggerType, GeneralTracker]],
+    logging_dir: Union[str, os.PathLike] = None,
 ):
     """
     Takes in a list of potential tracker types and checks that:

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -551,7 +551,7 @@ class AimTracker(GeneralTracker):
                 Additional key word arguments passed along to the `Run.Image` and `Run.track` method specified by the
                 keys `aim_image` and `track`, respectively.
         """
-        from aim import Image
+        import aim
 
         aim_image_kw = {}
         track_kw = {}
@@ -565,7 +565,7 @@ class AimTracker(GeneralTracker):
                 img, caption = value
             else:
                 img, caption = value, ""
-            aim_image = Image(img, caption=caption, **aim_image_kw)
+            aim_image = aim.Image(img, caption=caption, **aim_image_kw)
             self.writer.track(aim_image, name=key, step=step, **track_kw)
 
     @on_main_process


### PR DESCRIPTION
This PR aims to add `log_images` function to aim tracker for better integration between accelerate and aim.

Below is a simple file to check the integration result:

```python
import accelerate
import numpy as np
from PIL import Image


def main():
    accelerator = accelerate.Accelerator(
        project_dir="runs/test_aim_images",
        log_with=["aim"],
    )

    accelerator.init_trackers(project_name="test aim images")
    for cur_iter in range(0, 10):
        image_grid = Image.fromarray(np.random.randint(0, 255, size=(256, 256, 3), dtype=np.uint8))
        for tracker in accelerator.trackers:
            if tracker.name == "aim":
                tracker.log_images(
                    {"test_image": (image_grid, f"iter: {cur_iter}")}, step=cur_iter + 1
                )
    accelerator.end_training()


if __name__ == "__main__":
    main()
```

After running the sample code, users can open aim with `aim up --repo runs/test_aim_images` to check the result.