### PR TITLE
FIX: add oneCCL environment variable for non-MPI launcher (accelerate launch)

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -180,9 +180,9 @@ class PartialState:
                     if is_xpu_available and is_ccl_available():
                         # Set DeepSpeed backend to ccl for xpu
                         self.backend = "ccl"
-                        os.environ['CCL_PROCESS_LAUNCHER'] = 'none'
-                        os.environ['CCL_LOCAL_SIZE'] = os.environ.get("LOCAL_WORLD_SIZE", "1")
-                        os.environ['CCL_LOCAL_RANK'] = os.environ.get("LOCAL_RANK", "0")
+                        os.environ["CCL_PROCESS_LAUNCHER"] = "none"
+                        os.environ["CCL_LOCAL_SIZE"] = os.environ.get("LOCAL_WORLD_SIZE", "1")
+                        os.environ["CCL_LOCAL_RANK"] = os.environ.get("LOCAL_RANK", "0")
                     elif is_npu_available():
                         self.backend = "hccl"
                     else:
@@ -272,18 +272,19 @@ class PartialState:
                     ["LOCAL_RANK", "MPI_LOCALRANKID", "OMPI_COMM_WORLD_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK"], 0
                 )
                 local_size = get_int_from_env(
-                    ["LOCAL_WORLD_SIZE", "MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
+                    ["LOCAL_WORLD_SIZE", "MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"],
+                    1,
                 )
                 self.local_process_index = local_rank
                 os.environ["RANK"] = str(rank)
                 os.environ["WORLD_SIZE"] = str(size)
                 os.environ["LOCAL_RANK"] = str(local_rank)
-                os.environ["LOCAL_WORLD_SIZE"]=str(local_size)
-                
+                os.environ["LOCAL_WORLD_SIZE"] = str(local_size)
+
                 if backend == "ccl" and self.distributed_type == DistributedType.MULTI_XPU:
-                    os.environ['CCL_PROCESS_LAUNCHER'] = 'none'
-                    os.environ['CCL_LOCAL_SIZE'] = str(local_size)
-                    os.environ['CCL_LOCAL_RANK'] = str(local_rank)
+                    os.environ["CCL_PROCESS_LAUNCHER"] = "none"
+                    os.environ["CCL_LOCAL_SIZE"] = str(local_size)
+                    os.environ["CCL_LOCAL_RANK"] = str(local_rank)
                 if not os.environ.get("MASTER_PORT", None):
                     os.environ["MASTER_PORT"] = "29500"
                 if not os.environ.get("MASTER_ADDR", None):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -275,6 +275,10 @@ class PartialState:
                 os.environ["RANK"] = str(rank)
                 os.environ["WORLD_SIZE"] = str(size)
                 os.environ["LOCAL_RANK"] = str(local_rank)
+                if backend == "ccl" and self.distributed_type == DistributedType.MULTI_XPU:
+                    os.environ['CCL_PROCESS_LAUNCHER'] = 'none'
+                    os.environ['CCL_LOCAL_SIZE'] = str(size)
+                    os.environ['CCL_LOCAL_RANK'] = str(local_rank)
                 if not os.environ.get("MASTER_PORT", None):
                     os.environ["MASTER_PORT"] = "29500"
                 if not os.environ.get("MASTER_ADDR", None):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -269,15 +269,17 @@ class PartialState:
                     ["LOCAL_RANK", "MPI_LOCALRANKID", "OMPI_COMM_WORLD_LOCAL_RANK", "MV2_COMM_WORLD_LOCAL_RANK"], 0
                 )
                 local_size = get_int_from_env(
-                    ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
+                    ["LOCAL_WORLD_SIZE", "MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
                 )
                 self.local_process_index = local_rank
                 os.environ["RANK"] = str(rank)
                 os.environ["WORLD_SIZE"] = str(size)
                 os.environ["LOCAL_RANK"] = str(local_rank)
+                os.environ["LOCAL_WORLD_SIZE"]=str(local_size)
+                
                 if backend == "ccl" and self.distributed_type == DistributedType.MULTI_XPU:
                     os.environ['CCL_PROCESS_LAUNCHER'] = 'none'
-                    os.environ['CCL_LOCAL_SIZE'] = str(size)
+                    os.environ['CCL_LOCAL_SIZE'] = str(local_size)
                     os.environ['CCL_LOCAL_RANK'] = str(local_rank)
                 if not os.environ.get("MASTER_PORT", None):
                     os.environ["MASTER_PORT"] = "29500"

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -180,6 +180,9 @@ class PartialState:
                     if is_xpu_available and is_ccl_available():
                         # Set DeepSpeed backend to ccl for xpu
                         self.backend = "ccl"
+                        os.environ['CCL_PROCESS_LAUNCHER'] = 'none'
+                        os.environ['CCL_LOCAL_SIZE'] = os.environ.get("LOCAL_WORLD_SIZE", "1")
+                        os.environ['CCL_LOCAL_RANK'] = os.environ.get("LOCAL_RANK", "0")
                     elif is_npu_available():
                         self.backend = "hccl"
                     else:


### PR DESCRIPTION
## What does this PR do?

- Fixes issue https://github.com/huggingface/accelerate/issues/2340 fort both deepspeed path and none-deepspeed path 
- Adds the missing `LOCAL_WORLD_SIZE` environment variable 