### PR TITLE
Fix DeepSpeed related regression

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1572,10 +1572,7 @@ class Accelerator:
                         optimizer = DeepSpeedCPUAdam(optimizer.param_groups, **defaults)
                     kwargs["optimizer"] = optimizer
                     if scheduler is not None:
-                        if (
-                            isinstance(scheduler, LRScheduler)
-                            or type(scheduler).__name__ in deepspeed.runtime.lr_schedules.VALID_LR_SCHEDULES
-                        ):
+                        if type(scheduler).__name__ in deepspeed.runtime.lr_schedules.VALID_LR_SCHEDULES:
                             kwargs["lr_scheduler"] = scheduler
 
             engine, optimizer, _, lr_scheduler = deepspeed.initialize(**kwargs)

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -985,3 +985,27 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
             )
             with patch_environment(omp_num_threads=1):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
+
+    def test_lr_scheduler(self):
+        self.test_file_path = os.path.join(self.test_scripts_folder, "test_performance.py")
+        cmd = [
+            "accelerate",
+            "launch",
+            "--num_processes=2",
+            "--num_machines=1",
+            "--machine_rank=0",
+            "--mixed_precision=no",
+            "--use_deepspeed",
+            "--gradient_accumulation_steps=1",
+            "--gradient_clipping=1",
+            "--zero3_init_flag=True",
+            "--zero3_save_16bit_model=True",
+            "--zero_stage=3",
+            "--offload_optimizer_device=none",
+            "--offload_param_device=none",
+            self.test_file_path,
+            f"--output_dir={self.tmpdir}",
+            f"--performance_lower_bound={self.performance_lower_bound}",
+        ]
+        with patch_environment(omp_num_threads=1):
+            execute_subprocess_async(cmd, env=os.environ.copy())


### PR DESCRIPTION
# What does this PR do?
1. Revert a change from https://github.com/huggingface/accelerate/pull/1909 causing a regression in behaviour from version 0.22 to version 0.23

Details about the Regression: 
Accelerate caused regression:
Deepspeed 0.12.6, accelerate 0.22.0 works,
Deepspeed 0.12.6, accelerate 0.23.0 regresses
As you can see the learning is much slower on multi-gpu ds setup as compared to 1 gpu:
red is 1 gpu w/ either accelerate version
blue  is 2 gpus w/ accelerate 0.23.0
green is 2 gpus w/ accelerate 0.22.0

![Screenshot 2024-01-02 at 9 23 57 PM](https://github.com/huggingface/accelerate/assets/13534540/9b4eb583-f12e-41b9-aee9-8b8bb0611b16)

Reason: The changes of this PR https://github.com/huggingface/accelerate/pull/1909/files

This PR reverts the LR scheduler related changes. I have run all the slow tests of Trainer to make sure this revert doesn't impact trainer's DeepSpeed integration.
