### PR TITLE
Fixes bug in swapping weights when replacing with Transformer-Engine layers

### DIFF
--- a/src/accelerate/utils/transformer_engine.py
+++ b/src/accelerate/utils/transformer_engine.py
@@ -36,15 +36,15 @@ def convert_model(model, to_transformer_engine=True, _convert_linear=True, _conv
             te_module = te.Linear(
                 module.in_features, module.out_features, bias=has_bias, params_dtype=module.weight.dtype
             )
-            module.weight.copy_(te_module.weight)
+            te_module.weight.copy_(module.weight)
             if has_bias:
-                module.bias.copy_(te_module.bias)
+                te_module.bias.copy_(module.bias)
 
             setattr(model, name, te_module)
         elif isinstance(module, nn.LayerNorm) and to_transformer_engine and _convert_ln:
             te_module = te.LayerNorm(module.normalized_shape[0], eps=module.eps, params_dtype=module.weight.dtype)
-            module.weight.copy_(te_module.weight)
-            module.bias.copy_(te_module.bias)
+            te_module.weight.copy_(module.weight)
+            te_module.bias.copy_(module.bias)
 
             setattr(model, name, te_module)
         elif isinstance(module, te.Linear) and not to_transformer_engine and _convert_linear:
@@ -52,15 +52,15 @@ def convert_model(model, to_transformer_engine=True, _convert_linear=True, _conv
             new_module = nn.Linear(
                 module.in_features, module.out_features, bias=has_bias, params_dtype=module.weight.dtype
             )
-            module.weight.copy_(new_module.weight)
+            new_module.weight.copy_(module.weight)
             if has_bias:
-                module.bias.copy_(new_module.bias)
+                new_module.bias.copy_(module.bias)
 
             setattr(model, name, new_module)
         elif isinstance(module, te.LayerNorm) and not to_transformer_engine and _convert_ln:
             new_module = nn.LayerNorm(module.normalized_shape[0], eps=module.eps, params_dtype=module.weight.dtype)
-            module.weight.copy_(new_module.weight)
-            module.bias.copy_(new_module.bias)
+            new_module.weight.copy_(module.weight)
+            new_module.bias.copy_(module.bias)
 
             setattr(model, name, new_module)
         else:
@@ -79,6 +79,6 @@ def has_transformer_engine_layers(model):
     if not is_fp8_available():
         raise ImportError("Using `has_transformer_engine_layers` requires transformer_engine to be installed.")
     for m in model.modules():
-        if isinstance(m, (te.LayerNorm, te.Linear)):
+        if isinstance(m, (te.LayerNorm, te.Linear, te.TransformerLayer)):
             return True
     return False


### PR DESCRIPTION
# What does this PR do?
1. When `linear` layers in the model are replaced with Transformer-Engine's linear layers, the weights of the latter should be replaced with the weights of the former (currently, it's the other way around).
2. Adding TE's `TransformerLayer` to `has_transformer_engine_layers` function to allow the case when larger chunks of modules could be replaced (`TransformerLayer` could replace `LlamaDecoderLayer` in this case)

@muellerzr, could you pls take a look? Thanks!
