### PR TITLE
Fix pad_across_processes to allow negative dimensions

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -562,7 +562,7 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
                 CannotPadNestedTensorWarning,
             )
             return tensor
-        if dim >= len(tensor.shape):
+        if dim >= len(tensor.shape) or dim < -1 * len(tensor.shape):
             return tensor
 
         # Gather all sizes
@@ -577,14 +577,12 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
         new_size = list(old_size)
         new_size[dim] = max_size
         new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
-        if dim < 0:
-            dim = len(new_size) - dim
         if pad_first:
             indices = tuple(
-                slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(new_size))
+                slice(max_size - old_size[dim], max_size) if (i == dim or i == len(new_size) - dim) else slice(None) for i in range(len(new_size))
             )
         else:
-            indices = tuple(slice(0, old_size[dim]) if i == dim else slice(None) for i in range(len(new_size)))
+            indices = tuple(slice(0, old_size[dim]) if (i == dim or i == len(new_size) - dim) else slice(None) for i in range(len(new_size)))
         new_tensor[indices] = tensor
         return new_tensor
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -577,6 +577,8 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
         new_size = list(old_size)
         new_size[dim] = max_size
         new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
+        if dim < 0:
+            dim = len(new_size) - dim
         if pad_first:
             indices = tuple(
                 slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(new_size))

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -562,7 +562,11 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
                 CannotPadNestedTensorWarning,
             )
             return tensor
-        if dim >= len(tensor.shape) or dim < -1 * len(tensor.shape):
+
+        if dim < 0:
+            dim += len(tensor.shape)
+
+        if dim >= len(tensor.shape) or dim < 0:
             return tensor
 
         # Gather all sizes
@@ -577,13 +581,12 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
         new_size = list(old_size)
         new_size[dim] = max_size
         new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
-        is_dim = lambda i: i == dim or i == len(new_size) - dim
         if pad_first:
             indices = tuple(
-                slice(max_size - old_size[dim], max_size) if is_dim(i) else slice(None) for i in range(len(new_size))
+                slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(new_size))
             )
         else:
-            indices = tuple(slice(0, old_size[dim]) if is_dim(i) else slice(None) for i in range(len(new_size)))
+            indices = tuple(slice(0, old_size[dim]) if i == dim else slice(None) for i in range(len(new_size)))
         new_tensor[indices] = tensor
         return new_tensor
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -577,12 +577,13 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
         new_size = list(old_size)
         new_size[dim] = max_size
         new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
+        is_dim = lambda i: i == dim or i == len(new_size) - dim
         if pad_first:
             indices = tuple(
-                slice(max_size - old_size[dim], max_size) if (i == dim or i == len(new_size) - dim) else slice(None) for i in range(len(new_size))
+                slice(max_size - old_size[dim], max_size) if is_dim(i) else slice(None) for i in range(len(new_size))
             )
         else:
-            indices = tuple(slice(0, old_size[dim]) if (i == dim or i == len(new_size) - dim) else slice(None) for i in range(len(new_size)))
+            indices = tuple(slice(0, old_size[dim]) if is_dim(i) else slice(None) for i in range(len(new_size)))
         new_tensor[indices] = tensor
         return new_tensor
 


### PR DESCRIPTION
# What does this PR do?

Fix the `pad_across_processes` function so that you can input negative dimensions. Right now, `indices` will always have slices of `(None, None)` if `dim` is negative.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->