### PR TITLE
[deepspeed docs] auto-values aren't being covered

### DIFF
--- a/docs/source/usage_guides/deepspeed.md
+++ b/docs/source/usage_guides/deepspeed.md
@@ -422,6 +422,13 @@ We will look at the changes needed in the code when using these.
 based on model, dataloaders, dummy optimizer and dummy schedulers provided to `prepare` method. 
 Only the `auto` fields specified in above examples are handled by `prepare` method and the rest have to be explicitly specified by the user.
 
+The `auto` values are calculated as:
+
+- `reduce_bucket_size`: `hidden_size*hidden_size`
+- `stage3_prefetch_bucket_size`: `0.9 * hidden_size * hidden_size`
+- `stage3_param_persistence_threshold`: `10 * hidden_size`
+
+
 **Things to note when using DeepSpeed Config File**
 
 Below is a sample script using `deepspeed_config_file` in different scenarios.


### PR DESCRIPTION
When ported to Accelerate from Transformers the Deepspeed docs about `auto`-values didn't make it. This is very important information. How would a user otherwise know what those values get set to?

This PR adds the 3 critical ones, but more work is needed to explain which is which.

The original document had a very detailed section for each entry, explaining each `auto` 
https://huggingface.co/docs/transformers/main/en/main_classes/deepspeed
but for some reason Accelerate chose not to document any of it - which is super odd. It's already documented - why not just copy it as is?

But bottom line is that there are 2 types of auto-values:

1. sync the value with the CLI args or defaults
2. set the value based on the model's parameters

So perhaps a new `Auto Values` section can be added that just explains the above, if you don't want to document things in a detailed way.


@pacman100 