### PR TITLE
[RFC] Precisely exclude buffer size when inferring auto device map

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -567,7 +567,8 @@ def load_checkpoint_and_dispatch(
                 low_zero=(device_map == "balanced_low_0"),
             )
         device_map = infer_auto_device_map(
-            model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype
+            model, max_memory=max_memory, no_split_module_classes=no_split_module_classes, dtype=dtype, 
+            exclude_buffers=not offload_buffers
         )
     if offload_state_dict is None and device_map is not None and "disk" in device_map.values():
         offload_state_dict = True


### PR DESCRIPTION
Hello, I'm trying using `accelerate` to offload a large model (https://huggingface.co/TheBloke/WizardCoder-33B-V1.1-GPTQ) to CPU, with following code (requires https://github.com/huggingface/accelerate/pull/2383 and https://github.com/huggingface/transformers/pull/28755):

```python
import datetime

import torch
import intel_extension_for_pytorch

import accelerate
from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline

model_id = "/mnt/external2/LLMs/WizardCoder-33B-V1.1-GPTQ"
tokenizer = AutoTokenizer.from_pretrained(model_id)

# Without offload_buffers
pipe = pipeline("text-generation", model=model_id, model_kwargs={"torch_dtype": torch.bfloat16, "device_map": "auto", "max_memory": {0: "16GB", "cpu": "128GB"}})

# With offload_buffers (won't OOM)
#pipe = pipeline("text-generation", model=model_id, model_kwargs={"torch_dtype": torch.bfloat16, "device_map": "auto", "max_memory": {0: "16GB", "cpu": "128GB"}, "offload_buffers": True})
print(str(pipe.model.hf_device_map))

print(str(datetime.datetime.now()) + " Generating...")
results = pipe("public void helloWorld() {")

print(str(datetime.datetime.now()) + " Output:")
print(results)
``` 

I have one Intel Arc A770 16GB GPU in my machine, but the code above always OOM on the GPU.

After some digging, I found that this model `TheBloke/WizardCoder-33B-V1.1-GPTQ` contains a huge buffer (model is 17GB, but buffers are more than 16GB), so it will not fit into my GPU at all without `offload_buffers`.

So I created this PR, to calculate and exclude buffer size from device max memory before trying to put layers on GPU when not setting offload_buffers, and print a warning for such model with big buffers.
With this PR, the code above works well (fully on CPU without offload_buffers, and working with offload_buffers on GPU, ~97% VRAM usage).

It also contains another fix, but I'm not sure about this: the method in `utils/modeling.py`:

```python
def compute_module_sizes(
    # ... (other code) ...
            size = tensor.numel() * min(dtype_size, dtype_byte_size(tensor.dtype))
```

This will get wrong size (2) for that model `TheBloke/WizardCoder-33B-V1.1-GPTQ` , because it contains `int32` weights, which size should be 4, so I changed this `min` to `max`.
The `int32` weight won't be converted because of these lines in `utils/modeling.py`:

```python
def set_module_tensor_to_device(
  # ... (other code) ...
        elif not str(value.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):  # This line will ignore int32 values
            value = value.to(dtype)
```

With this modification, the layer containing `int32` values can get correct size.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->