### PR TITLE
Fix seedable sampler logic and expound docs

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -221,7 +221,7 @@ class Accelerator:
             Whether or not use a fully seedable random sampler ([`~data_loader.SeedableRandomSampler`]). Ensures
             training results are fully reproducable using a different sampling technique. While seed-to-seed results
             may differ, on average the differences are neglible when using multiple different seeds to compare. Should
-            also be ran with [`~utils.set_seed`] for the best results.
+            also be ran with [`~utils.set_seed`] each time for the best results.
         step_scheduler_with_optimizer (`bool`, *optional`, defaults to `True`):
             Set `True` if the learning rate scheduler is stepped at the same time as the optimizer, `False` if only
             done under certain circumstances (at the end of each epoch, for instance).

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -78,15 +78,16 @@ class SeedableRandomSampler(RandomSampler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.epoch = 0
-        self.seed = torch.random.initial_seed()
+        self.initial_seed = torch.random.initial_seed()
 
     def __iter__(self):
         if self.generator is None:
             self.generator = torch.Generator()
-        else:
-            self.seed = self.generator.initial_seed()
+            self.generator.manual_seed(self.initial_seed)
+
         # Allow `self.epoch` to modify the seed of the generator
-        seed = self.epoch + self.seed
+        seed = self.epoch + self.initial_seed
+        # print("Setting seed at epoch", self.epoch, seed)
         self.generator.manual_seed(seed)
         yield from super().__iter__()
         self.set_epoch(self.epoch + 1)


### PR DESCRIPTION
TL;DR the chunk for modifying the seedable sampler/adding it needs to be done *after* the new dataloader has been made. Otherwise we just modify the one we're getting rid of 😓 

Closes https://github.com/huggingface/accelerate/issues/2333

```
Original: tensor([ 6, 15, 22,  2, 10, 19,  3, 18, 12, 23, 21, 20,  7, 11, 16,  0,  4, 12,
         7, 22,  9,  6,  5, 20, 10, 23,  1, 11, 17,  2, 14, 15, 11, 19, 13, 17,
         8, 14,  1, 10,  3, 15, 18, 12, 22, 16, 21,  5], device='cuda:0')

New: tensor([ 8, 12, 11, 19,  7,  1, 10,  2, 23, 20, 18,  9, 17, 13, 22,  3, 21,  6,
        19,  3,  2,  5,  1, 13, 14, 15, 11,  7, 18, 10,  4, 20,  7,  5,  0, 21,
        23,  8, 10,  1, 17,  6, 11, 13, 18,  2, 12, 20], device='cuda:0')
```