### PR TITLE
Remove unnecessary `env=os.environ.copy()`s

### DIFF
--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -15,7 +15,6 @@
 # limitations under the License.
 
 import argparse
-import os
 
 from accelerate.test_utils import execute_subprocess_async, path_in_accelerate_package
 
@@ -51,7 +50,7 @@ def test_command(args):
         test_args = f"--config_file={args.config_file} {script_name}".split()
 
     cmd = ["accelerate-launch"] + test_args
-    result = execute_subprocess_async(cmd, env=os.environ.copy())
+    result = execute_subprocess_async(cmd)
     if result.returncode == 0:
         print("Test is a success! You are ready for your distributed training!")
 

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -832,7 +832,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 f"--output_dir={dirpath}",
             ]
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd, env=os.environ.copy())
+                execute_subprocess_async(cmd)
 
 
 @require_deepspeed
@@ -909,7 +909,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 ]
             )
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd_stage, env=os.environ.copy())
+                execute_subprocess_async(cmd_stage)
 
     def test_checkpointing(self):
         self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
@@ -953,7 +953,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 ]
             )
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd_stage, env=os.environ.copy())
+                execute_subprocess_async(cmd_stage)
 
             cmd_stage = cmd_stage[:-1]
             resume_from_checkpoint = os.path.join(self.tmpdir, "epoch_0")
@@ -963,7 +963,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 ]
             )
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd_stage, env=os.environ.copy())
+                execute_subprocess_async(cmd_stage)
 
     def test_peak_memory_usage(self):
         self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
@@ -1026,7 +1026,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 ]
             )
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd_stage, env=os.environ.copy())
+                execute_subprocess_async(cmd_stage)
 
     def test_lr_scheduler(self):
         self.test_file_path = self.test_scripts_folder / "test_performance.py"
@@ -1050,4 +1050,4 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
             f"--performance_lower_bound={self.performance_lower_bound}",
         ]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -241,7 +241,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                 ]
             )
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd_config, env=os.environ.copy())
+                execute_subprocess_async(cmd_config)
 
     def test_checkpointing(self):
         self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
@@ -276,7 +276,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                     ]
                 )
                 with patch_environment(omp_num_threads=1):
-                    execute_subprocess_async(cmd_config, env=os.environ.copy())
+                    execute_subprocess_async(cmd_config)
 
                 cmd_config = cmd_config[:-1]
                 resume_from_checkpoint = os.path.join(self.tmpdir, "epoch_0")
@@ -286,7 +286,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                     ]
                 )
                 with patch_environment(omp_num_threads=1):
-                    execute_subprocess_async(cmd_config, env=os.environ.copy())
+                    execute_subprocess_async(cmd_config)
 
     def test_peak_memory_usage(self):
         self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
@@ -330,4 +330,4 @@ class FSDPIntegrationTest(TempDirTestCase):
                 ]
             )
             with patch_environment(omp_num_threads=1):
-                execute_subprocess_async(cmd_config, env=os.environ.copy())
+                execute_subprocess_async(cmd_config)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,7 +74,7 @@ class AccelerateLauncherTester(unittest.TestCase):
                 continue
             with self.subTest(config_file=config):
                 cmd = get_launch_command(config_file=config) + [self.test_file_path]
-                execute_subprocess_async(cmd, env=os.environ.copy())
+                execute_subprocess_async(cmd)
 
     def test_invalid_keys(self):
         config_path = self.test_config_path / "invalid_keys.yaml"
@@ -83,10 +83,10 @@ class AccelerateLauncherTester(unittest.TestCase):
             msg="The config file at 'invalid_keys.yaml' had unknown keys ('another_invalid_key', 'invalid_key')",
         ):
             cmd = get_launch_command(config_file=config_path) + [self.test_file_path]
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)
 
     def test_accelerate_test(self):
-        execute_subprocess_async(["accelerate", "test"], env=os.environ.copy())
+        execute_subprocess_async(["accelerate", "test"])
 
     @require_multi_device
     def test_notebook_launcher(self):
