### PR TITLE
Make output end up on all GPUs at the end

### DIFF
--- a/docs/source/usage_guides/distributed_inference.md
+++ b/docs/source/usage_guides/distributed_inference.md
@@ -216,7 +216,7 @@ with torch.no_grad():
     output = model(*args)
 ```
 
-When finished all the data will be on the CPU on each process for convenience:
+When finished all the data will be on each GPU for convenience:
 
 ```{python}
 print(output)

--- a/docs/source/usage_guides/distributed_inference.md
+++ b/docs/source/usage_guides/distributed_inference.md
@@ -216,10 +216,20 @@ with torch.no_grad():
     output = model(*args)
 ```
 
-When finished all the data will be on each GPU for convenience:
+When finished all the data will be on the last process only:
 
 ```{python}
-print(output)
+from accelerate import PartialState
+if PartialState().is_last_process:
+    print(output)
 ```
+
+<Tip>
+
+    If you pass in `gather_output=True` to [`inference.prepare_pippy`], the output will be sent
+    across to all the GPUs afterwards without needing the `is_last_process` check. This is 
+    `False` by default as it incurs a communication call.
+    
+</Tip>
 
 And that's it! To explore more, please check out the examples in [this repository](https://github.com/muellerzr/pippy-device-map-playground/) and our documentation as we work to improving this integration. 

--- a/docs/source/usage_guides/distributed_inference.md
+++ b/docs/source/usage_guides/distributed_inference.md
@@ -216,13 +216,10 @@ with torch.no_grad():
     output = model(*args)
 ```
 
