### PR TITLE
Fix breakpoint API in test_script.py on TPU.

### DIFF
--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -602,8 +602,7 @@ def test_trigger():
     assert accelerator.check_trigger() is False
 
     # set a breakpoint on the main process
-    if accelerator.is_main_process:
-        accelerator.set_trigger()
+    accelerator.set_trigger()
 
     # check it's been activated across all processes
     # calls `all_reduce` and triggers a sync

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -602,7 +602,8 @@ def test_trigger():
     assert accelerator.check_trigger() is False
 
     # set a breakpoint on the main process
-    accelerator.set_trigger()
+    if accelerator.is_main_process:
+        accelerator.set_trigger()
 
     # check it's been activated across all processes
     # calls `all_reduce` and triggers a sync

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -615,6 +615,10 @@ def reduce(tensor, reduction="mean", scale=1.0):
         if state.distributed_type == DistributedType.NO:
             return cloned_tensor
         if state.distributed_type == DistributedType.TPU:
+            # Some processes may have different HLO graphs than other
+            # processes, for example in the breakpoint API
+            # accelerator.set_trigger(). Use mark_step to make HLOs
+            # the same on all processes.
             xm.mark_step()
             xm.all_reduce(xm.REDUCE_SUM, [cloned_tensor], scale)
         elif state.distributed_type.value in TORCH_DISTRIBUTED_OPERATION_TYPES:

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -615,7 +615,8 @@ def reduce(tensor, reduction="mean", scale=1.0):
         if state.distributed_type == DistributedType.NO:
             return cloned_tensor
         if state.distributed_type == DistributedType.TPU:
-            cloned_tensor = xm.all_reduce("sum", cloned_tensor, scale)
+            xm.mark_step()
+            xm.all_reduce(xm.REDUCE_SUM, [cloned_tensor], scale)
         elif state.distributed_type.value in TORCH_DISTRIBUTED_OPERATION_TYPES:
             torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
         if reduction == "mean":

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -615,7 +615,7 @@ def reduce(tensor, reduction="mean", scale=1.0):
         if state.distributed_type == DistributedType.NO:
             return cloned_tensor
         if state.distributed_type == DistributedType.TPU:
-            xm.all_reduce("sum", cloned_tensor, scale)
+            cloned_tensor = xm.all_reduce("sum", cloned_tensor, scale)
         elif state.distributed_type.value in TORCH_DISTRIBUTED_OPERATION_TYPES:
             torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
         if reduction == "mean":

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -621,6 +621,7 @@ def reduce(tensor, reduction="mean", scale=1.0):
             # the same on all processes.
             xm.mark_step()
             xm.all_reduce(xm.REDUCE_SUM, [cloned_tensor], scale)
+            xm.mark_step()
         elif state.distributed_type.value in TORCH_DISTRIBUTED_OPERATION_TYPES:
             torch.distributed.all_reduce(cloned_tensor, ReduceOp.SUM)
         if reduction == "mean":


### PR DESCRIPTION
# What does this PR do?

breakpoint API in test_script.py currently fails on TPU. This PR is intended to fix it:
- `xm.all_reduce("sum", cloned_tensor, scale)` doesn't do an in-place update so a return value should be used to get the value after the all_reduce.
- Run https://github.com/huggingface/accelerate/blob/b0528392c83c1d7afb823d87abb94a924f7f69b1/src/accelerate/test_utils/scripts/test_script.py#L605-L606 not just on the main process but on all processes.

Fixes [# (issue)](https://github.com/huggingface/accelerate/issues/2247)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->
