### PR TITLE
Add `adapter_only` option to `save_fsdp_model` and `load_fsdp_model` to only save/load PEFT weights

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -59,7 +59,6 @@ from .imports import (
     is_comet_ml_available,
     is_cuda_available,
     is_datasets_available,
-    is_peft_available,
     is_deepspeed_available,
     is_dvclive_available,
     is_fp8_available,
@@ -70,6 +69,7 @@ from .imports import (
     is_msamp_available,
     is_npu_available,
     is_pandas_available,
+    is_peft_available,
     is_rich_available,
     is_sagemaker_available,
     is_tensorboard_available,
@@ -81,7 +81,6 @@ from .imports import (
     is_xpu_available,
 )
 from .modeling import (
-    is_peft_model,
     calculate_maximum_sizes,
     check_device_map,
     check_tied_parameters_in_config,
@@ -96,6 +95,7 @@ from .modeling import (
     get_mixed_precision_context_manager,
     id_tensor_storage,
     infer_auto_device_map,
+    is_peft_model,
     load_checkpoint_in_model,
     load_offloaded_weights,
     load_state_dict,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -59,6 +59,7 @@ from .imports import (
     is_comet_ml_available,
     is_cuda_available,
     is_datasets_available,
+    is_peft_available,
     is_deepspeed_available,
     is_dvclive_available,
     is_fp8_available,
@@ -80,6 +81,7 @@ from .imports import (
     is_xpu_available,
 )
 from .modeling import (
+    is_peft_model,
     calculate_maximum_sizes,
     check_device_map,
     check_tied_parameters_in_config,

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -17,7 +17,7 @@ import torch
 
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, FSDP_PYTORCH_VERSION, OPTIMIZER_NAME
-from .imports import is_torch_distributed_available, is_peft_available
+from .imports import is_peft_available, is_torch_distributed_available
 from .other import extract_model_from_parallel
 from .versions import is_torch_version
 

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -35,14 +35,15 @@ logger = get_logger(__name__)
 def _is_peft_model(model):
     if is_peft_available():
         from peft import PeftModel
-    return is_peft_available() and isinstance(model.module, PeftModel)
+    unwrapped_model = getattr(model.module, "_orig_mod", model.module)
+    return is_peft_available() and isinstance(unwrapped_model, PeftModel)
 
 
 def _get_model_state_dict(model, adapter_only=False):
     if adapter_only and _is_peft_model(model):
         from peft import get_peft_model_state_dict
 
-        return get_peft_model_state_dict(model, adapter_name=model.active_adapter, unwrap_compiled=True)
+        return get_peft_model_state_dict(model, adapter_name=model.active_adapter)
     else:
         return model.state_dict()
 

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -18,6 +18,7 @@ import torch
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, FSDP_PYTORCH_VERSION, OPTIMIZER_NAME
 from .imports import is_torch_distributed_available, is_peft_available
+from .other import extract_model_from_parallel
 from .versions import is_torch_version
 
 
@@ -35,8 +36,7 @@ logger = get_logger(__name__)
 def _is_peft_model(model):
     if is_peft_available():
         from peft import PeftModel
-    unwrapped_model = getattr(model.module, "_orig_mod", model.module)
-    return is_peft_available() and isinstance(unwrapped_model, PeftModel)
+    return is_peft_available() and isinstance(extract_model_from_parallel(model), PeftModel)
 
 
 def _get_model_state_dict(model, adapter_only=False):

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -17,7 +17,7 @@ import torch
 
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, FSDP_PYTORCH_VERSION, OPTIMIZER_NAME
-from .imports import is_torch_distributed_available
+from .imports import is_torch_distributed_available, is_peft_available
 from .versions import is_torch_version
 
 
@@ -31,8 +31,27 @@ if is_torch_version(">=", FSDP_PYTORCH_VERSION) and is_torch_distributed_availab
 
 logger = get_logger(__name__)
 
+def _is_peft_model(model):
+    if is_peft_available():
+        from peft import PeftModel
+    return is_peft_available() and isinstance(model.module, PeftModel)
 
-def save_fsdp_model(fsdp_plugin, accelerator, model, output_dir, model_index=0):
+def _get_model_state_dict(model, adapter_only=False):
+    if _is_peft_model(model):
+        from peft import get_peft_model_state_dict
+        return get_peft_model_state_dict(model, adapter_name=model.active_adapter, unwrap_compiled=True)
+    else:
+        return model.state_dict()
+
+def _set_model_state_dict(model, state_dict, adapter_only=False):
+    if _is_peft_model(model):
+        from peft import set_peft_model_state_dict
+        return set_peft_model_state_dict(model, state_dict, adapter_name=model.active_adapter)
+    else:
+        return model.load_state_dict(state_dict)
+
+
+def save_fsdp_model(fsdp_plugin, accelerator, model, output_dir, model_index=0, adapter_only=False):
     os.makedirs(output_dir, exist_ok=True)
 
     if fsdp_plugin.state_dict_type == StateDictType.FULL_STATE_DICT:
@@ -45,7 +64,7 @@ def save_fsdp_model(fsdp_plugin, accelerator, model, output_dir, model_index=0):
     with FSDP.state_dict_type(
         model, fsdp_plugin.state_dict_type, fsdp_plugin.state_dict_config, fsdp_plugin.optim_state_dict_config
     ):
-        state_dict = model.state_dict()
+        state_dict = _get_model_state_dict(model, adapter_only=adapter_only)
         if fsdp_plugin.state_dict_type == StateDictType.FULL_STATE_DICT:
             weights_name = f"{FSDP_MODEL_NAME}.bin" if model_index == 0 else f"{FSDP_MODEL_NAME}_{model_index}.bin"
             output_model_file = os.path.join(output_dir, weights_name)
@@ -77,7 +96,7 @@ def save_fsdp_model(fsdp_plugin, accelerator, model, output_dir, model_index=0):
             logger.info(f"Model saved to {ckpt_dir}")
 
 
-def load_fsdp_model(fsdp_plugin, accelerator, model, input_dir, model_index=0):
+def load_fsdp_model(fsdp_plugin, accelerator, model, input_dir, model_index=0, adapter_only=False):
     accelerator.wait_for_everyone()
     if fsdp_plugin.state_dict_type == StateDictType.FULL_STATE_DICT:
         # FSDP raises error when single GPU is used with `offload_to_cpu=True` for FULL_STATE_DICT
@@ -118,7 +137,7 @@ def load_fsdp_model(fsdp_plugin, accelerator, model, input_dir, model_index=0):
                 else input_dir
             )
             logger.info(f"Loading model from {ckpt_dir}")
-            state_dict = {"model": model.state_dict()}
+            state_dict = {"model": _get_model_state_dict(model, adapter_only=adapter_only)}
             dist_cp.load_state_dict(
                 state_dict=state_dict,
                 storage_reader=dist_cp.FileSystemReader(ckpt_dir),
@@ -126,7 +145,7 @@ def load_fsdp_model(fsdp_plugin, accelerator, model, input_dir, model_index=0):
             )
             state_dict = state_dict["model"]
             logger.info(f"Model loaded from {ckpt_dir}")
-        load_result = model.load_state_dict(state_dict)
+        load_result = _set_model_state_dict(model, state_dict, adapter_only=adapter_only)
     return load_result
 
 
@@ -157,7 +176,7 @@ def save_fsdp_optimizer(fsdp_plugin, accelerator, optimizer, model, output_dir, 
             logger.info(f"Optimizer state saved in {ckpt_dir}")
 
 
-def load_fsdp_optimizer(fsdp_plugin, accelerator, optimizer, model, input_dir, optimizer_index=0):
+def load_fsdp_optimizer(fsdp_plugin, accelerator, optimizer, model, input_dir, optimizer_index=0, adapter_only=False):
     accelerator.wait_for_everyone()
     with FSDP.state_dict_type(
         model, fsdp_plugin.state_dict_type, fsdp_plugin.state_dict_config, fsdp_plugin.optim_state_dict_config
@@ -180,7 +199,7 @@ def load_fsdp_optimizer(fsdp_plugin, accelerator, optimizer, model, input_dir, o
             )
             logger.info(f"Loading Optimizer from {ckpt_dir}")
             optim_state = load_sharded_optimizer_state_dict(
-                model_state_dict=model.state_dict(),
+                model_state_dict=_get_model_state_dict(model, adapter_only=adapter_only),
                 optimizer_key="optimizer",
                 storage_reader=dist_cp.FileSystemReader(ckpt_dir),
             )

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -17,8 +17,8 @@ import torch
 
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, FSDP_PYTORCH_VERSION, OPTIMIZER_NAME
-from .imports import is_peft_available, is_torch_distributed_available
-from .other import extract_model_from_parallel
+from .imports import is_torch_distributed_available
+from .modeling import is_peft_model
 from .versions import is_torch_version
 
 
@@ -33,14 +33,8 @@ if is_torch_version(">=", FSDP_PYTORCH_VERSION) and is_torch_distributed_availab
 logger = get_logger(__name__)
 
 
-def _is_peft_model(model):
-    if is_peft_available():
-        from peft import PeftModel
-    return is_peft_available() and isinstance(extract_model_from_parallel(model), PeftModel)
-
-
 def _get_model_state_dict(model, adapter_only=False):
-    if adapter_only and _is_peft_model(model):
+    if adapter_only and is_peft_model(model):
         from peft import get_peft_model_state_dict
 
         return get_peft_model_state_dict(model, adapter_name=model.active_adapter)
@@ -49,7 +43,7 @@ def _get_model_state_dict(model, adapter_only=False):
 
 
 def _set_model_state_dict(model, state_dict, adapter_only=False):
-    if adapter_only and _is_peft_model(model):
+    if adapter_only and is_peft_model(model):
         from peft import set_peft_model_state_dict
 
         return set_peft_model_state_dict(model, state_dict, adapter_name=model.active_adapter)

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -31,21 +31,26 @@ if is_torch_version(">=", FSDP_PYTORCH_VERSION) and is_torch_distributed_availab
 
 logger = get_logger(__name__)
 
+
 def _is_peft_model(model):
     if is_peft_available():
         from peft import PeftModel
     return is_peft_available() and isinstance(model.module, PeftModel)
 
+
 def _get_model_state_dict(model, adapter_only=False):
     if adapter_only and _is_peft_model(model):
         from peft import get_peft_model_state_dict
+
         return get_peft_model_state_dict(model, adapter_name=model.active_adapter, unwrap_compiled=True)
     else:
         return model.state_dict()
 
+
 def _set_model_state_dict(model, state_dict, adapter_only=False):
     if adapter_only and _is_peft_model(model):
         from peft import set_peft_model_state_dict
+
         return set_peft_model_state_dict(model, state_dict, adapter_name=model.active_adapter)
     else:
         return model.load_state_dict(state_dict)

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -37,14 +37,14 @@ def _is_peft_model(model):
     return is_peft_available() and isinstance(model.module, PeftModel)
 
 def _get_model_state_dict(model, adapter_only=False):
-    if _is_peft_model(model):
+    if adapter_only and _is_peft_model(model):
         from peft import get_peft_model_state_dict
         return get_peft_model_state_dict(model, adapter_name=model.active_adapter, unwrap_compiled=True)
     else:
         return model.state_dict()
 
 def _set_model_state_dict(model, state_dict, adapter_only=False):
-    if _is_peft_model(model):
+    if adapter_only and _is_peft_model(model):
         from peft import set_peft_model_state_dict
         return set_peft_model_state_dict(model, state_dict, adapter_name=model.active_adapter)
     else:

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -174,8 +174,10 @@ def is_transformers_available():
 def is_datasets_available():
     return _is_package_available("datasets")
 
+
 def is_peft_available():
     return _is_package_available("peft")
+
 
 def is_timm_available():
     return _is_package_available("timm")

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -174,6 +174,8 @@ def is_transformers_available():
 def is_datasets_available():
     return _is_package_available("datasets")
 
+def is_peft_available():
+    return _is_package_available("peft")
 
 def is_timm_available():
     return _is_package_available("timm")

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -30,7 +30,7 @@ import torch.nn as nn
 from ..state import AcceleratorState
 from .constants import SAFE_WEIGHTS_NAME, WEIGHTS_NAME
 from .dataclasses import AutocastKwargs, CustomDtype, DistributedType
-from .imports import is_mps_available, is_npu_available, is_xpu_available, is_peft_available
+from .imports import is_mps_available, is_npu_available, is_peft_available, is_xpu_available
 from .offload import load_offloaded_weight, offload_weight, save_offload_index
 from .tqdm import is_tqdm_available, tqdm
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -30,7 +30,7 @@ import torch.nn as nn
 from ..state import AcceleratorState
 from .constants import SAFE_WEIGHTS_NAME, WEIGHTS_NAME
 from .dataclasses import AutocastKwargs, CustomDtype, DistributedType
-from .imports import is_mps_available, is_npu_available, is_xpu_available
+from .imports import is_mps_available, is_npu_available, is_xpu_available, is_peft_available
 from .offload import load_offloaded_weight, offload_weight, save_offload_index
 from .tqdm import is_tqdm_available, tqdm
 
@@ -45,6 +45,15 @@ from safetensors.torch import load_file as safe_load_file
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
 
 logger = logging.getLogger(__name__)
+
+
+def is_peft_model(model):
+    from .other import extract_model_from_parallel
+
+    if is_peft_available():
+        from peft import PeftModel
+
+    return is_peft_available() and isinstance(extract_model_from_parallel(model), PeftModel)
 
 
 def check_device_same(first_device, second_device):


### PR DESCRIPTION
# What does this PR do?

- See related PR in `transformers` for motivation: https://github.com/huggingface/transformers/pull/28297
- Adds the ability to only save/load PEFT weights for `save_fsdp_model` and `load_fsdp_model`
- The `adapter_only` parameter (default off) controls whether only the PEFT weights will be saved.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

