### PR TITLE
Make test assertions more idiomatic

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import inspect
 import io
 import itertools
@@ -153,7 +152,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             zero3_save_16bit_model=True,
             zero3_init_flag=True,
         )
-        self.assertFalse(deepspeed_plugin.zero3_init_flag)
+        assert not deepspeed_plugin.zero3_init_flag
         deepspeed_plugin.deepspeed_config = None
 
         # Test zero3_init_flag will be set to True only when ZeRO stage == 3
@@ -166,15 +165,15 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             zero3_save_16bit_model=True,
             zero3_init_flag=True,
         )
-        self.assertTrue(deepspeed_plugin.zero3_init_flag)
+        assert deepspeed_plugin.zero3_init_flag
         deepspeed_plugin.deepspeed_config = None
 
         # Test config files are loaded correctly
         deepspeed_plugin = DeepSpeedPlugin(hf_ds_config=self.ds_config_file[stage], zero3_init_flag=True)
         if stage == ZERO2:
-            self.assertFalse(deepspeed_plugin.zero3_init_flag)
+            assert not deepspeed_plugin.zero3_init_flag
         elif stage == ZERO3:
-            self.assertTrue(deepspeed_plugin.zero3_init_flag)
+            assert deepspeed_plugin.zero3_init_flag
 
         # Test `gradient_accumulation_steps` is set to 1 if unavailable in config file
         with tempfile.TemporaryDirectory() as dirpath:
@@ -183,7 +182,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             with open(os.path.join(dirpath, "ds_config.json"), "w") as out_file:
                 json.dump(ds_config, out_file)
             deepspeed_plugin = DeepSpeedPlugin(hf_ds_config=os.path.join(dirpath, "ds_config.json"))
-            self.assertEqual(deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"], 1)
+            assert deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"] == 1
             deepspeed_plugin.deepspeed_config = None
 
         # Test `ValueError` is raised if `zero_optimization` is unavailable in config file
@@ -194,9 +193,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 json.dump(ds_config, out_file)
             with self.assertRaises(ValueError) as cm:
                 deepspeed_plugin = DeepSpeedPlugin(hf_ds_config=os.path.join(dirpath, "ds_config.json"))
-            self.assertTrue(
-                "Please specify the ZeRO optimization config in the DeepSpeed config." in str(cm.exception)
-            )
+            assert "Please specify the ZeRO optimization config in the DeepSpeed config." in str(cm.exception)
             deepspeed_plugin.deepspeed_config = None
 
         # Test `deepspeed_config_process`
@@ -221,7 +218,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
         for ds_key_long, value in kwargs.items():
             config, ds_key = deepspeed_plugin.hf_ds_config.find_config_node(ds_key_long)
             if config.get(ds_key) is not None:
-                self.assertEqual(config.get(ds_key), value)
+                assert config.get(ds_key) == value
 
         # Test mismatches
         mismatches = {
@@ -234,17 +231,14 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             new_kwargs.update(mismatches)
             deepspeed_plugin.deepspeed_config_process(**new_kwargs)
         for key in mismatches.keys():
-            self.assertTrue(
-                key in str(cm.exception),
-                f"{key} is not in the exception message:\n{cm.exception}",
-            )
+            assert key in str(cm.exception), f"{key} is not in the exception message: {cm.exception}"
 
         # Test `ValueError` is raised if some config file fields with `auto` value is missing in `kwargs`
         deepspeed_plugin.deepspeed_config["optimizer"]["params"]["lr"] = "auto"
         with self.assertRaises(ValueError) as cm:
             del kwargs["optimizer.params.lr"]
             deepspeed_plugin.deepspeed_config_process(**kwargs)
-        self.assertTrue("`optimizer.params.lr` not found in kwargs." in str(cm.exception))
+        assert "`optimizer.params.lr` not found in kwargs." in str(cm.exception)
 
     @parameterized.expand([FP16, BF16], name_func=parameterized_custom_name_func)
     def test_accelerate_state_deepspeed(self, dtype):
@@ -260,7 +254,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
         )
         with mockenv_context(**self.dist_env):
             state = Accelerator(mixed_precision=dtype, deepspeed_plugin=deepspeed_plugin).state
-            self.assertTrue(state.deepspeed_plugin.deepspeed_config[dtype]["enabled"])
+            assert state.deepspeed_plugin.deepspeed_config[dtype]["enabled"]
 
     def test_init_zero3(self):
         deepspeed_plugin = DeepSpeedPlugin(
@@ -277,7 +271,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)  # noqa: F841
             from transformers.deepspeed import is_deepspeed_zero3_enabled
 
-            self.assertTrue(is_deepspeed_zero3_enabled())
+            assert is_deepspeed_zero3_enabled()
 
     @parameterized.expand(optim_scheduler_params, name_func=parameterized_custom_name_func)
     def test_prepare_deepspeed(self, optim_type, scheduler_type):
@@ -333,15 +327,14 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, dummy_optimizer, train_dataloader, eval_dataloader, lr_scheduler
                     )
-                self.assertTrue(
-                    "You cannot create a `DummyOptim` without specifying an optimizer in the config file."
-                    in str(cm.exception)
+                assert "You cannot create a `DummyOptim` without specifying an optimizer in the config file." in str(
+                    cm.exception
                 )
                 with self.assertRaises(ValueError) as cm:
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                     )
-                self.assertTrue(
+                assert (
                     "Either specify a scheduler in the config file or "
                     "pass in the `lr_scheduler_callable` parameter when using `accelerate.utils.DummyScheduler`."
                     in str(cm.exception)
@@ -349,7 +342,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 
                 with self.assertRaises(ValueError) as cm:
                     model, optimizer, lr_scheduler = accelerator.prepare(model, optimizer, lr_scheduler)
-                self.assertTrue(
+                assert (
                     "When using DeepSpeed, `accelerate.prepare()` requires you to pass at least one of training or evaluation dataloaders "
                     "with `batch_size` attribute returning an integer value "
                     "or alternatively set an integer value in `train_micro_batch_size_per_gpu` in the deepspeed config file "
@@ -360,12 +353,12 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
                 )
-                self.assertTrue(accelerator.deepspeed_config["zero_allow_untested_optimizer"])
-                self.assertTrue(accelerator.deepspeed_config["train_batch_size"], 16)
-                self.assertEqual(type(model), DeepSpeedEngine)
-                self.assertEqual(type(optimizer), DeepSpeedOptimizerWrapper)
-                self.assertEqual(type(lr_scheduler), AcceleratedScheduler)
-                self.assertEqual(type(accelerator.deepspeed_engine_wrapped), DeepSpeedEngineWrapper)
+                assert accelerator.deepspeed_config["zero_allow_untested_optimizer"]
+                assert accelerator.deepspeed_config["train_batch_size"], 16
+                assert type(model) == DeepSpeedEngine
+                assert type(optimizer) == DeepSpeedOptimizerWrapper
+                assert type(lr_scheduler) == AcceleratedScheduler
+                assert type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper
 
         elif optim_type == DS_OPTIMIZER and scheduler_type == DS_SCHEDULER:
             # Test DeepSpeed optimizer + DeepSpeed scheduler
@@ -396,36 +389,33 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                     )
-                self.assertTrue(
-                    "You cannot specify an optimizer in the config file and in the code at the same time"
-                    in str(cm.exception)
+                assert "You cannot specify an optimizer in the config file and in the code at the same time" in str(
+                    cm.exception
                 )
 
                 with self.assertRaises(ValueError) as cm:
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, dummy_optimizer, train_dataloader, eval_dataloader, lr_scheduler
                     )
-                self.assertTrue(
-                    "You cannot specify a scheduler in the config file and in the code at the same time"
-                    in str(cm.exception)
+                assert "You cannot specify a scheduler in the config file and in the code at the same time" in str(
+                    cm.exception
                 )
 
                 with self.assertRaises(ValueError) as cm:
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, dummy_optimizer, train_dataloader, eval_dataloader, lr_scheduler
                     )
-                self.assertTrue(
-                    "You cannot specify a scheduler in the config file and in the code at the same time"
-                    in str(cm.exception)
+                assert "You cannot specify a scheduler in the config file and in the code at the same time" in str(
+                    cm.exception
                 )
 
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, dummy_optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                 )
-                self.assertTrue(type(model) == DeepSpeedEngine)
-                self.assertTrue(type(optimizer) == DeepSpeedOptimizerWrapper)
-                self.assertTrue(type(lr_scheduler) == DeepSpeedSchedulerWrapper)
-                self.assertTrue(type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper)
+                assert type(model) == DeepSpeedEngine
+                assert type(optimizer) == DeepSpeedOptimizerWrapper
+                assert type(lr_scheduler) == DeepSpeedSchedulerWrapper
+                assert type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper
 
         elif optim_type == CUSTOM_OPTIMIZER and scheduler_type == DS_SCHEDULER:
             # Test custom optimizer + DeepSpeed scheduler
@@ -456,10 +446,10 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                 )
-                self.assertTrue(type(model) == DeepSpeedEngine)
-                self.assertTrue(type(optimizer) == DeepSpeedOptimizerWrapper)
-                self.assertTrue(type(lr_scheduler) == DeepSpeedSchedulerWrapper)
-                self.assertTrue(type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper)
+                assert type(model) == DeepSpeedEngine
+                assert type(optimizer) == DeepSpeedOptimizerWrapper
+                assert type(lr_scheduler) == DeepSpeedSchedulerWrapper
+                assert type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper
         elif optim_type == DS_OPTIMIZER and scheduler_type == CUSTOM_SCHEDULER:
             # Test deepspeed optimizer + custom scheduler
             deepspeed_plugin = DeepSpeedPlugin(hf_ds_config=self.ds_config_file[ZERO2])
@@ -490,7 +480,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, dummy_optimizer, train_dataloader, eval_dataloader, lr_scheduler
                     )
-                self.assertTrue(
+                assert (
                     "You can only specify `accelerate.utils.DummyScheduler` in the code when using `accelerate.utils.DummyOptim`."
                     in str(cm.exception)
                 )
@@ -500,7 +490,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, dummy_optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                     )
-                self.assertTrue(
+                assert (
                     "Either specify a scheduler in the config file or "
                     "pass in the `lr_scheduler_callable` parameter when using `accelerate.utils.DummyScheduler`."
                     in str(cm.exception)
@@ -554,7 +544,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
                 )
-            self.assertTrue(
+            assert (
                 "At least one of the dataloaders passed to `accelerate.prepare()` has `None` as batch size. "
                 "Please set an integer value in `train_micro_batch_size_per_gpu` in the deepspeed config file "
                 "or assign integer value to `AcceleratorState().deepspeed_plugin.deepspeed_config['train_micro_batch_size_per_gpu']`."
@@ -610,7 +600,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 "set `zero3_save_16bit_model` to True when using `accelerate config`. "
                 "To save the full checkpoint, run `model.save_checkpoint(save_dir)` and use `zero_to_fp32.py` to recover weights."
             )
-            self.assertTrue(msg in str(cm.exception))
+            assert msg in str(cm.exception)
 
     def test_autofill_dsconfig(self):
         deepspeed_plugin = DeepSpeedPlugin(
@@ -699,14 +689,14 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                         model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
                     )
                 msg = "Can't find `model.config` entry"
-                self.assertTrue(msg in str(cm.exception))
+                assert msg in str(cm.exception)
             elif model_type == CONFIG_WITH_NO_HIDDEN_SIZE:
                 with self.assertRaises(ValueError) as cm:
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                         model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
                     )
                 msg = "Can find neither `model.config.hidden_size` nor `model.config.hidden_sizes`"
-                self.assertTrue(msg in str(cm.exception))
+                assert msg in str(cm.exception)
             else:
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
@@ -769,7 +759,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
         with mockenv_context(**self.dist_env):
             with self.assertRaises(ValueError) as cm:
                 accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin, mixed_precision=diff_dtype)
-            self.assertTrue(
+            assert (
                 f"`--mixed_precision` arg cannot be set to `{diff_dtype}` when `{dtype}` is set in the DeepSpeed config file."
                 in str(cm.exception)
             )
@@ -780,7 +770,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
         with mockenv_context(**self.dist_env):
             accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin, mixed_precision=dtype)
             deepspeed_plugin = accelerator.state.deepspeed_plugin
-            self.assertEqual(deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"], 4)
+            assert deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"] == 4
 
         # filling the `auto` gradient_accumulation_steps via Accelerator's value
         AcceleratorState._reset_state(True)
@@ -808,7 +798,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 model, dummy_optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
             )
             deepspeed_plugin = accelerator.state.deepspeed_plugin
-            self.assertEqual(deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"], 8)
+            assert deepspeed_plugin.deepspeed_config["gradient_accumulation_steps"] == 8
 
     def test_ds_config_assertions(self):
         ambiguous_env = self.dist_env.copy()
@@ -829,7 +819,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                     zero3_save_16bit_model=True,
                 )
                 _ = Accelerator(deepspeed_plugin=deepspeed_plugin, mixed_precision=FP16)
-            self.assertTrue(
+            assert (
                 "If you are using an accelerate config file, remove others config variables mentioned in the above specified list."
                 in str(cm.exception)
             )
@@ -840,7 +830,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
             hf_ds_config=self.ds_config_file[stage],
             zero3_init_flag=True,
         )
-        self.assertEqual(deepspeed_plugin.zero_stage, int(stage.replace("zero", "")))
+        assert deepspeed_plugin.zero_stage == int(stage.replace("zero", ""))
 
     def test_basic_run(self):
         mod_file = inspect.getfile(accelerate.test_utils)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -75,7 +75,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
             env["FSDP_SHARDING_STRATEGY"] = f"{i + 1}"
             with mockenv_context(**env):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
-                self.assertEqual(fsdp_plugin.sharding_strategy, ShardingStrategy(i + 1))
+                assert fsdp_plugin.sharding_strategy == ShardingStrategy(i + 1)
 
         # check that giving names works fine
         for i, strategy in enumerate(FSDP_SHARDING_STRATEGY):
@@ -83,7 +83,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
             env["FSDP_SHARDING_STRATEGY"] = strategy
             with mockenv_context(**env):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
-                self.assertEqual(fsdp_plugin.sharding_strategy, ShardingStrategy(i + 1))
+                assert fsdp_plugin.sharding_strategy == ShardingStrategy(i + 1)
 
     def test_backward_prefetch(self):
         from torch.distributed.fsdp.fully_sharded_data_parallel import BackwardPrefetch
@@ -94,9 +94,9 @@ class FSDPPluginIntegration(AccelerateTestCase):
             with mockenv_context(**env):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
                 if prefetch_policy == "NO_PREFETCH":
-                    self.assertIsNone(fsdp_plugin.backward_prefetch)
+                    assert fsdp_plugin.backward_prefetch is None
                 else:
-                    self.assertEqual(fsdp_plugin.backward_prefetch, BackwardPrefetch(i + 1))
+                    assert fsdp_plugin.backward_prefetch == BackwardPrefetch(i + 1)
 
     def test_state_dict_type(self):
         from torch.distributed.fsdp.fully_sharded_data_parallel import StateDictType
@@ -106,10 +106,10 @@ class FSDPPluginIntegration(AccelerateTestCase):
             env["FSDP_STATE_DICT_TYPE"] = state_dict_type
             with mockenv_context(**env):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
-                self.assertEqual(fsdp_plugin.state_dict_type, StateDictType(i + 1))
+                assert fsdp_plugin.state_dict_type == StateDictType(i + 1)
                 if state_dict_type == "FULL_STATE_DICT":
-                    self.assertTrue(fsdp_plugin.state_dict_config.offload_to_cpu)
-                    self.assertTrue(fsdp_plugin.state_dict_config.rank0_only)
+                    assert fsdp_plugin.state_dict_config.offload_to_cpu
+                    assert fsdp_plugin.state_dict_config.rank0_only
 
     def test_auto_wrap_policy(self):
         model = AutoModel.from_pretrained(BERT_BASE_CASED)
