### PR TITLE
Fix CI tests due to pathlib issues

### DIFF
--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -48,7 +48,7 @@ def test_command(args):
     if args.config_file is None:
         test_args = [script_name]
     else:
-        test_args = (f"--config_file={args.config_file} {script_name}").split()
+        test_args = f"--config_file={args.config_file} {script_name}".split()
 
     cmd = ["accelerate-launch"] + test_args
     result = execute_subprocess_async(cmd, env=os.environ.copy())

--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -17,8 +17,7 @@
 import argparse
 import os
 
-from accelerate.test_utils import execute_subprocess_async
-from accelerate.utils.other import path_in_accelerate_package
+from accelerate.test_utils import execute_subprocess_async, path_in_accelerate_package
 
 
 def test_command_parser(subparsers=None):

--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -46,7 +46,7 @@ def test_command(args):
     script_name = path_in_accelerate_package("test_utils", "scripts", "test_script.py")
 
     if args.config_file is None:
-        test_args = script_name
+        test_args = [script_name]
     else:
         test_args = (f"--config_file={args.config_file} {script_name}").split()
 

--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -48,9 +48,9 @@ def test_command(args):
     if args.config_file is None:
         test_args = script_name
     else:
-        test_args = f"--config_file={args.config_file} {script_name}"
+        test_args = (f"--config_file={args.config_file} {script_name}").split()
 
-    cmd = ["accelerate-launch"] + test_args.split()
+    cmd = ["accelerate-launch"] + test_args
     result = execute_subprocess_async(cmd, env=os.environ.copy())
     if result.returncode == 0:
         print("Test is a success! You are ready for your distributed training!")

--- a/src/accelerate/commands/test.py
+++ b/src/accelerate/commands/test.py
@@ -47,7 +47,7 @@ def test_command(args):
     script_name = path_in_accelerate_package("test_utils", "scripts", "test_script.py")
 
     if args.config_file is None:
