### PR TITLE
Show DeepSpeed option when multi-XPU is selected in `accelerate config`

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -179,7 +179,11 @@ def get_cluster_input():
 
     use_mps = not use_cpu and is_mps_available()
     deepspeed_config = {}
-    if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_XPU, DistributedType.MULTI_NPU, DistributedType.NO] and not use_mps:
+    if (
+        distributed_type
+        in [DistributedType.MULTI_GPU, DistributedType.MULTI_XPU, DistributedType.MULTI_NPU, DistributedType.NO]
+        and not use_mps
+    ):
         use_deepspeed = _ask_field(
             "Do you want to use DeepSpeed? [yes/NO]: ",
             _convert_yes_no_to_bool,

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -179,7 +179,7 @@ def get_cluster_input():
 
     use_mps = not use_cpu and is_mps_available()
     deepspeed_config = {}
-    if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_NPU, DistributedType.NO] and not use_mps:
+    if distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_XPU, DistributedType.MULTI_NPU, DistributedType.NO] and not use_mps:
         use_deepspeed = _ask_field(
             "Do you want to use DeepSpeed? [yes/NO]: ",
             _convert_yes_no_to_bool,


### PR DESCRIPTION
## What does this PR do?
Currently, no DeepSpeed option is shown to users when multi-XPU is selected. This PR adds support for XPU. 

### Before Fix: 
![image](https://github.com/huggingface/accelerate/assets/24477841/e226b055-8fea-44cc-ad52-70b35f1f1cad)

### After Fix:
![image](https://github.com/huggingface/accelerate/assets/24477841/1f7d1c08-379e-437d-962e-0ea6b39ec832)

On NV GPU, the question "Do you want to use DeepSpeed? [yes/NO]:" comes before "Do you want to use FullyShardedDataParallel? [yes/NO]:". The same user experience should apply for XPU. 

@muellerzr @pacman100 