@@ -124,9 +124,9 @@ class FSDPPluginIntegration(AccelerateTestCase):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
                 fsdp_plugin.set_auto_wrap_policy(model)
                 if policy == "NO_WRAP":
-                    self.assertIsNone(fsdp_plugin.auto_wrap_policy)
+                    assert fsdp_plugin.auto_wrap_policy is None
                 else:
-                    self.assertIsNotNone(fsdp_plugin.auto_wrap_policy)
+                    assert fsdp_plugin.auto_wrap_policy is not None
 
         env = self.dist_env.copy()
         env["FSDP_AUTO_WRAP_POLICY"] = "TRANSFORMER_BASED_WRAP"
@@ -135,7 +135,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
             fsdp_plugin = FullyShardedDataParallelPlugin()
             with self.assertRaises(Exception) as cm:
                 fsdp_plugin.set_auto_wrap_policy(model)
-            self.assertTrue("Could not find the transformer layer class to wrap in the model." in str(cm.exception))
+            assert "Could not find the transformer layer class to wrap in the model." in str(cm.exception)
 
         env = self.dist_env.copy()
         env["FSDP_AUTO_WRAP_POLICY"] = "SIZE_BASED_WRAP"
@@ -143,7 +143,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
         with mockenv_context(**env):
             fsdp_plugin = FullyShardedDataParallelPlugin()
             fsdp_plugin.set_auto_wrap_policy(model)
-            self.assertIsNone(fsdp_plugin.auto_wrap_policy)
+            assert fsdp_plugin.auto_wrap_policy is None
 
     def test_mixed_precision(self):
         from torch.distributed.fsdp.fully_sharded_data_parallel import MixedPrecision
@@ -159,11 +159,11 @@ class FSDPPluginIntegration(AccelerateTestCase):
                 elif mp_dtype == "bf16":
                     dtype = torch.bfloat16
                 mp_policy = MixedPrecision(param_dtype=dtype, reduce_dtype=dtype, buffer_dtype=dtype)
-                self.assertEqual(accelerator.state.fsdp_plugin.mixed_precision_policy, mp_policy)
+                assert accelerator.state.fsdp_plugin.mixed_precision_policy == mp_policy
                 if mp_dtype == FP16:
-                    self.assertTrue(isinstance(accelerator.scaler, ShardedGradScaler))
+                    assert isinstance(accelerator.scaler, ShardedGradScaler)
                 elif mp_dtype == BF16:
-                    self.assertIsNone(accelerator.scaler)
+                    assert accelerator.scaler is None
                 AcceleratorState._reset_state(True)
 
     def test_cpu_offload(self):
@@ -174,7 +174,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
             env["FSDP_OFFLOAD_PARAMS"] = str(flag).lower()
             with mockenv_context(**env):
                 fsdp_plugin = FullyShardedDataParallelPlugin()
-                self.assertEqual(fsdp_plugin.cpu_offload, CPUOffload(offload_params=flag))
+                assert fsdp_plugin.cpu_offload == CPUOffload(offload_params=flag)
 
 
 @require_fsdp

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -87,11 +87,11 @@ class AcceleratorTester(AccelerateTestCase):
             prepared_valid_dl,
         ) = accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
 
-        self.assertTrue(prepared_model in accelerator._models)
-        self.assertTrue(prepared_optimizer in accelerator._optimizers)
-        self.assertTrue(prepared_scheduler in accelerator._schedulers)
-        self.assertTrue(prepared_train_dl in accelerator._dataloaders)
-        self.assertTrue(prepared_valid_dl in accelerator._dataloaders)
+        assert prepared_model in accelerator._models
+        assert prepared_optimizer in accelerator._optimizers
+        assert prepared_scheduler in accelerator._schedulers
+        assert prepared_train_dl in accelerator._dataloaders
+        assert prepared_valid_dl in accelerator._dataloaders
 
     def test_free_memory_dereferences_prepared_components(self):
         accelerator = Accelerator()
@@ -99,10 +99,10 @@ class AcceleratorTester(AccelerateTestCase):
         accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
         accelerator.free_memory()
 
-        self.assertTrue(len(accelerator._models) == 0)
-        self.assertTrue(len(accelerator._optimizers) == 0)
-        self.assertTrue(len(accelerator._schedulers) == 0)
-        self.assertTrue(len(accelerator._dataloaders) == 0)
+        assert len(accelerator._models) == 0
+        assert len(accelerator._optimizers) == 0
+        assert len(accelerator._schedulers) == 0
+        assert len(accelerator._dataloaders) == 0
 
     def test_env_var_device(self):
         """Tests that setting the torch device with ACCELERATE_TORCH_DEVICE overrides default device."""
@@ -114,7 +114,7 @@ class AcceleratorTester(AccelerateTestCase):
 
         with patch("torch.cuda.set_device", noop), patch_environment(ACCELERATE_TORCH_DEVICE="cuda:64"):
             accelerator = Accelerator()
-            self.assertEqual(str(accelerator.state.device), "cuda:64")
+            assert str(accelerator.state.device) == "cuda:64"
 
     @parameterized.expand((True, False), name_func=parameterized_custom_name_func)
     def test_save_load_model(self, use_safetensors):
@@ -129,11 +129,11 @@ class AcceleratorTester(AccelerateTestCase):
 
             # make sure random weights don't match
             load_random_weights(model)
-            self.assertTrue(abs(model_signature - get_signature(model)) > 1e-3)
+            assert abs(model_signature - get_signature(model)) > 1e-3
 
             # make sure loaded weights match
             accelerator.load_state(tmpdirname)
-            self.assertTrue(abs(model_signature - get_signature(model)) < 1e-3)
+            assert abs(model_signature - get_signature(model)) < 1e-3
 
     @parameterized.expand([True, False], name_func=parameterized_custom_name_func)
     def test_save_model(self, use_safetensors):
@@ -145,7 +145,7 @@ class AcceleratorTester(AccelerateTestCase):
             accelerator.save_model(model, tmpdirname, safe_serialization=use_safetensors)
             # make sure loaded weights match
             load_checkpoint_in_model(model, tmpdirname)
-            self.assertTrue(abs(model_signature - get_signature(model)) < 1e-3)
+            assert abs(model_signature - get_signature(model)) < 1e-3
 
     @parameterized.expand([True, False], name_func=parameterized_custom_name_func)
     def test_save_model_offload(self, use_safetensors):
@@ -165,7 +165,7 @@ class AcceleratorTester(AccelerateTestCase):
             # load weights that were saved from the offloaded model
             load_checkpoint_and_dispatch(model, tmp_dir)
             output = model(inputs)
-        self.assertTrue(torch.allclose(expected, output, atol=1e-5))
+        assert torch.allclose(expected, output, atol=1e-5)
 
     @parameterized.expand([True, False], name_func=parameterized_custom_name_func)
     def test_save_load_model_with_hooks(self, use_safetensors):
@@ -197,17 +197,17 @@ class AcceleratorTester(AccelerateTestCase):
 
             # make sure random weights don't match with hooks
             load_random_weights(model)
-            self.assertTrue(abs(model_signature - get_signature(model)) > 1e-3)
+            assert abs(model_signature - get_signature(model)) > 1e-3
 
             # random class name to verify correct one is loaded
             model.class_name = "random"
 
             # make sure loaded weights match with hooks
             accelerator.load_state(tmpdirname)
-            self.assertTrue(abs(model_signature - get_signature(model)) < 1e-3)
+            assert abs(model_signature - get_signature(model)) < 1e-3
 
             # mode.class_name is loaded from config
-            self.assertTrue(model.class_name == model.__class__.__name__)
+            assert model.class_name == model.__class__.__name__
 
         # remove hooks
         save_hook.remove()
@@ -218,17 +218,17 @@ class AcceleratorTester(AccelerateTestCase):
 
             # make sure random weights don't match with hooks removed
             load_random_weights(model)
-            self.assertTrue(abs(model_signature - get_signature(model)) > 1e-3)
+            assert abs(model_signature - get_signature(model)) > 1e-3
 
             # random class name to verify correct one is loaded
             model.class_name = "random"
 
             # make sure loaded weights match with hooks removed
             accelerator.load_state(tmpdirname)
-            self.assertTrue(abs(model_signature - get_signature(model)) < 1e-3)
+            assert abs(model_signature - get_signature(model)) < 1e-3
 
             # mode.class_name is NOT loaded from config
-            self.assertTrue(model.class_name != model.__class__.__name__)
+            assert model.class_name != model.__class__.__name__
 
     def test_accelerator_none(self):
         """Just test that passing None to accelerator.prepare() works."""
@@ -240,7 +240,7 @@ class AcceleratorTester(AccelerateTestCase):
         model, optimizer, scheduler, train_dl, valid_dl, dummy_obj = accelerator.prepare(
             model, optimizer, scheduler, train_dl, valid_dl, dummy_obj
         )
-        self.assertTrue(dummy_obj is None)
+        assert dummy_obj is None
 
     def test_is_accelerator_prepared(self):
         """Checks that `_is_accelerator_prepared` is set properly"""
@@ -252,36 +252,24 @@ class AcceleratorTester(AccelerateTestCase):
         model, optimizer, scheduler, train_dl, valid_dl, dummy_obj = accelerator.prepare(
             model, optimizer, scheduler, train_dl, valid_dl, dummy_obj
         )
-        self.assertEqual(
-            getattr(dummy_obj, "_is_accelerate_prepared", False),
-            False,
-            "Dummy object should have `_is_accelerate_prepared` set to `True`",
-        )
-        self.assertEqual(
-            getattr(model, "_is_accelerate_prepared", False),
-            True,
-            "Model is missing `_is_accelerator_prepared` or is set to `False`",
-        )
-        self.assertEqual(
-            getattr(optimizer, "_is_accelerate_prepared", False),
-            True,
-            "Optimizer is missing `_is_accelerator_prepared` or is set to `False`",
-        )
-        self.assertEqual(
-            getattr(scheduler, "_is_accelerate_prepared", False),
-            True,
-            "Scheduler is missing `_is_accelerator_prepared` or is set to `False`",
-        )
-        self.assertEqual(
-            getattr(train_dl, "_is_accelerate_prepared", False),
-            True,
-            "Train Dataloader is missing `_is_accelerator_prepared` or is set to `False`",
-        )
-        self.assertEqual(
-            getattr(valid_dl, "_is_accelerate_prepared", False),
-            True,
-            "Valid Dataloader is missing `_is_accelerator_prepared` or is set to `False`",
-        )
+        assert (
+            getattr(dummy_obj, "_is_accelerate_prepared", False) is False
+        ), "Dummy object should have `_is_accelerate_prepared` set to `True`"
+        assert (
+            getattr(model, "_is_accelerate_prepared", False) is True
+        ), "Model is missing `_is_accelerator_prepared` or is set to `False`"
+        assert (
+            getattr(optimizer, "_is_accelerate_prepared", False) is True
+        ), "Optimizer is missing `_is_accelerator_prepared` or is set to `False`"
+        assert (
+            getattr(scheduler, "_is_accelerate_prepared", False) is True
+        ), "Scheduler is missing `_is_accelerator_prepared` or is set to `False`"
+        assert (
+            getattr(train_dl, "_is_accelerate_prepared", False) is True
+        ), "Train Dataloader is missing `_is_accelerator_prepared` or is set to `False`"
+        assert (
+            getattr(valid_dl, "_is_accelerate_prepared", False) is True
+        ), "Valid Dataloader is missing `_is_accelerator_prepared` or is set to `False`"
 
     @slow
     @require_bnb

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -138,13 +138,13 @@ class BigModelingTester(unittest.TestCase):
         # base use
         with init_empty_weights():
             module = nn.Linear(4, 5)
-        self.assertEqual(module.weight.device, torch.device("meta"))
+        assert module.weight.device == torch.device("meta")
 
         # base use with buffers, they are not touched
         with init_empty_weights():
             module = nn.BatchNorm1d(4)
-        self.assertEqual(module.weight.device, torch.device("meta"))
-        self.assertEqual(module.running_mean.device, torch.device("cpu"))
+        assert module.weight.device == torch.device("meta")
+        assert module.running_mean.device == torch.device("cpu")
 
         # Use with include_buffers=True
         register_parameter_func = nn.Module.register_parameter
@@ -153,15 +153,15 @@ class BigModelingTester(unittest.TestCase):
             module = nn.BatchNorm1d(4)
             # nn.Module.register_parameter/buffer shouldn't be changed with torch >= 2.0
             if is_torch_version(">=", "2.0"):
-                self.assertEqual(register_parameter_func, nn.Module.register_parameter)
-                self.assertEqual(register_buffer_func, nn.Module.register_buffer)
-        self.assertEqual(module.weight.device, torch.device("meta"))
-        self.assertEqual(module.running_mean.device, torch.device("meta"))
+                assert register_parameter_func == nn.Module.register_parameter
+                assert register_buffer_func == nn.Module.register_buffer
+        assert module.weight.device == torch.device("meta")
+        assert module.running_mean.device == torch.device("meta")
 
         # Double check we didn't break PyTorch
         module = nn.BatchNorm1d(4)
-        self.assertEqual(module.weight.device, torch.device("cpu"))
-        self.assertEqual(module.running_mean.device, torch.device("cpu"))
+        assert module.weight.device == torch.device("cpu")
+        assert module.running_mean.device == torch.device("cpu")
 
     def test_init_empty_weights_very_large_model(self):
         # This is a 100 billion parameters model.
@@ -173,16 +173,16 @@ class BigModelingTester(unittest.TestCase):
         device = torch.device("cuda:0")
         with init_on_device(device):
             model = nn.Linear(10, 10)
-        self.assertEqual(model.weight.device, device)
-        self.assertEqual(model.weight.device, device)
+        assert model.weight.device == device
+        assert model.weight.device == device
 
     @require_mps
     def test_init_on_device_mps(self):
         device = torch.device("mps:0")
         with init_on_device(device):
             model = nn.Linear(10, 10)
-        self.assertEqual(model.weight.device, device)
-        self.assertEqual(model.weight.device, device)
+        assert model.weight.device == device
+        assert model.weight.device == device
 
     def test_cpu_offload(self):
         model = ModelForTest()
@@ -193,18 +193,14 @@ class BigModelingTester(unittest.TestCase):
 
         cpu_offload(model, execution_device=device)
         output = model(x)
-        self.assertTrue(
-            torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-        )
+        assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
         # Clean up for next test.
         remove_hook_from_submodules(model)
 
         cpu_offload(model, execution_device=device, offload_buffers=True)
         output = model(x)
-        self.assertTrue(
-            torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-        )
+        assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
     def test_cpu_offload_with_unused_submodules(self):
         model = ModelWithUnusedSubModulesForTest()
@@ -215,9 +211,7 @@ class BigModelingTester(unittest.TestCase):
 
         cpu_offload(model, execution_device=device, preload_module_classes=["ModuleWithUnusedSubModules"])
         output = model(x)
-        self.assertTrue(
-            torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-        )
+        assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
         # Clean up for next test.
         remove_hook_from_submodules(model)
@@ -229,9 +223,7 @@ class BigModelingTester(unittest.TestCase):
             preload_module_classes=["ModuleWithUnusedSubModules"],
         )
         output = model(x)
-        self.assertTrue(
-            torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-        )
+        assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
     @slow
     @require_cuda
@@ -242,9 +234,9 @@ class BigModelingTester(unittest.TestCase):
         gpt2 = AutoModelForCausalLM.from_pretrained("gpt2")
         cpu_offload(gpt2, execution_device=0)
         outputs = gpt2.generate(inputs["input_ids"])
