### PR TITLE
Pin Torch version to <2.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         ]
     },
     python_requires=">=3.8.0",
-    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.10.0", "huggingface_hub", "safetensors>=0.3.1"],
+    install_requires=["numpy>=1.17", "packaging>=20.0", "psutil", "pyyaml", "torch>=1.10.0,<2.2.0", "huggingface_hub", "safetensors>=0.3.1"],
     extras_require=extras,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
See https://github.com/huggingface/transformers/pull/28785 - torch 2.2.0 was pushed to pypi and broke the CI. We pinned the version in Transformers, but because it installs accelerate from `main` at the end of the other installations, we need to pin the version in `accelerate` as well, or the `accelerate` installation upgrades to `torch 2.2.0` regardless.