### PR TITLE
Solve CUDA issues

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -33,6 +33,7 @@ from ..utils import (
     is_bnb_available,
     is_clearml_available,
     is_comet_ml_available,
+    is_cuda_available,
     is_datasets_available,
     is_deepspeed_available,
     is_dvclive_available,
@@ -51,7 +52,7 @@ from ..utils import (
 
 
 def get_backend():
-    if torch.cuda.is_available():
+    if is_cuda_available():
         return "cuda", torch.cuda.device_count()
     elif is_mps_available():
         return "mps", 1
@@ -117,7 +118,7 @@ def require_cuda(test_case):
     """
     Decorator marking a test that requires CUDA. These tests are skipped when there are no GPU available.
     """
-    return unittest.skipUnless(torch.cuda.is_available(), "test requires a GPU")(test_case)
+    return unittest.skipUnless(is_cuda_available(), "test requires a GPU")(test_case)
 
 
 def require_xpu(test_case):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -41,6 +41,7 @@ from .environment import (
     are_libraries_initialized,
     check_cuda_p2p_ib_support,
     check_fp8_capability,
+    get_gpu_info,
     get_int_from_env,
     parse_choice_from_env,
     parse_flag_from_env,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -41,7 +41,6 @@ from .environment import (
     are_libraries_initialized,
     check_cuda_p2p_ib_support,
     check_fp8_capability,
-    get_gpu_info,
     get_int_from_env,
     parse_choice_from_env,
     parse_flag_from_env,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -130,7 +130,7 @@ def is_bf16_available(ignore_tpu=False):
     "Checks if bf16 is supported, optionally ignoring the TPU"
     if is_tpu_available():
         return not ignore_tpu
-    if torch.cuda.is_available():
+    if is_cuda_available():
         return torch.cuda.is_bf16_supported()
     return True
 


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/accelerate/pull/2123 introduced device agnostic testing, but it didn't account for the fact our testing suite relies on never spawning any CUDA processes explicitly until a test is fully called. Replaces all calls to `torch.cuda.is_available()` with our equivalent check that doesn't rely on touching `torch.cuda` (and causing issues with the `notebook_launcher`

Fixes # (issue)

The other failing test on main

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 