-        self.assertEqual(
-            tokenizer.decode(outputs[0].tolist()),
-            "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo",
+        assert (
+            tokenizer.decode(outputs[0].tolist())
+            == "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo"
         )
 
     def test_disk_offload(self):
@@ -257,9 +249,7 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             disk_offload(model, tmp_dir, execution_device=device)
             output = model(x)
-            self.assertTrue(
-                torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-            )
+            assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
             # Clean up for next test.
             remove_hook_from_submodules(model)
@@ -267,9 +257,7 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             disk_offload(model, tmp_dir, execution_device=device, offload_buffers=True)
             output = model(x)
-            self.assertTrue(
-                torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-            )
+            assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
     def test_disk_offload_with_unused_submodules(self):
         model = ModelWithUnusedSubModulesForTest()
@@ -283,9 +271,7 @@ class BigModelingTester(unittest.TestCase):
                 model, tmp_dir, execution_device=device, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
-            self.assertTrue(
-                torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-            )
+            assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
             # Clean up for next test.
             remove_hook_from_submodules(model)
@@ -299,9 +285,7 @@ class BigModelingTester(unittest.TestCase):
                 preload_module_classes=["ModuleWithUnusedSubModules"],
             )
             output = model(x)
-            self.assertTrue(
-                torch.allclose(expected, output.cpu(), 1e-4, 1e-5), msg=f"Expected: {expected}\nActual: {output.cpu()}"
-            )
+            assert torch.allclose(expected, output.cpu(), 1e-4, 1e-5), f"Expected: {expected}, Actual: {output.cpu()}"
 
     @slow
     @require_cuda
@@ -313,9 +297,9 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             disk_offload(gpt2, tmp_dir, execution_device=0)
             outputs = gpt2.generate(inputs["input_ids"])
-            self.assertEqual(
-                tokenizer.decode(outputs[0].tolist()),
-                "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo",
+            assert (
+                tokenizer.decode(outputs[0].tolist())
+                == "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo"
             )
 
     @require_cuda
@@ -329,7 +313,7 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_dispatch_model_with_non_persistent_buffers(self):
@@ -341,7 +325,7 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(model, device_map, offload_dir=tmp_dir, offload_buffers=True)
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_mps
     def test_dispatch_model_mps(self):
@@ -354,7 +338,7 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_dispatch_model_tied_weights(self):
@@ -363,7 +347,7 @@ class BigModelingTester(unittest.TestCase):
         device_map = {"linear1": 0, "batchnorm": 0, "linear2": 0}
 
         dispatch_model(model, device_map)
-        self.assertIs(model.linear2.weight, model.linear1.weight)
+        assert model.linear2.weight is model.linear1.weight
 
     @require_multi_gpu
     def test_dispatch_model_tied_weights_memory(self):
@@ -415,7 +399,7 @@ class BigModelingTester(unittest.TestCase):
 
         with torch.no_grad():
             output = model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_dispatch_model_tied_weights_memory_with_nested_offload_cpu(self):
@@ -480,7 +464,7 @@ class BigModelingTester(unittest.TestCase):
         dispatch_model(model, device_map)
         free_memory_bytes_after_dispatch = torch.cuda.mem_get_info("cuda:0")[0]
 
-        self.assertTrue((free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130)
+        assert (free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130
 
         original_pointer = model.compute1._hf_hook.weights_map["weight"].data_ptr()
 
@@ -494,16 +478,16 @@ class BigModelingTester(unittest.TestCase):
             except Exception as e:
                 raise e
 
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
         torch.cuda.empty_cache()
 
         free_memory_bytes_after_infer = torch.cuda.mem_get_info("cuda:0")[0]
 
         # Check that we have no more references on GPU for the offloaded tied weight.
-        self.assertTrue(len(model.compute1.weight_submodule._hf_hook.tied_params_map[original_pointer]) == 0)
-        self.assertTrue(len(model.compute1._hf_hook.tied_params_map[original_pointer]) == 0)
-        self.assertTrue((free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130)
+        assert len(model.compute1.weight_submodule._hf_hook.tied_params_map[original_pointer]) == 0
+        assert len(model.compute1._hf_hook.tied_params_map[original_pointer]) == 0
+        assert (free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130
 
         # Test is flacky otherwise.
         del model
@@ -573,7 +557,7 @@ class BigModelingTester(unittest.TestCase):
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             free_memory_bytes_after_dispatch = torch.cuda.mem_get_info("cuda:0")[0]
 
-            self.assertTrue((free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130)
+            assert (free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130
 
             with torch.no_grad():
                 try:
@@ -585,7 +569,7 @@ class BigModelingTester(unittest.TestCase):
                 except Exception as e:
                     raise e
 
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
             torch.cuda.empty_cache()
 
@@ -596,15 +580,15 @@ class BigModelingTester(unittest.TestCase):
             for pointer, pointer_dict in model.compute1.weight_submodule._hf_hook.tied_params_map.items():
                 if len(pointer_dict) > 0:
                     n_non_empty += 1
-            self.assertTrue(n_non_empty == 1)  # `compute` layer one.
+            assert n_non_empty == 1  # `compute` layer one.
 
             n_non_empty = 0
             for pointer, pointer_dict in model.compute1._hf_hook.tied_params_map.items():
                 if len(pointer_dict) > 0:
                     n_non_empty += 1
-            self.assertTrue(n_non_empty == 1)  # `compute` layer one.
+            assert n_non_empty == 1  # `compute` layer one.
 
-            self.assertTrue((free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130)
+            assert (free_memory_bytes_after_infer - free_memory_bytes_after_dispatch) * 1e-6 < 130
 
     @require_multi_gpu
     def test_dispatch_model_multi_gpu(self):
@@ -617,7 +601,7 @@ class BigModelingTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             dispatch_model(model, device_map, offload_dir=tmp_dir)
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_dispatch_model_copy(self):
@@ -633,10 +617,10 @@ class BigModelingTester(unittest.TestCase):
         copied_model.id = 2
         output, copied_output_id = copied_model(x)
 
-        self.assertEqual(original_model.id, original_output_id)
-        self.assertEqual(copied_model.id, copied_output_id)
-        self.assertFalse(copied_model.linear1.forward is original_model.linear1.forward)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert original_model.id == original_output_id
+        assert copied_model.id == copied_output_id
+        assert copied_model.linear1.forward is not original_model.linear1.forward
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_dispatch_model_move_offloaded_model(self):
@@ -680,9 +664,9 @@ class BigModelingTester(unittest.TestCase):
 
         gpt2 = dispatch_model(gpt2, device_map)
         outputs = gpt2.generate(inputs["input_ids"])
-        self.assertEqual(
-            tokenizer.decode(outputs[0].tolist()),
-            "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo",
+        assert (
+            tokenizer.decode(outputs[0].tolist())
+            == "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo"
         )
 
         # Dispatch with a bit of CPU offload
@@ -691,9 +675,9 @@ class BigModelingTester(unittest.TestCase):
             device_map[f"transformer.h.{i}"] = "cpu"
         gpt2 = dispatch_model(gpt2, device_map)
         outputs = gpt2.generate(inputs["input_ids"])
-        self.assertEqual(
-            tokenizer.decode(outputs[0].tolist()),
-            "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo",
+        assert (
+            tokenizer.decode(outputs[0].tolist())
+            == "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo"
         )
         # Dispatch with a bit of CPU and disk offload
         gpt2 = AutoModelForCausalLM.from_pretrained("gpt2")
@@ -707,9 +691,9 @@ class BigModelingTester(unittest.TestCase):
             offload_state_dict(tmp_dir, state_dict)
             gpt2 = dispatch_model(gpt2, device_map, offload_dir=tmp_dir)
             outputs = gpt2.generate(inputs["input_ids"])
-            self.assertEqual(
-                tokenizer.decode(outputs[0].tolist()),
-                "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo",
+            assert (
+                tokenizer.decode(outputs[0].tolist())
+                == "Hello world! My name is Kiyoshi, and I'm a student at the University of Tokyo"
             )
 
     @require_cuda
@@ -725,7 +709,7 @@ class BigModelingTester(unittest.TestCase):
                 model, device_map, offload_dir=tmp_dir, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_mps
     def test_dispatch_model_with_unused_submodules_mps(self):
@@ -740,7 +724,7 @@ class BigModelingTester(unittest.TestCase):
                 model, device_map, offload_dir=tmp_dir, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_multi_gpu
     def test_dispatch_model_with_unused_submodules_multi_gpu(self):
@@ -755,7 +739,7 @@ class BigModelingTester(unittest.TestCase):
                 model, device_map, offload_dir=tmp_dir, preload_module_classes=["ModuleWithUnusedSubModules"]
             )
             output = model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_dispatch_model_force_hooks(self):
@@ -767,7 +751,7 @@ class BigModelingTester(unittest.TestCase):
 
         dispatch_model(model, device_map, force_hooks=True)
         output = model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_load_checkpoint_and_dispatch(self):
@@ -785,11 +769,11 @@ class BigModelingTester(unittest.TestCase):
             new_model = load_checkpoint_and_dispatch(new_model, checkpoint, device_map=device_map)
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
-        self.assertEqual(new_model.linear1.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear2.weight.device, torch.device(0))
+        assert new_model.linear1.weight.device == torch.device("meta")
+        assert new_model.linear2.weight.device == torch.device(0)
 
         output = new_model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_mps
     def test_load_checkpoint_and_dispatch_mps(self):
@@ -809,11 +793,11 @@ class BigModelingTester(unittest.TestCase):
             )
 
             # CPU-offloaded weights are on the meta device while waiting for the forward pass.
-            self.assertEqual(new_model.linear1.weight.device, torch.device("mps:0"))
-            self.assertEqual(new_model.linear2.weight.device, torch.device("meta"))
+            assert new_model.linear1.weight.device == torch.device("mps:0")
+            assert new_model.linear2.weight.device == torch.device("meta")
 
             output = new_model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_multi_gpu
     def test_load_checkpoint_and_dispatch_multi_gpu(self):
@@ -831,13 +815,13 @@ class BigModelingTester(unittest.TestCase):
             new_model = load_checkpoint_and_dispatch(new_model, checkpoint, device_map=device_map)
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
-        self.assertEqual(new_model.linear1.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear2.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear3.weight.device, torch.device(0))
-        self.assertEqual(new_model.linear4.weight.device, torch.device(1))
+        assert new_model.linear1.weight.device == torch.device("meta")
+        assert new_model.linear2.weight.device == torch.device("meta")
+        assert new_model.linear3.weight.device == torch.device(0)
+        assert new_model.linear4.weight.device == torch.device(1)
 
         output = new_model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_load_checkpoint_and_dispatch_with_unused_submodules(self):
@@ -857,13 +841,13 @@ class BigModelingTester(unittest.TestCase):
             )
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
-        self.assertEqual(new_model.linear1.linear.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear2.linear.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear3.linear.weight.device, torch.device(0))
-        self.assertEqual(new_model.linear4.linear.weight.device, torch.device(0))
+        assert new_model.linear1.linear.weight.device == torch.device("meta")
+        assert new_model.linear2.linear.weight.device == torch.device("meta")
+        assert new_model.linear3.linear.weight.device == torch.device(0)
+        assert new_model.linear4.linear.weight.device == torch.device(0)
 
         output = new_model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_mps
     def test_load_checkpoint_and_dispatch_with_unused_submodules_mps(self):
@@ -887,13 +871,13 @@ class BigModelingTester(unittest.TestCase):
             )
 
             # CPU-offloaded weights are on the meta device while waiting for the forward pass.
-            self.assertEqual(new_model.linear1.linear.weight.device, torch.device("mps:0"))
-            self.assertEqual(new_model.linear2.linear.weight.device, torch.device("mps:0"))
-            self.assertEqual(new_model.linear3.linear.weight.device, torch.device("meta"))
-            self.assertEqual(new_model.linear4.linear.weight.device, torch.device("meta"))
+            assert new_model.linear1.linear.weight.device == torch.device("mps:0")
+            assert new_model.linear2.linear.weight.device == torch.device("mps:0")
+            assert new_model.linear3.linear.weight.device == torch.device("meta")
+            assert new_model.linear4.linear.weight.device == torch.device("meta")
 
             output = new_model(x)
-            self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+            assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_multi_gpu
     def test_load_checkpoint_and_dispatch_multi_gpu_with_unused_submodules(self):
@@ -913,43 +897,43 @@ class BigModelingTester(unittest.TestCase):
             )
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
-        self.assertEqual(new_model.linear1.linear.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear2.linear.weight.device, torch.device("meta"))
-        self.assertEqual(new_model.linear3.linear.weight.device, torch.device(0))
-        self.assertEqual(new_model.linear4.linear.weight.device, torch.device(1))
+        assert new_model.linear1.linear.weight.device == torch.device("meta")
+        assert new_model.linear2.linear.weight.device == torch.device("meta")
+        assert new_model.linear3.linear.weight.device == torch.device(0)
+        assert new_model.linear4.linear.weight.device == torch.device(1)
 
         output = new_model(x)
-        self.assertTrue(torch.allclose(expected, output.cpu(), atol=1e-5))
+        assert torch.allclose(expected, output.cpu(), atol=1e-5)
 
     @require_cuda
     def test_cpu_offload_with_hook(self):
         model1 = torch.nn.Linear(4, 5)
         model1, hook1 = cpu_offload_with_hook(model1)
-        self.assertEqual(model1.weight.device, torch.device("cpu"))
+        assert model1.weight.device == torch.device("cpu")
 
         inputs = torch.randn(3, 4)
         outputs = model1(inputs)
-        self.assertEqual(outputs.device, torch.device(0))
-        self.assertEqual(model1.weight.device, torch.device(0))
+        assert outputs.device == torch.device(0)
+        assert model1.weight.device == torch.device(0)
 
         hook1.offload()
-        self.assertEqual(model1.weight.device, torch.device("cpu"))
+        assert model1.weight.device == torch.device("cpu")
 
         model2 = torch.nn.Linear(5, 5)
         model2, hook2 = cpu_offload_with_hook(model2, prev_module_hook=hook1)
-        self.assertEqual(model2.weight.device, torch.device("cpu"))
+        assert model2.weight.device == torch.device("cpu")
 
         outputs = model1(inputs)
-        self.assertEqual(outputs.device, torch.device(0))
-        self.assertEqual(model1.weight.device, torch.device(0))
+        assert outputs.device == torch.device(0)
+        assert model1.weight.device == torch.device(0)
 
         outputs = model2(outputs)
-        self.assertEqual(outputs.device, torch.device(0))
-        self.assertEqual(model1.weight.device, torch.device("cpu"))
-        self.assertEqual(model2.weight.device, torch.device(0))
+        assert outputs.device == torch.device(0)
+        assert model1.weight.device == torch.device("cpu")
+        assert model2.weight.device == torch.device(0)
 
         hook2.offload()
-        self.assertEqual(model2.weight.device, torch.device("cpu"))
+        assert model2.weight.device == torch.device("cpu")
 
     @slow
     @require_bnb
@@ -976,11 +960,11 @@ class BigModelingTester(unittest.TestCase):
             device_map="balanced",
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.int8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0
 
-        self.assertTrue(model.h[-1].self_attention.query_key_value.weight.dtype == torch.int8)
-        self.assertTrue(model.h[-1].self_attention.query_key_value.weight.device.index == 1)
+        assert model.h[(-1)].self_attention.query_key_value.weight.dtype == torch.int8
+        assert model.h[(-1)].self_attention.query_key_value.weight.device.index == 1
 
     @slow
     @require_bnb
@@ -1007,8 +991,8 @@ class BigModelingTester(unittest.TestCase):
             device_map="auto",
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.int8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0
 
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
@@ -1024,8 +1008,8 @@ class BigModelingTester(unittest.TestCase):
             device_map={"": torch.device("cuda:0")},
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.int8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0
 
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
@@ -1041,8 +1025,8 @@ class BigModelingTester(unittest.TestCase):
             device_map={"": "cuda:0"},
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.int8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.int8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0
 
     @slow
     @require_bnb
@@ -1070,8 +1054,8 @@ class BigModelingTester(unittest.TestCase):
             device_map="auto",
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.uint8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.uint8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0
 
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
@@ -1087,8 +1071,8 @@ class BigModelingTester(unittest.TestCase):
             device_map={"": torch.device("cuda:0")},
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.uint8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.uint8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0
 
         with init_empty_weights():
             model = AutoModel.from_config(AutoConfig.from_pretrained("bigscience/bloom-560m"))
@@ -1104,5 +1088,5 @@ class BigModelingTester(unittest.TestCase):
             device_map={"": "cuda:0"},
         )
 
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.dtype == torch.uint8)
-        self.assertTrue(model.h[0].self_attention.query_key_value.weight.device.index == 0)
+        assert model.h[0].self_attention.query_key_value.weight.dtype == torch.uint8
+        assert model.h[0].self_attention.query_key_value.weight.device.index == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,10 +119,7 @@ class TpuConfigTester(unittest.TestCase):
             + ["--command", self.command, "--tpu_zone", self.tpu_zone, "--tpu_name", self.tpu_name, "--debug"],
             return_stdout=True,
         )
-        self.assertIn(
-            f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
-            output,
-        )
+        assert f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all" in output
 
     def test_base_backward_compatibility(self):
         output = run_command(
@@ -140,18 +137,15 @@ class TpuConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        self.assertIn(
-            f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
-            output,
-        )
+        assert f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all" in output
 
     def test_with_config_file(self):
         output = run_command(
             self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--debug"], return_stdout=True
         )
-        self.assertIn(
-            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
-            output,
+        assert (
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all'
+            in output
         )
 
     def test_with_config_file_and_command(self):
@@ -159,10 +153,7 @@ class TpuConfigTester(unittest.TestCase):
             self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--command", self.command, "--debug"],
             return_stdout=True,
         )
-        self.assertIn(
-            f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all",
-            output,
-        )
+        assert f"{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls --worker all" in output
 
     def test_with_config_file_and_multiple_command(self):
         output = run_command(
@@ -178,9 +169,9 @@ class TpuConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        self.assertIn(
-            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls; echo "Hello World" --worker all',
-            output,
+        assert (
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; ls; echo "Hello World" --worker all'
+            in output
         )
 
     def test_with_config_file_and_command_file(self):
@@ -189,9 +180,9 @@ class TpuConfigTester(unittest.TestCase):
             + ["--config_file", "tests/test_configs/latest.yaml", "--command_file", self.command_file, "--debug"],
             return_stdout=True,
         )
-        self.assertIn(
-            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
-            output,
+        assert (
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all'
+            in output
         )
 
     def test_with_config_file_and_command_file_backward_compatibility(self):
@@ -210,9 +201,9 @@ class TpuConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        self.assertIn(
-            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all',
-            output,
+        assert (
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; echo "hello world"; echo "this is a second command" --worker all'
+            in output
         )
 
     def test_accelerate_install(self):
@@ -220,9 +211,9 @@ class TpuConfigTester(unittest.TestCase):
             self.cmd + ["--config_file", "tests/test_configs/latest.yaml", "--install_accelerate", "--debug"],
             return_stdout=True,
         )
-        self.assertIn(
-            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate -U; echo "hello world"; echo "this is a second command" --worker all',
-            output,
+        assert (
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate -U; echo "hello world"; echo "this is a second command" --worker all'
+            in output
         )
 
     def test_accelerate_install_version(self):
@@ -238,9 +229,9 @@ class TpuConfigTester(unittest.TestCase):
             ],
             return_stdout=True,
         )
-        self.assertIn(
-            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate==12.0.0; echo "hello world"; echo "this is a second command" --worker all',
-            output,
+        assert (
+            f'{self.gcloud} test-tpu --zone us-central1-a --command {self.base_output}; pip install accelerate==12.0.0; echo "hello world"; echo "this is a second command" --worker all'
+            in output
         )
 
 
@@ -304,7 +295,7 @@ class ModelEstimatorTester(unittest.TestCase):
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 89075712, 433249280
         # Check that full precision -> int4 is calculating correctly
-        self.assertEqual(len(output), 2, f"Output was missing a precision, expected 2 but received {len(output)}")
+        assert len(output) == 2, f"Output was missing a precision, expected 2 but received {len(output)}"
 
         for i, factor in enumerate([1, 2]):
             precision = 32 // factor
@@ -313,23 +304,17 @@ class ModelEstimatorTester(unittest.TestCase):
             total_size_estimate = total_size / factor
             total_training_size_estimate = total_size_estimate * 4
 
-            self.assertEqual(precision_str, output[i][0], f"Output is missing precision `{precision_str}`")
-            self.assertEqual(
-                largest_layer_estimate,
-                output[i][1],
-                f"Calculation for largest layer size in `{precision_str}` is incorrect.",
-            )
+            assert precision_str == output[i][0], f"Output is missing precision `{precision_str}`"
+            assert (
+                largest_layer_estimate == output[i][1]
+            ), f"Calculation for largest layer size in `{precision_str}` is incorrect."
 
-            self.assertEqual(
-                total_size_estimate,
-                output[i][2],
-                msg=f"Calculation for total size in `{precision_str}` is incorrect.",
-            )
-            self.assertEqual(
-                total_training_size_estimate,
-                output[i][3],
-                msg=f"Calculation for total training size in `{precision_str}` is incorrect.",
-            )
+            assert (
+                total_size_estimate == output[i][2]
+            ), f"Calculation for total size in `{precision_str}` is incorrect."
+            assert (
+                total_training_size_estimate == output[i][3]
+            ), f"Calculation for total training size in `{precision_str}` is incorrect."
 
     @require_transformers
     def test_transformers_model(self):
@@ -337,16 +322,12 @@ class ModelEstimatorTester(unittest.TestCase):
         output = gather_data(args)
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 89075712, 433249280
-        self.assertEqual(
-            largest_layer,
-            output[0][1],
-            f"Calculation for largest layer size in `fp32` is incorrect, expected {largest_layer} but received {output[0][1]}",
-        )
-        self.assertEqual(
-            total_size,
-            output[0][2],
-            f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}",
-        )
+        assert (
+            largest_layer == output[0][1]
+        ), f"Calculation for largest layer size in `fp32` is incorrect, expected {largest_layer} but received {output[0][1]}"
+        assert (
+            total_size == output[0][2]
+        ), f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}"
 
     @require_transformers
     def test_no_split_modules(self):
@@ -354,11 +335,9 @@ class ModelEstimatorTester(unittest.TestCase):
         args = self.parser.parse_args(["HuggingFaceM4/idefics-80b-instruct", "--dtypes", "float32"])
         output = gather_data(args)
         # without factoring in `no_split` modules, the largest layer is 721420288 bytes
-        self.assertNotEqual(
-            output[0][1], 721420288, "Largest layer calculation incorrect, did not factor in `no_split` modules."
-        )
+        assert output[0][1] != 721420288, "Largest layer calculation incorrect, did not factor in `no_split` modules."
         # the real answer is 3240165632 bytes
-        self.assertEqual(output[0][1], 3240165632)
+        assert output[0][1] == 3240165632
 
     @require_timm
     def test_timm_model(self):
@@ -366,13 +345,9 @@ class ModelEstimatorTester(unittest.TestCase):
         output = gather_data(args)
         # The largest layer and total size of the model in bytes
         largest_layer, total_size = 9437184, 102441032
-        self.assertEqual(
-            largest_layer,
-            output[0][1],
-            f"Calculation for largest layer size in `fp32` is incorrect, expected {largest_layer} but received {output[0][1]}",
-        )
-        self.assertEqual(
-            total_size,
-            output[0][2],
-            f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}",
-        )
+        assert (
+            largest_layer == output[0][1]
+        ), f"Calculation for largest layer size in `fp32` is incorrect, expected {largest_layer} but received {output[0][1]}"
+        assert (
+            total_size == output[0][2]
+        ), f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}"

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -301,8 +301,8 @@ class DataLoaderTester(unittest.TestCase):
         batch_sampler = [[0, 1, 2], [3, 4], [5, 6, 7, 8], [9, 10, 11], [12, 13]]
         batch_sampler_shards = [BatchSamplerShard(batch_sampler, 2, i, even_batches=False) for i in range(2)]
 
-        self.assertEqual(len(batch_sampler_shards[0]), 3)
-        self.assertEqual(len(batch_sampler_shards[1]), 2)
+        assert len(batch_sampler_shards[0]) == 3
+        assert len(batch_sampler_shards[1]) == 2
 
         self.assertListEqual(list(batch_sampler_shards[0]), [[0, 1, 2], [5, 6, 7, 8], [12, 13]])
         self.assertListEqual(list(batch_sampler_shards[1]), [[3, 4], [9, 10, 11]])
@@ -334,8 +334,8 @@ class DataLoaderTester(unittest.TestCase):
         # All iterable dataset shard should have the same length, a round multiple of shard_batch_size
         first_list = iterable_dataset_lists[0]
         for l in iterable_dataset_lists[1:]:
-            self.assertEqual(len(l), len(first_list))
-            self.assertTrue(len(l) % shard_batch_size == 0)
+            assert len(l) == len(first_list)
+            assert (len(l) % shard_batch_size) == 0
 
         observed = []
         for idx in range(0, len(first_list), shard_batch_size):
@@ -381,18 +381,18 @@ class DataLoaderTester(unittest.TestCase):
     def test_end_of_dataloader(self):
         dataloader = DataLoaderShard(list(range(16)), batch_size=4)
         for idx, _ in enumerate(dataloader):
-            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+            assert dataloader.end_of_dataloader == (idx == 3)
 
         # Test it also works on the second iteration
         for idx, _ in enumerate(dataloader):
-            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+            assert dataloader.end_of_dataloader == (idx == 3)
 
     def test_end_of_dataloader_dispatcher(self):
         Accelerator()
         dataloader = DataLoaderDispatcher(range(16), batch_size=4)
         for idx, _ in enumerate(dataloader):
-            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+            assert dataloader.end_of_dataloader == (idx == 3)
 
         # Test it also works on the second iteration
         for idx, _ in enumerate(dataloader):
-            self.assertEqual(dataloader.end_of_dataloader, idx == 3)
+            assert dataloader.end_of_dataloader == (idx == 3)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -52,8 +52,8 @@ class DataLoaderTester(unittest.TestCase):
         ]
         batch_sampler_lists = [list(batch_sampler_shard) for batch_sampler_shard in batch_sampler_shards]
         if not split_batches:
-            self.assertListEqual([len(shard) for shard in batch_sampler_shards], [len(e) for e in expected])
-        self.assertListEqual(batch_sampler_lists, expected)
+            assert [len(shard) for shard in batch_sampler_shards] == [len(e) for e in expected]
+        assert batch_sampler_lists == expected
 
     def test_batch_sampler_shards_with_no_splits(self):
         # Check the shards when the dataset is a round multiple of total batch size.
@@ -304,8 +304,8 @@ class DataLoaderTester(unittest.TestCase):
         assert len(batch_sampler_shards[0]) == 3
         assert len(batch_sampler_shards[1]) == 2
 
-        self.assertListEqual(list(batch_sampler_shards[0]), [[0, 1, 2], [5, 6, 7, 8], [12, 13]])
-        self.assertListEqual(list(batch_sampler_shards[1]), [[3, 4], [9, 10, 11]])
+        assert list(batch_sampler_shards[0]) == [[0, 1, 2], [5, 6, 7, 8], [12, 13]]
+        assert list(batch_sampler_shards[1]) == [[3, 4], [9, 10, 11]]
 
     def check_iterable_dataset_shards(
         self, dataset, seed, batch_size, drop_last=False, num_processes=2, split_batches=False
@@ -345,7 +345,7 @@ class DataLoaderTester(unittest.TestCase):
         if not drop_last:
             while len(reference) < len(observed):
                 reference += reference
-        self.assertListEqual(observed, reference[: len(observed)])
+        assert observed == reference[: len(observed)]
 
     def test_iterable_dataset_shard(self):
         seed = 42
@@ -367,16 +367,16 @@ class DataLoaderTester(unittest.TestCase):
     def test_skip_batch_sampler(self):
         batch_sampler = BatchSampler(range(16), batch_size=4, drop_last=False)
         new_batch_sampler = SkipBatchSampler(batch_sampler, 2)
-        self.assertListEqual(list(new_batch_sampler), [[8, 9, 10, 11], [12, 13, 14, 15]])
+        assert list(new_batch_sampler) == [[8, 9, 10, 11], [12, 13, 14, 15]]
 
     def test_skip_data_loader(self):
         dataloader = SkipDataLoader(list(range(16)), batch_size=4, skip_batches=2)
-        self.assertListEqual([t.tolist() for t in dataloader], [[8, 9, 10, 11], [12, 13, 14, 15]])
+        assert [t.tolist() for t in dataloader] == [[8, 9, 10, 11], [12, 13, 14, 15]]
 
     def test_skip_first_batches(self):
         dataloader = DataLoader(list(range(16)), batch_size=4)
         new_dataloader = skip_first_batches(dataloader, num_batches=2)
-        self.assertListEqual([t.tolist() for t in new_dataloader], [[8, 9, 10, 11], [12, 13, 14, 15]])
+        assert [t.tolist() for t in new_dataloader] == [[8, 9, 10, 11], [12, 13, 14, 15]]
 
     def test_end_of_dataloader(self):
         dataloader = DataLoaderShard(list(range(16)), batch_size=4)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -109,7 +109,7 @@ class ExampleDifferenceTests(unittest.TestCase):
                         if special_strings is not None:
                             for string in special_strings:
                                 diff = diff.replace(string, "")
-                        self.assertEqual(diff, "")
+                        assert diff == ""
 
     def test_nlp_examples(self):
         self.one_complete_example("complete_nlp_example.py", True)
@@ -157,7 +157,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         run_command(self._launch_args + testargs)
-        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "epoch_0")))
+        assert os.path.exists(os.path.join(self.tmpdir, "epoch_0"))
 
     def test_checkpointing_by_steps(self):
         testargs = f"""
@@ -166,7 +166,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         _ = run_command(self._launch_args + testargs)
-        self.assertTrue(os.path.exists(os.path.join(self.tmpdir, "step_2")))
+        assert os.path.exists(os.path.join(self.tmpdir, "step_2"))
 
     def test_load_states_by_epoch(self):
         testargs = f"""
