### PR TITLE
Convert model.hf_device_map back to Dict

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -447,7 +447,8 @@ def dispatch_model(
             raise ValueError(
                 "You are trying to offload the whole model to the disk. Please use the `disk_offload` function instead."
             )
-    model.hf_device_map = device_map
+    # Convert OrderedDict back to dict for easier usage
+    model.hf_device_map = dict(device_map)
     return model
 
 


### PR DESCRIPTION
# What does this PR do ? 

This PR convert the model.hf_device_map to dict for better usage (make copy paste easier, better front ).
For ref,  the `device_map` was changed from dict to OrderedDict through this [PR](https://github.com/huggingface/accelerate/pull/2233). 