### PR TITLE
Update accelerator.py

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1354,7 +1354,8 @@ class Accelerator:
             model, "hf_device_map", False
         ):
             model_devices = set(model.hf_device_map.values())
-            if len(model_devices) > 1 and self.distributed_type != DistributedType.NO:
+            model_devices_str = str(list(model_devices)[0])
+            if model_devices_str == 'cuda' or (len(model_devices) > 1 and se:lf.distributed_type != DistributedType.NO):
                 raise ValueError(
                     "You can't train a model that has been loaded in 8-bit precision on multiple devices in any distributed mode."
                     " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1355,7 +1355,7 @@ class Accelerator:
         ):
             model_devices = set(model.hf_device_map.values())
             model_devices_str = str(list(model_devices)[0])
-            if model_devices_str == 'cuda' or (len(model_devices) > 1 and se:lf.distributed_type != DistributedType.NO):
+            if model_devices_str == 'cuda' or (len(model_devices) > 1 and self.distributed_type != DistributedType.NO):
                 raise ValueError(
                     "You can't train a model that has been loaded in 8-bit precision on multiple devices in any distributed mode."
                     " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."


### PR DESCRIPTION
TL;DR -- Fix error behavior for models initialized with 'cuda' device map

# What does this PR do?

If a model is initialized with a the 'cuda' device map, the prepare_model routine will silently fail due to current_device.index returning a None value. Instead, it seems the correct error message would be to catch this in the if statement above. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->