@@ -174,8 +174,8 @@ class FeatureExamplesTests(TempDirTestCase):
         --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_0")}
         """.split()
         output = run_command(self._launch_args + testargs, return_stdout=True)
-        self.assertNotIn("epoch 0:", output)
-        self.assertIn("epoch 1:", output)
+        assert "epoch 0:" not in output
+        assert "epoch 1:" in output
 
     def test_load_states_by_steps(self):
         testargs = f"""
@@ -188,11 +188,11 @@ class FeatureExamplesTests(TempDirTestCase):
         else:
             num_processes = 1
         if num_processes > 1:
-            self.assertNotIn("epoch 0:", output)
-            self.assertIn("epoch 1:", output)
+            assert "epoch 0:" not in output
+            assert "epoch 1:" in output
         else:
-            self.assertIn("epoch 0:", output)
-            self.assertIn("epoch 1:", output)
+            assert "epoch 0:" in output
+            assert "epoch 1:" in output
 
     @slow
     def test_cross_validation(self):
@@ -205,7 +205,7 @@ class FeatureExamplesTests(TempDirTestCase):
             results = re.findall("({.+})", output)
             results = [r for r in results if "accuracy" in r][-1]
             results = ast.literal_eval(results)
-            self.assertGreaterEqual(results["accuracy"], 0.75)
+            assert results["accuracy"] >= 0.75
 
     def test_multi_process_metrics(self):
         testargs = ["examples/by_feature/multi_process_metrics.py"]