@@ -96,7 +96,7 @@ class AccelerateLauncherTester(unittest.TestCase):
         """
         cmd = ["python", self.notebook_launcher_path]
         with patch_environment(omp_num_threads=1, accelerate_num_processes=2):
-            run_command(cmd, env=os.environ.copy())
+            run_command(cmd)
 
 
 class TpuConfigTester(unittest.TestCase):

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 from accelerate import debug_launcher
@@ -49,4 +48,4 @@ class SyncScheduler(unittest.TestCase):
         print(f"Found {device_count} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.test_file_path]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -69,7 +69,7 @@ class KwargsHandlerTester(unittest.TestCase):
     @require_multi_device
     def test_ddp_kwargs(self):
         cmd = DEFAULT_LAUNCH_COMMAND + [inspect.getfile(self.__class__)]
-        execute_subprocess_async(cmd, env=os.environ.copy())
+        execute_subprocess_async(cmd)
 
     @require_non_cpu
     def test_autocast_kwargs(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 from accelerate import debug_launcher
@@ -55,4 +54,4 @@ class MetricTester(unittest.TestCase):
         print(f"Found {device_count} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.test_file_path]
         with patch_environment(omp_num_threads=1, ACCELERATE_LOG_LEVEL="INFO"):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import inspect
-import os
 import unittest
 
 import torch
@@ -47,21 +46,21 @@ class MultiDeviceTester(unittest.TestCase):
         print(f"Found {device_count} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.test_file_path]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)
 
     @require_multi_device
     def test_multi_device_ops(self):
         print(f"Found {device_count} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.operation_file_path]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)
 
     @require_multi_device
     def test_pad_across_processes(self):
         print(f"Found {device_count} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [inspect.getfile(self.__class__)]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)
 
     @require_non_torch_xla
     @require_multi_gpu
@@ -73,7 +72,7 @@ class MultiDeviceTester(unittest.TestCase):
         print(f"Found {device_count} devices, using 2 devices only")
         cmd = get_launch_command(num_processes=2) + [self.data_loop_file_path]
         with patch_environment(omp_num_threads=1, cuda_visible_devices="0,1"):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)
 
     @require_multi_gpu
     @require_pippy
@@ -85,7 +84,7 @@ class MultiDeviceTester(unittest.TestCase):
         print(f"Found {device_count} devices")
         cmd = get_launch_command(multi_gpu=True, num_processes=device_count) + [self.pippy_file_path]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(cmd)
 
 
 if __name__ == "__main__":

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -379,10 +379,14 @@ class CheckpointTest(unittest.TestCase):
     @require_non_torch_xla
     def test_map_location(self):
         cmd = DEFAULT_LAUNCH_COMMAND + [inspect.getfile(self.__class__)]
-        env = os.environ.copy()
-        env["USE_SAFETENSORS"] = str(self.use_safetensors)
-        env["OMP_NUM_THREADS"] = "1"
-        execute_subprocess_async(cmd, env=env)
+        execute_subprocess_async(
+            cmd,
+            env={
+                **os.environ,
+                "USE_SAFETENSORS": str(self.use_safetensors),
+                "OMP_NUM_THREADS": "1",
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_tpu.py
+++ b/tests/test_tpu.py
@@ -31,4 +31,4 @@ class MultiTPUTester(unittest.TestCase):
             {self.test_file_path}
         """.split()
         cmd = [sys.executable] + distributed_args
-        execute_subprocess_async(cmd, env=os.environ.copy())
+        execute_subprocess_async(cmd)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -175,9 +175,8 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         # The latest offline log is stored at wandb/latest-run/*.wandb
         for child in Path(f"{self.tmpdir}/wandb/latest-run").glob("*"):
             if child.is_file() and child.suffix == ".wandb":
-                content = subprocess.check_output(
-                    ["wandb", "sync", "--view", "--verbose", str(child)], env=os.environ.copy()
-                ).decode("utf8", "ignore")
+                cmd = ["wandb", "sync", "--view", "--verbose", str(child)]
+                content = subprocess.check_output(cmd, encoding="utf8", errors="ignore")
                 break
 
         # Check HPS through careful parsing and cleaning


### PR DESCRIPTION
# What does this PR do?

Subprocess execution calls had a copy-pasted `env=os.environ.copy()` tacked onto them.

When `env=None`, quoth the docs for `subprocess.run`:

> If env is not `None`, it must be a mapping that defines the environment variables for the new process; these are used **instead of the default behavior of inheriting the current process’ environment.**

, emphasis mine.

Unless someone expects `execute_subprocess_async()` to modify the `env` passed in, these are all unnecessary copy-paste. If `execute_subprocess_async()` is expected to modify it, then we can add ```if env is None: env = os.environ.copy()` within it.

Sibling of #2446.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
  - No user-facing changes.
- [ ] Did you write any new necessary tests?
  - Shouldn't be necessary.

## Who can review?

cc @muellerzr @BenjaminBossan