### PR TITLE
[FIX] allow `Accelerator` to detect distributed type from the "LOCAL_RANK" env variable for XPU 

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -251,7 +251,10 @@ class PartialState:
                 if self.device is None:
                     self.device = torch.device("npu", self.local_process_index)
                 torch.npu.set_device(self.device)
-            elif get_int_from_env(["PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "WORLD_SIZE"], 1) > 1 or int(os.environ.get("LOCAL_RANK", -1)) != -1:
+            elif (
+                get_int_from_env(["PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "WORLD_SIZE"], 1) > 1
+                or int(os.environ.get("LOCAL_RANK", -1)) != -1
+            ):
                 if not cpu and is_xpu_available():
                     self.distributed_type = DistributedType.MULTI_XPU
                 else:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -251,7 +251,7 @@ class PartialState:
                 if self.device is None:
                     self.device = torch.device("npu", self.local_process_index)
                 torch.npu.set_device(self.device)
-            elif get_int_from_env(["PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "WORLD_SIZE"], 1) > 1:
+            elif get_int_from_env(["PMI_SIZE", "OMPI_COMM_WORLD_SIZE", "MV2_COMM_WORLD_SIZE", "WORLD_SIZE"], 1) > 1 or int(os.environ.get("LOCAL_RANK", -1)) != -1:
                 if not cpu and is_xpu_available():
                     self.distributed_type = DistributedType.MULTI_XPU
                 else:
@@ -336,7 +336,6 @@ class PartialState:
 
                 if self.device is None:
                     self.device = torch.device("cpu") if cpu else self.default_device
-
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
     def __repr__(self) -> str:
@@ -844,7 +843,6 @@ class AcceleratorState:
                         if self._mixed_precision != "no":
                             fsdp_plugin.set_mixed_precision(self._mixed_precision)
                         self.fsdp_plugin = fsdp_plugin
-
             if (
                 self.dynamo_plugin.backend != DynamoBackend.NO
                 and self._mixed_precision == "no"


### PR DESCRIPTION
## What does this PR do?
Inspired by the newly added test `test_fsdp.py`, I found that Accelerator's default distributed type is NO on XPU with the following approach, while on NV GPU it is FSDP: 
```bash
$ export ACCELERATE_USE_FSDP="true"
$ export MASTER_ADDR="localhost"
$ export MASTER_PORT="10999"
$ export RANK="0"
$ export LOCAL_RANK="0"
$ export WORLD_SIZE="1"
$ python
>>> from accelerate.accelerator import Accelerator
>>> accelerator = Accelerator()
>>> accelerator.state.distributed_type
<DistributedType.NO: 'NO'>
## on NV GPU
>>> accelerator.state.distributed_type
<DistributedType.FSDP: 'FSDP'>
```
The reason lies at [this ](https://github.com/faaany/accelerate/blob/main/src/accelerate/state.py#L254) line: currently, MUTLI_XPU/MULTI_CPU is detected by `WORLD_SIZE`, while on NPU or GPU, it is detected by `LOCAL_RANK` as shown [here](https://github.com/faaany/accelerate/blob/main/src/accelerate/state.py#L220). 

To be safe, I add an "or" condition to fix this issue instead of doing refactoring for the entire code block. After the fix, the behavior on XPU aligns with that on GPU and the `test_mixed_precision` unit test in the `test_fsdp.py` can run through. 

Pls have a review, thx! @muellerzr 
