### PR TITLE
Fix fp8 things

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -373,8 +373,6 @@ class Accelerator:
                         raise ValueError("You can only pass one `AutocastKwargs` in `kwargs_handler`.")
                     else:
                         self.autocast_handler = handler
-        if self.fp8_recipe_handler is None and mixed_precision == "fp8":
-            self.fp8_recipe_handler = FP8RecipeKwargs()
 
         kwargs = self.init_handler.to_kwargs() if self.init_handler is not None else {}
         self.state = AcceleratorState(
@@ -387,6 +385,9 @@ class Accelerator:
             _from_accelerator=True,
             **kwargs,
         )
+
+        if self.fp8_recipe_handler is None and self.state.mixed_precision == "fp8":
+            self.fp8_recipe_handler = FP8RecipeKwargs(backend="MSAMP")
 
         trackers = filter_trackers(log_with, self.logging_dir)
         if len(trackers) < 1 and log_with is not None:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -387,7 +387,7 @@ class Accelerator:
         )
 
         if self.fp8_recipe_handler is None and self.state.mixed_precision == "fp8":
-            self.fp8_recipe_handler = FP8RecipeKwargs(backend="MSAMP")
+            self.fp8_recipe_handler = FP8RecipeKwargs(backend="MSAMP" if is_msamp_available() else "TE")
 
         trackers = filter_trackers(log_with, self.logging_dir)
         if len(trackers) < 1 and log_with is not None:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -170,7 +170,7 @@ class InitProcessGroupKwargs(KwargsHandler):
 
 
 # Literals
-Backend = Literal["msamp", "te"]
+Backend = Literal["MSAMP", "TE"]
 OptLevel = Literal["O1", "O2"]
 FP8Format = Literal["E4M3", "HYBRID"]
 AmaxComputeAlgorithm = Literal["max", "most_recent"]
@@ -233,7 +233,7 @@ class FP8RecipeKwargs(KwargsHandler):
                     available currently).
     """
 
-    backend: Backend = "msamp"
+    backend: Backend = "MSAMP"
     opt_level: OptLevel = "O2"
     margin: int = 0
     interval: int = 1
@@ -243,7 +243,7 @@ class FP8RecipeKwargs(KwargsHandler):
     override_linear_precision: Tuple[bool, bool, bool] = (False, False, False)
 
     def __post_init__(self):
-        if self.backend not in get_args(Backend):
+        if self.backend.upper() not in get_args(Backend):
             raise ValueError("`backend` must be 'MSAMP' or 'TE' (TransformerEngine).")
 
         self.backend = self.backend.upper()


### PR DESCRIPTION
Fixes a few things with the fp8 integration since the merger of msamp:

* Couldn't just use the accelerate configuration and leave the defaults, as the mixed precision wasn't set yet for when we check to build a recipe handler default
* explicitly makes the backend te as the default (hit the dataclass not liking this w/o it being passed in)
* some fixes to allow users to pass in either `backend="te"` or `backend="TE"`