### PR TITLE
`add_hook_to_module` and `remove_hook_from_module` compatibility with fx.GraphModule

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -366,11 +366,14 @@ class HooksModelTester(unittest.TestCase):
             add_hook_to_module(graph_model, test_hook)
             remove_hook_from_module(graph_model, recurse=True)
 
+            # We want to make sure that `add_hook_to_module` and `remove_hook_from_module` yields back an fx.GraphModule
+            # that behaves correctly (for example that is not frozen, see https://github.com/huggingface/accelerate/pull/2369).
+            # For that, we add a sigmoid node to the FX graph and make sure that the new output (output3 below) is different than
+            # the original model's output.
             linear2_node = None
             for node in graph_model.graph.nodes:
                 if node.name == "linear2":
                     linear2_node = node
-
             self.assertTrue(linear2_node is not None)
 
             graph_model.graph.inserting_after(linear2_node)


### PR DESCRIPTION
It appears to be illegal to modify the forward method of a `GraphModuleImpl` instance, PyTorch rather favors modifying the class method (https://github.com/pytorch/pytorch/blob/c3780010a58a84920335296ee5f091a0db18259f/torch/fx/graph_module.py#L708-L723) though it is unclear why the behavior would be different.

Just modifying the class instance forward method results in a frozen forward call - despite modifying the graph (as in the test).

@Giuseppe5 and @nickfraser found this bug. cc @jamesr66a as this was quite a tricky one.