### PR TITLE
Check for None

### DIFF
--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -75,8 +75,10 @@ def build_pipeline(model, split_points, args, kwargs, num_chunks):
     annotate_split_points(model, {split_point: PipeSplitWrapper.SplitPoint.BEGINNING for split_point in split_points})
     found_batch_size = find_pippy_batch_size(args, kwargs)
     if found_batch_size != num_chunks:
-        args = pad_input_tensors(args, found_batch_size, num_chunks)
-        kwargs = pad_input_tensors(kwargs, found_batch_size, num_chunks)
+        if args is not None:
+            args = pad_input_tensors(args, found_batch_size, num_chunks)
+        if kwargs is not None:
+            kwargs = pad_input_tensors(kwargs, found_batch_size, num_chunks)
     pipe = Pipe.from_tracing(model, num_chunks=num_chunks, example_args=args, example_kwargs=kwargs)
     stage = PipelineStage(pipe, state.local_process_index, device=state.device)
 


### PR DESCRIPTION
# What does this PR do?

The CV models test showed a failure when `args` is defined but `kwargs` are none (why only them, unsure as gpt2 didn't face this, but I digress). This check makes sure that the padding is only checked for if the value is not `None` (otherwise we get an error about how we can't run it w/o a tensor-like item)

Fixes # (issue)

Failing test on main

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@SunMarc 