@@ -221,7 +221,7 @@ class FeatureExamplesTests(TempDirTestCase):
             --project_dir {tmpdir}
             """.split()
             run_command(self._launch_args + testargs)
-            self.assertTrue(os.path.exists(os.path.join(tmpdir, "tracking")))
+            assert os.path.exists(os.path.join(tmpdir, "tracking"))
 
     def test_gradient_accumulation(self):
         testargs = ["examples/by_feature/gradient_accumulation.py"]

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -63,7 +63,7 @@ class HooksModelTester(unittest.TestCase):
 
         # Check adding the hook did not change the name or the signature
         assert test_model.forward.__name__ == "forward"
-        self.assertListEqual(list(inspect.signature(test_model.forward).parameters), ["x"])
+        assert list(inspect.signature(test_model.forward).parameters) == ["x"]
 
         remove_hook_from_module(test_model)
         assert not hasattr(test_model, "_hf_hook")
@@ -82,7 +82,7 @@ class HooksModelTester(unittest.TestCase):
 
         # Check adding the hook did not change the name or the signature
         assert test_model.forward.__name__ == "forward"
-        self.assertListEqual(list(inspect.signature(test_model.forward).parameters), ["x"])
+        assert list(inspect.signature(test_model.forward).parameters) == ["x"]
 
         remove_hook_from_module(test_model)
         assert not hasattr(test_model, "_hf_hook")

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -57,13 +57,13 @@ class KwargsHandlerTester(unittest.TestCase):
         scaler = accelerator.scaler
 
         # Check the kwargs have been applied
-        self.assertEqual(scaler._init_scale, 1024.0)
-        self.assertEqual(scaler._growth_factor, 2.0)
+        assert scaler._init_scale == 1024.0
+        assert scaler._growth_factor == 2.0
 
         # Check the other values are at the default
-        self.assertEqual(scaler._backoff_factor, 0.5)
-        self.assertEqual(scaler._growth_interval, 2000)
-        self.assertEqual(scaler._enabled, True)
+        assert scaler._backoff_factor == 0.5
+        assert scaler._growth_interval == 2000
+        assert scaler._enabled is True
 
     @require_multi_device
     def test_ddp_kwargs(self):
@@ -103,7 +103,7 @@ class KwargsHandlerTester(unittest.TestCase):
             os.environ[prefix + "MODE"] = "reduce-overhead"
 
             dynamo_plugin_kwargs = TorchDynamoPlugin().to_kwargs()
-            self.assertEqual(dynamo_plugin_kwargs, {"backend": "aot_ts_nvfuser", "mode": "reduce-overhead"})
+            assert dynamo_plugin_kwargs == {"backend": "aot_ts_nvfuser", "mode": "reduce-overhead"}
 
 
 if __name__ == "__main__":

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -41,10 +41,10 @@ class MockClass(KwargsHandler):
 class KwargsHandlerTester(unittest.TestCase):
     def test_kwargs_handler(self):
         # If no defaults are changed, `to_kwargs` returns an empty dict.
-        self.assertDictEqual(MockClass().to_kwargs(), {})
-        self.assertDictEqual(MockClass(a=2).to_kwargs(), {"a": 2})
-        self.assertDictEqual(MockClass(a=2, b=True).to_kwargs(), {"a": 2, "b": True})
-        self.assertDictEqual(MockClass(a=2, c=2.25).to_kwargs(), {"a": 2, "c": 2.25})
+        assert MockClass().to_kwargs() == {}
+        assert MockClass(a=2).to_kwargs() == {"a": 2}
+        assert MockClass(a=2, b=True).to_kwargs() == {"a": 2, "b": True}
+        assert MockClass(a=2, c=2.25).to_kwargs() == {"a": 2, "c": 2.25}
 
     @require_non_cpu
     @require_non_xpu

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -71,7 +71,7 @@ class MemoryTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             mock_training_loop_function()
-            self.assertIn("No executable batch size found, reached zero.", cm.exception.args[0])
+            assert "No executable batch size found, reached zero." in cm.exception.args[0]
 
     def test_approach_zero(self):
         @find_executable_batch_size(starting_batch_size=16)
@@ -82,7 +82,7 @@ class MemoryTest(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             mock_training_loop_function()
-            self.assertIn("No executable batch size found, reached zero.", cm.exception.args[0])
+            assert "No executable batch size found, reached zero." in cm.exception.args[0]
 
     def test_verbose_guard(self):
         @find_executable_batch_size(starting_batch_size=128)
@@ -92,8 +92,8 @@ class MemoryTest(unittest.TestCase):
 
         with self.assertRaises(TypeError) as cm:
             mock_training_loop_function(128, "hello", "world")
-            self.assertIn("Batch size was passed into `f`", cm.exception.args[0])
-            self.assertIn("`f(arg1='hello', arg2='world')", cm.exception.args[0])
+            assert "Batch size was passed into `f`" in cm.exception.args[0]
+            assert "`f(arg1='hello', arg2='world')" in cm.exception.args[0]
 
     def test_any_other_error(self):
         @find_executable_batch_size(starting_batch_size=16)
@@ -102,13 +102,13 @@ class MemoryTest(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             mock_training_loop_function()
-            self.assertIn("Oops, we had an error!", cm.exception.args[0])
+            assert "Oops, we had an error!" in cm.exception.args[0]
 
     @require_non_cpu
     def test_release_memory(self):
         starting_memory = memory_allocated_func()
         model = ModelForTest()
         model.to(torch_device)
-        self.assertGreater(memory_allocated_func(), starting_memory)
+        assert memory_allocated_func() > starting_memory
         model = release_memory(model)
-        self.assertEqual(memory_allocated_func(), starting_memory)
+        assert memory_allocated_func() == starting_memory

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -47,7 +47,7 @@ class MemoryTest(unittest.TestCase):
                 raise_fake_out_of_memory()
 
         mock_training_loop_function()
-        self.assertListEqual(batch_sizes, [128, 64, 32, 16, 8])
+        assert batch_sizes == [128, 64, 32, 16, 8]
 
     def test_memory_explicit(self):
         batch_sizes = []
@@ -61,8 +61,8 @@ class MemoryTest(unittest.TestCase):
             return batch_size, arg1
 
         bs, arg1 = mock_training_loop_function("hello")
-        self.assertListEqual(batch_sizes, [128, 64, 32, 16, 8])
-        self.assertListEqual([bs, arg1], [8, "hello"])
+        assert batch_sizes == [128, 64, 32, 16, 8]
+        assert [bs, arg1] == [8, "hello"]
 
     def test_start_zero(self):
         @find_executable_batch_size(starting_batch_size=0)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -84,11 +84,11 @@ def sequential_model(num_layers):
 
 class ModelingUtilsTester(unittest.TestCase):
     def check_set_module_tensor_for_device(self, model, device1, device2):
-        self.assertEqual(model.linear1.weight.device, torch.device(device1))
+        assert model.linear1.weight.device == torch.device(device1)
 
         with self.subTest("Access by submodule and direct name for a parameter"):
             set_module_tensor_to_device(model.linear1, "weight", device2)
-            self.assertEqual(model.linear1.weight.device, torch.device(device2))
+            assert model.linear1.weight.device == torch.device(device2)
 
             if torch.device(device2) == torch.device("meta"):
                 with self.assertRaises(ValueError):
@@ -98,11 +98,11 @@ class ModelingUtilsTester(unittest.TestCase):
                 set_module_tensor_to_device(model.linear1, "weight", device1, value=torch.randn(4, 3))
             else:
                 set_module_tensor_to_device(model.linear1, "weight", device1)
-            self.assertEqual(model.linear1.weight.device, torch.device(device1))
+            assert model.linear1.weight.device == torch.device(device1)
 
         with self.subTest("Access by module and full name for a parameter"):
             set_module_tensor_to_device(model, "linear1.weight", device2)
-            self.assertEqual(model.linear1.weight.device, torch.device(device2))
+            assert model.linear1.weight.device == torch.device(device2)
 
             if torch.device(device2) == torch.device("meta"):
                 with self.assertRaises(ValueError):
@@ -111,13 +111,13 @@ class ModelingUtilsTester(unittest.TestCase):
                 set_module_tensor_to_device(model, "linear1.weight", device1, value=torch.randn(4, 3))
             else:
                 set_module_tensor_to_device(model, "linear1.weight", device1)
-            self.assertEqual(model.linear1.weight.device, torch.device(device1))
+            assert model.linear1.weight.device == torch.device(device1)
 
-        self.assertEqual(model.batchnorm.running_mean.device, torch.device(device1))
+        assert model.batchnorm.running_mean.device == torch.device(device1)
 
         with self.subTest("Access by submodule and direct name for a buffer"):
             set_module_tensor_to_device(model.batchnorm, "running_mean", device2)
-            self.assertEqual(model.batchnorm.running_mean.device, torch.device(device2))
+            assert model.batchnorm.running_mean.device == torch.device(device2)
 
             if torch.device(device2) == torch.device("meta"):
                 with self.assertRaises(ValueError):
@@ -126,11 +126,11 @@ class ModelingUtilsTester(unittest.TestCase):
                 set_module_tensor_to_device(model.batchnorm, "running_mean", device1, value=torch.randn(4))
             else:
                 set_module_tensor_to_device(model.batchnorm, "running_mean", device1)
-            self.assertEqual(model.batchnorm.running_mean.device, torch.device(device1))
+            assert model.batchnorm.running_mean.device == torch.device(device1)
 
         with self.subTest("Access by module and full name for a parameter"):
             set_module_tensor_to_device(model, "batchnorm.running_mean", device2)
-            self.assertEqual(model.batchnorm.running_mean.device, torch.device(device2))
+            assert model.batchnorm.running_mean.device == torch.device(device2)
 
             if torch.device(device2) == torch.device("meta"):
                 with self.assertRaises(ValueError):
@@ -140,7 +140,7 @@ class ModelingUtilsTester(unittest.TestCase):
                 set_module_tensor_to_device(model, "batchnorm.running_mean", device1, value=torch.randn(4))
             else:
                 set_module_tensor_to_device(model, "batchnorm.running_mean", device1)
-            self.assertEqual(model.batchnorm.running_mean.device, torch.device(device1))
+            assert model.batchnorm.running_mean.device == torch.device(device1)
 
     def test_set_module_tensor_to_meta_and_cpu(self):
         model = ModelForTest()
@@ -164,16 +164,16 @@ class ModelingUtilsTester(unittest.TestCase):
     def test_set_module_tensor_sets_dtype(self):
         model = ModelForTest()
         set_module_tensor_to_device(model, "linear1.weight", "cpu", value=model.linear1.weight, dtype=torch.float16)
-        self.assertEqual(model.linear1.weight.dtype, torch.float16)
+        assert model.linear1.weight.dtype == torch.float16
 
     def test_set_module_tensor_checks_shape(self):
         model = ModelForTest()
         tensor = torch.zeros((2, 2))
         with self.assertRaises(ValueError) as cm:
             set_module_tensor_to_device(model, "linear1.weight", "cpu", value=tensor)
-        self.assertEqual(
-            str(cm.exception),
-            'Trying to set a tensor of shape torch.Size([2, 2]) in "weight" (which has shape torch.Size([4, 3])), this look incorrect.',
+        assert (
+            str(cm.exception)
+            == 'Trying to set a tensor of shape torch.Size([2, 2]) in "weight" (which has shape torch.Size([4, 3])), this look incorrect.'
         )
 
     def test_named_tensors(self):
@@ -247,27 +247,27 @@ class ModelingUtilsTester(unittest.TestCase):
     def test_retie_parameters(self):
         model = sequential_model(2)
         retie_parameters(model, [["linear1.weight", "linear2.weight"]])
-        self.assertIs(model.linear1.weight, model.linear2.weight)
+        assert model.linear1.weight is model.linear2.weight
 
         model = sequential_model(3)
         retie_parameters(model, [["linear1.weight", "linear2.weight", "linear3.weight"]])
 
-        self.assertIs(model.linear1.weight, model.linear2.weight)
-        self.assertIs(model.linear1.weight, model.linear3.weight)
+        assert model.linear1.weight is model.linear2.weight
+        assert model.linear1.weight is model.linear3.weight
 
         model = sequential_model(5)
         retie_parameters(
             model, [["linear1.weight", "linear4.weight"], ["linear2.weight", "linear3.weight", "linear5.weight"]]
         )
 
-        self.assertIs(model.linear1.weight, model.linear4.weight)
-        self.assertIs(model.linear2.weight, model.linear3.weight)
-        self.assertIs(model.linear2.weight, model.linear5.weight)
+        assert model.linear1.weight is model.linear4.weight
+        assert model.linear2.weight is model.linear3.weight
+        assert model.linear2.weight is model.linear5.weight
 
         model = nn.Sequential(OrderedDict([("block1", sequential_model(4)), ("block2", sequential_model(4))]))
         retie_parameters(model, [["block1.linear1.weight", "block2.linear1.weight"]])
 
-        self.assertIs(model.block1.linear1.weight, model.block2.linear1.weight)
+        assert model.block1.linear1.weight is model.block2.linear1.weight
 
     def test_compute_module_sizes(self):
         model = ModelForTest()
@@ -350,9 +350,9 @@ class ModelingUtilsTester(unittest.TestCase):
             fname = os.path.join(tmp_dir, "pt_model.bin")
             torch.save(model.state_dict(), fname)
             load_checkpoint_in_model(model, fname, device_map=device_map)
-        self.assertEqual(model.linear1.weight.device, torch.device(0))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device("cpu"))
+        assert model.linear1.weight.device == torch.device(0)
+        assert model.batchnorm.weight.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device("cpu")
 
         # Check with sharded index
         model = ModelForTest()
@@ -361,9 +361,9 @@ class ModelingUtilsTester(unittest.TestCase):
             index_file = os.path.join(tmp_dir, "weight_map.index.json")
             load_checkpoint_in_model(model, index_file, device_map=device_map)
 
-        self.assertEqual(model.linear1.weight.device, torch.device(0))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device("cpu"))
+        assert model.linear1.weight.device == torch.device(0)
+        assert model.batchnorm.weight.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device("cpu")
 
         # Check with sharded checkpoint folder
         model = ModelForTest()
@@ -371,9 +371,9 @@ class ModelingUtilsTester(unittest.TestCase):
             self.shard_test_model(model, tmp_dir)
             load_checkpoint_in_model(model, tmp_dir, device_map=device_map)
 
-        self.assertEqual(model.linear1.weight.device, torch.device(0))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device("cpu"))
+        assert model.linear1.weight.device == torch.device(0)
+        assert model.batchnorm.weight.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device("cpu")
 
     @require_cuda
     def test_load_checkpoint_in_model_disk_offload(self):
@@ -384,21 +384,21 @@ class ModelingUtilsTester(unittest.TestCase):
             fname = os.path.join(tmp_dir, "pt_model.bin")
             torch.save(model.state_dict(), fname)
             load_checkpoint_in_model(model, fname, device_map=device_map, offload_folder=tmp_dir)
-        self.assertEqual(model.linear1.weight.device, torch.device("cpu"))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("meta"))
+        assert model.linear1.weight.device == torch.device("cpu")
+        assert model.batchnorm.weight.device == torch.device("meta")
         # Buffers are not offloaded by default
-        self.assertEqual(model.batchnorm.running_mean.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device("cpu"))
+        assert model.batchnorm.running_mean.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device("cpu")
 
         model = ModelForTest()
         with tempfile.TemporaryDirectory() as tmp_dir:
             fname = os.path.join(tmp_dir, "pt_model.bin")
             torch.save(model.state_dict(), fname)
             load_checkpoint_in_model(model, fname, device_map=device_map, offload_folder=tmp_dir, offload_buffers=True)
-        self.assertEqual(model.linear1.weight.device, torch.device("cpu"))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("meta"))
-        self.assertEqual(model.batchnorm.running_mean.device, torch.device("meta"))
-        self.assertEqual(model.linear2.weight.device, torch.device("cpu"))
+        assert model.linear1.weight.device == torch.device("cpu")
+        assert model.batchnorm.weight.device == torch.device("meta")
+        assert model.batchnorm.running_mean.device == torch.device("meta")
+        assert model.linear2.weight.device == torch.device("cpu")
 
     @require_multi_gpu
     def test_load_checkpoint_in_model_two_gpu(self):
@@ -410,9 +410,9 @@ class ModelingUtilsTester(unittest.TestCase):
             fname = os.path.join(tmp_dir, "pt_model.bin")
             torch.save(model.state_dict(), fname)
             load_checkpoint_in_model(model, fname, device_map=device_map)
-        self.assertEqual(model.linear1.weight.device, torch.device(0))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device(1))
+        assert model.linear1.weight.device == torch.device(0)
+        assert model.batchnorm.weight.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device(1)
 
         # Check with sharded index
         model = ModelForTest()
@@ -421,9 +421,9 @@ class ModelingUtilsTester(unittest.TestCase):
             index_file = os.path.join(tmp_dir, "weight_map.index.json")
             load_checkpoint_in_model(model, index_file, device_map=device_map)
 
-        self.assertEqual(model.linear1.weight.device, torch.device(0))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device(1))
+        assert model.linear1.weight.device == torch.device(0)
+        assert model.batchnorm.weight.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device(1)
 
         # Check with sharded checkpoint
         model = ModelForTest()
@@ -431,9 +431,9 @@ class ModelingUtilsTester(unittest.TestCase):
             self.shard_test_model(model, tmp_dir)
             load_checkpoint_in_model(model, tmp_dir, device_map=device_map)
 
-        self.assertEqual(model.linear1.weight.device, torch.device(0))
-        self.assertEqual(model.batchnorm.weight.device, torch.device("cpu"))
-        self.assertEqual(model.linear2.weight.device, torch.device(1))
+        assert model.linear1.weight.device == torch.device(0)
+        assert model.batchnorm.weight.device == torch.device("cpu")
+        assert model.linear2.weight.device == torch.device(1)
 
     def test_load_checkpoint_in_model_dtype(self):
         with tempfile.NamedTemporaryFile(suffix=".pt") as tmpfile:
@@ -445,8 +445,8 @@ class ModelingUtilsTester(unittest.TestCase):
                 new_model, tmpfile.name, offload_state_dict=True, dtype=torch.float16, device_map={"": "cpu"}
             )
 
-            self.assertEqual(new_model.int_param.dtype, torch.int64)
-            self.assertEqual(new_model.float_param.dtype, torch.float16)
+            assert new_model.int_param.dtype == torch.int64
+            assert new_model.float_param.dtype == torch.float16
 
     def test_clean_device_map(self):
         # Regroup everything if all is on the same device
@@ -595,9 +595,9 @@ class ModelingUtilsTester(unittest.TestCase):
         )
 
         # The 3 tied weights should all be on device 0
-        self.assertEqual(device_map["shared"], 0)
-        self.assertEqual(device_map["encoder.embed_tokens"], 0)
-        self.assertEqual(device_map["decoder.embed_tokens"], 0)
+        assert device_map["shared"] == 0
+        assert device_map["encoder.embed_tokens"] == 0
+        assert device_map["decoder.embed_tokens"] == 0
 
     @require_cuda
     def test_get_balanced_memory(self):
@@ -643,26 +643,26 @@ class ModelingUtilsTester(unittest.TestCase):
 
             for param, device in device_map.items():
                 device = device if device != "disk" else "cpu"
-                self.assertEqual(loaded_state_dict[param].device, torch.device(device))
+                assert loaded_state_dict[param].device == torch.device(device)
 
     def test_convert_file_size(self):
         result = convert_file_size_to_int("100MB")
-        self.assertEqual(result, 100 * (10**6))
+        assert result == (100 * (10**6))
 
         result = convert_file_size_to_int("2GiB")
-        self.assertEqual(result, 2 * (2**30))
+        assert result == (2 * (2**30))
 
         result = convert_file_size_to_int("512KiB")
-        self.assertEqual(result, 512 * (2**10))
+        assert result == (512 * (2**10))
 
         result = convert_file_size_to_int("1.5GB")
-        self.assertEqual(result, 1.5 * (10**9))
+        assert result == (1.5 * (10**9))
 
         result = convert_file_size_to_int("100KB")
-        self.assertEqual(result, 100 * (10**3))
+        assert result == (100 * (10**3))
 
         result = convert_file_size_to_int(500)
-        self.assertEqual(result, 500)
+        assert result == 500
 
         with self.assertRaises(ValueError):
             convert_file_size_to_int("5MBB")

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -62,7 +62,7 @@ class OffloadTester(unittest.TestCase):
                 index = offload_weight(weight, "weight", tmp_dir, {})
                 weight_file = os.path.join(tmp_dir, "weight.dat")
                 assert os.path.isfile(weight_file)
-                self.assertDictEqual(index, {"weight": {"shape": [2, 3], "dtype": str(dtype).split(".")[1]}})
+                assert index == {"weight": {"shape": [2, 3], "dtype": str(dtype).split(".")[1]}}
 
                 new_weight = load_offloaded_weight(weight_file, index["weight"])
                 assert torch.equal(weight, new_weight)
@@ -107,8 +107,8 @@ class OffloadTester(unittest.TestCase):
     def test_extract_submodules_state_dict(self):
         state_dict = {"a.1": 0, "a.10": 1, "a.2": 2}
         extracted = extract_submodules_state_dict(state_dict, ["a.1", "a.2"])
-        self.assertDictEqual(extracted, {"a.1": 0, "a.2": 2})
+        assert extracted == {"a.1": 0, "a.2": 2}
 
         state_dict = {"a.1.a": 0, "a.10.a": 1, "a.2.a": 2}
         extracted = extract_submodules_state_dict(state_dict, ["a.1", "a.2"])
-        self.assertDictEqual(extracted, {"a.1.a": 0, "a.2.a": 2})
+        assert extracted == {"a.1.a": 0, "a.2.a": 2}

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -45,12 +45,12 @@ class OffloadTester(unittest.TestCase):
         with TemporaryDirectory() as tmp_dir:
             offload_state_dict(tmp_dir, model.state_dict())
             index_file = os.path.join(tmp_dir, "index.json")
-            self.assertTrue(os.path.isfile(index_file))
+            assert os.path.isfile(index_file)
             # TODO: add tests on what is inside the index
 
             for key in ["linear1.weight", "linear1.bias", "linear2.weight", "linear2.bias"]:
                 weight_file = os.path.join(tmp_dir, f"{key}.dat")
-                self.assertTrue(os.path.isfile(weight_file))
+                assert os.path.isfile(weight_file)
                 # TODO: add tests on the fact weights are properly loaded
 
     def test_offload_weight(self):
@@ -61,11 +61,11 @@ class OffloadTester(unittest.TestCase):
             with TemporaryDirectory() as tmp_dir:
                 index = offload_weight(weight, "weight", tmp_dir, {})
                 weight_file = os.path.join(tmp_dir, "weight.dat")
-                self.assertTrue(os.path.isfile(weight_file))
+                assert os.path.isfile(weight_file)
                 self.assertDictEqual(index, {"weight": {"shape": [2, 3], "dtype": str(dtype).split(".")[1]}})
 
                 new_weight = load_offloaded_weight(weight_file, index["weight"])
-                self.assertTrue(torch.equal(weight, new_weight))
+                assert torch.equal(weight, new_weight)
 
     def test_offload_weights_loader(self):
         model = ModelForTest()
@@ -78,9 +78,9 @@ class OffloadTester(unittest.TestCase):
             weight_map = OffloadedWeightsLoader(state_dict=cpu_part, save_folder=tmp_dir)
 
             # Every key is there with the right value
-            self.assertEqual(sorted(weight_map), sorted(state_dict.keys()))
+            assert sorted(weight_map) == sorted(state_dict.keys())
             for key, param in state_dict.items():
-                self.assertTrue(torch.allclose(param, weight_map[key]))
+                assert torch.allclose(param, weight_map[key])
 
         cpu_part = {k: v for k, v in state_dict.items() if "weight" in k}
         disk_part = {k: v for k, v in state_dict.items() if "weight" not in k}
@@ -90,9 +90,9 @@ class OffloadTester(unittest.TestCase):
             weight_map = OffloadedWeightsLoader(state_dict=cpu_part, save_folder=tmp_dir)
 
             # Every key is there with the right value
-            self.assertEqual(sorted(weight_map), sorted(state_dict.keys()))
+            assert sorted(weight_map) == sorted(state_dict.keys())
             for key, param in state_dict.items():
-                self.assertTrue(torch.allclose(param, weight_map[key]))
+                assert torch.allclose(param, weight_map[key])
 
         with TemporaryDirectory() as tmp_dir:
             offload_state_dict(tmp_dir, state_dict)
@@ -100,9 +100,9 @@ class OffloadTester(unittest.TestCase):
             weight_map = OffloadedWeightsLoader(state_dict=cpu_part, save_folder=tmp_dir)
 
             # Every key is there with the right value
-            self.assertEqual(sorted(weight_map), sorted(state_dict.keys()))
+            assert sorted(weight_map) == sorted(state_dict.keys())
             for key, param in state_dict.items():
-                self.assertTrue(torch.allclose(param, weight_map[key]))
+                assert torch.allclose(param, weight_map[key])
 
     def test_extract_submodules_state_dict(self):
         state_dict = {"a.1": 0, "a.10": 1, "a.2": 2}

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -52,7 +52,7 @@ class OptimizerTester(unittest.TestCase):
             p.grad.fill_(0.01)
 
         optimizer.step()
-        self.assertTrue(optimizer.step_was_skipped is False)
+        assert optimizer.step_was_skipped is False
 
         loss = model(torch.randn(2, 5, device=accelerator.device)).sum()
         accelerator.backward(loss)
@@ -62,7 +62,7 @@ class OptimizerTester(unittest.TestCase):
         p.grad[0] = torch.tensor(float("nan"))
 
         optimizer.step()
-        self.assertTrue(optimizer.step_was_skipped is True)
+        assert optimizer.step_was_skipped is True
 
         loss = model(torch.randn(2, 5, device=accelerator.device)).sum()
         accelerator.backward(loss)
@@ -72,7 +72,7 @@ class OptimizerTester(unittest.TestCase):
         p.grad[0] = torch.tensor(float("nan"))
 
         optimizer.step()
-        self.assertTrue(optimizer.step_was_skipped is True)
+        assert optimizer.step_was_skipped is True
 
         loss = model(torch.randn(2, 5, device=accelerator.device)).sum()
         accelerator.backward(loss)
@@ -81,6 +81,6 @@ class OptimizerTester(unittest.TestCase):
             p.grad.fill_(0.01)
 
         optimizer.step()
-        self.assertTrue(optimizer.step_was_skipped is False)
+        assert optimizer.step_was_skipped is False
 
         AcceleratorState._reset_state()

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -102,8 +102,8 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
         mem_fp16 = self.model_fp16.get_memory_footprint()
         mem_8bit = self.model_8bit.get_memory_footprint()
 
-        self.assertAlmostEqual(mem_fp16 / mem_8bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+        assert round((mem_fp16 / mem_8bit) - self.EXPECTED_RELATIVE_DIFFERENCE, 7) >= 0
+        assert self.model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params
 
     def test_linear_are_8bit(self):
         r"""
