### PR TITLE
Prefer `is_torch_tensor` over `hasattr` for torch.compile.

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -177,12 +177,14 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             return tensor.to(device, non_blocking=non_blocking)
         except TypeError:  # .to() doesn't accept non_blocking as kwarg
             return tensor.to(device)
-        except AssertionError:
+        except AssertionError as error:
             # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).
             # This call is inside the try-block since is_npu_available is not supported by torch.compile.
             if is_npu_available():
                 if isinstance(device, int):
                     device = f"npu:{device}"
+            else:
+                raise error
         except Exception as error:
             if is_xpu_available():
                 if isinstance(device, int):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -174,7 +174,7 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
         })
     elif is_torch_tensor(tensor) or hasattr(tensor, "to"):
         # `torch.Tensor.to("npu")` could not find context when called for the first time (see this [issue](https://gitee.com/ascend/pytorch/issues/I8KECW?from=project-issue)).
-        if device == torch.device("npu"):
+        if device == "npu":
             device = "npu:0"
         if device == "xpu":
             device = "xpu:0"

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -33,6 +33,7 @@ from .imports import (
     is_xpu_available,
 )
 
+
 if is_tpu_available(check_device=False):
     import torch_xla.core.xla_model as xm
 
@@ -87,12 +88,7 @@ def honor_type(obj, generator):
         return type(obj)(generator)
 
 
-def recursively_apply(func,
-                      data,
-                      *args,
-                      test_type=is_torch_tensor,
-                      error_on_other_type=False,
-                      **kwargs):
+def recursively_apply(func, data, *args, test_type=is_torch_tensor, error_on_other_type=False, **kwargs):
     """
     Recursively apply a function on a data structure that is a nested list/tuple/dictionary of a given base type.
 
@@ -117,23 +113,22 @@ def recursively_apply(func,
     if isinstance(data, (tuple, list)):
         return honor_type(
             data,
-            (recursively_apply(func,
-                               o,
-                               *args,
-                               test_type=test_type,
-                               error_on_other_type=error_on_other_type,
-                               **kwargs) for o in data),
+            (
+                recursively_apply(
+                    func, o, *args, test_type=test_type, error_on_other_type=error_on_other_type, **kwargs
+                )
+                for o in data
+            ),
         )
     elif isinstance(data, Mapping):
-        return type(data)({
-            k:
-                recursively_apply(func,
-                                  v,
-                                  *args,
-                                  test_type=test_type,
-                                  error_on_other_type=error_on_other_type,
-                                  **kwargs) for k, v in data.items()
-        })
+        return type(data)(
+            {
+                k: recursively_apply(
+                    func, v, *args, test_type=test_type, error_on_other_type=error_on_other_type, **kwargs
+                )
+                for k, v in data.items()
+            }
+        )
     elif test_type(data):
         return func(data, *args, **kwargs)
     elif error_on_other_type:
@@ -158,20 +153,20 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
         The same data structure as `tensor` with all tensors sent to the proper device.
     """
     if isinstance(tensor, (tuple, list)):
-        return honor_type(tensor, (send_to_device(
-            t, device, non_blocking=non_blocking, skip_keys=skip_keys)
-                                   for t in tensor))
+        return honor_type(
+            tensor, (send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys) for t in tensor)
+        )
     elif isinstance(tensor, Mapping):
         if isinstance(skip_keys, str):
             skip_keys = [skip_keys]
         elif skip_keys is None:
             skip_keys = []
-        return type(tensor)({
-            k:
-                t if k in skip_keys else send_to_device(
-                    t, device, non_blocking=non_blocking, skip_keys=skip_keys)
-            for k, t in tensor.items()
-        })
+        return type(tensor)(
+            {
+                k: t if k in skip_keys else send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys)
+                for k, t in tensor.items()
+            }
+        )
     elif is_torch_tensor(tensor) or hasattr(tensor, "to"):
         # `torch.Tensor.to("npu")` could not find context when called for the first time (see this [issue](https://gitee.com/ascend/pytorch/issues/I8KECW?from=project-issue)).
         if device == "npu":
