### PR TITLE
Fix the size of int and bool type when computing module size

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -696,6 +696,10 @@ def compute_module_sizes(
             size = tensor.numel() * special_dtypes_size[name]
         elif dtype is None:
             size = tensor.numel() * dtype_byte_size(tensor.dtype)
+        elif str(tensor.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):
+            # According to the code in set_module_tensor_to_device, these types won't be converted
+            # so use their original size here
+            size = tensor.numel() * dtype_byte_size(tensor.dtype)
         else:
             size = tensor.numel() * min(dtype_size, dtype_byte_size(tensor.dtype))
         name_parts = name.split(".")


### PR DESCRIPTION
# What does this PR do?

Hello, I'm trying using accelerate to offload a large model (https://huggingface.co/TheBloke/WizardCoder-33B-V1.1-GPTQ) to CPU, with following code (requires https://github.com/huggingface/accelerate/pull/2383 if using Intel GPU, and https://github.com/huggingface/transformers/pull/28755):

```python
import datetime

import torch
import intel_extension_for_pytorch

import accelerate
from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline

model_id = "/mnt/external2/LLMs/WizardCoder-33B-V1.1-GPTQ"
tokenizer = AutoTokenizer.from_pretrained(model_id)

pipe = pipeline("text-generation", model=model_id, model_kwargs={"torch_dtype": torch.bfloat16, "device_map": "auto", "max_memory": {0: "16GB", "cpu": "128GB"}, "offload_buffers": True})
print(str(pipe.model.hf_device_map))

print(str(datetime.datetime.now()) + " Generating...")
results = pipe("public void helloWorld() {")

print(str(datetime.datetime.now()) + " Output:")
print(results)
```

I have one Intel Arc A770 16GB GPU in my machine, but the code above always OOM on the GPU.

After some digging, I found that in the utils/modeling.py:

```python
def compute_module_sizes(
    # ... (other code) ...
            size = tensor.numel() * min(dtype_size, dtype_byte_size(tensor.dtype))  # here, dtype_size = 2, dtype_byte_size = 4
```

This will get wrong size 2 for that model `TheBloke/WizardCoder-33B-V1.1-GPTQ`, because it contains `int32` weights, which size should be 4, so the layer size has been under-estimated, causing an OOM on real load.

The int32 weight won't be converted because of these lines in utils/modeling.py:

```python
def set_module_tensor_to_device(
  # ... (other code) ...
        elif not str(value.dtype).startswith(("torch.uint", "torch.int", "torch.bool")):  # This line will ignore int32 values
            value = value.to(dtype)
```

So I added a check in `compute_module_sizes`, matching the `set_module_tensor_to_device`.

With this PR, the layer containing int32 values can get correct size, and my code can finish correctly without OOM.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->