### PR TITLE
Fix the pytest version to be less than 8.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras["quality"] = [
     "ruff ~= 0.2.1",
 ]
 extras["docs"] = []
-extras["test_prod"] = ["pytest>=7.2.0,<8.0.0", "pytest-xdist", "pytest-subtests", "parameterized"]
+extras["test_prod"] = ["pytest>=7.2.0,<=8.0.0", "pytest-xdist", "pytest-subtests", "parameterized"]
 extras["test_dev"] = [
     "datasets",
     "evaluate",

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras["quality"] = [
     "ruff ~= 0.2.1",
 ]
 extras["docs"] = []
-extras["test_prod"] = ["pytest", "pytest-xdist", "pytest-subtests", "parameterized"]
+extras["test_prod"] = ["pytest>=7.2.0,<8.0.0", "pytest-xdist", "pytest-subtests", "parameterized"]
 extras["test_dev"] = [
     "datasets",
     "evaluate",


### PR DESCRIPTION
# What does this PR do?

Fixes the pytest version.

We're getting errors such as this one:

https://github.com/huggingface/accelerate/actions/runs/7958684877/job/21725397566?pr=2450