### PR TITLE
Update docs: Add warning for device_map=None for load_checkpoint_and_dispatch

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -73,7 +73,9 @@ def init_empty_weights(include_buffers: bool = None):
 
     Any model created under this context manager has no weights. As such you can't do something like
     `model.to(some_device)` with it. To load weights inside your empty model, see [`load_checkpoint_and_dispatch`].
-    Make sure to overwrite the default device_map param, otherwise dispatch is not called.
+    Make sure to overwrite the default device_map param for [`load_checkpoint_and_dispatch`], otherwise dispatch is not
+    called.
+
     </Tip>
     """
     if include_buffers is None:
@@ -480,7 +482,7 @@ def load_checkpoint_and_dispatch(
 
             To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For more
             information about each option see [here](../concept_guides/big_model_inference#designing-a-device-map).
-            Defaults to None, which means `dispatch_model` will not be called.
+            Defaults to None, which means [`dispatch_model`] will not be called.
         max_memory (`Dict`, *optional*):
             A dictionary device identifier to maximum memory. Will default to the maximum memory available for each GPU
             and the available CPU RAM if unset.

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -73,7 +73,7 @@ def init_empty_weights(include_buffers: bool = None):
 
     Any model created under this context manager has no weights. As such you can't do something like
     `model.to(some_device)` with it. To load weights inside your empty model, see [`load_checkpoint_and_dispatch`].
-
+    Make sure to overwrite the default device_map param, otherwise dispatch is not called.
     </Tip>
     """
     if include_buffers is None:
@@ -479,7 +479,8 @@ def load_checkpoint_and_dispatch(
             name, once a given module name is inside, every submodule of it will be sent to the same device.
 
             To have Accelerate compute the most optimized `device_map` automatically, set `device_map="auto"`. For more
-            information about each option see [here](big_modeling#designing-a-device-map).
+            information about each option see [here](../concept_guides/big_model_inference#designing-a-device-map).
+            Defaults to None, which means `dispatch_model` will not be called.
         max_memory (`Dict`, *optional*):
             A dictionary device identifier to maximum memory. Will default to the maximum memory available for each GPU
             and the available CPU RAM if unset.


### PR DESCRIPTION
# What does this PR do?
This PR adds a warning that device_map should not be left as `None` when using the `init_empty_weights` context,
as dispatch won't be called in this case.
At the moment, pytorch prints warning that tensors can't be copied from meta device, but that's difficult to trace back to this.

Note: I've also tried to fix the broken link to designing a device map but not sure if this works - the doc preview didn't work for me (--html incompatible with my installed node version).




## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@SunMarc @muellerzr