@@ -182,7 +177,7 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             return tensor.to(device, non_blocking=non_blocking)
         except TypeError:  # .to() doesn't accept non_blocking as kwarg
             return tensor.to(device)
-        except AssertionError as error:
+        except AssertionError:
             # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).
             # This call is inside the try-block since is_npu_available is not supported by torch.compile.
             if is_npu_available():
@@ -249,9 +244,7 @@ def initialize_tensors(data_structure):
     def _initialize_tensor(tensor_info):
         return torch.empty(*tensor_info.shape, dtype=tensor_info.dtype)
 
-    return recursively_apply(_initialize_tensor,
-                             data_structure,
-                             test_type=is_tensor_information)
+    return recursively_apply(_initialize_tensor, data_structure, test_type=is_tensor_information)
 
 
 def find_batch_size(data):
@@ -273,8 +266,7 @@ def find_batch_size(data):
         for k in data.keys():
             return find_batch_size(data[k])
     elif not isinstance(data, torch.Tensor):
-        raise TypeError(
-            f"Can only find the batch size of tensors but got {type(data)}.")
+        raise TypeError(f"Can only find the batch size of tensors but got {type(data)}.")
     return data.shape[0]
 
 
@@ -319,7 +311,6 @@ def listify(data):
 
 
 def _tpu_gather(tensor):
-
     def _tpu_gather_one(tensor):
         if tensor.ndim == 0:
             tensor = tensor.clone()[None]
@@ -365,9 +356,7 @@ def _gpu_gather(tensor):
             # a backend of `None` is always CPU
             # also gloo does not support `all_gather_into_tensor`,
             # which will result in a larger memory overhead for the op
-            output_tensors = [
-                torch.empty_like(tensor) for _ in range(state.num_processes)
-            ]
+            output_tensors = [torch.empty_like(tensor) for _ in range(state.num_processes)]
             torch.distributed.all_gather(output_tensors, tensor)
             return torch.cat(output_tensors, dim=0)
 
@@ -390,8 +379,7 @@ def verify_operation(function):
 
     @wraps(function)
     def wrapper(*args, **kwargs):
-        if PartialState(
-        ).distributed_type == DistributedType.NO or not PartialState().debug:
+        if PartialState().distributed_type == DistributedType.NO or not PartialState().debug:
             return function(*args, **kwargs)
         operation = f"{function.__module__}.{function.__name__}"
         if "tensor" in kwargs:
@@ -408,8 +396,7 @@ def verify_operation(function):
         if output[0] is not None:
             are_same = output.count(output[0]) == len(output)
             if not are_same:
-                process_shape_str = "\n  - ".join(
-                    [f"Process {i}: {shape}" for i, shape in enumerate(output)])
+                process_shape_str = "\n  - ".join([f"Process {i}: {shape}" for i, shape in enumerate(output)])
                 raise DistributedOperationException(
                     f"Cannot apply desired operation due to shape mismatches. "
                     "All shapes across devices must be valid."
@@ -486,25 +473,18 @@ def gather_object(object: Any):
 
 
 def _gpu_broadcast(data, src=0):
-
     def _gpu_broadcast_one(tensor, src=0):
         torch.distributed.broadcast(tensor, src=src)
         return tensor
 
-    return recursively_apply(_gpu_broadcast_one,
-                             data,
-                             error_on_other_type=True,
-                             src=src)
+    return recursively_apply(_gpu_broadcast_one, data, error_on_other_type=True, src=src)
 
 
 def _tpu_broadcast(tensor, src=0, name="broadcast tensor"):
     if isinstance(tensor, (list, tuple)):
-        return honor_type(tensor, (_tpu_broadcast(t, name=f"{name}_{i}")
-                                   for i, t in enumerate(tensor)))
+        return honor_type(tensor, (_tpu_broadcast(t, name=f"{name}_{i}") for i, t in enumerate(tensor)))
     elif isinstance(tensor, Mapping):
-        return type(tensor)({
-            k: _tpu_broadcast(v, name=f"{name}_{k}") for k, v in tensor.items()
-        })
+        return type(tensor)({k: _tpu_broadcast(v, name=f"{name}_{k}") for k, v in tensor.items()})
     return xm.mesh_reduce(name, tensor, lambda x: x[src])
 
 
@@ -581,9 +561,7 @@ def broadcast(tensor, from_process: int = 0):
         The same data structure as `tensor` with all tensors broadcasted to the proper device.
     """
     if PartialState().distributed_type == DistributedType.TPU:
-        return _tpu_broadcast(tensor,
-                              src=from_process,
-                              name="accelerate.utils.broadcast")
+        return _tpu_broadcast(tensor, src=from_process, name="accelerate.utils.broadcast")
     elif PartialState().distributed_type in TORCH_DISTRIBUTED_OPERATION_TYPES:
         return _gpu_broadcast(tensor, src=from_process)
     else:
@@ -605,9 +583,7 @@ def broadcast_object_list(object_list, from_process: int = 0):
     """
     if PartialState().distributed_type == DistributedType.TPU:
         for i, obj in enumerate(object_list):
-            object_list[i] = xm.mesh_reduce(
-                "accelerate.utils.broadcast_object_list", obj,
-                lambda x: x[from_process])
+            object_list[i] = xm.mesh_reduce("accelerate.utils.broadcast_object_list", obj, lambda x: x[from_process])
     elif PartialState().distributed_type in TORCH_DISTRIBUTED_OPERATION_TYPES:
         torch.distributed.broadcast_object_list(object_list, src=from_process)
     return object_list
@@ -647,14 +623,9 @@ def concatenate(data, dim=0):
         The same data structure as `data` with all the tensors concatenated.
     """
     if isinstance(data[0], (tuple, list)):
-        return honor_type(data[0], (concatenate([d[i]
-                                                 for d in data], dim=dim)
-                                    for i in range(len(data[0]))))
+        return honor_type(data[0], (concatenate([d[i] for d in data], dim=dim) for i in range(len(data[0]))))
     elif isinstance(data[0], Mapping):
-        return type(data[0])({
-            k: concatenate([d[k] for d in data], dim=dim)
-            for k in data[0].keys()
-        })
+        return type(data[0])({k: concatenate([d[k] for d in data], dim=dim) for k in data[0].keys()})
     elif not isinstance(data[0], torch.Tensor):
         raise TypeError(f"Can only concatenate tensors but got {type(data[0])}")
     return torch.cat(data, dim=dim)
@@ -705,22 +676,16 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
         new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
         if pad_first:
             indices = tuple(
-                slice(max_size -
-                      old_size[dim], max_size) if i == dim else slice(None)
-                for i in range(len(new_size)))
+                slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(new_size))
+            )
         else:
-            indices = tuple(
-                slice(0, old_size[dim]) if i == dim else slice(None)
-                for i in range(len(new_size)))
+            indices = tuple(slice(0, old_size[dim]) if i == dim else slice(None) for i in range(len(new_size)))
         new_tensor[indices] = tensor
         return new_tensor
 
-    return recursively_apply(_pad_across_processes,
-                             tensor,
-                             error_on_other_type=True,
-                             dim=dim,
-                             pad_index=pad_index,
-                             pad_first=pad_first)
+    return recursively_apply(
+        _pad_across_processes, tensor, error_on_other_type=True, dim=dim, pad_index=pad_index, pad_first=pad_first
+    )
 
 
 def pad_input_tensors(tensor, batch_size, num_processes, dim=0):
@@ -749,9 +714,7 @@ def pad_input_tensors(tensor, batch_size, num_processes, dim=0):
         new_size = list(old_size)
         new_size[0] = batch_size + to_pad
         new_tensor = tensor.new_zeros(tuple(new_size))
-        indices = tuple(
-            slice(0, old_size[dim]) if i == dim else slice(None)
-            for i in range(len(new_size)))
+        indices = tuple(slice(0, old_size[dim]) if i == dim else slice(None) for i in range(len(new_size)))
         new_tensor[indices] = tensor
         return new_tensor
 
@@ -802,11 +765,9 @@ def reduce(tensor, reduction="mean", scale=1.0):
             cloned_tensor /= state.num_processes
         return cloned_tensor
 
-    return recursively_apply(_reduce_across_processes,
-                             tensor,
-                             error_on_other_type=True,
-                             reduction=reduction,
-                             scale=scale)
+    return recursively_apply(
+        _reduce_across_processes, tensor, error_on_other_type=True, reduction=reduction, scale=scale
+    )
 
 
 def convert_to_fp32(tensor):
@@ -825,15 +786,12 @@ def convert_to_fp32(tensor):
         return tensor.float()
 
     def _is_fp16_bf16_tensor(tensor):
-        return (is_torch_tensor(tensor) or
-                hasattr(tensor, "dtype")) and tensor.dtype in (
-                    torch.float16,
-                    torch.bfloat16,
-                )
+        return (is_torch_tensor(tensor) or hasattr(tensor, "dtype")) and tensor.dtype in (
+            torch.float16,
+            torch.bfloat16,
+        )
 
-    return recursively_apply(_convert_to_fp32,
-                             tensor,
-                             test_type=_is_fp16_bf16_tensor)
+    return recursively_apply(_convert_to_fp32, tensor, test_type=_is_fp16_bf16_tensor)
 
 
 class ConvertOutputsToFp32:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,7 +32,6 @@ from accelerate.utils import (
     extract_model_from_parallel,
     find_device,
     listify,
-    operations,
     pad_across_processes,
     pad_input_tensors,
     patch_environment,
@@ -40,6 +39,7 @@ from accelerate.utils import (
     save,
     send_to_device,
 )
+from accelerate.utils.operations import send_to_device, convert_to_fp32
 
 
 ExampleNamedTuple = namedtuple("ExampleNamedTuple", "a b c")
@@ -305,9 +305,9 @@ class UtilsTester(unittest.TestCase):
         assert result.shape == torch.Size([66, 4, 4])
 
     def test_send_to_device_compiles(self):
-        compiled_send_to_device = torch.compile(operations.send_to_device, fullgraph=True)
+        compiled_send_to_device = torch.compile(send_to_device, fullgraph=True)
         compiled_send_to_device(torch.zeros([1], dtype=torch.bfloat16), "cpu")
 
     def test_convert_to_fp32(self):
-        compiled_convert_to_fp32 = torch.compile(operations.convert_to_fp32, fullgraph=True)
+        compiled_convert_to_fp32 = torch.compile(convert_to_fp32, fullgraph=True)
         compiled_convert_to_fp32(torch.zeros([1], dtype=torch.bfloat16))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,19 +41,18 @@ from accelerate.utils import (
     send_to_device,
 )
 
+
 ExampleNamedTuple = namedtuple("ExampleNamedTuple", "a b c")
 
 
 class UtilsTester(unittest.TestCase):
-
     def setUp(self):
         # logging requires initialized state
         PartialState()
 
     def test_send_to_device(self):
         tensor = torch.randn(5, 2)
-        device = torch.device(
-            "cuda") if torch.cuda.is_available() else torch.device("cpu")
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
         result1 = send_to_device(tensor, device)
         self.assertTrue(torch.equal(result1.cpu(), tensor))
@@ -66,11 +65,7 @@ class UtilsTester(unittest.TestCase):
         self.assertTrue(torch.equal(result2[1][1].cpu(), tensor))
         self.assertEqual(result2[2], 1)
 
-        result2 = send_to_device({
-            "a": tensor,
-            "b": [tensor, tensor],
-            "c": 1
-        }, device)
+        result2 = send_to_device({"a": tensor, "b": [tensor, tensor], "c": 1}, device)
         self.assertIsInstance(result2, dict)
         self.assertTrue(torch.equal(result2["a"].cpu(), tensor))
         self.assertIsInstance(result2["b"], list)
@@ -78,8 +73,7 @@ class UtilsTester(unittest.TestCase):
         self.assertTrue(torch.equal(result2["b"][1].cpu(), tensor))
         self.assertEqual(result2["c"], 1)
 
-        result3 = send_to_device(
-            ExampleNamedTuple(a=tensor, b=[tensor, tensor], c=1), device)
+        result3 = send_to_device(ExampleNamedTuple(a=tensor, b=[tensor, tensor], c=1), device)
         self.assertIsInstance(result3, ExampleNamedTuple)
         self.assertTrue(torch.equal(result3.a.cpu(), tensor))
         self.assertIsInstance(result3.b, list)
@@ -87,12 +81,7 @@ class UtilsTester(unittest.TestCase):
         self.assertTrue(torch.equal(result3.b[1].cpu(), tensor))
         self.assertEqual(result3.c, 1)
 
-        result4 = send_to_device(
-            UserDict({
-                "a": tensor,
-                "b": [tensor, tensor],
-                "c": 1
-            }), device)
+        result4 = send_to_device(UserDict({"a": tensor, "b": [tensor, tensor], "c": 1}), device)
         self.assertIsInstance(result4, UserDict)
         self.assertTrue(torch.equal(result4["a"].cpu(), tensor))
         self.assertIsInstance(result4["b"], list)
@@ -102,8 +91,7 @@ class UtilsTester(unittest.TestCase):
 
     def test_honor_type(self):
         with self.assertRaises(TypeError) as cm:
-            _ = recursively_apply(torch.tensor, (torch.tensor(1), 1),
-                                  error_on_other_type=True)
+            _ = recursively_apply(torch.tensor, (torch.tensor(1), 1), error_on_other_type=True)
         self.assertEqual(
             str(cm.exception),
             "Unsupported types (<class 'int'>) passed to `tensor`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed.",
@@ -116,11 +104,10 @@ class UtilsTester(unittest.TestCase):
         tensor = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
         self.assertEqual(listify(tensor), [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
 
-        tensor = torch.tensor([[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
-                               [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]])
-        self.assertEqual(listify(tensor),
-                         [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]],
-                          [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]])
+        tensor = torch.tensor([[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]])
+        self.assertEqual(
+            listify(tensor), [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
+        )
 
     def test_patch_environment(self):
         with patch_environment(aa=1, BB=2):
@@ -160,8 +147,7 @@ class UtilsTester(unittest.TestCase):
     def test_can_undo_fp16_conversion(self):
         model = RegressionModel()
         model._original_forward = model.forward
-        model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(
-            model.forward)
+        model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
         model.forward = convert_outputs_to_fp32(model.forward)
         model = extract_model_from_parallel(model, keep_fp32_wrapper=False)
         _ = pickle.dumps(model)
@@ -171,8 +157,7 @@ class UtilsTester(unittest.TestCase):
     def test_dynamo(self):
         model = RegressionModel()
         model._original_forward = model.forward
-        model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(
-            model.forward)
+        model.forward = torch.cuda.amp.autocast(dtype=torch.float16)(model.forward)
         model.forward = convert_outputs_to_fp32(model.forward)
         model.forward = torch.compile(model.forward, backend="inductor")
         inputs = torch.randn(4, 10).cuda()
@@ -194,44 +179,32 @@ class UtilsTester(unittest.TestCase):
         # could also do a test with DistributedDataParallel, but difficult to run on CPU or single GPU
         distributed_model = torch.nn.parallel.DataParallel(model)
         distributed_compiled_model = torch.compile(distributed_model)
-        compiled_model_unwrapped = extract_model_from_parallel(
-            distributed_compiled_model)
+        compiled_model_unwrapped = extract_model_from_parallel(distributed_compiled_model)
 
-        self.assertEqual(compiled_model._orig_mod,
-                         compiled_model_unwrapped._orig_mod)
+        self.assertEqual(compiled_model._orig_mod, compiled_model_unwrapped._orig_mod)
 
     def test_find_device(self):
-        self.assertEqual(find_device([1, "a", torch.tensor([1, 2, 3])]),
-                         torch.device("cpu"))
-        self.assertEqual(find_device({
-            "a": 1,
-            "b": torch.tensor([1, 2, 3])
-        }), torch.device("cpu"))
+        self.assertEqual(find_device([1, "a", torch.tensor([1, 2, 3])]), torch.device("cpu"))
+        self.assertEqual(find_device({"a": 1, "b": torch.tensor([1, 2, 3])}), torch.device("cpu"))
         self.assertIsNone(find_device([1, "a"]))
 
     def test_check_os_kernel_no_warning_when_release_gt_min(self):
         # min version is 5.5
-        with patch("platform.uname",
-                   return_value=Mock(release="5.15.0-35-generic",
-                                     system="Linux")):
+        with patch("platform.uname", return_value=Mock(release="5.15.0-35-generic", system="Linux")):
             with warnings.catch_warnings(record=True) as w:
                 check_os_kernel()
             self.assertEqual(len(w), 0)
 
     def test_check_os_kernel_no_warning_when_not_linux(self):
         # system must be Linux
-        with patch("platform.uname",
-                   return_value=Mock(release="5.4.0-35-generic",
-                                     system="Darwin")):
+        with patch("platform.uname", return_value=Mock(release="5.4.0-35-generic", system="Darwin")):
             with warnings.catch_warnings(record=True) as w:
                 check_os_kernel()
             self.assertEqual(len(w), 0)
 
     def test_check_os_kernel_warning_when_release_lt_min(self):
         # min version is 5.5
-        with patch("platform.uname",
-                   return_value=Mock(release="5.4.0-35-generic",
-                                     system="Linux")):
+        with patch("platform.uname", return_value=Mock(release="5.4.0-35-generic", system="Linux")):
             with self.assertLogs() as ctx:
                 check_os_kernel()
             self.assertEqual(len(ctx.records), 1)
@@ -240,9 +213,7 @@ class UtilsTester(unittest.TestCase):
             self.assertIn("5.5.0", ctx.records[0].msg)
 
     def test_save_safetensor_shared_memory(self):
-
         class Model(nn.Module):
-
             def __init__(self):
                 super().__init__()
                 self.a = nn.Linear(100, 100)
@@ -334,11 +305,9 @@ class UtilsTester(unittest.TestCase):
         assert result.shape == torch.Size([66, 4, 4])
 
     def test_send_to_device_compiles(self):
-        compiled_send_to_device = torch.compile(operations.send_to_device,
-                                                fullgraph=True)
+        compiled_send_to_device = torch.compile(operations.send_to_device, fullgraph=True)
         compiled_send_to_device(torch.zeros([1], dtype=torch.bfloat16), "cpu")
 
     def test_convert_to_fp32(self):
-        compiled_convert_to_fp32 = torch.compile(operations.convert_to_fp32,
-                                                 fullgraph=True)
+        compiled_convert_to_fp32 = torch.compile(operations.convert_to_fp32, fullgraph=True)
         compiled_convert_to_fp32(torch.zeros([1], dtype=torch.bfloat16))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ from accelerate.utils import (
     CannotPadNestedTensorWarning,
     check_os_kernel,
     convert_outputs_to_fp32,
+    convert_to_fp32,
     extract_model_from_parallel,
     find_device,
     listify,
@@ -39,7 +40,6 @@ from accelerate.utils import (
     save,
     send_to_device,
 )
-from accelerate.utils.operations import convert_to_fp32
 
 
 ExampleNamedTuple = namedtuple("ExampleNamedTuple", "a b c")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -342,7 +342,3 @@ class UtilsTester(unittest.TestCase):
         compiled_convert_to_fp32 = torch.compile(operations.convert_to_fp32,
                                                  fullgraph=True)
         compiled_convert_to_fp32(torch.zeros([1], dtype=torch.bfloat16))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,7 +39,7 @@ from accelerate.utils import (
     save,
     send_to_device,
 )
-from accelerate.utils.operations import send_to_device, convert_to_fp32
+from accelerate.utils.operations import convert_to_fp32
 
 
 ExampleNamedTuple = namedtuple("ExampleNamedTuple", "a b c")


### PR DESCRIPTION
# What does this PR do?
`torch.compile` breaks when using `hasattr` but succeeds when using `isinstance(torch.Tensor)`.  This commit short-circuits the `hasattr` call for `torch.Tensor`s if possible.

Note: `is_npu_available` is also not torch.compile compatible due to (1) lru_cache and (2) importlib checks, so I've moved it into the try block, catching the AssertionError instead.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [X] Did you write any new necessary tests?


## Who can review?
- Core parts of the library: @muellerzr @BenjaminBossan
