### PR TITLE
Drop `parameterized` dependency in favor of Pytest's parametrize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras["quality"] = [
     "ruff ~= 0.1.15",
 ]
 extras["docs"] = []
-extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
+extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests"]
 extras["test_dev"] = [
     "datasets",
     "evaluate",


### PR DESCRIPTION
# What does this PR do?

This PR drops the `parameterized` test dependency in favor of Pytest's own [`pytest.mark.parametrize`](https://docs.pytest.org/en/7.3.x/how-to/parametrize.html) feature.

Sibling of #2420 and https://github.com/TimDettmers/bitsandbytes/pull/1001.

> [!WARNING]  
> This will apparently need #2420 to land first.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

cc @muellerzr @BenjaminBossan 