### PR TITLE
Disable P2P in *just* the 4000 series

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -650,7 +650,7 @@ def multi_gpu_launcher(args):
 
     current_env = prepare_multi_gpu_env(args)
     if not check_cuda_p2p_ib_support():
-        message = "Using RTX 3090 or 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
+        message = "Using RTX 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
         warn = False
         if "NCCL_P2P_DISABLE" not in current_env:
             current_env["NCCL_P2P_DISABLE"] = "1"
@@ -687,7 +687,7 @@ def deepspeed_launcher(args):
 
     cmd, current_env = prepare_deepspeed_cmd_env(args)
     if not check_cuda_p2p_ib_support():
-        message = "Using RTX 3090 or 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
+        message = "Using RTX 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
         warn = False
         if "NCCL_P2P_DISABLE" not in current_env:
             current_env["NCCL_P2P_DISABLE"] = "1"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -205,7 +205,7 @@ class PartialState:
                 if self.device.type == "cuda" and not check_cuda_p2p_ib_support():
                     if "NCCL_P2P_DISABLE" not in os.environ or "NCCL_IB_DISABLE" not in os.environ:
                         raise NotImplementedError(
-                            "Using RTX 3090 or 4000 series doesn't support faster communication broadband via P2P or IB. "
+                            "Using RTX 4000 series doesn't support faster communication broadband via P2P or IB. "
                             'Please set `NCCL_P2P_DISABLE="1"` and `NCCL_IB_DISABLE="1" or use `accelerate launch` which '
                             "will do this automatically."
                         )
@@ -221,7 +221,7 @@ class PartialState:
                 if not check_cuda_p2p_ib_support():
                     if "NCCL_P2P_DISABLE" not in os.environ or "NCCL_IB_DISABLE" not in os.environ:
                         raise NotImplementedError(
-                            "Using RTX 3090 or 4000 series doesn't support faster communication broadband via P2P or IB. "
+                            "Using RTX 4000 series doesn't support faster communication broadband via P2P or IB. "
                             'Please set `NCCL_P2P_DISABLE="1"` and `NCCL_IB_DISABLE="1" or use `accelerate launch` which '
                             "will do this automatically."
                         )

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -99,7 +99,8 @@ def check_cuda_p2p_ib_support():
     """
     try:
         device_names, device_count = get_gpu_info()
-        unsupported_devices = {"RTX 3090", "RTX 40"}
+        # As new consumer GPUs get released, add them to `unsupported_devices``
+        unsupported_devices = {"RTX 40"}
         if device_count > 1:
             if any(
                 unsupported_device in device_name


### PR DESCRIPTION
# What does this PR do?

My research was a bit off, the 3090's can still do P2P from what this user reports, so I adjusted the limit to only happen on 40* series.

Fixes https://github.com/huggingface/accelerate/issues/2328

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 