### PR TITLE
Avoid duplicating memory for tied weights in `dispatch_model`, and in forward with offloading 

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -43,6 +43,7 @@ from .utils import (
     parse_flag_from_env,
     retie_parameters,
 )
+from .utils.other import recursive_getattr
 
 
 logger = logging.getLogger(__name__)
@@ -395,7 +396,22 @@ def dispatch_model(
         else:
             weights_map = None
 
+        # When dispatching the model's parameters to the devices specified in device_map, we want to avoid allocating memory several times for the
+        # tied parameters. The dictionary tied_params_map keeps track of the already allocated data for a given tied parameter (represented by its
+        # original pointer) on each devices.
         tied_params = find_tied_parameters(model)
+
+        tied_params_map = {}
+        for group in tied_params:
+            for param_name in group:
+                # data_ptr() is enough here, as `find_tied_parameters` finds tied params simply by comparing `param1 is param2`, so we don't need
+                # to care about views of tensors through storage_offset.
+                data_ptr = recursive_getattr(model, param_name).data_ptr()
+                tied_params_map[data_ptr] = {}
+
+                # Note: To handle the disk offloading case, we can not simply use weights_map[param_name].data_ptr() as the reference pointer,
+                # as we have no guarantee that safetensors' `file.get_tensor()` will always give the same pointer.
+
         attach_align_device_hook_on_blocks(
             model,
             execution_device=execution_device,
@@ -404,6 +420,7 @@ def dispatch_model(
             weights_map=weights_map,
             skip_keys=skip_keys,
             preload_module_classes=preload_module_classes,
+            tied_params_map=tied_params_map,
         )
 
         # warn if there is any params on the meta device

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -350,6 +350,9 @@ def dispatch_model(
         getattr(model, "is_quantized", False) or getattr(model, "is_loaded_in_8bit", False)
     ) and getattr(model, "quantization_method", "bitsandbytes") == "bitsandbytes"
 
+    #print("data ptr 0 before hook:", model[0].weight.data_ptr())
+    #print("data ptr 2 before hook:", model[2].weight.data_ptr())
+
     # We attach hooks if the device_map has at least 2 different devices or if
     # force_hooks is set to `True`. Otherwise, the model in already loaded
     # in the unique device and the user can decide where to dispatch the model.
@@ -395,7 +398,14 @@ def dispatch_model(
         else:
             weights_map = None
 
+        #print("data ptr 0:", model[0].weight.data_ptr())
+        #print("data ptr 1:", model[1].weight.data_ptr())
+        #print("data ptr 2:", model[2].weight.data_ptr())
+        #print("data ptr 3:", model[3].weight.data_ptr())
+        #print("execution_device", execution_device)
+
         tied_params = find_tied_parameters(model)
+
         attach_align_device_hook_on_blocks(
             model,
             execution_device=execution_device,
@@ -406,6 +416,9 @@ def dispatch_model(
             preload_module_classes=preload_module_classes,
         )
 
+        #print("data ptr 0 after attach:", model[0].weight.data_ptr())
+        #print("data ptr 2 after attach:", model[2].weight.data_ptr())
+
         # warn if there is any params on the meta device
         offloaded_devices_str = " and ".join(
             [device for device in set(device_map.values()) if device in ("cpu", "disk")]
@@ -415,8 +428,15 @@ def dispatch_model(
                 f"Some parameters are on the meta device device because they were offloaded to the {offloaded_devices_str}."
             )
 
+        #print("model here", model)
+        #print("data ptr 0:", model[0].weight.data_ptr())
+        #print("data ptr 2:", model[2].weight.data_ptr())
+
         # Attaching the hook may break tied weights, so we retie them
         retie_parameters(model, tied_params)
+
+        #print("data ptr after retie:", model[0].weight.data_ptr())
+        #print("data ptr after retie:", model[2].weight.data_ptr())
 
         # add warning to cuda and to method
         def add_warning(fn, model):

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -350,9 +350,6 @@ def dispatch_model(
         getattr(model, "is_quantized", False) or getattr(model, "is_loaded_in_8bit", False)
     ) and getattr(model, "quantization_method", "bitsandbytes") == "bitsandbytes"
 
-    #print("data ptr 0 before hook:", model[0].weight.data_ptr())
-    #print("data ptr 2 before hook:", model[2].weight.data_ptr())
-
     # We attach hooks if the device_map has at least 2 different devices or if
     # force_hooks is set to `True`. Otherwise, the model in already loaded
     # in the unique device and the user can decide where to dispatch the model.
@@ -398,12 +395,6 @@ def dispatch_model(
         else:
             weights_map = None
 
-        #print("data ptr 0:", model[0].weight.data_ptr())
-        #print("data ptr 1:", model[1].weight.data_ptr())
-        #print("data ptr 2:", model[2].weight.data_ptr())
-        #print("data ptr 3:", model[3].weight.data_ptr())
-        #print("execution_device", execution_device)
-
         tied_params = find_tied_parameters(model)
 
         attach_align_device_hook_on_blocks(
@@ -416,9 +407,6 @@ def dispatch_model(
             preload_module_classes=preload_module_classes,
         )
 
-        #print("data ptr 0 after attach:", model[0].weight.data_ptr())
-        #print("data ptr 2 after attach:", model[2].weight.data_ptr())
-
         # warn if there is any params on the meta device
         offloaded_devices_str = " and ".join(
             [device for device in set(device_map.values()) if device in ("cpu", "disk")]
@@ -428,15 +416,8 @@ def dispatch_model(
                 f"Some parameters are on the meta device device because they were offloaded to the {offloaded_devices_str}."
             )
 
-        #print("model here", model)
-        #print("data ptr 0:", model[0].weight.data_ptr())
-        #print("data ptr 2:", model[2].weight.data_ptr())
-
         # Attaching the hook may break tied weights, so we retie them
         retie_parameters(model, tied_params)
-
-        #print("data ptr after retie:", model[0].weight.data_ptr())
-        #print("data ptr after retie:", model[2].weight.data_ptr())
 
         # add warning to cuda and to method
         def add_warning(fn, model):

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -396,7 +396,6 @@ def dispatch_model(
             weights_map = None
 
         tied_params = find_tied_parameters(model)
-
         attach_align_device_hook_on_blocks(
             model,
             execution_device=execution_device,

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -22,13 +22,13 @@ from .state import PartialState
 from .utils import (
     PrefixedDataset,
     find_device,
+    find_tied_parameters,
     named_module_tensors,
     send_to_device,
     set_module_tensor_to_device,
-    find_tied_parameters,
 )
-from .utils.other import recursive_getattr
 from .utils.modeling import get_non_persistent_buffers
+from .utils.other import recursive_getattr
 
 
 class ModelHook:
@@ -118,7 +118,9 @@ class SequentialHook(ModelHook):
         return module
 
 
-def add_hook_to_module(module: nn.Module, hook: ModelHook, append: bool = False, init_hook_kwargs: Optional[Dict] = None):
+def add_hook_to_module(
+    module: nn.Module, hook: ModelHook, append: bool = False, init_hook_kwargs: Optional[Dict] = None
+):
     """
     Adds a hook to a given module. This will rewrite the `forward` method of the module to include the hook, to remove
     this behavior and restore the original `forward` method, use `remove_hook_from_module`.
@@ -332,7 +334,12 @@ class AlignDevicesHook(ModelHook):
         return module
 
 
-def add_align_hook_to_module(module: nn.Module, hook: AlignDevicesHook, append: bool = False, tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None):
+def add_align_hook_to_module(
+    module: nn.Module,
+    hook: AlignDevicesHook,
+    append: bool = False,
+    tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
+):
     """
     Adds a AlignDevicesHook hook to a given module, supporting the `tied_params_map` argument. Please refer to the `add_hook_to_module` function documentation as well.
 
@@ -342,9 +349,13 @@ def add_align_hook_to_module(module: nn.Module, hook: AlignDevicesHook, append: 
             to reuse the first available pointer of a shared weight for all others, instead of duplicating memory.
     """
     if not isinstance(hook, AlignDevicesHook):
-        raise ValueError(f"The hook passed to add_align_hook_to_module should be a AlignDevicesHook, found a {hook.__class__.__name__}.")
+        raise ValueError(
+            f"The hook passed to add_align_hook_to_module should be a AlignDevicesHook, found a {hook.__class__.__name__}."
+        )
 
-    return add_hook_to_module(module=module, hook=hook, append=append, init_hook_kwargs={"tied_params_map": tied_params_map})
+    return add_hook_to_module(
+        module=module, hook=hook, append=append, init_hook_kwargs={"tied_params_map": tied_params_map}
+    )
 
 
 def attach_execution_device_hook(

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -361,8 +361,6 @@ class AlignDevicesHook(ModelHook):
 
             # We may have loaded tied weights into self.tied_params_map (avoiding to load them several times in e.g. submodules): remove them from
             # this dictionary to allow the garbage collector to do its job.
-            # This is useful only for RAM offloading, as for disk offloading safetensors natively
-            # handles tied weights, and tied_params_map is not populated.
             for value_pointer, device in self.tied_pointers_to_remove:
                 del self.tied_params_map[value_pointer][device]
             self.tied_pointers_to_remove = None

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -257,7 +257,7 @@ class AlignDevicesHook(ModelHook):
             f"place_submodules={self.place_submodules}, skip_keys={repr(self.skip_keys)})"
         )
 
-    def init_hook(self, module, tied_params_map):
+    def init_hook(self, module, tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None):
         if not self.offload and self.execution_device is not None:
             for name, _ in named_module_tensors(module, recurse=self.place_submodules):
                 set_module_tensor_to_device(module, name, self.execution_device, tied_params_map=tied_params_map)
@@ -341,12 +341,14 @@ def add_align_hook_to_module(
     tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
 ):
     """
-    Adds a AlignDevicesHook hook to a given module, supporting the `tied_params_map` argument. Please refer to the `add_hook_to_module` function documentation as well.
+    Adds a AlignDevicesHook hook to a given module, supporting the `tied_params_map` argument. Please refer to the
+    `add_hook_to_module` function documentation as well.
 
     Args:
         tied_params_map (Optional[Dict[int, Dict[torch.device, torch.Tensor]]], *optional*, defaults to `None`):
-            A map of data pointers to dictionaries of devices to already dispatched tied weights. For a given execution device, this parameter is useful
-            to reuse the first available pointer of a shared weight for all others, instead of duplicating memory.
+            A map of data pointers to dictionaries of devices to already dispatched tied weights. For a given execution
+            device, this parameter is useful to reuse the first available pointer of a shared weight for all others,
+            instead of duplicating memory.
     """
     if not isinstance(hook, AlignDevicesHook):
         raise ValueError(
@@ -517,8 +519,9 @@ def attach_align_device_hook_on_blocks(
             called directly during the forward, for instance if a `dense` linear layer is registered, but at forward,
             `dense.weight` and `dense.bias` are used in some operations instead of calling `dense` directly.
         tied_params_map (Optional[Dict[int, Dict[torch.device, torch.Tensor]]], *optional*, defaults to `None`):
-            A map of data pointers to dictionaries of devices to already dispatched tied weights. For a given execution device, this parameter is useful
-            to reuse the first available pointer of a shared weight for all others, instead of duplicating memory.
+            A map of data pointers to dictionaries of devices to already dispatched tied weights. For a given execution
+            device, this parameter is useful to reuse the first available pointer of a shared weight for all others,
+            instead of duplicating memory.
     """
     # When dispatching the model's parameters to the devices specified in device_map, we want to avoid allocating memory several times for the
     # tied parameters. The dictionary tied_params_map keeps track of the already allocated data for a given tied parameter (represented by its

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -266,7 +266,6 @@ class AlignDevicesHook(ModelHook):
             for name, _ in named_module_tensors(module, recurse=self.place_submodules):
                 set_module_tensor_to_device(module, name, self.execution_device, tied_params_map=tied_params_map)
         elif self.offload:
-            # TODO: validate that this tied param fix works correctly with offloading
             self.original_devices = {
                 name: param.device for name, param in named_module_tensors(module, recurse=self.place_submodules)
             }
@@ -281,7 +280,6 @@ class AlignDevicesHook(ModelHook):
                 module, include_buffers=self.offload_buffers, recurse=self.place_submodules, remove_non_persistent=True
             ):
                 set_module_tensor_to_device(module, name, "meta")
-
             if not self.offload_buffers and self.execution_device is not None:
                 for name, _ in module.named_buffers(recurse=self.place_submodules):
                     set_module_tensor_to_device(module, name, self.execution_device, tied_params_map=tied_params_map)
@@ -317,8 +315,7 @@ class AlignDevicesHook(ModelHook):
                 # self.tied_params_map in order to allow to free memory.
                 value = self.weights_map[name]
                 if (
-                    len(self.tied_params_map) > 0
-                    and value is not None
+                    value is not None
                     and self.tied_params_map is not None
                     and value.data_ptr() in self.tied_params_map
                     and self.execution_device not in self.tied_params_map[value.data_ptr()]

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -188,10 +188,10 @@ from .other import (
     is_port_in_use,
     merge_dicts,
     patch_environment,
+    recursive_getattr,
     save,
     wait_for_everyone,
     write_basic_config,
-    recursive_getattr,
 )
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
 from .torch_xla import install_xla

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -191,6 +191,7 @@ from .other import (
     save,
     wait_for_everyone,
     write_basic_config,
+    recursive_getattr,
 )
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
 from .torch_xla import install_xla

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -377,12 +377,7 @@ def set_module_tensor_to_device(
                 else:
                     new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
             else:
-                #print("new_value data_ptr here", new_value.data_ptr())
-                #print("old_value data_ptr", old_value.data_ptr())
-
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)
-
-                #print("new_value data_ptr", new_value.data_ptr())
 
             module._parameters[tensor_name] = new_value
             if fp16_statistics is not None:
@@ -747,7 +742,6 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
         else:
             max_memory["cpu"] = psutil.virtual_memory().available
 
-        print("max_memory", max_memory)
         return max_memory
 
     for key in max_memory:
@@ -777,8 +771,6 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                 f"Device {k} is not recognized, available devices are integers(for GPU/XPU), 'mps', 'cpu' and 'disk'"
             )
     max_memory = {k: max_memory[k] for k in all_devices}
-
-    print("max_memory", max_memory)
 
     return max_memory
 
@@ -857,7 +849,7 @@ def get_balanced_memory(
         model (`torch.nn.Module`):
             The model to analyze.
         max_memory (`Dict`, *optional*):
-            A dictionary device identifier to maximum memory. Will default to the maximum memory available if unset.
+            A dictionary device identifier to maximum memory (in bytes). Will default to the maximum memory available if unset.
         no_split_module_classes (`List[str]`, *optional*):
             A list of layer class names that should never be split across device (for instance any layer that has a
             residual connection).
@@ -1014,7 +1006,7 @@ def infer_auto_device_map(
         model (`torch.nn.Module`):
             The model to analyze.
         max_memory (`Dict`, *optional*):
-            A dictionary device identifier to maximum memory. Will default to the maximum memory available if unset.
+            A dictionary device identifier to maximum memory (in bytes). Will default to the maximum memory available if unset.
         no_split_module_classes (`List[str]`, *optional*):
             A list of layer class names that should never be split across device (for instance any layer that has a
             residual connection).

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -390,6 +390,7 @@ def set_module_tensor_to_device(
                     new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
             else:
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)
+
             module._parameters[tensor_name] = new_value
             if fp16_statistics is not None:
                 setattr(module._parameters[tensor_name], "SCB", fp16_statistics.to(device))

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -288,8 +288,9 @@ def set_module_tensor_to_device(
         fp16_statistics (`torch.HalfTensor`, *optional*):
             The list of fp16 statistics to set on the module, used for 8 bit model serialization.
         tied_params_map (Dict[int, Dict[torch.device, torch.Tensor]], *optional*, defaults to `None`):
-            A map of current data pointers to dictionaries of devices to already dispatched tied weights. For a given execution device,
-            this parameter is useful to reuse the first available pointer of a shared weight on the device for all others, instead of duplicating memory.
+            A map of current data pointers to dictionaries of devices to already dispatched tied weights. For a given
+            execution device, this parameter is useful to reuse the first available pointer of a shared weight on the
+            device for all others, instead of duplicating memory.
     """
     # Recurse if needed
     if "." in tensor_name:
@@ -363,7 +364,6 @@ def set_module_tensor_to_device(
             new_value = torch.tensor(value, device=device)
         if device_quantization is not None:
             device = device_quantization
-
         if is_buffer:
             module._buffers[tensor_name] = new_value
         elif value is not None or not check_device_same(torch.device(device), module._parameters[tensor_name].device):
@@ -382,7 +382,6 @@ def set_module_tensor_to_device(
                     new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
             else:
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)
-
             module._parameters[tensor_name] = new_value
             if fp16_statistics is not None:
                 setattr(module._parameters[tensor_name], "SCB", fp16_statistics.to(device))
@@ -749,7 +748,6 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
             max_memory["mps"] = psutil.virtual_memory().available
         else:
             max_memory["cpu"] = psutil.virtual_memory().available
-
         return max_memory
 
     for key in max_memory:
@@ -857,7 +855,8 @@ def get_balanced_memory(
         model (`torch.nn.Module`):
             The model to analyze.
         max_memory (`Dict`, *optional*):
-            A dictionary device identifier to maximum memory (in bytes). Will default to the maximum memory available if unset.
+            A dictionary device identifier to maximum memory (in bytes). Will default to the maximum memory available
+            if unset.
         no_split_module_classes (`List[str]`, *optional*):
             A list of layer class names that should never be split across device (for instance any layer that has a
             residual connection).
@@ -1014,7 +1013,8 @@ def infer_auto_device_map(
         model (`torch.nn.Module`):
             The model to analyze.
         max_memory (`Dict`, *optional*):
-            A dictionary device identifier to maximum memory (in bytes). Will default to the maximum memory available if unset.
+            A dictionary device identifier to maximum memory (in bytes). Will default to the maximum memory available
+            if unset.
         no_split_module_classes (`List[str]`, *optional*):
             A list of layer class names that should never be split across device (for instance any layer that has a
             residual connection).

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -315,12 +315,36 @@ def set_module_tensor_to_device(
     if old_value.device == torch.device("meta") and device not in ["meta", torch.device("meta")] and value is None:
         raise ValueError(f"{tensor_name} is on the meta device, we need a `value` to put in on {device}.")
 
-    print("value", value)
+    if value is not None:
+        if old_value.shape != value.shape:
+            raise ValueError(
+                f'Trying to set a tensor of shape {value.shape} in "{tensor_name}" (which has shape {old_value.shape}), this look incorrect.'
+            )
+
+        if dtype is None:
+            # For compatibility with PyTorch load_state_dict which converts state dict dtype to existing dtype in model
+            value = value.to(old_value.dtype)
+        elif not str(value.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):
+            value = value.to(dtype)
+
     param = module._parameters[tensor_name] if tensor_name in module._parameters else None
     param_cls = type(param)
 
     device_quantization = None
     with torch.no_grad():
+        # leave it on cpu first before moving them to cuda
+        # # fix the case where the device is meta, we don't want to put it on cpu because there is no data =0
+        if (
+            param is not None
+            and param.device.type != "cuda"
+            and torch.device(device).type == "cuda"
+            and param_cls.__name__ in ["Int8Params", "FP4Params", "Params4bit"]
+        ):
+            device_quantization = device
+            device = "cpu"
+        # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).
+        if is_npu_available() and isinstance(device, int):
+            device = f"npu:{device}"
         if value is None:
             new_value = old_value.to(device)
             if dtype is not None and device in ["meta", torch.device("meta")]:
@@ -329,7 +353,10 @@ def set_module_tensor_to_device(
 
                 if not is_buffer:
                     module._parameters[tensor_name] = param_cls(new_value, requires_grad=old_value.requires_grad)
-
+        elif isinstance(value, torch.Tensor):
+            new_value = value.to(device)
+        else:
+            new_value = torch.tensor(value, device=device)
         if device_quantization is not None:
             device = device_quantization
 
@@ -338,15 +365,49 @@ def set_module_tensor_to_device(
         elif value is not None or not check_device_same(torch.device(device), module._parameters[tensor_name].device):
             param_cls = type(module._parameters[tensor_name])
             kwargs = module._parameters[tensor_name].__dict__
-            #print("new_value data_ptr here", new_value.data_ptr())
-            #print("old_value data_ptr", old_value.data_ptr())
-            new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)
+            if param_cls.__name__ in ["Int8Params", "FP4Params"]:
+                if param_cls.__name__ == "Int8Params" and new_value.dtype == torch.float32:
+                    # downcast to fp16 if any - needed for 8bit serialization
+                    new_value = new_value.to(torch.float16)
+                # quantize module that are going to stay on the cpu so that we offload quantized weights
+                if device == "cpu" and param_cls.__name__ == "Int8Params":
+                    new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(0).to("cpu")
+                    new_value.CB = new_value.CB.to("cpu")
+                    new_value.SCB = new_value.SCB.to("cpu")
+                else:
+                    new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
+            else:
+                #print("new_value data_ptr here", new_value.data_ptr())
+                #print("old_value data_ptr", old_value.data_ptr())
 
-            #print("new_value data_ptr", new_value.data_ptr())
+                new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)
+
+                #print("new_value data_ptr", new_value.data_ptr())
+
             module._parameters[tensor_name] = new_value
             if fp16_statistics is not None:
                 setattr(module._parameters[tensor_name], "SCB", fp16_statistics.to(device))
                 del fp16_statistics
+            # as we put the weight to meta, it doesn't have SCB attr anymore. make sure that it is not a meta weight
+            if (
+                module.__class__.__name__ == "Linear8bitLt"
+                and getattr(module.weight, "SCB", None) is None
+                and str(module.weight.device) != "meta"
+            ):
+                # quantize only if necessary
+                device_index = torch.device(device).index if torch.device(device).type == "cuda" else None
+                if not getattr(module.weight, "SCB", None) and device_index is not None:
+                    if module.bias is not None and module.bias.device.type != "meta":
+                        # if a bias exists, we need to wait until the bias is set on the correct device
+                        module = module.cuda(device_index)
+                    elif module.bias is None:
+                        # if no bias exists, we can quantize right away
+                        module = module.cuda(device_index)
+            elif module.__class__.__name__ == "Linear4bit" and getattr(module.weight, "quant_state", None) is None:
+                # quantize only if necessary
+                device_index = torch.device(device).index if torch.device(device).type == "cuda" else None
+                if not getattr(module.weight, "quant_state", None) and device_index is not None:
+                    module.weight = module.weight.cuda(device_index)
     # clean pre and post foward hook
     if is_npu_available():
         torch.npu.empty_cache()

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -308,7 +308,11 @@ def set_module_tensor_to_device(
 
     # Treat the case where old_value belongs to a tied group, and one of the weight in the tied group has already been dispatched to the device,
     # by avoiding reallocating memory on the device and just copying the pointer.
-    if tied_params_map is not None and old_value.data_ptr() in tied_params_map and device in tied_params_map[old_value.data_ptr()]:
+    if (
+        tied_params_map is not None
+        and old_value.data_ptr() in tied_params_map
+        and device in tied_params_map[old_value.data_ptr()]
+    ):
         module._parameters[tensor_name] = tied_params_map[old_value.data_ptr()][device]
         return
 
@@ -411,7 +415,11 @@ def set_module_tensor_to_device(
 
     # When handling tied weights, we update tied_params_map to keep track of the tied weights that have already been allocated on the device in
     # order to avoid duplicating memory, see above.
-    if tied_params_map is not None and old_value.data_ptr() in tied_params_map and device not in tied_params_map[old_value.data_ptr()]:
+    if (
+        tied_params_map is not None
+        and old_value.data_ptr() in tied_params_map
+        and device not in tied_params_map[old_value.data_ptr()]
+    ):
         tied_params_map[old_value.data_ptr()][device] = new_value
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -321,6 +321,7 @@ def check_os_kernel():
         )
         logger.warning(msg, main_process_only=True)
 
+
 def recursive_getattr(obj, attr: str):
     """
     Recursive `getattr`.

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -18,7 +18,7 @@ import platform
 import re
 import socket
 from contextlib import contextmanager
-from functools import partial
+from functools import partial, reduce
 from types import MethodType
 from typing import OrderedDict
 
@@ -320,3 +320,19 @@ def check_os_kernel():
             "cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher."
         )
         logger.warning(msg, main_process_only=True)
+
+def recursive_getattr(obj, attr: str):
+    """
+    Recursive `getattr`.
+
+    Args:
+        obj:
+            A class instance holding the attribute.
+        attr (`str`):
+            The attribute that is to be retrieved, e.g. 'attribute1.attribute2'.
+    """
+
+    def _getattr(obj, attr):
+        return getattr(obj, attr)
+
+    return reduce(_getattr, [obj] + attr.split("."))

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -14,8 +14,8 @@
 import copy
 import os
 import unittest
-from tempfile import TemporaryDirectory
 from collections import OrderedDict
+from tempfile import TemporaryDirectory
 
 import torch
 import torch.nn as nn
@@ -390,23 +390,26 @@ class BigModelingTester(unittest.TestCase):
         # We should need only 5000 * 5000 * 32 // 8 * 1e-6 = 100 MB on the device 0 for the three linear weights.
         device_map = {"linear0": 0, "linear1": 1, "linear2": 0, "linear3": 0, "linear4": 0}
 
-        a = torch.rand(5).to("cuda:0")  # Just to intialize CUDA context.
-        free_memory_bytes = torch.cuda.mem_get_info("cuda:0")[0]
+        # Just to intialize CUDA context.
+        a = torch.rand(5).to("cuda:0")  # noqa: F841
 
+        free_memory_bytes = torch.cuda.mem_get_info("cuda:0")[0]
         required_memory_bytes = 5000 * 5000 * (32 // 8)
 
         # Leaving 50 MB of free memory for possible buffers, etc.
         n_vals = (free_memory_bytes - required_memory_bytes - int(50e6)) // (32 // 8)
-        foo = torch.rand(n_vals, device="cuda:0")
+        foo = torch.rand(n_vals, device="cuda:0")  # noqa: F841
 
         # If this does OOM: there is an issue in somewhere in dispatch_model, memory of tied weights is duplicated.
         try:
             dispatch_model(model, device_map)
         except torch.cuda.OutOfMemoryError as e:
-            raise torch.cuda.OutOfMemoryError(f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory. {e}")
+            raise torch.cuda.OutOfMemoryError(
+                f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory. {e}"
+            )
         except Exception as e:
             raise e
-        
+
         with torch.no_grad():
             output = model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -15,6 +15,7 @@ import copy
 import os
 import unittest
 from tempfile import TemporaryDirectory
+from collections import OrderedDict
 
 import torch
 import torch.nn as nn
@@ -525,10 +526,6 @@ class BigModelingTester(unittest.TestCase):
         dispatch_model(model, device_map, force_hooks=True)
         output = model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
-
-    #@require_cuda
-    #def test_dispatch_model_tied_weights(self):
-        ## Test that we do not duplicate
 
     @require_cuda
     def test_load_checkpoint_and_dispatch(self):

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -416,61 +416,8 @@ class BigModelingTester(unittest.TestCase):
             output = model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
-    @require_multi_gpu
-    def test_dispatch_model_tied_weights_memory_with_offload(self):
-        # Test that we do not duplicate tied weights at any point during dispatch_model call.
-
-        torch.cuda.empty_cache()  # Needed in case we run several tests in a row.
-
-        model = nn.Sequential(
-            OrderedDict(
-                [
-                    ("linear0", nn.Linear(5000, 5000, bias=False)),
-                    ("linear1", nn.Linear(5000, 5000, bias=False)),
-                    ("linear2", nn.Linear(5000, 5000, bias=False)),
-                    ("linear3", nn.Linear(5000, 5000, bias=False)),
-                    ("linear4", nn.Linear(5000, 5000, bias=False)),
-                ]
-            )
-        )
-
-        model.linear2.weight = model.linear0.weight
-        model.linear3.weight = model.linear0.weight
-        model.linear4.weight = model.linear0.weight
-
-        x = torch.randn(5, 5000)
-        with torch.no_grad():
-            expected = model(x)
-
-        # We should need only 5000 * 5000 * 32 // 8 * 1e-6 = 100 MB on the device 0 for the four linear weights.
-        device_map = {"linear0": 0, "linear1": 1, "linear2": 0, "linear3": "cpu", "linear4": 0}
-
-        # Just to intialize CUDA context.
-        a = torch.rand(5).to("cuda:0")  # noqa: F841
-
-        free_memory_bytes = torch.cuda.mem_get_info("cuda:0")[0]
-        required_memory_bytes = 5000 * 5000 * (32 // 8)
-
-        # Leaving 50 MB of free memory for possible buffers, etc.
-        n_vals = (free_memory_bytes - required_memory_bytes - int(50e6)) // (32 // 8)
-        foo = torch.rand(n_vals, device="cuda:0")  # noqa: F841
-
-        # If this does OOM: there is an issue in somewhere in dispatch_model, memory of tied weights is duplicated.
-        try:
-            dispatch_model(model, device_map)
-        except torch.cuda.OutOfMemoryError as e:
-            raise torch.cuda.OutOfMemoryError(
-                f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory_with_offload. {e}"
-            )
-        except Exception as e:
-            raise e
-
-        with torch.no_grad():
-            output = model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
-
     @require_cuda
-    def test_dispatch_model_tied_weights_memory_with_nested_offload(self):
+    def test_dispatch_model_tied_weights_memory_with_nested_offload_cpu(self):
         # Test that we do not duplicate tied weights at any point during dispatch_model call.
 
         torch.cuda.empty_cache()  # Needed in case we run several tests in a row.
@@ -541,7 +488,7 @@ class BigModelingTester(unittest.TestCase):
                 output = model(x)
             except torch.cuda.OutOfMemoryError as e:
                 raise torch.cuda.OutOfMemoryError(
-                    f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory_with_nested_offload. {e}"
+                    f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory_with_nested_offload_cpu. {e}"
                 )
             except Exception as e:
                 raise e
@@ -556,6 +503,95 @@ class BigModelingTester(unittest.TestCase):
         self.assertTrue(len(model.compute1.weight_submodule._hf_hook.tied_params_map[original_pointer]) == 0)
         self.assertTrue(len(model.compute1._hf_hook.tied_params_map[original_pointer]) == 0)
         self.assertTrue((free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130)
+
+    @require_cuda
+    def test_dispatch_model_tied_weights_memory_with_nested_offload_disk(self):
+        # Test that we do not duplicate tied weights at any point during dispatch_model call.
+
+        torch.cuda.empty_cache()  # Needed in case we run several tests in a row.
+
+        class SubModule(torch.nn.Module):
+            def __init__(self, ref_to_parameter):
+                super().__init__()
+                self.parameter = ref_to_parameter
+
+            def forward(self, x):
+                return x + torch.max(self.parameter)
+
+        class LinearModuleAndSubModule(torch.nn.Linear):
+            def __init__(self, in_features, out_features):
+                super().__init__(in_features, out_features, bias=False)
+                self.weight_submodule = SubModule(self.weight)
+                self.weight_submodule2 = SubModule(self.weight)
+                self.weight_submodule3 = SubModule(self.weight)
+                self.weight_submodule4 = SubModule(self.weight)
+
+            def forward(self, x):
+                a = torch.nn.functional.linear(self.weight_submodule(x), self.weight)
+                b = torch.nn.functional.linear(self.weight_submodule2(x), self.weight)
+                c = torch.nn.functional.linear(self.weight_submodule3(x), self.weight)
+                d = torch.nn.functional.linear(self.weight_submodule4(x), self.weight)
+                return a + b + c + d
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.compute = LinearModuleAndSubModule(5000, 5000)
+                self.compute1 = LinearModuleAndSubModule(5000, 5000)
+
+            def forward(self, x):
+                a = self.compute(x)
+                b = self.compute1(x)
+                return a + b
+
+        # We should need only 2 * 5000 * 5000 * 32 // 8 * 1e-6 = 200 MB on the device 0 for the whole model forward, and not 600 MB.
+        device_map = {"compute": 0, "compute1": "disk"}
+
+        model = Model()
+
+        x = torch.randn(1, 5000)
+        with torch.no_grad():
+            expected = model(x)
+
+        # Just to intialize CUDA context.
+        a = torch.rand(5).to("cuda:0")  # noqa: F841
+
+        free_memory_bytes = torch.cuda.mem_get_info("cuda:0")[0]
+        required_memory_bytes = 2 * 5000 * 5000 * (32 // 8)  # 200 MB
+
+        # Leaving 150 MB of free memory for possible buffers, etc.
+        n_vals = (free_memory_bytes - required_memory_bytes - int(200e6)) // (32 // 8)
+        foo = torch.rand(n_vals, device="cuda:0")  # noqa: F841
+
+        free_memory_bytes_before_dispatch = torch.cuda.mem_get_info("cuda:0")[0]
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir)
+            free_memory_bytes_after_dispatch = torch.cuda.mem_get_info("cuda:0")[0]
+
+            self.assertTrue((free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130)
+
+            original_pointer = model.compute1._hf_hook.weights_map["weight"].data_ptr()
+
+            with torch.no_grad():
+                try:
+                    output = model(x)
+                except torch.cuda.OutOfMemoryError as e:
+                    raise torch.cuda.OutOfMemoryError(
+                        f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory_with_nested_offload_disk. {e}"
+                    )
+                except Exception as e:
+                    raise e
+
+            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+
+            torch.cuda.empty_cache()
+
+            free_memory_bytes_after_infer = torch.cuda.mem_get_info("cuda:0")[0]
+
+            # Check that we have no more references on GPU for the offloaded tied weight.
+            self.assertTrue(len(model.compute1.weight_submodule._hf_hook.tied_params_map[original_pointer]) == 0)
+            self.assertTrue(len(model.compute1._hf_hook.tied_params_map[original_pointer]) == 0)
+            self.assertTrue((free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130)
 
     @require_multi_gpu
     def test_dispatch_model_multi_gpu(self):

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -541,7 +541,7 @@ class BigModelingTester(unittest.TestCase):
                 output = model(x)
             except torch.cuda.OutOfMemoryError as e:
                 raise torch.cuda.OutOfMemoryError(
-                    f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory. {e}"
+                    f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory_with_nested_offload. {e}"
                 )
             except Exception as e:
                 raise e

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -469,7 +469,7 @@ class BigModelingTester(unittest.TestCase):
             output = model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
-    @require_multi_gpu
+    @require_cuda
     def test_dispatch_model_tied_weights_memory_with_nested_offload(self):
         # Test that we do not duplicate tied weights at any point during dispatch_model call.
 

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -368,6 +368,8 @@ class BigModelingTester(unittest.TestCase):
     def test_dispatch_model_tied_weights_memory(self):
         # Test that we do not duplicate tied weights at any point during dispatch_model call.
 
+        torch.cuda.empty_cache()  # Needed in case we run several tests in a row.
+
         model = nn.Sequential(
             OrderedDict(
                 [
@@ -387,7 +389,7 @@ class BigModelingTester(unittest.TestCase):
         with torch.no_grad():
             expected = model(x)
 
-        # We should need only 5000 * 5000 * 32 // 8 * 1e-6 = 100 MB on the device 0 for the three linear weights.
+        # We should need only 5000 * 5000 * 32 // 8 * 1e-6 = 100 MB on the device 0 for the four linear weights.
         device_map = {"linear0": 0, "linear1": 1, "linear2": 0, "linear3": 0, "linear4": 0}
 
         # Just to intialize CUDA context.
@@ -413,6 +415,147 @@ class BigModelingTester(unittest.TestCase):
         with torch.no_grad():
             output = model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+
+    @require_multi_gpu
+    def test_dispatch_model_tied_weights_memory_with_offload(self):
+        # Test that we do not duplicate tied weights at any point during dispatch_model call.
+
+        torch.cuda.empty_cache()  # Needed in case we run several tests in a row.
+
+        model = nn.Sequential(
+            OrderedDict(
+                [
+                    ("linear0", nn.Linear(5000, 5000, bias=False)),
+                    ("linear1", nn.Linear(5000, 5000, bias=False)),
+                    ("linear2", nn.Linear(5000, 5000, bias=False)),
+                    ("linear3", nn.Linear(5000, 5000, bias=False)),
+                    ("linear4", nn.Linear(5000, 5000, bias=False)),
+                ]
+            )
+        )
+
+        model.linear2.weight = model.linear0.weight
+        model.linear3.weight = model.linear0.weight
+        model.linear4.weight = model.linear0.weight
+
+        x = torch.randn(5, 5000)
+        with torch.no_grad():
+            expected = model(x)
+
+        # We should need only 5000 * 5000 * 32 // 8 * 1e-6 = 100 MB on the device 0 for the four linear weights.
+        device_map = {"linear0": 0, "linear1": 1, "linear2": 0, "linear3": "cpu", "linear4": 0}
+
+        # Just to intialize CUDA context.
+        a = torch.rand(5).to("cuda:0")  # noqa: F841
+
+        free_memory_bytes = torch.cuda.mem_get_info("cuda:0")[0]
+        required_memory_bytes = 5000 * 5000 * (32 // 8)
+
+        # Leaving 50 MB of free memory for possible buffers, etc.
+        n_vals = (free_memory_bytes - required_memory_bytes - int(50e6)) // (32 // 8)
+        foo = torch.rand(n_vals, device="cuda:0")  # noqa: F841
+
+        # If this does OOM: there is an issue in somewhere in dispatch_model, memory of tied weights is duplicated.
+        try:
+            dispatch_model(model, device_map)
+        except torch.cuda.OutOfMemoryError as e:
+            raise torch.cuda.OutOfMemoryError(
+                f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory. {e}"
+            )
+        except Exception as e:
+            raise e
+
+        with torch.no_grad():
+            output = model(x)
+        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+
+    @require_multi_gpu
+    def test_dispatch_model_tied_weights_memory_with_nested_offload(self):
+        # Test that we do not duplicate tied weights at any point during dispatch_model call.
+
+        torch.cuda.empty_cache()  # Needed in case we run several tests in a row.
+
+        class SubModule(torch.nn.Module):
+            def __init__(self, ref_to_parameter):
+                super().__init__()
+                self.parameter = ref_to_parameter
+
+            def forward(self, x):
+                return x + torch.max(self.parameter)
+
+        class LinearModuleAndSubModule(torch.nn.Linear):
+            def __init__(self, in_features, out_features):
+                super().__init__(in_features, out_features, bias=False)
+                self.weight_submodule = SubModule(self.weight)
+                self.weight_submodule2 = SubModule(self.weight)
+                self.weight_submodule3 = SubModule(self.weight)
+                self.weight_submodule4 = SubModule(self.weight)
+
+            def forward(self, x):
+                a = torch.nn.functional.linear(self.weight_submodule(x), self.weight)
+                b = torch.nn.functional.linear(self.weight_submodule2(x), self.weight)
+                c = torch.nn.functional.linear(self.weight_submodule3(x), self.weight)
+                d = torch.nn.functional.linear(self.weight_submodule4(x), self.weight)
+                return a + b + c + d
+
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.compute = LinearModuleAndSubModule(5000, 5000)
+                self.compute1 = LinearModuleAndSubModule(5000, 5000)
+
+            def forward(self, x):
+                a = self.compute(x)
+                b = self.compute1(x)
+                return a + b
+
+        # We should need only 2 * 5000 * 5000 * 32 // 8 * 1e-6 = 200 MB on the device 0 for the whole model forward, and not 600 MB.
+        device_map = {"compute": 0, "compute1": "cpu"}
+
+        model = Model()
+
+        x = torch.randn(1, 5000)
+        with torch.no_grad():
+            expected = model(x)
+
+        # Just to intialize CUDA context.
+        a = torch.rand(5).to("cuda:0")  # noqa: F841
+
+        free_memory_bytes = torch.cuda.mem_get_info("cuda:0")[0]
+        required_memory_bytes = 2 * 5000 * 5000 * (32 // 8)  # 200 MB
+
+        # Leaving 150 MB of free memory for possible buffers, etc.
+        n_vals = (free_memory_bytes - required_memory_bytes - int(150e6)) // (32 // 8)
+        foo = torch.rand(n_vals, device="cuda:0")  # noqa: F841
+
+        free_memory_bytes_before_dispatch = torch.cuda.mem_get_info("cuda:0")[0]
+        dispatch_model(model, device_map)
+        free_memory_bytes_after_dispatch = torch.cuda.mem_get_info("cuda:0")[0]
+
+        self.assertTrue((free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130)
+
+        original_pointer = model.compute1._hf_hook.weights_map["weight"].data_ptr()
+
+        with torch.no_grad():
+            try:
+                output = model(x)
+            except torch.cuda.OutOfMemoryError as e:
+                raise torch.cuda.OutOfMemoryError(
+                    f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory. {e}"
+                )
+            except Exception as e:
+                raise e
+
+        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+
+        torch.cuda.empty_cache()
+
+        free_memory_bytes_after_infer = torch.cuda.mem_get_info("cuda:0")[0]
+
+        # Check that we have no more references on GPU for the offloaded tied weight.
+        self.assertTrue(len(model.compute1.weight_submodule._hf_hook.tied_params_map[original_pointer]) == 0)
+        self.assertTrue(len(model.compute1._hf_hook.tied_params_map[original_pointer]) == 0)
+        self.assertTrue((free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130)
 
     @require_multi_gpu
     def test_dispatch_model_multi_gpu(self):

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -460,7 +460,7 @@ class BigModelingTester(unittest.TestCase):
             dispatch_model(model, device_map)
         except torch.cuda.OutOfMemoryError as e:
             raise torch.cuda.OutOfMemoryError(
-                f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory. {e}"
+                f"OOM error in dispatch_model. This is a bug and should not happen, see test_dispatch_model_tied_weights_memory_with_offload. {e}"
             )
         except Exception as e:
             raise e

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -526,6 +526,10 @@ class BigModelingTester(unittest.TestCase):
         output = model(x)
         self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
 
+    #@require_cuda
+    #def test_dispatch_model_tied_weights(self):
+        ## Test that we do not duplicate
+
     @require_cuda
     def test_load_checkpoint_and_dispatch(self):
         model = ModelForTest()


### PR DESCRIPTION
@Giuseppe5 noticed that `dispatch_model` does not preserve tied weights during its call, although `retie_parameters` as the end so the end model dispatched model preserves tied weights.

This results in possible large memory spike during `dispatch_model` in case many weights are tied. The core issue in `init_hook` and `set_module_tensor_to_device` is:

```python
import torch
import torch.nn as nn
from collections import OrderedDict

model = nn.Sequential(
    OrderedDict(
        [
            ("linear0", nn.Linear(4, 4)),
            ("linear1", nn.Linear(6, 6)),
            ("linear2", nn.Linear(4, 4)),
            ("linear3", nn.Linear(6, 6)),
        ]
    )
)
model.linear2.weight = model.linear0.weight
model.linear2.bias = model.linear0.bias

old_value0 = getattr(model.linear0, "weight")
old_value2 = getattr(model.linear2, "weight")
print("on cpu linear0:", old_value0.data_ptr())
print("on cpu linear2:", old_value2.data_ptr())

model[0]._parameters["weight"] = old_value0.to("cuda")
model[2]._parameters["weight"] = old_value2.to("cuda")

print("on cuda linear0:", model.linear0.weight.data_ptr())
print("on cuda linear2:", model.linear2.weight.data_ptr())

# Printing
# on cpu linear0: 94179276421568
# on cpu linear2: 94179276421568
# on cuda linear0: 140074192732672
# on cuda linear2: 140074192733184
```

This PR proposes to keep track of a dictionary `tied_params_map` that maps the model's data pointers to tied parameters to a dictionary that maps devices to dispatched data.

When a tied weight has already been dispatched, we can reuse the dispatched data for the other tied weights instead of allocating memory (as currently).

@muellerzr @SunMarc What do you think? Do you see a more elegant solution?

@SunMarc suggested
```python
model.linear0.weight.data = model.linear0.weight.to("cuda")
model.linear2.weight.data = model.linear2.weight.to("cuda")
```

but I did not manage to have this work, the `new_value` [here](https://github.com/huggingface/accelerate/blob/fce61a99eca8cef2a65726d7f4feac41889691cf/src/accelerate/utils/modeling.py#L339) always points to a different data pointer, despite the `old_value` being shared, see:

```
device_map OrderedDict([('linear0', 0), ('linear2', 0), ('linear1', 1), ('linear3', 1)])
---- call attach_align_device_hook_on_blocks linear0
old_value dataptr 115696640
new_value dataptr 140711905198080  <----------------- here
new_value dataptr after param_cls 140711905198080
module weight data_ptr after add hook 140711905198080
---- call attach_align_device_hook_on_blocks linear1
old_value dataptr 118073344
new_value dataptr 140711368327168
new_value dataptr after param_cls 140711368327168
module weight data_ptr after add hook 140711368327168
---- call attach_align_device_hook_on_blocks linear2
old_value dataptr 115696640
new_value dataptr 140711905198592  <----------------- here
new_value dataptr after param_cls 140711905198592
module weight data_ptr after add hook 140711905198592
---- call attach_align_device_hook_on_blocks linear3
old_value dataptr 114558400
new_value dataptr 140711368327680
new_value dataptr after param_cls 140711368327680
module weight data_ptr after add hook 140711368327680
```

It's not clear to me why this is not the same pointer, I could not reproduce locally. Maybe some PyTorch issue.
