### PR TITLE
add use_ipex for XPU and simplify code 

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1210,11 +1210,9 @@ class Accelerator:
             # 1. grabbing old model parameters
             old_named_params = self._get_named_parameters(*args)
 
-        if self.distributed_type in [DistributedType.MULTI_CPU, DistributedType.MULTI_XPU, DistributedType.NO]:
-            if self.device.type == "cpu" and self.state.use_ipex:
-                args = self._prepare_ipex(*args)
-            elif self.device.type == "xpu" and is_xpu_available():
-                args = self._prepare_ipex(*args)
+        if self.state.use_ipex and self.device.type in ["cpu", "xpu"]:
+            args = self._prepare_ipex(*args)
+
         if self.distributed_type == DistributedType.DEEPSPEED:
             result = self._prepare_deepspeed(*args)
         elif self.distributed_type == DistributedType.MEGATRON_LM:


### PR DESCRIPTION
## What does this PR do?
This PR adds the missing control of `use_ipex` for XPU and simplifies the code. 

## Explanation 
In the current code logic, 
```python
if self.distributed_type in [DistributedType.MULTI_CPU, DistributedType.MULTI_XPU, DistributedType.NO]:
     if self.device.type == "cpu" and self.state.use_ipex:
           args = self._prepare_ipex(*args)
     elif self.device.type == "xpu" and is_xpu_available():
           args = self._prepare_ipex(*args)
```

if `self.distributed_type == DistributedType.MULTI_XPU` and xpu is available, the `prepare_ipex` function will be called. But what if users don't want to use IPEX in the distributed training? So there is a missing `use_ipex` control for XPU. We should add the `use_ipex` control for XPU just like in CPU.

But if we take a bird's-eye view of this code block, we will see that this code block has nothing to do with the `distributed_type`. It is more about whether to prepare the model and other args with IPEX. So we can further simplify the code as IPEX is an intel software and is only applicable for CPU and XPU. We can delete `is_xpu_available()` as well, because in `_prepare_ipex` , there is again a `is_xpu_available` function. 

Pls have a review, thanks!
@muellerzr @pacman100 