### PR TITLE
Fix infer_auto_device_map when tied weights share the same prefix name

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1061,8 +1061,8 @@ def infer_auto_device_map(
 
         # We keep relevant tied parameters only: one of the tied parameters in the group is inside the current module
         # and the other is not.
-        # Note: If are currently processing the name `compute.weight`, an other parameter named e.g. `compute.weight_submodule.parameter`
-        # needs to outside the current module, hence the check with additional dots.
+        # Note: If we are currently processing the name `compute.weight`, an other parameter named e.g. `compute.weight_submodule.parameter`
+        # needs to be considered outside the current module, hence the check with additional dots.
         tied_param_goups = [
             tied_group
             for tied_group in tied_parameters

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1061,15 +1061,22 @@ def infer_auto_device_map(
 
         # We keep relevant tied parameters only: one of the tied parameters in the group is inside the current module
         # and the other is not.
+        # Note: If are currently processing the name `compute.weight`, an other parameter named e.g. `compute.weight_submodule.parameter`
+        # needs to outside the current module, hence the check with additional dots.
         tied_param_goups = [
             tied_group
             for tied_group in tied_parameters
-            if any(name in k for k in tied_group) and not all(name in k for k in tied_group)
+            if any(name + "." in k + "." for k in tied_group) and not all(name + "." in k + "." for k in tied_group)
         ]
+
         if verbose and len(tied_param_goups) > 0:
             print(f"  Found the relevant tied param groups {tied_param_goups}")
+
         # Then we keep track of all the parameters that are tied to the current module, but not in the current module
-        tied_params = sum([[p for p in tied_group if name not in p] for tied_group in tied_param_goups], [])
+        tied_params = sum(
+            [[p for p in tied_group if name + "." not in p + "."] for tied_group in tied_param_goups], []
+        )
+
         if verbose and len(tied_params) > 0:
             print(f"  So those parameters need to be taken into account {tied_params}")
 


### PR DESCRIPTION
As per title, thanks to @giuseppe5 & @nickfraser notice.

On main currently, the detection of `tied_param_goups` and `tied_params` is wrong as e.g. if we have a group `["compute.weight", "compute.weight_submodule.parameter"]` and we are currently treating the parameter `compute.weight`, `tied_param_goups` will wrongfully be empty as `all(name in k for k in tied_group)` is True.

This result in an error in this example:

```python
import torch
import accelerate

class SubModule(torch.nn.Module):
  def __init__(self, ref_to_parameter):
    super().__init__()
    self.parameter = ref_to_parameter
  def forward(self, x):
    return self.x + torch.max(self.parameter)

class LinearModuleAndSubModule(torch.nn.Linear):
  def __init__(self, in_features, out_features):
    super().__init__(in_features, out_features)
    self.weight_submodule = SubModule(self.weight)
  def forward(self, x):
    return torch.nn.functional.linear(self.weight_submodule(x), self.weight)

class Model(torch.nn.Module):
  def __init__(self):
    super().__init__()
    self.compute = LinearModuleAndSubModule(3, 8)
  def forward(self, x):
    return self.compute(x)

model = Model()
print(model)

from accelerate.utils import infer_auto_device_map
# Low memory device, just to force splitting and trigger the error
device_memory = {0: 4, 'cpu': 96000}
device_map = infer_auto_device_map(model, device_memory, verbose=True)
```

The error does not exist if we use the name `self.brrrweight_submodule` instead of `self.weight_submodule`. 