### PR TITLE
Fix `block_size` picking in `megatron_lm_gpt_pretraining` example.

### DIFF
--- a/examples/by_feature/megatron_lm_gpt_pretraining.py
+++ b/examples/by_feature/megatron_lm_gpt_pretraining.py
@@ -405,7 +405,7 @@ def main():
                 f"The tokenizer picked seems to have a very large `model_max_length` ({tokenizer.model_max_length}). "
                 "Picking 1024 instead. You can change that default value by passing --block_size xxx."
             )
-        block_size = 1024
+            block_size = 1024
     else:
         if args.block_size > tokenizer.model_max_length:
             logger.warning(


### PR DESCRIPTION
# What does this PR do?

If no `block_size` is explicitly passed, and the tokenizer happens to have a `model_max_length` of less than 1024, the current example will produce a bad `block_size`. With this change, we only cap `block_size` to 1024 if `tokenizer.model_max_length` is actually greater than 1024.

## Who can review?

Tagging @pacman100 / @sgugger as the authors of the surrounding code.