### PR TITLE
Fix tied_pointers_to_remove type

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -374,7 +374,7 @@ class AlignDevicesHook(ModelHook):
             # this dictionary to allow the garbage collector to do its job.
             for value_pointer, device in self.tied_pointers_to_remove:
                 del self.tied_params_map[value_pointer][device]
-            self.tied_pointers_to_remove = None
+            self.tied_pointers_to_remove = set()
 
         if self.io_same_device and self.input_device is not None:
             output = send_to_device(output, self.input_device, skip_keys=self.skip_keys)


### PR DESCRIPTION
Keep this variable as a set, since some people may call `post_forward` multiple times.

Having it reset as `None` is breaking in the sense that `post_forward` may be called multiple times before, while it can not anymore on main.

Context: https://github.com/huggingface/optimum-amd/pull/62