@@ -120,7 +120,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
                     self.bnb_quantization_config.keep_in_fp32_modules + self.bnb_quantization_config.skip_modules
                 )
                 if name not in modules_not_converted:
-                    self.assertTrue(module.weight.dtype == torch.int8)
+                    assert module.weight.dtype == torch.int8
 
     def test_llm_skip(self):
         r"""
@@ -145,10 +145,10 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             no_split_module_classes=["BloomBlock"],
         )
 
-        self.assertTrue(model.transformer.h[1].mlp.dense_4h_to_h.weight.dtype == torch.int8)
-        self.assertTrue(isinstance(model.transformer.h[1].mlp.dense_4h_to_h, bnb.nn.Linear8bitLt))
-        self.assertTrue(isinstance(model.lm_head, nn.Linear))
-        self.assertTrue(model.lm_head.weight.dtype != torch.int8)
+        assert model.transformer.h[1].mlp.dense_4h_to_h.weight.dtype == torch.int8
+        assert isinstance(model.transformer.h[1].mlp.dense_4h_to_h, bnb.nn.Linear8bitLt)
+        assert isinstance(model.lm_head, nn.Linear)
+        assert model.lm_head.weight.dtype != torch.int8
 
     def check_inference_correctness(self, model):
         r"""
@@ -164,7 +164,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
 
         # Get the generation
         output_text = self.tokenizer.decode(output_parallel[0], skip_special_tokens=True)
-        self.assertEqual(output_text, self.EXPECTED_OUTPUT)
+        assert output_text == self.EXPECTED_OUTPUT
 
     def test_generate_quality(self):
         self.check_inference_correctness(self.model_8bit)
@@ -188,7 +188,7 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             device_map="auto",
             no_split_module_classes=["BloomBlock"],
         )
-        self.assertTrue(model.lm_head.weight.dtype == torch.float32)
+        assert model.lm_head.weight.dtype == torch.float32
 
     @require_multi_gpu
     def test_cpu_gpu_loading_custom_device_map(self):
@@ -241,8 +241,8 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             device_map=device_map,
             no_split_module_classes=["BloomBlock"],
         )
