### PR TITLE
Guard timeout early if we cannot actually set it

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -323,6 +323,16 @@ class PartialState:
                 if self.device is None:
                     self.device = torch.device("cpu") if cpu else self.default_device
 
+        # Verify that `timeout` can actually be set if using nccl
+        if self.backend == "nccl" and "timeout" in kwargs:
+            blocking = parse_flag_from_env("NCCL_BLOCKING_WAIT")
+            error_handling = parse_flag_from_env("NCCL_ASYNC_ERROR_HANDLING")
+            if not blocking and not error_handling:
+                raise ValueError(
+                    "Setting `timeout` while using NCCL requires setting either the `NCCL_BLOCKING_WAIT` or "
+                    "NCCL_ASYNC_ERROR_HANDLING` environment variables to `1`."
+                )
+
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
     def __repr__(self) -> str:


### PR DESCRIPTION
# What does this PR do?

This PR checks if a user has tried setting `timeout` in the `InitProcessGroupKwargs` and the environment isn't setup for this to actually work in an NCCL-based multiprocess system

Fixes # (issue)

Fixes https://github.com/huggingface/accelerate/issues/2236


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 