### PR TITLE
Pin DeepSpeed until patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extras["quality"] = ["black ~= 23.1", "ruff >= 0.0.241", "hf-doc-builder >= 0.3.
 extras["docs"] = []
 extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
 extras["test_dev"] = [
-    "datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed", "tqdm", "bitsandbytes", "timm"
+    "datasets", "evaluate", "transformers", "scipy", "scikit-learn", "deepspeed<0.13.0", "tqdm", "bitsandbytes", "timm"
 ]
 extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["rich"] = ["rich"]


### PR DESCRIPTION
Yet another deepspeed release that broke things, this time though we can't install it on our main runners so we need to pin until a fix is released so PR CI can pass.

w.r.t: https://github.com/microsoft/DeepSpeed/issues/4984