### PR TITLE
Fix warning when dispatching model 

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -441,9 +441,13 @@ def dispatch_model(
         def add_warning(fn, model):
             @wraps(fn)
             def wrapper(*args, **kwargs):
-                to_device = torch._C._nn._parse_to(*args, **kwargs)[0]
-                if to_device is not None:
-                    logger.warning("You shouldn't move a model that is dispatched using accelerate hooks.")
+                warning_msg = "You shouldn't move a model that is dispatched using accelerate hooks."
+                if str(fn.__name__) == "to":
+                    to_device = torch._C._nn._parse_to(*args, **kwargs)[0]
+                    if to_device is not None:
+                        logger.warning(warning_msg)
+                else:
+                    logger.warning(warning_msg)
                 for param in model.parameters():
                     if param.device == torch.device("meta"):
                         raise RuntimeError("You can't move a model that has some modules offloaded to cpu or disk.")

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -441,7 +441,9 @@ def dispatch_model(
         def add_warning(fn, model):
             @wraps(fn)
             def wrapper(*args, **kwargs):
-                logger.warning("You shouldn't move a model when it is dispatched on multiple devices.")
+                to_device = torch._C._nn._parse_to(*args, **kwargs)[0]
+                if to_device is not None:
+                    logger.warning("You shouldn't move a model that is dispatched using accelerate hooks.")
                 for param in model.parameters():
                     if param.device == torch.device("meta"):
                         raise RuntimeError("You can't move a model that has some modules offloaded to cpu or disk.")


### PR DESCRIPTION
# What does this PR do ?
This PR fixes the wraper around .to() method when we dispatch the model. We were displaying this warning even when the user was not moving the model but casting the model to a specific dtype for example. cc @sayakpaul 
Fixes one of the issues in this PR https://github.com/huggingface/diffusers/pull/6857