### PR TITLE
Uninstall DVC in the Trainer tests

### DIFF
--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Install transformers
         run: |
           source activate accelerate;
-          git clone https://github.com/huggingface/transformers --depth 1;
+          git clone https://github.com/huggingface/transformers;
           cd transformers;
+          git checkout muellerzr-fix-integration-tests;
           pip install .[torch,deepspeed-testing];
           cd ..;
 
@@ -86,40 +87,40 @@ jobs:
           pip install -r examples/pytorch/_tests_requirements.txt
           pytest -sv examples/pytorch/test_accelerate_examples.py examples/pytorch/test_pytorch_examples.py
 
-  run-skorch-tests:
-    container:
-      image: huggingface/accelerate-gpu:latest
-      options: --gpus all --shm-size "16gb"
-    runs-on: [self-hosted, multi-gpu, nvidia-gpu, t4, ci]
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Install accelerate
-        run: 
-          source activate accelerate;
-          git clone https://github.com/huggingface/accelerate;
-          cd accelerate;
-          git checkout ${{ github.sha }};
-          pip install -e .[testing];
-          cd ..
+  # run-skorch-tests:
+  #   container:
+  #     image: huggingface/accelerate-gpu:latest
+  #     options: --gpus all --shm-size "16gb"
+  #   runs-on: [self-hosted, multi-gpu, nvidia-gpu, t4, ci]
+  #   strategy:
+  #     fail-fast: false
+  #   steps:
+  #     - name: Install accelerate
+  #       run: 
+  #         source activate accelerate;
+  #         git clone https://github.com/huggingface/accelerate;
+  #         cd accelerate;
+  #         git checkout ${{ github.sha }};
+  #         pip install -e .[testing];
+  #         cd ..
 
-      - name: Install skorch
-        run: |
-          source activate accelerate
-          git clone https://github.com/skorch-dev/skorch;
-          cd skorch;
-          git config --global --add safe.directory '*'
-          git checkout master && git pull
-          pip install .[testing]
-          pip install flaky
+  #     - name: Install skorch
+  #       run: |
+  #         source activate accelerate
+  #         git clone https://github.com/skorch-dev/skorch;
+  #         cd skorch;
+  #         git config --global --add safe.directory '*'
+  #         git checkout master && git pull
+  #         pip install .[testing]
+  #         pip install flaky
 
-      - name: Show installed libraries
-        run: |
-          source activate accelerate;
-          pip freeze
+  #     - name: Show installed libraries
+  #       run: |
+  #         source activate accelerate;
+  #         pip freeze
 
-      - name: Run skorch tests
-        working-directory: skorch/
-        run: |
-          source activate accelerate;
-          pytest -sv -k TestAccelerate
+  #     - name: Run skorch tests
+  #       working-directory: skorch/
+  #       run: |
+  #         source activate accelerate;
+  #         pytest -sv -k TestAccelerate

--- a/.github/workflows/self_hosted_integration_tests.yml
+++ b/.github/workflows/self_hosted_integration_tests.yml
@@ -37,9 +37,8 @@ jobs:
       - name: Install transformers
         run: |
           source activate accelerate;
-          git clone https://github.com/huggingface/transformers;
+          git clone https://github.com/huggingface/transformers --depth 1;
           cd transformers;
-          git checkout muellerzr-fix-integration-tests;
           pip install .[torch,deepspeed-testing];
           cd ..;
 
@@ -50,7 +49,7 @@ jobs:
           cd accelerate;
           git checkout ${{ github.sha }} ;
           pip install -e .[testing];
-          pip uninstall comet_ml wandb -y
+          pip uninstall comet_ml wandb dvclive -y
           cd ..;
       
       - name: Show installed libraries
@@ -87,40 +86,40 @@ jobs:
           pip install -r examples/pytorch/_tests_requirements.txt
           pytest -sv examples/pytorch/test_accelerate_examples.py examples/pytorch/test_pytorch_examples.py
 
-  # run-skorch-tests:
-  #   container:
-  #     image: huggingface/accelerate-gpu:latest
-  #     options: --gpus all --shm-size "16gb"
-  #   runs-on: [self-hosted, multi-gpu, nvidia-gpu, t4, ci]
-  #   strategy:
-  #     fail-fast: false
-  #   steps:
-  #     - name: Install accelerate
-  #       run: 
-  #         source activate accelerate;
-  #         git clone https://github.com/huggingface/accelerate;
-  #         cd accelerate;
-  #         git checkout ${{ github.sha }};
-  #         pip install -e .[testing];
-  #         cd ..
+  run-skorch-tests:
+    container:
+      image: huggingface/accelerate-gpu:latest
+      options: --gpus all --shm-size "16gb"
+    runs-on: [self-hosted, multi-gpu, nvidia-gpu, t4, ci]
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Install accelerate
+        run: 
+          source activate accelerate;
+          git clone https://github.com/huggingface/accelerate;
+          cd accelerate;
+          git checkout ${{ github.sha }};
+          pip install -e .[testing];
+          cd ..
 
-  #     - name: Install skorch
-  #       run: |
-  #         source activate accelerate
-  #         git clone https://github.com/skorch-dev/skorch;
-  #         cd skorch;
-  #         git config --global --add safe.directory '*'
-  #         git checkout master && git pull
-  #         pip install .[testing]
-  #         pip install flaky
+      - name: Install skorch
+        run: |
+          source activate accelerate
+          git clone https://github.com/skorch-dev/skorch;
+          cd skorch;
+          git config --global --add safe.directory '*'
+          git checkout master && git pull
+          pip install .[testing]
+          pip install flaky
 
-  #     - name: Show installed libraries
-  #       run: |
-  #         source activate accelerate;
-  #         pip freeze
+      - name: Show installed libraries
+        run: |
+          source activate accelerate;
+          pip freeze
 
-  #     - name: Run skorch tests
-  #       working-directory: skorch/
-  #       run: |
-  #         source activate accelerate;
-  #         pytest -sv -k TestAccelerate
+      - name: Run skorch tests
+        working-directory: skorch/
+        run: |
+          source activate accelerate;
+          pytest -sv -k TestAccelerate


### PR DESCRIPTION
# What does this PR do?

Autopicking up DVC in the env leads to very annoying DVC issues related to git configs for the trainer specifically. Since these tests are already ran nightly on the trainer side this PR just disables them in Accelerate locally by uninstalling yet another problematic tracker during tests. 

Fixes # (issue)

The failing tests on main. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@SunMarc 