### PR TITLE
Fix type hints for PEP 484 compliance, enable UP007

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ ignore = [
     "E501", # Line length (handled by ruff-format)
     "E741", # Ambiguous variable name
     "W605", # Invalid escape sequence
-    "UP007", # X | Y type annotations
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -27,7 +27,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from functools import partial
 from types import MethodType
-from typing import Any, Callable, Union
+from typing import Any, Callable
 
 import torch
 import torch.utils.hooks as hooks
@@ -625,7 +625,7 @@ class Accelerator:
         with PartialState().split_between_processes(inputs, apply_padding=apply_padding) as inputs:
             yield inputs
 
-    def on_main_process(self, function: Callable[..., Any] = None):
+    def on_main_process(self, function: Callable[..., Any] | None = None):
         """
         A decorator that will run the decorated function on the main process only. Can also be called using the
         `PartialState` class.
@@ -664,7 +664,7 @@ class Accelerator:
 
         return _inner
 
-    def on_local_main_process(self, function: Callable[..., Any] = None):
+    def on_local_main_process(self, function: Callable[..., Any] | None = None):
         """
         A decorator that will run the decorated function on the local main process only. Can also be called using the
         `PartialState` class.
@@ -745,7 +745,7 @@ class Accelerator:
 
         return _inner
 
-    def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
+    def on_process(self, function: Callable[..., Any] | None = None, process_index: int | None = None):
         """
         A decorator that will run the decorated function on a given process index only. Can also be called using the
         `PartialState` class.
@@ -790,7 +790,7 @@ class Accelerator:
 
         return _inner
 
-    def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
+    def on_local_process(self, function: Callable[..., Any] | None = None, local_process_index: int | None = None):
         """
         A decorator that will run the decorated function on a given local process index only. Can also be called using
         the `PartialState` class.
@@ -1282,7 +1282,9 @@ class Accelerator:
 
         return result if len(result) > 1 else result[0]
 
-    def prepare_model(self, model: torch.nn.Module, device_placement: bool = None, evaluation_mode: bool = False):
+    def prepare_model(
+        self, model: torch.nn.Module, device_placement: bool | None = None, evaluation_mode: bool = False
+    ):
         """
         Prepares a PyTorch model for training in any distributed setup. It is recommended to use
         [`Accelerator.prepare`] instead.
@@ -2554,8 +2556,8 @@ class Accelerator:
     def save_model(
         self,
         model: torch.nn.Module,
-        save_directory: Union[str, os.PathLike],
-        max_shard_size: Union[int, str] = "10GB",
+        save_directory: str | os.PathLike,
+        max_shard_size: int | str = "10GB",
         safe_serialization: bool = True,
     ):
         """
@@ -2690,7 +2692,7 @@ class Accelerator:
         self._save_model_state_pre_hook[handle.id] = hook
         return handle
 
-    def save_state(self, output_dir: str = None, safe_serialization: bool = True, **save_model_func_kwargs):
+    def save_state(self, output_dir: str | None = None, safe_serialization: bool = True, **save_model_func_kwargs):
         """
         Saves the current states of the model, optimizer, scaler, RNG generators, and registered objects to a folder.
 
@@ -2855,7 +2857,7 @@ class Accelerator:
         self._load_model_state_pre_hook[handle.id] = hook
         return handle
 
-    def load_state(self, input_dir: str = None, **load_model_func_kwargs):
+    def load_state(self, input_dir: str | None = None, **load_model_func_kwargs):
         """
         Loads the current states of the model, optimizer, scaler, RNG generators, and registered objects.
 
@@ -3149,7 +3151,7 @@ class Accelerator:
         self._custom_objects.extend(objects)
 
     @contextmanager
-    def autocast(self, cache_enabled: bool = False, autocast_handler: AutocastKwargs = None):
+    def autocast(self, cache_enabled: bool = False, autocast_handler: AutocastKwargs | None = None):
         """
         Will apply automatic mixed-precision inside the block inside this context manager, if it is enabled. Nothing
         different will happen otherwise.

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 
 @contextmanager
-def init_empty_weights(include_buffers: bool = None):
+def init_empty_weights(include_buffers: Optional[bool] = None):
     """
     A context manager under which models are initialized with all parameters on the meta device, therefore creating an
     empty model. Useful when just initializing the model would blow the available RAM.
@@ -87,7 +87,7 @@ def init_empty_weights(include_buffers: bool = None):
 
 
 @contextmanager
-def init_on_device(device: torch.device, include_buffers: bool = None):
+def init_on_device(device: torch.device, include_buffers: Optional[bool] = None):
     """
     A context manager under which models are initialized with all parameters on the specified device.
 

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -14,7 +14,7 @@
 
 import random
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import torch
@@ -55,7 +55,7 @@ def save_accelerator_state(
     schedulers: list,
     dataloaders: list,
     process_index: int,
-    scaler: GradScaler = None,
+    scaler: Optional[GradScaler] = None,
     save_on_each_node: bool = False,
     safe_serialization: bool = True,
 ):

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+from typing import Optional
 
 from huggingface_hub import model_info
 from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
@@ -35,7 +36,7 @@ if is_timm_available():
     import timm
 
 
-def verify_on_hub(repo: str, token: str = None):
+def verify_on_hub(repo: str, token: Optional[str] = None):
     "Verifies that the model is on the hub and returns the model info."
     try:
         return model_info(repo, token=token)
@@ -61,7 +62,9 @@ def check_has_model(error):
         return "unknown"
 
 
-def create_empty_model(model_name: str, library_name: str, trust_remote_code: bool = False, access_token: str = None):
+def create_empty_model(
+    model_name: str, library_name: str, trust_remote_code: bool = False, access_token: Optional[str] = None
+):
     """
     Creates an empty model from its parent library on the `Hub` to calculate the overall memory consumption.
 

--- a/src/accelerate/commands/menu/selection_menu.py
+++ b/src/accelerate/commands/menu/selection_menu.py
@@ -18,6 +18,7 @@ Main driver for the selection menu, based on https://github.com/bchao1/bullet
 
 import builtins
 import sys
+from typing import Optional
 
 from ...utils.imports import _is_package_available
 from . import cursor, input
@@ -38,7 +39,7 @@ class BulletMenu:
     A CLI menu to select a choice from a list of choices using the keyboard.
     """
 
-    def __init__(self, prompt: str = None, choices: list = []):
+    def __init__(self, prompt: Optional[str] = None, choices: list = []):
         self.position = 0
         self.choices = choices
         self.prompt = prompt

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -530,7 +530,7 @@ def attach_align_device_hook_on_blocks(
     module: nn.Module,
     execution_device: Optional[Union[torch.device, Dict[str, torch.device]]] = None,
     offload: Union[bool, Dict[str, bool]] = False,
-    weights_map: Mapping = None,
+    weights_map: Optional[Mapping] = None,
     offload_buffers: bool = False,
     module_name: str = "",
     skip_keys: Optional[Union[str, List[str]]] = None,

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -33,7 +33,9 @@ if is_pippy_available():
     from pippy.PipelineStage import PipelineStage
 
 
-def generate_device_map(model, num_processes: int = 1, no_split_module_classes=None, max_memory: dict = None):
+def generate_device_map(
+    model, num_processes: int = 1, no_split_module_classes=None, max_memory: Optional[dict] = None
+):
     """
     Calculates the device map for `model` with an offset for PiPPy
     """

--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -15,6 +15,7 @@
 import functools
 import logging
 import os
+from typing import Optional
 
 from .state import PartialState
 
@@ -80,7 +81,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         self.warning(*args, **kwargs)
 
 
-def get_logger(name: str, log_level: str = None):
+def get_logger(name: str, log_level: Optional[str] = None):
     """
     Returns a `logging.Logger` for `name` that can handle multiprocessing.
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -21,7 +21,7 @@ import threading
 import warnings
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import torch
 
@@ -552,7 +552,7 @@ class PartialState:
         """
         yield from self._goes_first(self.is_local_main_process)
 
-    def on_main_process(self, function: Callable[..., Any] = None):
+    def on_main_process(self, function: Callable[..., Any] | None = None):
         """
         Decorator that only runs the decorated function on the main process.
 
@@ -582,7 +582,7 @@ class PartialState:
             return function
         return do_nothing
 
-    def on_local_main_process(self, function: Callable[..., Any] = None):
+    def on_local_main_process(self, function: Callable[..., Any] | None = None):
         """
         Decorator that only runs the decorated function on the local main process.
 
@@ -641,7 +641,7 @@ class PartialState:
             return function
         return do_nothing
 
-    def on_process(self, function: Callable[..., Any] = None, process_index: int = None):
+    def on_process(self, function: Callable[..., Any] | None = None, process_index: int | None = None):
         """
         Decorator that only runs the decorated function on the process with the given index.
 
@@ -674,7 +674,7 @@ class PartialState:
             return function
         return do_nothing
 
-    def on_local_process(self, function: Callable[..., Any] = None, local_process_index: int = None):
+    def on_local_process(self, function: Callable[..., Any] | None = None, local_process_index: int | None = None):
         """
         Decorator that only runs the decorated function on the process with the given index on the current node.
 
@@ -761,7 +761,7 @@ class AcceleratorState:
 
     def __init__(
         self,
-        mixed_precision: str = None,
+        mixed_precision: str | None = None,
         cpu: bool = False,
         dynamo_plugin=None,
         deepspeed_plugin=None,
@@ -1024,7 +1024,7 @@ class GradientState:
 
     _shared_state = SharedDict()
 
-    def __init__(self, gradient_accumulation_plugin: Optional[GradientAccumulationPlugin] = None):
+    def __init__(self, gradient_accumulation_plugin: GradientAccumulationPlugin | None = None):
         self.__dict__ = self._shared_state
         if not self.initialized:
             self.sync_gradients = True

--- a/src/accelerate/test_utils/examples.py
+++ b/src/accelerate/test_utils/examples.py
@@ -20,7 +20,7 @@ others are used to either get the code that matters, or to preprocess them (such
 """
 
 import os
-from typing import List
+from typing import List, Optional
 
 
 def get_function_contents_by_name(lines: List[str], name: str):
@@ -60,7 +60,9 @@ def clean_lines(lines: List[str]):
     return [line for line in lines if not line.lstrip().startswith("#") and line != "\n"]
 
 
-def compare_against_test(base_filename: str, feature_filename: str, parser_only: bool, secondary_filename: str = None):
+def compare_against_test(
+    base_filename: str, feature_filename: str, parser_only: bool, secondary_filename: Optional[str] = None
+):
     """
     Tests whether the additional code inside of `feature_filename` was implemented in `base_filename`. This should be
     used when testing to see if `complete_*_.py` examples have all of the implementations from each of the

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -23,7 +23,7 @@ import unittest
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
-from typing import List, Union
+from typing import List, Optional, Union
 from unittest import mock
 
 import torch
@@ -577,7 +577,7 @@ def path_in_accelerate_package(*components: str) -> Path:
 
 
 @contextmanager
-def assert_exception(exception_class: Exception, msg: str = None) -> bool:
+def assert_exception(exception_class: Exception, msg: Optional[str] = None) -> bool:
     """
     Context manager to assert that the right `Exception` class was raised.
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -360,9 +360,9 @@ class WandBTracker(GeneralTracker):
     def log_table(
         self,
         table_name: str,
-        columns: List[str] = None,
-        data: List[List[Any]] = None,
-        dataframe: Any = None,
+        columns: Optional[List[str]] = None,
+        data: Optional[List[List[Any]]] = None,
+        dataframe: Optional[Any] = None,
         step: Optional[int] = None,
         **kwargs,
     ):
@@ -610,7 +610,7 @@ class MLflowTracker(GeneralTracker):
     @on_main_process
     def __init__(
         self,
-        experiment_name: str = None,
+        experiment_name: Optional[str] = None,
         logging_dir: Optional[Union[str, os.PathLike]] = None,
         run_id: Optional[str] = None,
         tags: Optional[Union[Dict[str, Any], str]] = None,
@@ -737,7 +737,7 @@ class ClearMLTracker(GeneralTracker):
     requires_logging_directory = False
 
     @on_main_process
-    def __init__(self, run_name: str = None, **kwargs):
+    def __init__(self, run_name: Optional[str] = None, **kwargs):
         from clearml import Task
 
         current_task = Task.current_task()
@@ -822,9 +822,9 @@ class ClearMLTracker(GeneralTracker):
     def log_table(
         self,
         table_name: str,
-        columns: List[str] = None,
-        data: List[List[Any]] = None,
-        dataframe: Any = None,
+        columns: Optional[List[str]] = None,
+        data: Optional[List[List[Any]]] = None,
+        dataframe: Optional[Any] = None,
         step: Optional[int] = None,
         **kwargs,
     ):
@@ -970,7 +970,7 @@ LOGGER_TYPE_TO_CLASS = {
 
 def filter_trackers(
     log_with: List[Union[str, LoggerType, GeneralTracker]],
-    logging_dir: Union[str, os.PathLike] = None,
+    logging_dir: Optional[Union[str, os.PathLike]] = None,
 ):
     """
     Takes in a list of potential tracker types and checks that:

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 def load_and_quantize_model(
     model: torch.nn.Module,
     bnb_quantization_config: BnbQuantizationConfig,
-    weights_location: Union[str, os.PathLike] = None,
+    weights_location: Optional[Union[str, os.PathLike]] = None,
     device_map: Optional[Dict[str, Union[int, str, torch.device]]] = None,
     no_split_module_classes: Optional[List[str]] = None,
     max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -561,7 +561,7 @@ class ProjectConfiguration:
         },
     )
 
-    def set_directories(self, project_dir: str = None):
+    def set_directories(self, project_dir: Optional[str] = None):
         "Sets `self.project_dir` and `self.logging_dir` to the appropriate values."
         self.project_dir = project_dir
         if self.logging_dir is None:

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -20,6 +20,7 @@ A collection of utilities for ensuring that training can always occur. Heavily i
 import functools
 import gc
 import inspect
+from typing import Optional
 
 import torch
 
@@ -82,7 +83,7 @@ def should_reduce_batch_size(exception: Exception) -> bool:
     return False
 
 
-def find_executable_batch_size(function: callable = None, starting_batch_size: int = 128):
+def find_executable_batch_size(function: Optional[callable] = None, starting_batch_size: int = 128):
     """
     A basic decorator that will try to execute `function`. If it fails from exceptions related to out-of-memory or
     CUDNN, the batch size is cut in half and passed to `function`

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1454,7 +1454,7 @@ def load_checkpoint_in_model(
     dtype: Optional[Union[str, torch.dtype]] = None,
     offload_state_dict: bool = False,
     offload_buffers: bool = False,
-    keep_in_fp32_modules: List[str] = None,
+    keep_in_fp32_modules: Optional[List[str]] = None,
     offload_8bit_bnb: bool = False,
 ):
     """
@@ -1652,7 +1652,7 @@ def load_checkpoint_in_model(
     retie_parameters(model, tied_params)
 
 
-def get_mixed_precision_context_manager(native_amp: bool = False, autocast_kwargs: AutocastKwargs = None):
+def get_mixed_precision_context_manager(native_amp: bool = False, autocast_kwargs: Optional[AutocastKwargs] = None):
     """
     Return a context manager for autocasting mixed precision
 

--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -140,9 +140,9 @@ class OffloadedWeightsLoader(Mapping):
 
     def __init__(
         self,
-        state_dict: Dict[str, torch.Tensor] = None,
+        state_dict: Optional[Dict[str, torch.Tensor]] = None,
         save_folder: Optional[Union[str, os.PathLike]] = None,
-        index: Mapping = None,
+        index: Optional[Mapping] = None,
         device=None,
     ):
         if state_dict is None and save_folder is None and index is None:

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -20,7 +20,7 @@ import socket
 from contextlib import contextmanager
 from functools import partial, reduce
 from types import MethodType
-from typing import OrderedDict
+from typing import Optional, OrderedDict
 
 import torch
 from packaging.version import Version
@@ -290,7 +290,7 @@ def merge_dicts(source, destination):
     return destination
 
 
-def is_port_in_use(port: int = None) -> bool:
+def is_port_in_use(port: Optional[int] = None) -> bool:
     """
     Checks if a port is in use on `localhost`. Useful for checking if multiple `accelerate launch` commands have been
     run and need to see if the port is already in use.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -19,6 +19,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Optional
 from unittest import mock
 
 import torch
@@ -79,7 +80,11 @@ class ExampleDifferenceTests(unittest.TestCase):
     examples_path = Path("examples").resolve()
 
     def one_complete_example(
-        self, complete_file_name: str, parser_only: bool, secondary_filename: str = None, special_strings: list = None
+        self,
+        complete_file_name: str,
+        parser_only: bool,
+        secondary_filename: Optional[str] = None,
+        special_strings: Optional[list] = None,
     ):
         """
         Tests a single `complete` example against all of the implemented `by_feature` scripts


### PR DESCRIPTION
# What does this PR do?

This PR runs [`no_implicit_optional`](https://github.com/hauntsaninja/no_implicit_optional) to make the type hinting compliant with [PEP 484](https://peps.python.org/pep-0484/) (see the readme for `no_implicit_optional` for context), IOW more accurate.

It then enables the previously-disabled `UP007` Ruff rule to make the type annotations shorter (`X | Y`) where possible. (Since not all modules are using `from __typing__ import annotations`, and `accelerate` targets Python 3.8+, that's not everywhere. Targeting Python 3.10 will enable `X | Y` everywhere, see [PEP 604](https://peps.python.org/pep-0604/).)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?

## Who can review?

cc @muellerzr @BenjaminBossan