-When finished, all the data will be on the last GPU, which you can use the [`PartialState`] to find and extract:
+When finished all the data will be on the CPU on each process for convenience:
 
 ```{python}
-from accelerate import PartialState
-
-if PartialState().is_last_process:
-    print(output)
+print(output)
 ```
 
 And that's it! To explore more, please check out the examples in [this repository](https://github.com/muellerzr/pippy-device-map-playground/) and our documentation as we work to improving this integration. 

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -1,6 +1,6 @@
 import math
 from types import MethodType
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from .state import PartialState
 from .utils import (
@@ -110,12 +110,12 @@ def pippy_forward(forward, num_chunks, gather_output, *args, **kwargs):
 
 def prepare_pippy(
     model,
-    split_points="auto",
-    no_split_module_classes=None,
-    example_args=(),
+    split_points: Optional[Union[str, List[str]]] = "auto",
+    no_split_module_classes: Optional[List[str]] = None,
+    example_args: Optional[Tuple[Any]] = (),
     example_kwargs: Optional[Dict[str, Any]] = None,
-    num_chunks=None,
-    gather_output=False,
+    num_chunks: Optional[int] = None,
+    gather_output: Optional[bool] = False,
 ):
     """
     Wraps `model` for pipeline parallel inference.
@@ -123,14 +123,14 @@ def prepare_pippy(
     Args:
         model (`torch.nn.Module`):
             A model we want to split for pipeline-parallel inference
-        split_points (`str`, defaults to 'auto'):
+        split_points (`str` or `List[str]`, defaults to 'auto'):
             How to generate the split points and chunk the model across each GPU. 'auto' will find the best balanced
-            split given any model.
+            split given any model. Should be a list of layer names in the model to split by otherwise.
         no_split_module_classes (`List[str]`):
             A list of class names for layers we don't want to be split.
-        example_args (tuple of `torch.Tensor`):
+        example_args (tuple of model inputs):
             The expected inputs for the model that uses order-based inputs. Recommended to use this method if possible.
-        example_kwargs (dict of `torch.Tensor`)
+        example_kwargs (dict of model inputs)
             The expected inputs for the model that uses dictionary-based inputs. This is a *highly* limiting structure
             that requires the same keys be present at *all* inference calls. Not recommended unless the prior condition
             is true for all cases.

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -102,7 +102,7 @@ def pippy_forward(forward, num_chunks, gather_output, *args, **kwargs):
         output = forward()
     else:
         forward()
-    if gather_output is True:
+    if gather_output:
         # Each node will get a copy of the full output which is only on the last GPU
         output = copy_tensor_to_devices(output)
     return output

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -115,7 +115,7 @@ def prepare_pippy(
     example_args=(),
     example_kwargs: Optional[Dict[str, Any]] = None,
     num_chunks=None,
-    gather_output=True,
+    gather_output=False,
 ):
     """
     Wraps `model` for pipeline parallel inference.
@@ -137,9 +137,8 @@ def prepare_pippy(
         num_chunks (`int`):
             The number of different stages the Pipeline will have. By default it will assign one chunk per GPU, but
             this can be tuned and played with. In general one should have num_chunks >= num_gpus.
-        gather_output (`bool`, defaults to `True`):
-            Whether or not to copy the output from the last GPU (which holds the true outputs) and send them across to
-            all GPUs.
+        gather_output (`bool`):
+            If `True`, the output from the last GPU (which holds the true outputs) is sent across to all GPUs.
     """
     if not is_pippy_available():
         raise ImportError(

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -118,8 +118,7 @@ def prepare_pippy(
     gather_output=True,
 ):
     """
-    Wraps `model` for PipelineParallelism. Also ensures that the output is sent to each GPU at the end, reducing the
-    need to check for process indexes.
+    Wraps `model` for pipeline parallel inference.
 
     Args:
         model (`torch.nn.Module`):

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -102,10 +102,10 @@ def pippy_forward(forward, num_chunks, send_output_to_cpu, *args, **kwargs):
         output = forward()
     else:
         forward()
+    # Each node will get a copy of the full output, which is only on the last GPU
+    output = gather_object([output if output is not None else object()])[-1]
     if send_output_to_cpu:
-        output = gather_object([output if output is not None else object()])
-        # The outputs themselves are on the last GPU, so they will be the last item
-        output = send_to_device(output[-1], "cpu")
+        output = send_to_device(output, "cpu")
     return output
 
 

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -134,10 +134,10 @@ def prepare_pippy(
             The expected inputs for the model that uses dictionary-based inputs. This is a *highly* limiting structure
             that requires the same keys be present at *all* inference calls. Not recommended unless the prior condition
             is true for all cases.
-        num_chunks (`int`):
+        num_chunks (`int`, defaults to the number of available GPUs):
             The number of different stages the Pipeline will have. By default it will assign one chunk per GPU, but
             this can be tuned and played with. In general one should have num_chunks >= num_gpus.
-        gather_output (`bool`):
+        gather_output (`bool`, defaults to `False`):
             If `True`, the output from the last GPU (which holds the true outputs) is sent across to all GPUs.
     """
     if not is_pippy_available():

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -131,6 +131,8 @@ def test_op_checker(state):
 
 
 def test_copy_tensor_to_devices(state):
+    if state.distributed_type not in [DistributedType.MULTI_GPU, DistributedType.TPU]:
+        return
     if state.is_main_process:
         tensor = torch.tensor([1, 2, 3], dtype=torch.int).to(state.device)
     else:
@@ -147,22 +149,22 @@ def _mp_fn(index):
 def main():
     state = PartialState()
     state.print(f"State: {state}")
-    # state.print("testing gather")
-    # test_gather(state)
-    # state.print("testing gather_object")
-    # test_gather_object(state)
-    # state.print("testing gather non-contigous")
-    # test_gather_non_contigous(state)
-    # state.print("testing broadcast")
-    # test_broadcast(state)
-    # state.print("testing pad_across_processes")
-    # test_pad_across_processes(state)
-    # state.print("testing reduce_sum")
-    # test_reduce_sum(state)
-    # state.print("testing reduce_mean")
-    # test_reduce_mean(state)
-    # state.print("testing op_checker")
-    # test_op_checker(state)
+    state.print("testing gather")
+    test_gather(state)
+    state.print("testing gather_object")
+    test_gather_object(state)
+    state.print("testing gather non-contigous")
+    test_gather_non_contigous(state)
+    state.print("testing broadcast")
+    test_broadcast(state)
+    state.print("testing pad_across_processes")
+    test_pad_across_processes(state)
+    state.print("testing reduce_sum")
+    test_reduce_sum(state)
+    state.print("testing reduce_mean")
+    test_reduce_mean(state)
+    state.print("testing op_checker")
+    test_op_checker(state)
     state.print("testing sending tensors across devices")
     test_copy_tensor_to_devices(state)
 

--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -22,6 +22,7 @@ from accelerate.utils.dataclasses import DistributedType
 from accelerate.utils.operations import (
     DistributedOperationException,
     broadcast,
+    copy_tensor_to_devices,
     gather,
     gather_object,
     pad_across_processes,
@@ -129,6 +130,15 @@ def test_op_checker(state):
     state.debug = False
 
 
+def test_copy_tensor_to_devices(state):
+    if state.is_main_process:
+        tensor = torch.tensor([1, 2, 3], dtype=torch.int).to(state.device)
+    else:
+        tensor = None
+    tensor = copy_tensor_to_devices(tensor)
+    assert torch.allclose(tensor, torch.tensor([1, 2, 3], dtype=torch.int, device="cuda"))
+
+
 def _mp_fn(index):
     # For xla_spawn (TPUs)
     main()
@@ -137,22 +147,24 @@ def _mp_fn(index):
 def main():
     state = PartialState()
     state.print(f"State: {state}")
-    state.print("testing gather")
-    test_gather(state)
-    state.print("testing gather_object")
-    test_gather_object(state)
-    state.print("testing gather non-contigous")
-    test_gather_non_contigous(state)
-    state.print("testing broadcast")
-    test_broadcast(state)
-    state.print("testing pad_across_processes")
-    test_pad_across_processes(state)
-    state.print("testing reduce_sum")
-    test_reduce_sum(state)
-    state.print("testing reduce_mean")
-    test_reduce_mean(state)
-    state.print("testing op_checker")
-    test_op_checker(state)
+    # state.print("testing gather")
+    # test_gather(state)
+    # state.print("testing gather_object")
+    # test_gather_object(state)
+    # state.print("testing gather non-contigous")
+    # test_gather_non_contigous(state)
+    # state.print("testing broadcast")
+    # test_broadcast(state)
+    # state.print("testing pad_across_processes")
+    # test_pad_across_processes(state)
+    # state.print("testing reduce_sum")
+    # test_reduce_sum(state)
+    # state.print("testing reduce_mean")
+    # test_reduce_mean(state)
+    # state.print("testing op_checker")
+    # test_op_checker(state)
+    state.print("testing sending tensors across devices")
+    test_copy_tensor_to_devices(state)
 
 
 if __name__ == "__main__":

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -121,6 +121,7 @@ from .operations import (
     concatenate,
     convert_outputs_to_fp32,
     convert_to_fp32,
+    copy_tensor_to_devices,
     find_batch_size,
     find_device,
     gather,

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -481,6 +481,60 @@ def _tpu_broadcast(tensor, src=0, name="broadcast tensor"):
     return xm.mesh_reduce(name, tensor, lambda x: x[src])
 
 
+TENSOR_TYPE_TO_INT = {
+    torch.float: 1,
+    torch.double: 2,
+    torch.half: 3,
+    torch.bfloat16: 4,
+    torch.uint8: 5,
+    torch.int8: 6,
+    torch.int16: 7,
+    torch.int32: 8,
+    torch.int64: 9,
+    torch.bool: 10,
+}
+
+TENSOR_INT_TO_DTYPE = {v: k for k, v in TENSOR_TYPE_TO_INT.items()}
+
+
+def gather_tensor_shape(tensor):
+    """
+    Grabs the shape of `tensor` only available on one process and returns a tensor of its shape
+    """
+    # Allocate 80 bytes to store the shape
+    max_tensor_dimension = 2**20
+    state = PartialState()
+    base_tensor = torch.empty(max_tensor_dimension, dtype=torch.int, device=state.device)
+
+    if tensor is not None:
+        shape = tensor.shape
+        tensor_dtype = TENSOR_TYPE_TO_INT[tensor.dtype]
+        base_tensor[: len(shape) + 1] = torch.tensor(list(shape) + [tensor_dtype], dtype=int)
+    # Perform a reduction
+    base_tensor = reduce(base_tensor, reduction="sum")
+    base_tensor = base_tensor[base_tensor.nonzero()]
+    dtype = int(base_tensor[-1:][0])
+    base_tensor = base_tensor[:-1]
+    return base_tensor, dtype
+
+
+def copy_tensor_to_devices(tensor=None) -> torch.Tensor:
+    """
+    Copys a tensor that only exists on a single device and broadcasts it to other devices. Differs from `broadcast` as
+    each worker doesn't need to know its shape when used (and tensor can be `None`)
+
+    Args:
+        tensor (`torch.tensor`):
+            The tensor that should be sent to all devices. Must only have it be defined on a single device, the rest
+            should be `None`.
+    """
+    state = PartialState()
+    shape, dtype = gather_tensor_shape(tensor)
+    if tensor is None:
+        tensor = torch.empty(shape, dtype=TENSOR_INT_TO_DTYPE[dtype]).to(state.device)
+    return reduce(tensor, reduction="sum")
+
+
 @verify_operation
 def broadcast(tensor, from_process: int = 0):
     """


### PR DESCRIPTION
# What does this PR do?

This PR makes it so that after running pippy inference, the outputs are gathered and returned on each GPU at the end. This does incur a comms call so this can be disabled if users want to keep it on the last GPU only


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @kwen2501