### PR TITLE
Context manager fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,9 @@ extend-select = [
     "E", # PEP8 errors
     "F", # PEP8 formatting
     "I", # Import sorting
-    "W", # PEP8 warnings
+    "TID251", # Banned API
     "UP", # Pyupgrade
+    "W", # PEP8 warnings
 ]
 ignore = [
     "E501", # Line length (handled by ruff-format)
@@ -34,3 +35,8 @@ known-first-party = ["accelerate"]
 exclude = [
     "manim_animations/*"
 ]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"os.getenv".msg = "Use os.environ instead"
+"os.putenv".msg = "Use os.environ instead"
+"os.unsetenv".msg = "Use os.environ instead"

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3186,6 +3186,7 @@ class Accelerator:
             autocast_handler = self.autocast_handler
         autocast_context = get_mixed_precision_context_manager(self.native_amp, autocast_handler)
         autocast_context.__enter__()
+        # TODO: should the `yield` be in a try/finally block?
         yield
         autocast_context.__exit__(*sys.exc_info())
 

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -27,7 +27,7 @@ from ...utils.constants import SAGEMAKER_PYTHON_VERSION, SAGEMAKER_PYTORCH_VERSI
 
 
 hf_cache_home = os.path.expanduser(
-    os.getenv("HF_HOME", os.path.join(os.getenv("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
+    os.environ.get("HF_HOME", os.path.join(os.environ.get("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
 )
 cache_dir = os.path.join(hf_cache_home, "accelerate")
 default_json_config_file = os.path.join(cache_dir, "default_config.yaml")

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -618,13 +618,13 @@ class MLflowTracker(GeneralTracker):
         run_name: Optional[str] = None,
         description: Optional[str] = None,
     ):
-        experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME", experiment_name)
-        run_id = os.getenv("MLFLOW_RUN_ID", run_id)
-        tags = os.getenv("MLFLOW_TAGS", tags)
+        experiment_name = os.environ.get("MLFLOW_EXPERIMENT_NAME", experiment_name)
+        run_id = os.environ.get("MLFLOW_RUN_ID", run_id)
+        tags = os.environ.get("MLFLOW_TAGS", tags)
         if isinstance(tags, str):
             tags = json.loads(tags)
 
-        nested_run = os.getenv("MLFLOW_NESTED_RUN", nested_run)
+        nested_run = os.environ.get("MLFLOW_NESTED_RUN", nested_run)
 
         import mlflow
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -215,10 +215,11 @@ def clear_environment():
     _old_os_environ = os.environ.copy()
     os.environ.clear()
 
-    yield
-
-    os.environ.clear()  # clear any added keys,
-    os.environ.update(_old_os_environ)  # then restore previous environment
+    try:
+        yield
+    finally:
+        os.environ.clear()  # clear any added keys,
+        os.environ.update(_old_os_environ)  # then restore previous environment
 
 
 @contextmanager
@@ -246,15 +247,16 @@ def patch_environment(**kwargs):
             existing_vars[key] = os.environ[key]
         os.environ[key] = str(value)
 
-    yield
-
-    for key in kwargs:
-        key = key.upper()
-        if key in existing_vars:
-            # restore previous value
-            os.environ[key] = existing_vars[key]
-        else:
-            os.environ.pop(key, None)
+    try:
+        yield
+    finally:
+        for key in kwargs:
+            key = key.upper()
+            if key in existing_vars:
+                # restore previous value
+                os.environ[key] = existing_vars[key]
+            else:
+                os.environ.pop(key, None)
 
 
 def get_pretty_name(obj):

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -190,9 +190,9 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Fal
 @contextmanager
 def clear_environment():
     """
-    A context manager that will cache origin `os.environ` and replace it with a empty dictionary in this context.
+    A context manager that will temporarily clear environment variables.
 
-    When this context exits, the cached `os.environ` will be back.
+    When this context exits, the previous environment variables will be back.
 
     Example:
 
@@ -212,12 +212,13 @@ def clear_environment():
     bar
     ```
     """
-    _old_os_environ = os.environ
-    os.environ = dict()
+    _old_os_environ = os.environ.copy()
+    os.environ.clear()
 
     yield
 
-    os.environ = _old_os_environ
+    os.environ.clear()  # clear any added keys,
+    os.environ.update(_old_os_environ)  # then restore previous environment
 
 
 @contextmanager

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -105,6 +105,7 @@ class KwargsHandlerTester(unittest.TestCase):
 
             dynamo_plugin_kwargs = TorchDynamoPlugin().to_kwargs()
             assert dynamo_plugin_kwargs == {"backend": "aot_ts_nvfuser", "mode": "reduce-overhead"}
+        assert os.environ.get(prefix + "BACKEND") != "aot_ts_nvfuser"
 
 
 def main():


### PR DESCRIPTION
# What does this PR do?

* Configures Ruff to prevent `os.getenv` and `os.setenv`; there should be one way to manage the env, and `os.environ` was used more.
* `clear_environment()` didn't actually clear environment variables, it just assigned a new `os.environ` proxy dictionary.
* The environment management context managers wouldn't clean up after themselves if the inner block raised.
  * There was another suspect place where cleanup code after `yield` is not wrapped; marked that as a TODO (@muellerzr seems to have touched that function last))

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
  -  No user-facing changes other than the CMs being more "do-what-I-mean"
- [x] Did you write any new necessary tests?
  - Sure did!

## Who can review?

cc @muellerzr @BenjaminBossan