-        self.assertTrue(model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-        self.assertTrue(model_8bit.transformer.h[1].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+        assert model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params
+        assert model_8bit.transformer.h[1].mlp.dense_4h_to_h.weight.__class__ == Int8Params
         self.check_inference_correctness(model_8bit)
 
     @require_multi_gpu
@@ -298,8 +298,8 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
             no_split_module_classes=["BloomBlock"],
             offload_state_dict=True,
         )
-        self.assertTrue(model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-        self.assertTrue(model_8bit.transformer.h[1].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+        assert model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params
+        assert model_8bit.transformer.h[1].mlp.dense_4h_to_h.weight.__class__ == Int8Params
         self.check_inference_correctness(model_8bit)
 
     @require_multi_gpu
@@ -357,8 +357,8 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
                 offload_folder=tmpdirname,
                 offload_state_dict=True,
             )
-            self.assertTrue(model_8bit.transformer.h[4].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-            self.assertTrue(model_8bit.transformer.h[5].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+            assert model_8bit.transformer.h[4].mlp.dense_4h_to_h.weight.__class__ == Int8Params
+            assert model_8bit.transformer.h[5].mlp.dense_4h_to_h.weight.__class__ == Int8Params
             self.check_inference_correctness(model_8bit)
 
     def test_int8_serialization(self):
@@ -387,9 +387,9 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
                 no_split_module_classes=["BloomBlock"],
             )
 
-            self.assertTrue(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-            self.assertTrue(hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB"))
-            self.assertTrue(hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "CB"))
+            assert model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params
+            assert hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB")
+            assert hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "CB")
 
             self.check_inference_correctness(model_8bit_from_saved)
 
@@ -451,8 +451,8 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
                 offload_state_dict=True,
             )
 
-            self.assertTrue(model_8bit_from_saved.transformer.h[4].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-            self.assertTrue(model_8bit_from_saved.transformer.h[5].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+            assert model_8bit_from_saved.transformer.h[4].mlp.dense_4h_to_h.weight.__class__ == Int8Params
+            assert model_8bit_from_saved.transformer.h[5].mlp.dense_4h_to_h.weight.__class__ == Int8Params
             self.check_inference_correctness(model_8bit_from_saved)
 
     def test_int8_serialization_shard(self):
@@ -482,9 +482,9 @@ class MixedInt8EmptyModelTest(unittest.TestCase):
                 no_split_module_classes=["BloomBlock"],
             )
 
-            self.assertTrue(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
-            self.assertTrue(hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB"))
-            self.assertTrue(hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "CB"))
+            assert model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params
+            assert hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "SCB")
+            assert hasattr(model_8bit_from_saved.transformer.h[0].mlp.dense_4h_to_h.weight, "CB")
 
             self.check_inference_correctness(model_8bit_from_saved)
 
@@ -547,8 +547,8 @@ class MixedInt8LoaddedModelTest(unittest.TestCase):
         mem_fp16 = self.model_fp16.get_memory_footprint()
         mem_8bit = self.model_8bit.get_memory_footprint()
 
-        self.assertAlmostEqual(mem_fp16 / mem_8bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params)
+        assert round((mem_fp16 / mem_8bit) - self.EXPECTED_RELATIVE_DIFFERENCE, 7) >= 0
+        assert self.model_8bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Int8Params
 
     def test_linear_are_8bit(self):
         r"""
@@ -565,7 +565,7 @@ class MixedInt8LoaddedModelTest(unittest.TestCase):
                     self.bnb_quantization_config.keep_in_fp32_modules + self.bnb_quantization_config.skip_modules
                 )
                 if name not in modules_not_converted:
-                    self.assertTrue(module.weight.dtype == torch.int8)
+                    assert module.weight.dtype == torch.int8
 
     def test_generate_quality(self):
         r"""
@@ -579,7 +579,7 @@ class MixedInt8LoaddedModelTest(unittest.TestCase):
             input_ids=encoded_input["input_ids"].to(self.model_8bit.device), max_new_tokens=10
         )
 
-        self.assertEqual(self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
+        assert self.tokenizer.decode(output_sequences[0], skip_special_tokens=True) == self.EXPECTED_OUTPUT
 
     def test_fp32_8bit_conversion(self):
         r"""
@@ -591,7 +591,7 @@ class MixedInt8LoaddedModelTest(unittest.TestCase):
 
         model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype=torch.float16)
         model = load_and_quantize_model(model, bnb_quantization_config)
-        self.assertTrue(model.lm_head.weight.dtype == torch.float32)
+        assert model.lm_head.weight.dtype == torch.float32
 
 
 @slow
@@ -666,8 +666,8 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
         mem_fp16 = self.model_fp16.get_memory_footprint()
         mem_4bit = self.model_4bit.get_memory_footprint()
 
-        self.assertAlmostEqual(mem_fp16 / mem_4bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_4bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Params4bit)
+        assert round((mem_fp16 / mem_4bit) - self.EXPECTED_RELATIVE_DIFFERENCE, 7) >= 0
+        assert self.model_4bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Params4bit
 
     def check_inference_correctness(self, model):
         r"""
@@ -681,7 +681,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
         # Check the exactness of the results
         output_sequences = model.generate(input_ids=encoded_input["input_ids"].to(0), max_new_tokens=10)
 
-        self.assertIn(self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUTS)
+        assert self.tokenizer.decode(output_sequences[0], skip_special_tokens=True) in self.EXPECTED_OUTPUTS
 
     def test_generate_quality(self):
         self.check_inference_correctness(self.model_4bit)
@@ -703,7 +703,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
                     + self.bnb_quantization_config.skip_modules
                 ):
                     # 4-bit parameters are packed in uint8 variables
-                    self.assertTrue(module.weight.dtype == torch.uint8)
+                    assert module.weight.dtype == torch.uint8
 
     def test_fp32_4bit_conversion(self):
         r"""
@@ -724,7 +724,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
             device_map="auto",
             no_split_module_classes=["BloomBlock"],
         )
-        self.assertTrue(model.lm_head.weight.dtype == torch.float32)
+        assert model.lm_head.weight.dtype == torch.float32
 
     @require_multi_gpu
     def test_cpu_gpu_loading_random_device_map(self):
@@ -906,8 +906,8 @@ class Bnb4BitTestLoadedModel(unittest.TestCase):
         mem_fp16 = self.model_fp16.get_memory_footprint()
         mem_4bit = self.model_4bit.get_memory_footprint()
 
-        self.assertAlmostEqual(mem_fp16 / mem_4bit, self.EXPECTED_RELATIVE_DIFFERENCE)
-        self.assertTrue(self.model_4bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Params4bit)
+        assert round((mem_fp16 / mem_4bit) - self.EXPECTED_RELATIVE_DIFFERENCE, 7) >= 0
+        assert self.model_4bit.transformer.h[0].mlp.dense_4h_to_h.weight.__class__ == Params4bit
 
     def test_linear_are_4bit(self):
         r"""
@@ -926,7 +926,7 @@ class Bnb4BitTestLoadedModel(unittest.TestCase):
                     + self.bnb_quantization_config.skip_modules
                 ):
                     # 4-bit parameters are packed in uint8 variables
-                    self.assertTrue(module.weight.dtype == torch.uint8)
+                    assert module.weight.dtype == torch.uint8
 
     def test_generate_quality(self):
         r"""
@@ -940,7 +940,7 @@ class Bnb4BitTestLoadedModel(unittest.TestCase):
             input_ids=encoded_input["input_ids"].to(self.model_4bit.device), max_new_tokens=10
         )
 
-        self.assertIn(self.tokenizer.decode(output_sequences[0], skip_special_tokens=True), self.EXPECTED_OUTPUTS)
+        assert self.tokenizer.decode(output_sequences[0], skip_special_tokens=True) in self.EXPECTED_OUTPUTS
 
     def test_fp32_4bit_conversion(self):
         r"""
@@ -952,4 +952,4 @@ class Bnb4BitTestLoadedModel(unittest.TestCase):
 
         model = AutoModelForCausalLM.from_pretrained(self.model_name, torch_dtype=torch.float16)
         model = load_and_quantize_model(model, bnb_quantization_config)
-        self.assertTrue(model.lm_head.weight.dtype == torch.float32)
+        assert model.lm_head.weight.dtype == torch.float32

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -107,7 +107,7 @@ class CheckpointTest(unittest.TestCase):
 
             # Save second state
             accelerator.save_state(safe_serialization=self.use_safetensors)
-            self.assertEqual(len(os.listdir(accelerator.project_dir)), 1)
+            assert len(os.listdir(accelerator.project_dir)) == 1
 
     def test_can_resume_training_with_folder(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -141,9 +141,9 @@ class CheckpointTest(unittest.TestCase):
             accelerator.load_state(initial)
             (a2, b2) = model.a.item(), model.b.item()
             opt_state2 = optimizer.state_dict()
-            self.assertEqual(a, a2)
-            self.assertEqual(b, b2)
-            self.assertEqual(opt_state, opt_state2)
+            assert a == a2
+            assert b == b2
+            assert opt_state == opt_state2
 
             test_rands = train(2, model, train_dataloader, optimizer, accelerator)
             # Save everything
@@ -155,10 +155,10 @@ class CheckpointTest(unittest.TestCase):
             test_rands += train(1, model, train_dataloader, optimizer, accelerator)
             (a3, b3) = model.a.item(), model.b.item()
             opt_state3 = optimizer.state_dict()
-            self.assertEqual(a1, a3)
-            self.assertEqual(b1, b3)
-            self.assertEqual(opt_state1, opt_state3)
-            self.assertEqual(ground_truth_rands, test_rands)
+            assert a1 == a3
+            assert b1 == b3
+            assert opt_state1 == opt_state3
+            assert ground_truth_rands == test_rands
 
     def test_can_resume_training(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -194,9 +194,9 @@ class CheckpointTest(unittest.TestCase):
             accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"))
             (a2, b2) = model.a.item(), model.b.item()
             opt_state2 = optimizer.state_dict()
-            self.assertEqual(a, a2)
-            self.assertEqual(b, b2)
-            self.assertEqual(opt_state, opt_state2)
+            assert a == a2
+            assert b == b2
+            assert opt_state == opt_state2
 
             test_rands = train(2, model, train_dataloader, optimizer, accelerator)
             # Save everything
@@ -207,10 +207,10 @@ class CheckpointTest(unittest.TestCase):
             test_rands += train(1, model, train_dataloader, optimizer, accelerator)
             (a3, b3) = model.a.item(), model.b.item()
             opt_state3 = optimizer.state_dict()
-            self.assertEqual(a1, a3)
-            self.assertEqual(b1, b3)
-            self.assertEqual(opt_state1, opt_state3)
-            self.assertEqual(ground_truth_rands, test_rands)
+            assert a1 == a3
+            assert b1 == b3
+            assert opt_state1 == opt_state3
+            assert ground_truth_rands == test_rands
 
     def test_can_resume_training_checkpoints_relative_path(self):
         # See #1983
@@ -259,9 +259,9 @@ class CheckpointTest(unittest.TestCase):
             accelerator.load_state()  # <= infer the directory automatically
             (a2, b2) = model.a.item(), model.b.item()
             opt_state2 = optimizer.state_dict()
-            self.assertEqual(a, a2)
-            self.assertEqual(b, b2)
-            self.assertEqual(opt_state, opt_state2)
+            assert a == a2
+            assert b == b2
+            assert opt_state == opt_state2
 
             test_rands = train(2, model, train_dataloader, optimizer, accelerator)
             # Save everything
@@ -272,10 +272,10 @@ class CheckpointTest(unittest.TestCase):
             test_rands += train(1, model, train_dataloader, optimizer, accelerator)
             (a3, b3) = model.a.item(), model.b.item()
             opt_state3 = optimizer.state_dict()
-            self.assertEqual(a1, a3)
-            self.assertEqual(b1, b3)
-            self.assertEqual(opt_state1, opt_state3)
-            self.assertEqual(ground_truth_rands, test_rands)
+            assert a1 == a3
+            assert b1 == b3
+            assert opt_state1 == opt_state3
+            assert ground_truth_rands == test_rands
 
     def test_invalid_registration(self):
         t = torch.tensor([1, 2, 3])
@@ -286,10 +286,10 @@ class CheckpointTest(unittest.TestCase):
         with self.assertRaises(ValueError) as ve:
             accelerator.register_for_checkpointing(t, t1, net, opt)
         message = str(ve.exception)
-        self.assertTrue("Item at index 0" in message)
-        self.assertTrue("Item at index 1" in message)
-        self.assertFalse("Item at index 2" in message)
-        self.assertFalse("Item at index 3" in message)
+        assert "Item at index 0" in message
+        assert "Item at index 1" in message
+        assert "Item at index 2" not in message
+        assert "Item at index 3" not in message
 
     def test_with_scheduler(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -308,11 +308,11 @@ class CheckpointTest(unittest.TestCase):
             accelerator.save_state(safe_serialization=self.use_safetensors)
             scheduler_state = scheduler.state_dict()
             train(3, model, train_dataloader, optimizer, accelerator, scheduler)
-            self.assertNotEqual(scheduler_state, scheduler.state_dict())
+            assert scheduler_state != scheduler.state_dict()
 
             # Load everything back in and make sure all states work
             accelerator.load_state(os.path.join(tmpdir, "checkpoints", "checkpoint_0"))
-            self.assertEqual(scheduler_state, scheduler.state_dict())
+            assert scheduler_state == scheduler.state_dict()
 
     def test_automatic_loading(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -338,10 +338,10 @@ class CheckpointTest(unittest.TestCase):
 
             # Load back in the last saved checkpoint, should point to a2, b2
             accelerator.load_state()
-            self.assertNotEqual(a3, model.a.item())
-            self.assertNotEqual(b3, model.b.item())
-            self.assertEqual(a2, model.a.item())
-            self.assertEqual(b2, model.b.item())
+            assert a3 != model.a.item()
+            assert b3 != model.b.item()
+            assert a2 == model.a.item()
+            assert b2 == model.b.item()
 
     def test_checkpoint_deletion(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -354,9 +354,9 @@ class CheckpointTest(unittest.TestCase):
             # Save 3 states:
             for _ in range(11):
                 accelerator.save_state(safe_serialization=self.use_safetensors)
-            self.assertTrue(not os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_0")))
-            self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_9")))
-            self.assertTrue(os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_10")))
+            assert not os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_0"))
+            assert os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_9"))
+            assert os.path.exists(os.path.join(tmpdir, "checkpoints", "checkpoint_10"))
 
     @require_non_cpu
     def test_map_location(self):

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -77,7 +77,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
             accelerator.end_training()
             for child in Path(f"{dirpath}/{project_name}").glob("*/**"):
                 log = list(filter(lambda x: x.is_file(), child.iterdir()))[0]
-            self.assertNotEqual(str(log), "")
+            assert str(log) != ""
 
     def test_log(self):
         project_name = "test_project_with_log"
@@ -90,7 +90,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
             # Logged values are stored in the outermost-tfevents file and can be read in as a TFRecord
             # Names are randomly generated each time
             log = list(filter(lambda x: x.is_file(), Path(f"{dirpath}/{project_name}").iterdir()))[0]
-            self.assertNotEqual(str(log), "")
+            assert str(log) != ""
 
     def test_log_with_tensor(self):
         project_name = "test_project_with_log"
@@ -119,7 +119,7 @@ class TensorBoardTrackingTest(unittest.TestCase):
                     for value in event.summary.value:
                         if value.simple_value == 1.0 and value.tag == "tensor":
                             found_tensor = True
-            self.assertTrue(found_tensor, "Converted tensor was not found in the log file!")
+            assert found_tensor, "Converted tensor was not found in the log file!"
 
     def test_project_dir(self):
         with self.assertRaisesRegex(ValueError, "Logging with `tensorboard` requires a `logging_dir`"):
@@ -182,22 +182,22 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
 
         # Check HPS through careful parsing and cleaning
         logged_items = self.parse_log(content, "config")
-        self.assertEqual(logged_items["num_iterations"], "12")
-        self.assertEqual(logged_items["learning_rate"], "0.01")
-        self.assertEqual(logged_items["some_boolean"], "false")
-        self.assertEqual(logged_items["some_string"], "some_value")
-        self.assertEqual(logged_items["some_string"], "some_value")
+        assert logged_items["num_iterations"] == "12"
+        assert logged_items["learning_rate"] == "0.01"
+        assert logged_items["some_boolean"] == "false"
+        assert logged_items["some_string"] == "some_value"
+        assert logged_items["some_string"] == "some_value"
 
         # Run tags
         logged_items = self.parse_log(content, "run", False)
-        self.assertEqual(logged_items["tags"], "my_tag")
+        assert logged_items["tags"] == "my_tag"
 
         # Actual logging
         logged_items = self.parse_log(content, "history")
-        self.assertEqual(logged_items["total_loss"], "0.1")
-        self.assertEqual(logged_items["iteration"], "1")
-        self.assertEqual(logged_items["my_text"], "some_value")
-        self.assertEqual(logged_items["_step"], "0")
+        assert logged_items["total_loss"] == "0.1"
+        assert logged_items["iteration"] == "1"
+        assert logged_items["my_text"] == "some_value"
+        assert logged_items["_step"] == "0"
 
 
 # Comet has a special `OfflineExperiment` we need to use for testing
@@ -239,10 +239,10 @@ class CometMLTest(unittest.TestCase):
             archive = zipfile.ZipFile(p, "r")
             log = archive.open("messages.json").read().decode("utf-8")
         list_of_json = log.split("\n")[:-1]
-        self.assertEqual(self.get_value_from_key(list_of_json, "num_iterations", True), 12)
-        self.assertEqual(self.get_value_from_key(list_of_json, "learning_rate", True), 0.01)
-        self.assertEqual(self.get_value_from_key(list_of_json, "some_boolean", True), False)
-        self.assertEqual(self.get_value_from_key(list_of_json, "some_string", True), "some_value")
+        assert self.get_value_from_key(list_of_json, "num_iterations", True) == 12
+        assert self.get_value_from_key(list_of_json, "learning_rate", True) == 0.01
+        assert self.get_value_from_key(list_of_json, "some_boolean", True) is False
+        assert self.get_value_from_key(list_of_json, "some_string", True) == "some_value"
 
     def test_log(self):
         with tempfile.TemporaryDirectory() as d:
@@ -258,10 +258,10 @@ class CometMLTest(unittest.TestCase):
             archive = zipfile.ZipFile(p, "r")
             log = archive.open("messages.json").read().decode("utf-8")
         list_of_json = log.split("\n")[:-1]
-        self.assertEqual(self.get_value_from_key(list_of_json, "curr_step", True), 0)
-        self.assertEqual(self.get_value_from_key(list_of_json, "total_loss"), 0.1)
-        self.assertEqual(self.get_value_from_key(list_of_json, "iteration"), 1)
-        self.assertEqual(self.get_value_from_key(list_of_json, "my_text"), "some_value")
+        assert self.get_value_from_key(list_of_json, "curr_step", True) == 0
+        assert self.get_value_from_key(list_of_json, "total_loss") == 0.1
+        assert self.get_value_from_key(list_of_json, "iteration") == 1
+        assert self.get_value_from_key(list_of_json, "my_text") == "some_value"
 
 
 @require_clearml
@@ -318,20 +318,20 @@ class ClearMLTest(TempDirTestCase, MockingTestCase):
         accelerator.end_training()
 
         metrics = ClearMLTest._get_metrics(offline_dir)
-        self.assertEqual(len(values_with_iteration) + len(single_values), len(metrics))
+        assert (len(values_with_iteration) + len(single_values)) == len(metrics)
         for metric in metrics:
             if metric["metric"] == "Summary":
-                self.assertIn(metric["variant"], single_values)
-                self.assertEqual(metric["value"], single_values[metric["variant"]])
+                assert metric["variant"] in single_values
+                assert metric["value"] == single_values[metric["variant"]]
             elif metric["metric"] == "should_be_under_train":
-                self.assertEqual(metric["variant"], "train")
-                self.assertEqual(metric["iter"], 1)
-                self.assertEqual(metric["value"], values_with_iteration["should_be_under_train"])
+                assert metric["variant"] == "train"
+                assert metric["iter"] == 1
+                assert metric["value"] == values_with_iteration["should_be_under_train"]
             else:
                 values_with_iteration_key = metric["variant"] + "_" + metric["metric"]
-                self.assertIn(values_with_iteration_key, values_with_iteration)
-                self.assertEqual(metric["iter"], 1)
-                self.assertEqual(metric["value"], values_with_iteration[values_with_iteration_key])
+                assert values_with_iteration_key in values_with_iteration
+                assert metric["iter"] == 1
+                assert metric["value"] == values_with_iteration[values_with_iteration_key]
 
     def test_log_images(self):
         from clearml import Task
@@ -352,7 +352,7 @@ class ClearMLTest(TempDirTestCase, MockingTestCase):
         accelerator.end_training()
 
         images_saved = Path(os.path.join(offline_dir, "data")).rglob("*.jpeg")
-        self.assertEqual(len(list(images_saved)), len(images))
+        assert len(list(images_saved)) == len(images)
 
     def test_log_table(self):
         from clearml import Task
@@ -369,9 +369,9 @@ class ClearMLTest(TempDirTestCase, MockingTestCase):
         accelerator.end_training()
 
         metrics = ClearMLTest._get_metrics(offline_dir)
-        self.assertEqual(len(metrics), 2)
+        assert len(metrics) == 2
         for metric in metrics:
-            self.assertIn(metric["metric"], ["from lists", "from lists with columns"])
+            assert metric["metric"] in ("from lists", "from lists with columns")
             plot = json.loads(metric["plot_str"])
             if metric["metric"] == "from lists with columns":
                 print(plot["data"][0])
@@ -398,8 +398,8 @@ class ClearMLTest(TempDirTestCase, MockingTestCase):
         accelerator.end_training()
 
         metrics = ClearMLTest._get_metrics(offline_dir)
-        self.assertEqual(len(metrics), 1)
-        self.assertEqual(metrics[0]["metric"], "from df")
+        assert len(metrics) == 1
+        assert metrics[0]["metric"] == "from df"
         plot = json.loads(metrics[0]["plot_str"])
         self.assertCountEqual(plot["data"][0]["header"]["values"], [["A"], ["B"], ["C"]])
         self.assertCountEqual(plot["data"][0]["cells"]["values"], [[1, 2], [3, 4], [5, 6]])

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -301,7 +301,7 @@ class ClearMLTest(TempDirTestCase, MockingTestCase):
         with open(os.path.join(offline_dir, "task.json")) as f:
             offline_session = json.load(f)
         clearml_offline_config = text_to_config_dict(offline_session["configuration"]["General"]["value"])
-        self.assertDictEqual(config, clearml_offline_config)
+        assert config == clearml_offline_config
 
     def test_log(self):
         from clearml import Task
@@ -462,7 +462,7 @@ class CustomTrackerTestCase(unittest.TestCase):
                     "some_boolean": "False",
                     "some_string": "some_value",
                 }
-                self.assertDictEqual(data, truth)
+                assert data == truth
 
     def test_log(self):
         with tempfile.TemporaryDirectory() as d:
@@ -484,7 +484,7 @@ class CustomTrackerTestCase(unittest.TestCase):
                     "some_boolean": "",
                     "some_string": "",
                 }
-                self.assertDictEqual(data, truth)
+                assert data == truth
 
 
 @require_dvclive

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,86 +54,84 @@ class UtilsTester(unittest.TestCase):
         device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
         result1 = send_to_device(tensor, device)
-        self.assertTrue(torch.equal(result1.cpu(), tensor))
+        assert torch.equal(result1.cpu(), tensor)
 
         result2 = send_to_device((tensor, [tensor, tensor], 1), device)
-        self.assertIsInstance(result2, tuple)
-        self.assertTrue(torch.equal(result2[0].cpu(), tensor))
-        self.assertIsInstance(result2[1], list)
-        self.assertTrue(torch.equal(result2[1][0].cpu(), tensor))
-        self.assertTrue(torch.equal(result2[1][1].cpu(), tensor))
-        self.assertEqual(result2[2], 1)
+        assert isinstance(result2, tuple)
+        assert torch.equal(result2[0].cpu(), tensor)
+        assert isinstance(result2[1], list)
+        assert torch.equal(result2[1][0].cpu(), tensor)
+        assert torch.equal(result2[1][1].cpu(), tensor)
+        assert result2[2] == 1
 
         result2 = send_to_device({"a": tensor, "b": [tensor, tensor], "c": 1}, device)
-        self.assertIsInstance(result2, dict)
-        self.assertTrue(torch.equal(result2["a"].cpu(), tensor))
-        self.assertIsInstance(result2["b"], list)
-        self.assertTrue(torch.equal(result2["b"][0].cpu(), tensor))
-        self.assertTrue(torch.equal(result2["b"][1].cpu(), tensor))
-        self.assertEqual(result2["c"], 1)
+        assert isinstance(result2, dict)
+        assert torch.equal(result2["a"].cpu(), tensor)
+        assert isinstance(result2["b"], list)
+        assert torch.equal(result2["b"][0].cpu(), tensor)
+        assert torch.equal(result2["b"][1].cpu(), tensor)
+        assert result2["c"] == 1
 
         result3 = send_to_device(ExampleNamedTuple(a=tensor, b=[tensor, tensor], c=1), device)
-        self.assertIsInstance(result3, ExampleNamedTuple)
-        self.assertTrue(torch.equal(result3.a.cpu(), tensor))
-        self.assertIsInstance(result3.b, list)
-        self.assertTrue(torch.equal(result3.b[0].cpu(), tensor))
-        self.assertTrue(torch.equal(result3.b[1].cpu(), tensor))
-        self.assertEqual(result3.c, 1)
+        assert isinstance(result3, ExampleNamedTuple)
+        assert torch.equal(result3.a.cpu(), tensor)
+        assert isinstance(result3.b, list)
+        assert torch.equal(result3.b[0].cpu(), tensor)
+        assert torch.equal(result3.b[1].cpu(), tensor)
+        assert result3.c == 1
 
         result4 = send_to_device(UserDict({"a": tensor, "b": [tensor, tensor], "c": 1}), device)
-        self.assertIsInstance(result4, UserDict)
-        self.assertTrue(torch.equal(result4["a"].cpu(), tensor))
-        self.assertIsInstance(result4["b"], list)
-        self.assertTrue(torch.equal(result4["b"][0].cpu(), tensor))
-        self.assertTrue(torch.equal(result4["b"][1].cpu(), tensor))
-        self.assertEqual(result4["c"], 1)
+        assert isinstance(result4, UserDict)
+        assert torch.equal(result4["a"].cpu(), tensor)
+        assert isinstance(result4["b"], list)
+        assert torch.equal(result4["b"][0].cpu(), tensor)
+        assert torch.equal(result4["b"][1].cpu(), tensor)
+        assert result4["c"] == 1
 
     def test_honor_type(self):
         with self.assertRaises(TypeError) as cm:
             _ = recursively_apply(torch.tensor, (torch.tensor(1), 1), error_on_other_type=True)
-        self.assertEqual(
-            str(cm.exception),
-            "Unsupported types (<class 'int'>) passed to `tensor`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed.",
+        assert (
+            str(cm.exception)
+            == "Unsupported types (<class 'int'>) passed to `tensor`. Only nested list/tuple/dicts of objects that are valid for `is_torch_tensor` should be passed."
         )
 
     def test_listify(self):
         tensor = torch.tensor([1, 2, 3, 4, 5])
-        self.assertEqual(listify(tensor), [1, 2, 3, 4, 5])
+        assert listify(tensor) == [1, 2, 3, 4, 5]
 
         tensor = torch.tensor([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
-        self.assertEqual(listify(tensor), [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]])
+        assert listify(tensor) == [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
 
         tensor = torch.tensor([[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]])
-        self.assertEqual(
-            listify(tensor), [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
-        )
+        assert listify(tensor) == [[[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], [[11, 12, 13, 14, 15], [16, 17, 18, 19, 20]]]
 
     def test_patch_environment(self):
         with patch_environment(aa=1, BB=2):
-            self.assertEqual(os.environ.get("AA"), "1")
-            self.assertEqual(os.environ.get("BB"), "2")
+            assert os.environ.get("AA") == "1"
+            assert os.environ.get("BB") == "2"
 
-        self.assertNotIn("AA", os.environ)
-        self.assertNotIn("BB", os.environ)
+        assert "AA" not in os.environ
+        assert "BB" not in os.environ
 
     def test_patch_environment_key_exists(self):
         # check that patch_environment correctly restores pre-existing env vars
         with patch_environment(aa=1, BB=2):
-            self.assertEqual(os.environ.get("AA"), "1")
-            self.assertEqual(os.environ.get("BB"), "2")
+            assert os.environ.get("AA") == "1"
+            assert os.environ.get("BB") == "2"
 
             with patch_environment(Aa=10, bb="20", cC=30):
-                self.assertEqual(os.environ.get("AA"), "10")
-                self.assertEqual(os.environ.get("BB"), "20")
-                self.assertEqual(os.environ.get("CC"), "30")
+                assert os.environ.get("AA") == "10"
+                assert os.environ.get("BB") == "20"
+                assert os.environ.get("CC") == "30"
 
-            self.assertEqual(os.environ.get("AA"), "1")
-            self.assertEqual(os.environ.get("BB"), "2")
-            self.assertNotIn("CC", os.environ)
+            assert os.environ.get("AA") == "1"
+            assert os.environ.get("BB") == "2"
+            assert "CC" not in os.environ
 
-        self.assertNotIn("AA", os.environ)
-        self.assertNotIn("BB", os.environ)
-        self.assertNotIn("CC", os.environ)
+        assert "AA" not in os.environ
+        assert "BB" not in os.environ
+        assert "CC" not in os.environ
 
     def test_can_undo_convert_outputs(self):
         model = RegressionModel()
@@ -168,7 +166,7 @@ class UtilsTester(unittest.TestCase):
         distributed_model = torch.nn.parallel.DataParallel(model)
         model_unwrapped = extract_model_from_parallel(distributed_model)
 
-        self.assertEqual(model, model_unwrapped)
+        assert model == model_unwrapped
 
     @require_torch_min_version(version="2.0")
     def test_dynamo_extract_model(self):
@@ -180,36 +178,36 @@ class UtilsTester(unittest.TestCase):
         distributed_compiled_model = torch.compile(distributed_model)
         compiled_model_unwrapped = extract_model_from_parallel(distributed_compiled_model)
 
-        self.assertEqual(compiled_model._orig_mod, compiled_model_unwrapped._orig_mod)
+        assert compiled_model._orig_mod == compiled_model_unwrapped._orig_mod
 
     def test_find_device(self):
-        self.assertEqual(find_device([1, "a", torch.tensor([1, 2, 3])]), torch.device("cpu"))
-        self.assertEqual(find_device({"a": 1, "b": torch.tensor([1, 2, 3])}), torch.device("cpu"))
-        self.assertIsNone(find_device([1, "a"]))
+        assert find_device([1, "a", torch.tensor([1, 2, 3])]) == torch.device("cpu")
+        assert find_device({"a": 1, "b": torch.tensor([1, 2, 3])}) == torch.device("cpu")
+        assert find_device([1, "a"]) is None
 
     def test_check_os_kernel_no_warning_when_release_gt_min(self):
         # min version is 5.5
         with patch("platform.uname", return_value=Mock(release="5.15.0-35-generic", system="Linux")):
             with warnings.catch_warnings(record=True) as w:
                 check_os_kernel()
-            self.assertEqual(len(w), 0)
+            assert len(w) == 0
 
     def test_check_os_kernel_no_warning_when_not_linux(self):
         # system must be Linux
         with patch("platform.uname", return_value=Mock(release="5.4.0-35-generic", system="Darwin")):
             with warnings.catch_warnings(record=True) as w:
                 check_os_kernel()
-            self.assertEqual(len(w), 0)
+            assert len(w) == 0
 
     def test_check_os_kernel_warning_when_release_lt_min(self):
         # min version is 5.5
         with patch("platform.uname", return_value=Mock(release="5.4.0-35-generic", system="Linux")):
             with self.assertLogs() as ctx:
                 check_os_kernel()
-            self.assertEqual(len(ctx.records), 1)
-            self.assertEqual(ctx.records[0].levelname, "WARNING")
-            self.assertIn("5.4.0", ctx.records[0].msg)
-            self.assertIn("5.5.0", ctx.records[0].msg)
+            assert len(ctx.records) == 1
+            assert ctx.records[0].levelname == "WARNING"
+            assert "5.4.0" in ctx.records[0].msg
+            assert "5.5.0" in ctx.records[0].msg
 
     def test_save_safetensor_shared_memory(self):
         class Model(nn.Module):
@@ -226,8 +224,8 @@ class UtilsTester(unittest.TestCase):
             save_path = os.path.join(tmp_dir, "model.safetensors")
             with self.assertLogs(level="WARNING") as log:
                 save(model.state_dict(), save_path, safe_serialization=True)
-                self.assertEqual(len(log.records), 1)
-                self.assertIn("Removed shared tensor", log.output[0])
+                assert len(log.records) == 1
+                assert "Removed shared tensor" in log.output[0]
 
     @require_torch_min_version(version="1.12")
     def test_pad_across_processes(self):
@@ -236,7 +234,7 @@ class UtilsTester(unittest.TestCase):
         nt = nested_tensor([[1, 2, 3], [1], [1, 2]])
         with self.assertWarns(CannotPadNestedTensorWarning):
             nt2 = pad_across_processes(nt)
-        self.assertIs(nt, nt2)
+        assert nt is nt2
 
     def test_slice_and_concatenate(self):
         # First base case: 2 processes, batch size of 1


### PR DESCRIPTION
# What does this PR do?

This PR makes the assertions used in the test suite [more idiomatic for Pytest](https://docs.pytest.org/en/stable/how-to/assert.html).

Idiomatic assertions are rewritten by Pytest, making debugging much easier.

Namely, I did a first pass using [codemod-unittest-to-pytest-asserts](https://github.com/akx/codemod-unittest-to-pytest-asserts), followed by some `ast-grep` powered fixes, followed up with some manual fixes to make things neater still.

Sibling of https://github.com/huggingface/trl/pull/1301.

I don't have easy access to hardware suitable for running all tests locally (Apple Silicon 😄), but the tests I could run seem to pass, so here's hoping CI agrees!

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?

## Who can review?

cc @muellerzr 