### PR TITLE
[FIX] enable nlp_example.py to run on XPU for both single and distributed modes

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1753,10 +1753,11 @@ class Accelerator:
         for obj in result:
             if isinstance(obj, torch.nn.Module):
                 model = obj
+                model.train()
             elif isinstance(obj, (torch.optim.Optimizer)):
                 optimizer = obj
         if optimizer is not None and model is not None:
-            dtype = torch.bfloat16 if self.state.mixed_precision == "bf16" else torch.float32
+            dtype = torch.bfloat16 if self.state.mixed_precision == "bf16" else None
             if self.device.type == "xpu" and is_xpu_available():
                 model = model.to(self.device)
                 model, optimizer = torch.xpu.optimize(


### PR DESCRIPTION
## What does this PR do?
When trying to run the `nlp_example.py` on Intel GPU, I found that there is 1 bug in the `_prepare_ipex` function and 1 place for improvement:
- when used for training, the `ipex.optimize` function expects the model to be in training mode, otherwise it will assume that the user is doing inference and [this line](https://github.com/intel/intel-extension-for-pytorch/blob/release/xpu/2.1.10/intel_extension_for_pytorch/frontend.py#L339) will complain. 
- `ipex.optimize()` expects the dtype to be either `bf16` or `fp16` and the default value is None as stated in [this](https://github.com/intel/intel-extension-for-pytorch/blob/release/xpu/2.1.10/intel_extension_for_pytorch/frontend.py#L212) argument explanation. So if no `mixed_precision` is used for training (currently only bf16 is supported), the dtype should keep the same with the default None

## Who can review?
@muellerzr or @sywangyi 