### PR TITLE
Raise error when using batches of different sizes with `dispatch_batches=True`

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -608,12 +608,11 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                         batches.append(next(iterator))
                     try:
                         batch = concatenate(batches, dim=0)
-                    except RuntimeError:
+                    except RuntimeError as e:
                         raise RuntimeError(
                             "You can't use batches of different size with `dispatch_batches=True` or when using an `IterableDataset`."
-                            "As an alternative, you can either: 1) Have batches of same size 2) Set `dispatch_batches=False`. "
-                            "This way, each process will get fetch their own batch. "
-                            "3) Set `split_batches=True`. By doing so, the main process will fetch a full batch and "
+                            "either pass `dispatch_batches=False` and have each process fetch its own batch "
+                            " or pass `split_batches=True`. By doing so, the main process will fetch a full batch and "
                             "slice it into `num_processes` batches for each process."
                         )
                 # In both cases, we need to get the structure of the batch that we will broadcast on other

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -608,7 +608,7 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                         batches.append(next(iterator))
                     try:
                         batch = concatenate(batches, dim=0)
-                    except RuntimeError as e:
+                    except RuntimeError:
                         raise RuntimeError(
                             "You can't use batches of different size with `dispatch_batches=True` or when using an `IterableDataset`."
                             "either pass `dispatch_batches=False` and have each process fetch its own batch "

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -606,7 +606,16 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                     batches = []
                     for _ in range(self.state.num_processes):
                         batches.append(next(iterator))
-                    batch = concatenate(batches, dim=0)
+                    try:
+                        batch = concatenate(batches, dim=0)
+                    except RuntimeError:
+                        raise RuntimeError(
+                            "You can't use batches of different sizes with `dispatch_batches=True` or when using an `IterableDataset`."
+                            "As an alternative, you can either: 1) Have batches of same size 2) Set `dispatch_batches=False`. "
+                            "This way, each process will get fetch their own batch. "
+                            "3) Set `split_batches=True`. By doing so, the main process will fetch a full batch and "
+                            "slice it into `num_processes` batches for each process."
+                        )
                 # In both cases, we need to get the structure of the batch that we will broadcast on other
                 # processes to initialize the tensors with the right shape.
                 # data_structure, stop_iteration

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -608,13 +608,13 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                         batches.append(next(iterator))
                     try:
                         batch = concatenate(batches, dim=0)
-                    except RuntimeError:
+                    except RuntimeError as e:
                         raise RuntimeError(
                             "You can't use batches of different size with `dispatch_batches=True` or when using an `IterableDataset`."
                             "either pass `dispatch_batches=False` and have each process fetch its own batch "
                             " or pass `split_batches=True`. By doing so, the main process will fetch a full batch and "
                             "slice it into `num_processes` batches for each process."
-                        )
+                        ) from e
                 # In both cases, we need to get the structure of the batch that we will broadcast on other
                 # processes to initialize the tensors with the right shape.
                 # data_structure, stop_iteration

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -610,7 +610,7 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
                         batch = concatenate(batches, dim=0)
                     except RuntimeError:
                         raise RuntimeError(
-                            "You can't use batches of different sizes with `dispatch_batches=True` or when using an `IterableDataset`."
+                            "You can't use batches of different size with `dispatch_batches=True` or when using an `IterableDataset`."
                             "As an alternative, you can either: 1) Have batches of same size 2) Set `dispatch_batches=False`. "
                             "This way, each process will get fetch their own batch. "
                             "3) Set `split_batches=True`. By doing so, the main process will fetch a full batch and "


### PR DESCRIPTION
# What does this PR do ? 

This PR raise an error when the user tries to use batches of different sizes with `dispatch_batches=True`. This arg is set to `True` when using an `IterableDataset`. 
Solves [26548](https://github.com/huggingface/transformers/issues/26548). See this [comment](https://github.com/huggingface/transformers/issues/26548#issuecomment-1885798533) for more details. 