### PR TITLE
Fix TPU with new `XLA` device type

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -470,7 +470,7 @@ class Accelerator:
                 self.native_amp = True
             else:
                 self.native_amp = is_bf16_available(True)
-            if mixed_precision == "bf16" and not self.native_amp and not is_torch_xla_available(check_is_gpu=True):
+            if mixed_precision == "bf16" and not self.native_amp and not is_torch_xla_available():
                 raise ValueError("bf16 mixed precision requires PyTorch >= 1.10 and a supported device.")
 
         # Start of internal step tracking

--- a/src/accelerate/commands/config/config_utils.py
+++ b/src/accelerate/commands/config/config_utils.py
@@ -68,7 +68,7 @@ def _convert_compute_environment(value):
 
 def _convert_distributed_mode(value):
     value = int(value)
-    return DistributedType(["NO", "MULTI_CPU", "MULTI_XPU", "MULTI_GPU", "MULTI_NPU", "TPU"][value])
+    return DistributedType(["NO", "MULTI_CPU", "MULTI_XPU", "MULTI_GPU", "MULTI_NPU", "XLA"][value])
 
 
 def _convert_dynamo_backend(value):

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -32,8 +32,8 @@ USE_TORCH_XLA = parse_flag_from_env("USE_TORCH_XLA", default=True)
 _torch_xla_available = False
 if USE_TORCH_XLA:
     try:
-        import torch_xla.runtime
         import torch_xla.core.xla_model as xm  # noqa: F401
+        import torch_xla.runtime
 
         _torch_xla_available = True
     except ImportError:

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -138,6 +138,10 @@ def is_torch_xla_available(check_is_tpu=False, check_is_gpu=False):
     if not _torch_xla_available:
         return False
 
+    # Don't initialize the XLA client unless we want to check the device type.
+    if not (check_is_tpu or check_is_gpu):
+        return True
+
     try:
         xla_device = xm.xla_device()
         hardware_type = xm.xla_device_hw(xla_device)
@@ -145,7 +149,6 @@ def is_torch_xla_available(check_is_tpu=False, check_is_gpu=False):
             [
                 check_is_tpu and hardware_type == "TPU",
                 check_is_gpu and hardware_type == "GPU",
-                not (check_is_tpu or check_is_gpu),
             ]
         )
     except RuntimeError:

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -32,6 +32,7 @@ USE_TORCH_XLA = parse_flag_from_env("USE_TORCH_XLA", default=True)
 _torch_xla_available = False
 if USE_TORCH_XLA:
     try:
+        import torch_xla.runtime
         import torch_xla.core.xla_model as xm  # noqa: F401
 
         _torch_xla_available = True
@@ -137,22 +138,12 @@ def is_torch_xla_available(check_is_tpu=False, check_is_gpu=False):
 
     if not _torch_xla_available:
         return False
+    elif check_is_gpu:
+        return torch_xla.runtime.device_type() in ["GPU", "CUDA"]
+    elif check_is_tpu:
+        return torch_xla.runtime.device_type() == "TPU"
 
-    # Don't initialize the XLA client unless we want to check the device type.
-    if not (check_is_tpu or check_is_gpu):
-        return True
-
-    try:
-        xla_device = xm.xla_device()
-        hardware_type = xm.xla_device_hw(xla_device)
-        return any(
-            [
-                check_is_tpu and hardware_type == "TPU",
-                check_is_gpu and hardware_type == "GPU",
-            ]
-        )
-    except RuntimeError:
-        return False
+    return True
 
 
 def is_deepspeed_available():


### PR DESCRIPTION
# What does this PR do?

#2176 replaces the `TPU` device type with `XLA`, letting us use GPUs with `accelerate` now :confetti_ball: 

This PR fixes some issues that pop up on TPU after that PR:

- Don't check the `xm.xla_device` in `is_torch_xla_available`. Calling `xm.xla_device` before `xmp.spawn` causes issues. This causes `torch_xla` to initialize the runtime parent process, reserving some space on GPU that can't be used by the child processes and causing TPU workloads to outright crash (message below).
- Fix menu of options in `accelerate config` to offer `XLA` as an option. Selecting `TPU` causes an error because that device type no longer exists.
- Allow bf16 mixed precision on TPU. Matches old behavior before #2176.

Currently, running `accelerate` on TPU causes this crash due to the first issue:

```
...
F0000 00:00:1708382221.197251   23274 pjrt_registry.cc:117] Non-OK-status: pjrt::LoadPjrtPlugin("tpu", tpu_library_path).status() status: ALREADY_EXISTS: PJRT_Api already exists for device type tpu
...
```

Tested `accelerate test` on TPU v4-8.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

cc @muellerzr  @anw90 @vanbasten23 