### PR TITLE
bugfix to allow usage of TE or MSAMP in `FP8RecipeKwargs`

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -243,9 +243,10 @@ class FP8RecipeKwargs(KwargsHandler):
     override_linear_precision: Tuple[bool, bool, bool] = (False, False, False)
 
     def __post_init__(self):
-        self.backend = self.backend.upper()
         if self.backend not in get_args(Backend):
             raise ValueError("`backend` must be 'MSAMP' or 'TE' (TransformerEngine).")
+
+        self.backend = self.backend.upper()
         # Check TE args
         if self.backend == "TE":
             self.fp8_format = self.fp8_format.upper()


### PR DESCRIPTION
# What does this PR do?
Fix the usage of `FP8RecipeKwargs`

@muellerzr 