### PR TITLE
`Params4bit` added to bnb classes in set_module_tensor_to_device()

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -328,7 +328,7 @@ def set_module_tensor_to_device(
             param is not None
             and param.device.type != "cuda"
             and torch.device(device).type == "cuda"
-            and param_cls.__name__ in ["Int8Params", "FP4Params"]
+            and param_cls.__name__ in ["Int8Params", "FP4Params", "Params4bit"]
         ):
             device_quantization = device
             device = "cpu"


### PR DESCRIPTION
adding `"Params4bit"` to the list of bnb classes in set_module_tensor_to_device(). 
It looks like this class was originally named "FP4Params", but later renamed to "Params4bit", and it was not reflected in accelerate.  See https://github.com/huggingface/accelerate/issues/2250 for discovery details.

This issue was not affecting anything until recently, but as of today (possibly due to some other changes) this breaks 4-bit bnb serialization tests in transformers.

I left `"FP4Params"` intact in case there are compatibility issues with some older bnb version.

tagging @younesbelkada, @SunMarc @TimDettmers @Titus-von-Koeller 