### PR TITLE
Address PIP-632 deprecation of distutils

### DIFF
--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -16,7 +16,7 @@ import os
 import platform
 import subprocess
 import sys
-from distutils import spawn
+from shutil import which
 from typing import Dict
 
 import torch
@@ -72,8 +72,8 @@ def get_gpu_info():
     """
     if platform.system() == "Windows":
         # If platform is Windows and nvidia-smi can't be found in path
-        # try from systemd rive with default installation path
-        command = spawn.find_executable("nvidia-smi")
+        # try from systemd drive with default installation path
+        command = which("nvidia-smi")
         if command is None:
             command = "%s\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe" % os.environ["systemdrive"]
     else:


### PR DESCRIPTION
# What does this PR do?

[PEP-632](https://peps.python.org/pep-0632/) deprecated use of distutils, which are now completely removed in Python 3.12+. environment.py still uses distutils.spawn to detect full path of nvidia-smi executable for GPU detection. 
This PR replaces deprecated distutils.spawn with supported shutils.which to ensure conpatibility with Python 3.12+
Code path impacted is windows-only and requires Nvidia GPU, so not a good candidate for automated tests.

Fixes #2379 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?
@muellerzr 