-        test_args = str(script_name)
+        test_args = script_name
     else:
         test_args = f"--config_file={args.config_file} {script_name}"
 

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -4,6 +4,7 @@ from .testing import (
     device_count,
     execute_subprocess_async,
     memory_allocated_func,
+    path_in_accelerate_package,
     require_bnb,
     require_cpu,
     require_cuda,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -490,7 +490,7 @@ async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=Fals
     return _RunOutput(await p.wait(), out, err)
 
 
-def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
+def execute_subprocess_async(cmd: list, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
     # Cast everything in `cmd` to a string
     for i, c in enumerate(cmd):
         if isinstance(c, Path):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -492,7 +492,9 @@ async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=Fals
 
 def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
     # Cast everything in `cmd` to a string
-    cmd = [str(c) for c in cmd]
+    for i, c in enumerate(cmd):
+        if isinstance(c, Path):
+            cmd[i] = str(c)
     loop = asyncio.get_event_loop()
     result = loop.run_until_complete(
         _stream_subprocess(cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo)

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import inspect
 import os
 import shutil
 import subprocess
@@ -26,6 +27,8 @@ from typing import List, Union
 from unittest import mock
 
 import torch
+
+import accelerate
 
 from ..state import AcceleratorState, PartialState
 from ..utils import (
@@ -354,7 +357,7 @@ class TempDirTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         "Creates a `tempfile.TemporaryDirectory` and stores it in `cls.tmpdir`"
-        cls.tmpdir = tempfile.mkdtemp()
+        cls.tmpdir = Path(tempfile.mkdtemp())
 
     @classmethod
     def tearDownClass(cls):
@@ -365,7 +368,7 @@ class TempDirTestCase(unittest.TestCase):
     def setUp(self):
         "Destroy all contents in `self.tmpdir`, but not `self.tmpdir`"
         if self.clear_on_setup:
-            for path in Path(self.tmpdir).glob("**/*"):
+            for path in self.tmpdir.glob("**/*"):
                 if path.is_file():
                     path.unlink()
                 elif path.is_dir():
@@ -488,6 +491,8 @@ async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=Fals
 
 
 def execute_subprocess_async(cmd, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
+    # Cast everything in `cmd` to a string
+    cmd = [str(c) for c in cmd]
     loop = asyncio.get_event_loop()
     result = loop.run_until_complete(
         _stream_subprocess(cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo)
@@ -513,6 +518,8 @@ def run_command(command: List[str], return_stdout=False, env=None):
     Runs `command` with `subprocess.check_output` and will potentially return the `stdout`. Will also properly capture
     if an error occured while running `command`
     """
+    # Cast everything in `cmd` to a string
+    command = [str(c) for c in command]
     if env is None:
         env = os.environ.copy()
     try:
@@ -525,6 +532,21 @@ def run_command(command: List[str], return_stdout=False, env=None):
         raise SubprocessCallException(
             f"Command `{' '.join(command)}` failed with the following error:\n\n{e.output.decode()}"
         ) from e
+
+
+def path_in_accelerate_package(*components: str) -> Path:
+    """
+    Get a path within the `accelerate` package's directory.
+
+    Args:
+        *components: Components of the path to join after the package directory.
+
+    Returns:
+        `Path`: The path to the requested file or directory.
+    """
+
+    accelerate_package_dir = Path(inspect.getfile(accelerate)).parent
+    return accelerate_package_dir.joinpath(*components)
 
 
 @contextmanager

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -491,7 +491,7 @@ async def _stream_subprocess(cmd, env=None, stdin=None, timeout=None, quiet=Fals
 
 
 def execute_subprocess_async(cmd: list, env=None, stdin=None, timeout=180, quiet=False, echo=True) -> _RunOutput:
-    # Cast everything in `cmd` to a string
+    # Cast every path in `cmd` to a string
     for i, c in enumerate(cmd):
         if isinstance(c, Path):
             cmd[i] = str(c)
@@ -520,8 +520,10 @@ def run_command(command: List[str], return_stdout=False, env=None):
     Runs `command` with `subprocess.check_output` and will potentially return the `stdout`. Will also properly capture
     if an error occured while running `command`
     """
-    # Cast everything in `cmd` to a string
-    command = [str(c) for c in command]
+    # Cast every path in `command` to a string
+    for i, c in enumerate(command):
+        if isinstance(c, Path):
+            command[i] = str(c)
     if env is None:
         env = os.environ.copy()
     try:

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -350,7 +350,7 @@ def recursive_getattr(obj, attr: str):
     return reduce(_getattr, [obj] + attr.split("."))
 
 
-def path_in_accelerate_package(*components: str) -> pathlib.Path:
+def path_in_accelerate_package(*components: str) -> str:
     """
     Get a path within the `accelerate` package's directory.
 
@@ -358,8 +358,8 @@ def path_in_accelerate_package(*components: str) -> pathlib.Path:
         *components: Components of the path to join after the package directory.
 
     Returns:
-        `pathlib.Path`: The path to the requested file or directory.
+        `str`: The path to the requested file or directory.
     """
 
     accelerate_package_dir = pathlib.Path(inspect.getfile(accelerate)).parent
-    return accelerate_package_dir.joinpath(*components)
+    return str(accelerate_package_dir.joinpath(*components))

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 import collections
-import inspect
 import os
-import pathlib
 import platform
 import re
 import socket
@@ -27,8 +25,6 @@ from typing import OrderedDict
 import torch
 from packaging.version import Version
 from safetensors.torch import save_file as safe_save_file
-
-import accelerate
 
 from ..commands.config.default import write_basic_config  # noqa: F401
 from ..logging import get_logger
@@ -348,18 +344,3 @@ def recursive_getattr(obj, attr: str):
         return getattr(obj, attr)
 
     return reduce(_getattr, [obj] + attr.split("."))
-
-
-def path_in_accelerate_package(*components: str) -> str:
-    """
-    Get a path within the `accelerate` package's directory.
-
-    Args:
-        *components: Components of the path to join after the package directory.
-
-    Returns:
-        `str`: The path to the requested file or directory.
-    """
-
-    accelerate_package_dir = pathlib.Path(inspect.getfile(accelerate)).parent
-    return str(accelerate_package_dir.joinpath(*components))

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -867,7 +867,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        test_file_path = str(self.test_scripts_folder / "test_performance.py")
+        self.test_file_path = str(self.test_scripts_folder / "test_performance.py")
         cmd = [
             "accelerate",
             "launch",
@@ -902,7 +902,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
             cmd_stage.extend(
                 [
-                    test_file_path,
+                    self.test_file_path,
                     f"--output_dir={self.tmpdir}",
                     f"--performance_lower_bound={self.performance_lower_bound}",
                 ]
@@ -911,7 +911,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_checkpointing(self):
-        test_file_path = self.test_scripts_folder / "test_checkpointing.py"
+        self.test_file_path = str(self.test_scripts_folder / "test_checkpointing.py")
         cmd = [
             "accelerate",
             "launch",
@@ -946,7 +946,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
             cmd_stage.extend(
                 [
-                    str(test_file_path),
+                    self.test_file_path,
                     f"--output_dir={self.tmpdir}",
                     "--partial_train_epoch=1",
                 ]
@@ -965,7 +965,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
+        self.test_file_path = str(self.test_scripts_folder / "test_peak_memory_usage.py")
         cmd = [
             "accelerate",
             "launch",
@@ -1017,7 +1017,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
             cmd_stage.extend(
                 [
-                    str(test_file_path),
+                    self.test_file_path,
                     f"--output_dir={self.tmpdir}",
                     f"--peak_memory_upper_bound={peak_mem_upper_bound}",
                     f"--n_train={self.n_train}",
@@ -1028,7 +1028,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_lr_scheduler(self):
-        test_file_path = self.test_scripts_folder / "test_performance.py"
+        self.test_file_path = str(self.test_scripts_folder / "test_performance.py")
         cmd = [
             "accelerate",
             "launch",
@@ -1044,7 +1044,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
             "--zero_stage=3",
             "--offload_optimizer_device=none",
             "--offload_param_device=none",
-            str(test_file_path),
+            self.test_file_path,
             f"--output_dir={self.tmpdir}",
             f"--performance_lower_bound={self.performance_lower_bound}",
         ]

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -34,6 +34,7 @@ from accelerate.test_utils.testing import (
     AccelerateTestCase,
     TempDirTestCase,
     execute_subprocess_async,
+    path_in_accelerate_package,
     require_deepspeed,
     require_multi_device,
     require_non_cpu,
@@ -48,7 +49,7 @@ from accelerate.utils.deepspeed import (
     DummyOptim,
     DummyScheduler,
 )
-from accelerate.utils.other import patch_environment, path_in_accelerate_package
+from accelerate.utils.other import patch_environment
 
 
 set_seed(42)
@@ -825,7 +826,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 "--zero_stage=2",
                 "--offload_optimizer_device=none",
                 "--offload_param_device=none",
-                str(test_file_path),
+                test_file_path,
                 "--model_name_or_path=distilbert-base-uncased",
                 "--num_epochs=1",
                 f"--output_dir={dirpath}",
@@ -838,7 +839,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 @require_multi_device
 @slow
 class DeepSpeedIntegrationTest(TempDirTestCase):
-    test_scripts_folder = Path(path_in_accelerate_package("test_utils", "scripts", "external_deps"))
+    test_scripts_folder = path_in_accelerate_package("test_utils", "scripts", "external_deps")
 
     def setUp(self):
         super().setUp()
@@ -867,7 +868,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_performance.py")
+        self.test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = [
             "accelerate",
             "launch",
@@ -911,7 +912,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_checkpointing(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_checkpointing.py")
+        self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
         cmd = [
             "accelerate",
             "launch",
@@ -965,7 +966,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_peak_memory_usage.py")
+        self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [
             "accelerate",
             "launch",
@@ -1028,7 +1029,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_lr_scheduler(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_performance.py")
+        self.test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = [
             "accelerate",
             "launch",

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -867,7 +867,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        self.test_file_path = self.test_scripts_folder / "test_performance.py"
+        test_file_path = str(self.test_scripts_folder / "test_performance.py")
         cmd = [
             "accelerate",
             "launch",
@@ -902,7 +902,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
             cmd_stage.extend(
                 [
-                    self.test_file_path,
+                    test_file_path,
                     f"--output_dir={self.tmpdir}",
                     f"--performance_lower_bound={self.performance_lower_bound}",
                 ]
@@ -911,7 +911,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_checkpointing(self):
-        self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
+        test_file_path = self.test_scripts_folder / "test_checkpointing.py"
         cmd = [
             "accelerate",
             "launch",
@@ -946,7 +946,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
             cmd_stage.extend(
                 [
-                    self.test_file_path,
+                    str(test_file_path),
                     f"--output_dir={self.tmpdir}",
                     "--partial_train_epoch=1",
                 ]
@@ -965,7 +965,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
+        test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [
             "accelerate",
             "launch",
@@ -1017,7 +1017,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
             cmd_stage.extend(
                 [
-                    self.test_file_path,
+                    str(test_file_path),
                     f"--output_dir={self.tmpdir}",
                     f"--peak_memory_upper_bound={peak_mem_upper_bound}",
                     f"--n_train={self.n_train}",
@@ -1028,7 +1028,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_lr_scheduler(self):
-        self.test_file_path = self.test_scripts_folder / "test_performance.py"
+        test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = [
             "accelerate",
             "launch",
@@ -1044,7 +1044,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
             "--zero_stage=3",
             "--offload_optimizer_device=none",
             "--offload_param_device=none",
-            self.test_file_path,
+            str(test_file_path),
             f"--output_dir={self.tmpdir}",
             f"--performance_lower_bound={self.performance_lower_bound}",
         ]

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -838,7 +838,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 @require_multi_device
 @slow
 class DeepSpeedIntegrationTest(TempDirTestCase):
-    test_scripts_folder = path_in_accelerate_package("test_utils", "scripts", "external_deps")
+    test_scripts_folder = Path(path_in_accelerate_package("test_utils", "scripts", "external_deps"))
 
     def setUp(self):
         super().setUp()
@@ -867,7 +867,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_performance.py")
+        self.test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = [
             "accelerate",
             "launch",
@@ -911,7 +911,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_checkpointing(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_checkpointing.py")
+        self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
         cmd = [
             "accelerate",
             "launch",
@@ -965,7 +965,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_peak_memory_usage.py")
+        self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [
             "accelerate",
             "launch",
@@ -1028,7 +1028,7 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage, env=os.environ.copy())
 
     def test_lr_scheduler(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_performance.py")
+        self.test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = [
             "accelerate",
             "launch",

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -14,7 +14,6 @@
 
 
 import os
-from pathlib import Path
 
 import torch
 from transformers import AutoModel
@@ -27,6 +26,7 @@ from accelerate.test_utils.testing import (
     AccelerateTestCase,
     TempDirTestCase,
     execute_subprocess_async,
+    path_in_accelerate_package,
     require_fsdp,
     require_multi_device,
     require_non_cpu,
@@ -40,7 +40,7 @@ from accelerate.utils.constants import (
     FSDP_STATE_DICT_TYPE,
 )
 from accelerate.utils.dataclasses import FullyShardedDataParallelPlugin
-from accelerate.utils.other import patch_environment, path_in_accelerate_package
+from accelerate.utils.other import patch_environment
 
 
 set_seed(42)
@@ -184,7 +184,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
 @require_multi_device
 @slow
 class FSDPIntegrationTest(TempDirTestCase):
-    test_scripts_folder = Path(path_in_accelerate_package("test_utils", "scripts", "external_deps"))
+    test_scripts_folder = path_in_accelerate_package("test_utils", "scripts", "external_deps")
 
     def setUp(self):
         super().setUp()
@@ -205,7 +205,7 @@ class FSDPIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_performance.py")
+        self.test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = ["accelerate", "launch", "--num_processes=2", "--num_machines=1", "--machine_rank=0", "--use_fsdp"]
         for config in self.performance_configs:
             cmd_config = cmd.copy()
@@ -243,7 +243,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_config, env=os.environ.copy())
 
     def test_checkpointing(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_checkpointing.py")
+        self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
         cmd = [
             "accelerate",
             "launch",
@@ -290,7 +290,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                     execute_subprocess_async(cmd_config, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        self.test_file_path = str(self.test_scripts_folder / "test_peak_memory_usage.py")
+        self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [
             "accelerate",
             "launch",

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -205,7 +205,7 @@ class FSDPIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        self.test_file_path = self.test_scripts_folder / "test_performance.py"
+        self.test_file_path = str(self.test_scripts_folder / "test_performance.py")
         cmd = ["accelerate", "launch", "--num_processes=2", "--num_machines=1", "--machine_rank=0", "--use_fsdp"]
         for config in self.performance_configs:
             cmd_config = cmd.copy()
@@ -243,7 +243,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_config, env=os.environ.copy())
 
     def test_checkpointing(self):
-        self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
+        self.test_file_path = str(self.test_scripts_folder / "test_checkpointing.py")
         cmd = [
             "accelerate",
             "launch",
@@ -290,7 +290,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                     execute_subprocess_async(cmd_config, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
+        self.test_file_path = str(self.test_scripts_folder / "test_peak_memory_usage.py")
         cmd = [
             "accelerate",
             "launch",

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -14,6 +14,7 @@
 
 
 import os
+from pathlib import Path
 
 import torch
 from transformers import AutoModel
@@ -183,7 +184,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
 @require_multi_device
 @slow
 class FSDPIntegrationTest(TempDirTestCase):
-    test_scripts_folder = path_in_accelerate_package("test_utils", "scripts", "external_deps")
+    test_scripts_folder = Path(path_in_accelerate_package("test_utils", "scripts", "external_deps"))
 
     def setUp(self):
         super().setUp()
@@ -204,7 +205,7 @@ class FSDPIntegrationTest(TempDirTestCase):
         self.n_val = 160
 
     def test_performance(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_performance.py")
+        self.test_file_path = self.test_scripts_folder / "test_performance.py"
         cmd = ["accelerate", "launch", "--num_processes=2", "--num_machines=1", "--machine_rank=0", "--use_fsdp"]
         for config in self.performance_configs:
             cmd_config = cmd.copy()
@@ -242,7 +243,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_config, env=os.environ.copy())
 
     def test_checkpointing(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_checkpointing.py")
+        self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
         cmd = [
             "accelerate",
             "launch",
@@ -289,7 +290,7 @@ class FSDPIntegrationTest(TempDirTestCase):
                     execute_subprocess_async(cmd_config, env=os.environ.copy())
 
     def test_peak_memory_usage(self):
-        self.test_file_path = os.path.join(self.test_scripts_folder, "test_peak_memory_usage.py")
+        self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [
             "accelerate",
             "launch",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,13 +22,13 @@ from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
 from accelerate.test_utils.testing import (
+    path_in_accelerate_package,
     require_multi_device,
     require_timm,
     require_transformers,
     run_command,
 )
 from accelerate.utils import patch_environment
-from accelerate.utils.other import path_in_accelerate_package
 
 
 class AccelerateLauncherTester(unittest.TestCase):
@@ -74,13 +74,13 @@ class AccelerateLauncherTester(unittest.TestCase):
                     "accelerate",
                     "launch",
                     "--config_file",
-                    str(config),
+                    config,
                     self.test_file_path,
                 ]
                 execute_subprocess_async(cmd, env=os.environ.copy())
 
     def test_invalid_keys(self):
-        config_path = Path(self.test_config_path) / "invalid_keys.yaml"
+        config_path = self.test_config_path / "invalid_keys.yaml"
         with self.assertRaises(
             RuntimeError,
             msg="The config file at 'invalid_keys.yaml' had unknown keys ('another_invalid_key', 'invalid_key')",
@@ -89,7 +89,7 @@ class AccelerateLauncherTester(unittest.TestCase):
                 "accelerate",
                 "launch",
                 "--config_file",
-                str(config_path),
+                config_path,
                 self.test_file_path,
             ]
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -89,7 +89,7 @@ class AccelerateLauncherTester(unittest.TestCase):
                 "accelerate",
                 "launch",
                 "--config_file",
-                config_path,
+                str(config_path),
                 self.test_file_path,
             ]
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,7 @@ class AccelerateLauncherTester(unittest.TestCase):
                 execute_subprocess_async(cmd, env=os.environ.copy())
 
     def test_invalid_keys(self):
+        config_path = Path(self.test_config_path) / "invalid_keys.yaml"
         with self.assertRaises(
             RuntimeError,
             msg="The config file at 'invalid_keys.yaml' had unknown keys ('another_invalid_key', 'invalid_key')",
@@ -88,7 +89,7 @@ class AccelerateLauncherTester(unittest.TestCase):
                 "accelerate",
                 "launch",
                 "--config_file",
-                Path(self.test_config_path) / "invalid_keys.yaml",
+                config_path,
                 self.test_file_path,
             ]
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,7 +62,7 @@ class AccelerateLauncherTester(unittest.TestCase):
         cmd = ["accelerate", "launch"]
         if torch.cuda.is_available() and (torch.cuda.device_count() > 1):
             cmd += ["--multi_gpu"]
-        cmd.append(str(self.test_file_path))
+        cmd.append(self.test_file_path)
         execute_subprocess_async(cmd, env=os.environ.copy())
 
     def test_config_compatibility(self):
@@ -75,7 +75,7 @@ class AccelerateLauncherTester(unittest.TestCase):
                     "launch",
                     "--config_file",
                     str(config),
-                    str(self.test_file_path),
+                    self.test_file_path,
                 ]
                 execute_subprocess_async(cmd, env=os.environ.copy())
 
@@ -88,8 +88,8 @@ class AccelerateLauncherTester(unittest.TestCase):
                 "accelerate",
                 "launch",
                 "--config_file",
-                str(self.test_config_path / "invalid_keys.yaml"),
-                str(self.test_file_path),
+                Path(self.test_config_path) / "invalid_keys.yaml",
+                self.test_file_path,
             ]
             execute_subprocess_async(cmd, env=os.environ.copy())
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -18,6 +18,7 @@ import re
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import torch
@@ -72,6 +73,9 @@ class ExampleDifferenceTests(unittest.TestCase):
     etc (such as calls to `Accelerate.log()`)
     """
 
+    by_feature_path = Path("examples", "by_feature").resolve()
+    examples_path = Path("examples").resolve()
+
     def one_complete_example(
         self, complete_file_name: str, parser_only: bool, secondary_filename: str = None, special_strings: list = None
     ):
@@ -91,19 +95,17 @@ class ExampleDifferenceTests(unittest.TestCase):
                 diffs that are file specific, such as different logging variations between files.
         """
         self.maxDiff = None
-        by_feature_path = os.path.abspath(os.path.join("examples", "by_feature"))
-        examples_path = os.path.abspath("examples")
-        for item in os.listdir(by_feature_path):
+        for item in os.listdir(self.by_feature_path):
             if item not in EXCLUDE_EXAMPLES:
-                item_path = os.path.join(by_feature_path, item)
-                if os.path.isfile(item_path) and ".py" in item_path:
+                item_path = self.by_feature_path / item
+                if item_path.is_file() and item_path.suffix == ".py":
                     with self.subTest(
                         tested_script=complete_file_name,
                         feature_script=item,
                         tested_section="main()" if parser_only else "training_function()",
                     ):
                         diff = compare_against_test(
-                            os.path.join(examples_path, complete_file_name), item_path, parser_only, secondary_filename
+                            self.examples_path / complete_file_name, item_path, parser_only, secondary_filename
                         )
                         diff = "\n".join(diff)
                         if special_strings is not None:
@@ -116,7 +118,7 @@ class ExampleDifferenceTests(unittest.TestCase):
         self.one_complete_example("complete_nlp_example.py", False)
 
     def test_cv_examples(self):
-        cv_path = os.path.abspath(os.path.join("examples", "cv_example.py"))
+        cv_path = (self.examples_path / "cv_example.py").resolve()
         special_strings = [
             " " * 16 + "{\n\n",
             " " * 20 + '"accuracy": eval_metric["accuracy"],\n\n',
@@ -140,7 +142,7 @@ class FeatureExamplesTests(TempDirTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls._tmpdir = tempfile.mkdtemp()
-        cls.configPath = os.path.join(cls._tmpdir, "default_config.yml")
+        cls.configPath = Path(cls._tmpdir) / "default_config.yml"
 
         write_basic_config(save_location=cls.configPath)
         cls._launch_args = ["accelerate", "launch", "--config_file", cls.configPath]
@@ -157,7 +159,7 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         run_command(self._launch_args + testargs)
-        assert os.path.exists(os.path.join(self.tmpdir, "epoch_0"))
+        assert (self.tmpdir / "epoch_0").exists()
 
     def test_checkpointing_by_steps(self):
         testargs = f"""
@@ -166,12 +168,12 @@ class FeatureExamplesTests(TempDirTestCase):
         --output_dir {self.tmpdir}
         """.split()
         _ = run_command(self._launch_args + testargs)
-        assert os.path.exists(os.path.join(self.tmpdir, "step_2"))
+        assert (self.tmpdir / "step_2").exists()
 
     def test_load_states_by_epoch(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "epoch_0")}
+        --resume_from_checkpoint {self.tmpdir / "epoch_0"}
         """.split()
         output = run_command(self._launch_args + testargs, return_stdout=True)
         assert "epoch 0:" not in output
@@ -180,7 +182,7 @@ class FeatureExamplesTests(TempDirTestCase):
     def test_load_states_by_steps(self):
         testargs = f"""
         examples/by_feature/checkpointing.py
-        --resume_from_checkpoint {os.path.join(self.tmpdir, "step_2")}
+        --resume_from_checkpoint {self.tmpdir / "step_2"}
         """.split()
         output = run_command(self._launch_args + testargs, return_stdout=True)
         if torch.cuda.is_available():

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -46,6 +46,6 @@ class SyncScheduler(unittest.TestCase):
     @require_multi_device
     def test_gradient_sync_gpu_multi(self):
         print(f"Found {device_count} devices.")
-        cmd = ["torchrun", f"--nproc_per_node={device_count}", str(self.test_file_path)]
+        cmd = ["torchrun", f"--nproc_per_node={device_count}", self.test_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -19,13 +19,13 @@ from accelerate import debug_launcher
 from accelerate.test_utils import (
     device_count,
     execute_subprocess_async,
+    path_in_accelerate_package,
     require_cpu,
     require_multi_device,
     require_non_cpu,
     test_sync,
 )
 from accelerate.utils import patch_environment
-from accelerate.utils.other import path_in_accelerate_package
 
 
 class SyncScheduler(unittest.TestCase):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,13 +19,13 @@ from accelerate import debug_launcher
 from accelerate.test_utils import (
     device_count,
     execute_subprocess_async,
+    path_in_accelerate_package,
     require_cpu,
     require_huggingface_suite,
     require_multi_device,
     require_single_device,
 )
 from accelerate.utils import patch_environment
-from accelerate.utils.other import path_in_accelerate_package
 
 
 @require_huggingface_suite

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -84,7 +84,7 @@ class MultiDeviceTester(unittest.TestCase):
             "launch",
             "--multi_gpu",
             f"--num_processes={torch.cuda.device_count()}",
-            str(self.pippy_file_path),
+            self.pippy_file_path,
         ]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -24,13 +24,13 @@ from accelerate.test_utils import (
     assert_exception,
     device_count,
     execute_subprocess_async,
+    path_in_accelerate_package,
     require_multi_device,
     require_multi_gpu,
     require_non_torch_xla,
     require_pippy,
 )
 from accelerate.utils import patch_environment
-from accelerate.utils.other import path_in_accelerate_package
 
 
 class MultiDeviceTester(unittest.TestCase):

--- a/tests/test_tpu.py
+++ b/tests/test_tpu.py
@@ -16,8 +16,7 @@ import os
 import sys
 import unittest
 
-from accelerate.test_utils import execute_subprocess_async, require_tpu
-from accelerate.utils.other import path_in_accelerate_package
+from accelerate.test_utils import execute_subprocess_async, path_in_accelerate_package, require_tpu
 
 
 class MultiTPUTester(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

`subprocess` requires strings, it cannot use paths. Since the helper introduced in https://github.com/huggingface/accelerate/pull/2446 doesn't handle anything externally-facing and is just for testing, and a *vast majority of our tests* require `subprocess`, this PR makes it return a string instead and casts it back to a Path object if applicable. 

Fixes failures on main (and soon-to-be nightlies)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @akx 