### PR TITLE
[FIX] fix the wrong `nproc_per_node` in the multi gpu test  

### DIFF
--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -62,14 +62,14 @@ class MultiDeviceTester(unittest.TestCase):
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())
 
-    @require_multi_device
+    @require_multi_gpu
     def test_distributed_data_loop(self):
         """
         This TestCase checks the behaviour that occurs during distributed training or evaluation,
         when the batch size does not evenly divide the dataset size.
         """
         print(f"Found {device_count} devices, using 2 devices only")
-        cmd = ["torchrun", f"--nproc_per_node=2", self.data_loop_file_path]
+        cmd = ["torchrun", "--nproc_per_node=2", self.data_loop_file_path]
         with patch_environment(omp_num_threads=1, cuda_visible_devices="0,1"):
             execute_subprocess_async(cmd, env=os.environ.copy())
 

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -69,7 +69,7 @@ class MultiDeviceTester(unittest.TestCase):
         when the batch size does not evenly divide the dataset size.
         """
         print(f"Found {device_count} devices, using 2 devices only")
-        cmd = ["torchrun", f"--nproc_per_node={device_count}", self.data_loop_file_path]
+        cmd = ["torchrun", f"--nproc_per_node=2", self.data_loop_file_path]
         with patch_environment(omp_num_threads=1, cuda_visible_devices="0,1"):
             execute_subprocess_async(cmd, env=os.environ.copy())
 


### PR DESCRIPTION
## What does this PR do?
With the command `pytest test_multigpu.py` on my NV A100 device, I got a failed test for `test_distributed_data_loop`. Based on the code, I think it is intended to use 2 processes instead of the available device number. 

I also change the `require_multi_device` to `require_multi_gpu`, because `cuda_visible_devices=0,1` reveals that this test can only be applied to GPU. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


Pls have a review, thanks!
@muellerzr or @pacman100

 