### PR TITLE
Remove all cases of torchrun in tests and centralize as `accelerate launch`

### DIFF
--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -1,4 +1,5 @@
 from .testing import (
+    LaunchTestCase,
     are_the_same_tensors,
     assert_exception,
     device_count,

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -1,9 +1,10 @@
 from .testing import (
-    LaunchTestCase,
+    DEFAULT_LAUNCH_COMMAND,
     are_the_same_tensors,
     assert_exception,
     device_count,
     execute_subprocess_async,
+    get_launch_command,
     memory_allocated_func,
     path_in_accelerate_package,
     require_bnb,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -389,6 +389,24 @@ class AccelerateTestCase(unittest.TestCase):
         PartialState._reset_state()
 
 
+class LaunchTestCase(unittest.TestCase):
+    """
+    A TestCase class that helps prepare and run a test with `accelerate.launch`.
+    """
+
+    def get_launch_command(self, **kwargs):
+        command = ["accelerate", "launch"]
+        for k, v in kwargs.items():
+            if v is not None:
+                command.append(f"--{k}={v}")
+            elif isinstance(v, bool) and v:
+                command.append(f"--{k}")
+        return command
+
+    def setUp(self):
+        self.default_command = self.get_launch_command(num_processes=device_count)
+
+
 class MockingTestCase(unittest.TestCase):
     """
     A TestCase class designed to dynamically add various mockers that should be used in every test, mimicking the

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -73,6 +73,28 @@ def get_backend():
 torch_device, device_count, memory_allocated_func = get_backend()
 
 
+def get_launch_command(**kwargs) -> list:
+    """
+    Wraps around `kwargs` to help simplify launching from `subprocess`.
+
+    Example:
+    ```python
+    # returns ['accelerate', 'launch', '--num_processes=2', '--device_count=2']
+    get_launch_command(num_processes=2, device_count=2)
+    ```
+    """
+    command = ["accelerate", "launch"]
+    for k, v in kwargs.items():
+        if v is not None:
+            command.append(f"--{k}={v}")
+        elif isinstance(v, bool) and v:
+            command.append(f"--{k}")
+    return command
+
+
+DEFAULT_LAUNCH_COMMAND = get_launch_command(num_processes=device_count)
+
+
 def parse_flag_from_env(key, default=False):
     try:
         value = os.environ[key]
@@ -387,24 +409,6 @@ class AccelerateTestCase(unittest.TestCase):
         # Reset the state of the AcceleratorState singleton.
         AcceleratorState._reset_state()
         PartialState._reset_state()
-
-
-class LaunchTestCase(unittest.TestCase):
-    """
-    A TestCase class that helps prepare and run a test with `accelerate.launch`.
-    """
-
-    def get_launch_command(self, **kwargs):
-        command = ["accelerate", "launch"]
-        for k, v in kwargs.items():
-            if v is not None:
-                command.append(f"--{k}={v}")
-            elif isinstance(v, bool) and v:
-                command.append(f"--{k}")
-        return command
-
-    def setUp(self):
-        self.default_command = self.get_launch_command(num_processes=device_count)
 
 
 class MockingTestCase(unittest.TestCase):

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -24,9 +24,9 @@ from accelerate.accelerator import Accelerator
 from accelerate.state import AcceleratorState
 from accelerate.test_utils.testing import (
     AccelerateTestCase,
-    LaunchTestCase,
     TempDirTestCase,
     execute_subprocess_async,
+    get_launch_command,
     path_in_accelerate_package,
     require_fsdp,
     require_multi_device,
@@ -184,7 +184,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
 @require_fsdp
 @require_multi_device
 @slow
-class FSDPIntegrationTest(TempDirTestCase, LaunchTestCase):
+class FSDPIntegrationTest(TempDirTestCase):
     test_scripts_folder = path_in_accelerate_package("test_utils", "scripts", "external_deps")
 
     def setUp(self):
@@ -207,7 +207,7 @@ class FSDPIntegrationTest(TempDirTestCase, LaunchTestCase):
 
     def test_performance(self):
         self.test_file_path = self.test_scripts_folder / "test_performance.py"
-        cmd = self.get_launch_command(num_processes=2, num_machines=1, machine_rank=0, use_fsdp=True)
+        cmd = get_launch_command(num_processes=2, num_machines=1, machine_rank=0, use_fsdp=True)
         for config in self.performance_configs:
             cmd_config = cmd.copy()
             for i, strategy in enumerate(FSDP_SHARDING_STRATEGY):
@@ -245,7 +245,7 @@ class FSDPIntegrationTest(TempDirTestCase, LaunchTestCase):
 
     def test_checkpointing(self):
         self.test_file_path = self.test_scripts_folder / "test_checkpointing.py"
-        cmd = self.get_launch_command(
+        cmd = get_launch_command(
             num_processes=2,
             num_machines=1,
             machine_rank=0,
@@ -290,7 +290,7 @@ class FSDPIntegrationTest(TempDirTestCase, LaunchTestCase):
 
     def test_peak_memory_usage(self):
         self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
-        cmd = self.get_launch_command(num_processes=2, num_machines=1, machine_rank=0)
+        cmd = get_launch_command(num_processes=2, num_machines=1, machine_rank=0)
         for spec, peak_mem_upper_bound in self.peak_memory_usage_upper_bound.items():
             cmd_config = cmd.copy()
             if "fp16" in spec:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,8 @@ from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.test_utils import execute_subprocess_async
 from accelerate.test_utils.testing import (
-    LaunchTestCase,
+    DEFAULT_LAUNCH_COMMAND,
+    get_launch_command,
     path_in_accelerate_package,
     require_multi_device,
     require_timm,
@@ -32,7 +33,7 @@ from accelerate.test_utils.testing import (
 from accelerate.utils import patch_environment
 
 
-class AccelerateLauncherTester(LaunchTestCase):
+class AccelerateLauncherTester(unittest.TestCase):
     """
     Test case for verifying the `accelerate launch` CLI operates correctly.
     If a `default_config.yaml` file is located in the cache it will temporarily move it
@@ -61,9 +62,9 @@ class AccelerateLauncherTester(LaunchTestCase):
 
     def test_no_config(self):
         if torch.cuda.is_available() and (torch.cuda.device_count() > 1):
-            cmd = self.get_launch_command(multi_gpu=True)
+            cmd = get_launch_command(multi_gpu=True)
         else:
-            cmd = self.default_command
+            cmd = DEFAULT_LAUNCH_COMMAND
         cmd.append(self.test_file_path)
         execute_subprocess_async(cmd, env=os.environ.copy())
 
@@ -72,7 +73,7 @@ class AccelerateLauncherTester(LaunchTestCase):
             if "invalid" in str(config):
                 continue
             with self.subTest(config_file=config):
-                cmd = self.get_launch_command(config_file=config) + [self.test_file_path]
+                cmd = get_launch_command(config_file=config) + [self.test_file_path]
                 execute_subprocess_async(cmd, env=os.environ.copy())
 
     def test_invalid_keys(self):
@@ -81,7 +82,7 @@ class AccelerateLauncherTester(LaunchTestCase):
             RuntimeError,
             msg="The config file at 'invalid_keys.yaml' had unknown keys ('another_invalid_key', 'invalid_key')",
         ):
-            cmd = self.get_launch_command(config_file=config_path) + [self.test_file_path]
+            cmd = get_launch_command(config_file=config_path) + [self.test_file_path]
             execute_subprocess_async(cmd, env=os.environ.copy())
 
     def test_accelerate_test(self):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -146,15 +146,12 @@ class FeatureExamplesTests(TempDirTestCase):
         cls.config_file = Path(cls._tmpdir) / "default_config.yml"
 
         write_basic_config(save_location=cls.config_file)
+        cls.launch_args = get_launch_command(config_file=cls.config_file)
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         shutil.rmtree(cls._tmpdir)
-
-    def setUp(self):
-        super().setUp()
-        self.launch_args = get_launch_command(config_file=self.config_file)
 
     def test_checkpointing_by_epoch(self):
         testargs = f"""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -146,12 +146,15 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
         cls.configPath = Path(cls._tmpdir) / "default_config.yml"
 
         write_basic_config(save_location=cls.configPath)
-        cls._launch_args = cls.get_launch_command(config_file=cls.configPath)
 
     @classmethod
     def tearDownClass(cls):
         super().tearDownClass()
         shutil.rmtree(cls._tmpdir)
+
+    def setUp(self):
+        super().setUp()
+        self.launch_args = self.get_launch_command(config_path=self.configPath)
 
     def test_checkpointing_by_epoch(self):
         testargs = f"""
@@ -159,7 +162,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
         --checkpointing_steps epoch
         --output_dir {self.tmpdir}
         """.split()
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
         assert (self.tmpdir / "epoch_0").exists()
 
     def test_checkpointing_by_steps(self):
@@ -168,7 +171,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
         --checkpointing_steps 1
         --output_dir {self.tmpdir}
         """.split()
-        _ = run_command(self._launch_args + testargs)
+        _ = run_command(self.launch_args + testargs)
         assert (self.tmpdir / "step_2").exists()
 
     def test_load_states_by_epoch(self):
@@ -176,7 +179,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {self.tmpdir / "epoch_0"}
         """.split()
-        output = run_command(self._launch_args + testargs, return_stdout=True)
+        output = run_command(self.launch_args + testargs, return_stdout=True)
         assert "epoch 0:" not in output
         assert "epoch 1:" in output
 
@@ -185,7 +188,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
         examples/by_feature/checkpointing.py
         --resume_from_checkpoint {self.tmpdir / "step_2"}
         """.split()
-        output = run_command(self._launch_args + testargs, return_stdout=True)
+        output = run_command(self.launch_args + testargs, return_stdout=True)
         if torch.cuda.is_available():
             num_processes = torch.cuda.device_count()
         else:
@@ -204,7 +207,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
         --num_folds 2
         """.split()
         with mock.patch.dict(os.environ, {"TESTING_MOCKED_DATALOADERS": "0"}):
-            output = run_command(self._launch_args + testargs, return_stdout=True)
+            output = run_command(self.launch_args + testargs, return_stdout=True)
             results = re.findall("({.+})", output)
             results = [r for r in results if "accuracy" in r][-1]
             results = ast.literal_eval(results)
@@ -212,7 +215,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
 
     def test_multi_process_metrics(self):
         testargs = ["examples/by_feature/multi_process_metrics.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     @require_trackers
     @mock.patch.dict(os.environ, {"WANDB_MODE": "offline", "DVCLIVE_TEST": "true"})
@@ -223,42 +226,42 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
             --with_tracking
             --project_dir {tmpdir}
             """.split()
-            run_command(self._launch_args + testargs)
+            run_command(self.launch_args + testargs)
             assert os.path.exists(os.path.join(tmpdir, "tracking"))
 
     def test_gradient_accumulation(self):
         testargs = ["examples/by_feature/gradient_accumulation.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     def test_local_sgd(self):
         testargs = ["examples/by_feature/local_sgd.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     def test_early_stopping(self):
         testargs = ["examples/by_feature/early_stopping.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     @require_pippy
     @require_multi_gpu
     def test_pippy_examples_bert(self):
         testargs = ["examples/inference/bert.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     @require_pippy
     @require_multi_gpu
     def test_pippy_examples_gpt2(self):
         testargs = ["examples/inference/gpt2.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     @require_pippy
     @require_multi_gpu
     def test_pippy_examples_t5(self):
         testargs = ["examples/inference/t5.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)
 
     @slow
     @require_pippy
     @require_multi_gpu
     def test_pippy_examples_llama(self):
         testargs = ["examples/inference/llama.py"]
-        run_command(self._launch_args + testargs)
+        run_command(self.launch_args + testargs)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,6 +25,7 @@ import torch
 
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import (
+    LaunchTestCase,
     TempDirTestCase,
     require_multi_gpu,
     require_pippy,
@@ -135,7 +136,7 @@ class ExampleDifferenceTests(unittest.TestCase):
 
 
 @mock.patch.dict(os.environ, {"TESTING_MOCKED_DATALOADERS": "1"})
-class FeatureExamplesTests(TempDirTestCase):
+class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
     clear_on_setup = False
 
     @classmethod
@@ -145,7 +146,7 @@ class FeatureExamplesTests(TempDirTestCase):
         cls.configPath = Path(cls._tmpdir) / "default_config.yml"
 
         write_basic_config(save_location=cls.configPath)
-        cls._launch_args = ["accelerate", "launch", "--config_file", cls.configPath]
+        cls._launch_args = cls.get_launch_command(config_file=cls.configPath)
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -25,8 +25,8 @@ import torch
 
 from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import (
-    LaunchTestCase,
     TempDirTestCase,
+    get_launch_command,
     require_multi_gpu,
     require_pippy,
     require_trackers,
@@ -136,7 +136,7 @@ class ExampleDifferenceTests(unittest.TestCase):
 
 
 @mock.patch.dict(os.environ, {"TESTING_MOCKED_DATALOADERS": "1"})
-class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
+class FeatureExamplesTests(TempDirTestCase):
     clear_on_setup = False
 
     @classmethod
@@ -154,7 +154,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
 
     def setUp(self):
         super().setUp()
-        self.launch_args = self.get_launch_command(config_file=self.config_file)
+        self.launch_args = get_launch_command(config_file=self.config_file)
 
     def test_checkpointing_by_epoch(self):
         testargs = f"""

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -143,9 +143,9 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls._tmpdir = tempfile.mkdtemp()
-        cls.configPath = Path(cls._tmpdir) / "default_config.yml"
+        cls.config_file = Path(cls._tmpdir) / "default_config.yml"
 
-        write_basic_config(save_location=cls.configPath)
+        write_basic_config(save_location=cls.config_file)
 
     @classmethod
     def tearDownClass(cls):
@@ -154,7 +154,7 @@ class FeatureExamplesTests(TempDirTestCase, LaunchTestCase):
 
     def setUp(self):
         super().setUp()
-        self.launch_args = self.get_launch_command(config_path=self.configPath)
+        self.launch_args = self.get_launch_command(config_file=self.config_file)
 
     def test_checkpointing_by_epoch(self):
         testargs = f"""

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
+import unittest
 
 from accelerate import debug_launcher
 from accelerate.test_utils import (
-    LaunchTestCase,
+    DEFAULT_LAUNCH_COMMAND,
     device_count,
     execute_subprocess_async,
     path_in_accelerate_package,
@@ -28,7 +29,7 @@ from accelerate.test_utils import (
 from accelerate.utils import patch_environment
 
 
-class SyncScheduler(LaunchTestCase):
+class SyncScheduler(unittest.TestCase):
     test_file_path = path_in_accelerate_package("test_utils", "scripts", "test_sync.py")
 
     @require_cpu
@@ -46,6 +47,6 @@ class SyncScheduler(LaunchTestCase):
     @require_multi_device
     def test_gradient_sync_gpu_multi(self):
         print(f"Found {device_count} devices.")
-        cmd = self.default_command + [self.test_file_path]
+        cmd = DEFAULT_LAUNCH_COMMAND + [self.test_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_grad_sync.py
+++ b/tests/test_grad_sync.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import os
-import unittest
 
 from accelerate import debug_launcher
 from accelerate.test_utils import (
+    LaunchTestCase,
     device_count,
     execute_subprocess_async,
     path_in_accelerate_package,
@@ -28,7 +28,7 @@ from accelerate.test_utils import (
 from accelerate.utils import patch_environment
 
 
-class SyncScheduler(unittest.TestCase):
+class SyncScheduler(LaunchTestCase):
     test_file_path = path_in_accelerate_package("test_utils", "scripts", "test_sync.py")
 
     @require_cpu
@@ -46,6 +46,6 @@ class SyncScheduler(unittest.TestCase):
     @require_multi_device
     def test_gradient_sync_gpu_multi(self):
         print(f"Found {device_count} devices.")
-        cmd = ["torchrun", f"--nproc_per_node={device_count}", self.test_file_path]
+        cmd = self.default_command + [self.test_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -14,7 +14,6 @@
 
 import inspect
 import os
-import unittest
 from dataclasses import dataclass
 
 import torch
@@ -22,7 +21,7 @@ import torch
 from accelerate import Accelerator, DistributedDataParallelKwargs, GradScalerKwargs
 from accelerate.state import AcceleratorState
 from accelerate.test_utils import (
-    device_count,
+    LaunchTestCase,
     execute_subprocess_async,
     require_multi_device,
     require_non_cpu,
@@ -39,7 +38,7 @@ class MockClass(KwargsHandler):
     c: float = 3.0
 
 
-class KwargsHandlerTester(unittest.TestCase):
+class KwargsHandlerTester(LaunchTestCase):
     def test_kwargs_handler(self):
         # If no defaults are changed, `to_kwargs` returns an empty dict.
         assert MockClass().to_kwargs() == {}
@@ -68,7 +67,7 @@ class KwargsHandlerTester(unittest.TestCase):
 
     @require_multi_device
     def test_ddp_kwargs(self):
-        cmd = ["torchrun", f"--nproc_per_node={device_count}", inspect.getfile(self.__class__)]
+        cmd = self.default_command + [inspect.getfile(self.__class__)]
         execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_non_cpu

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -14,6 +14,7 @@
 
 import inspect
 import os
+import unittest
 from dataclasses import dataclass
 
 import torch
@@ -21,7 +22,7 @@ import torch
 from accelerate import Accelerator, DistributedDataParallelKwargs, GradScalerKwargs
 from accelerate.state import AcceleratorState
 from accelerate.test_utils import (
-    LaunchTestCase,
+    DEFAULT_LAUNCH_COMMAND,
     execute_subprocess_async,
     require_multi_device,
     require_non_cpu,
@@ -38,7 +39,7 @@ class MockClass(KwargsHandler):
     c: float = 3.0
 
 
-class KwargsHandlerTester(LaunchTestCase):
+class KwargsHandlerTester(unittest.TestCase):
     def test_kwargs_handler(self):
         # If no defaults are changed, `to_kwargs` returns an empty dict.
         assert MockClass().to_kwargs() == {}
@@ -67,7 +68,7 @@ class KwargsHandlerTester(LaunchTestCase):
 
     @require_multi_device
     def test_ddp_kwargs(self):
-        cmd = self.default_command + [inspect.getfile(self.__class__)]
+        cmd = DEFAULT_LAUNCH_COMMAND + [inspect.getfile(self.__class__)]
         execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_non_cpu

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import os
-import unittest
 
 from accelerate import debug_launcher
 from accelerate.test_utils import (
+    LaunchTestCase,
     device_count,
     execute_subprocess_async,
     path_in_accelerate_package,
@@ -29,7 +29,7 @@ from accelerate.utils import patch_environment
 
 
 @require_huggingface_suite
-class MetricTester(unittest.TestCase):
+class MetricTester(LaunchTestCase):
     def setUp(self):
         self.test_file_path = path_in_accelerate_package("test_utils", "scripts", "external_deps", "test_metrics.py")
 
@@ -52,6 +52,6 @@ class MetricTester(unittest.TestCase):
     @require_multi_device
     def test_metric_accelerator_multi(self):
         print(f"Found {device_count} devices.")
-        cmd = ["torchrun", f"--nproc_per_node={device_count}", self.test_file_path]
+        command = self.default_command + [self.test_file_path]
         with patch_environment(omp_num_threads=1, ACCELERATE_LOG_LEVEL="INFO"):
-            execute_subprocess_async(cmd, env=os.environ.copy())
+            execute_subprocess_async(command, env=os.environ.copy())

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import os
+import unittest
 
 from accelerate import debug_launcher
 from accelerate.test_utils import (
-    LaunchTestCase,
+    DEFAULT_LAUNCH_COMMAND,
     device_count,
     execute_subprocess_async,
     path_in_accelerate_package,
@@ -29,7 +30,7 @@ from accelerate.utils import patch_environment
 
 
 @require_huggingface_suite
-class MetricTester(LaunchTestCase):
+class MetricTester(unittest.TestCase):
     def setUp(self):
         self.test_file_path = path_in_accelerate_package("test_utils", "scripts", "external_deps", "test_metrics.py")
 
@@ -52,6 +53,6 @@ class MetricTester(LaunchTestCase):
     @require_multi_device
     def test_metric_accelerator_multi(self):
         print(f"Found {device_count} devices.")
-        cmd = self.default_command + [self.test_file_path]
+        cmd = DEFAULT_LAUNCH_COMMAND + [self.test_file_path]
         with patch_environment(omp_num_threads=1, ACCELERATE_LOG_LEVEL="INFO"):
             execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -52,6 +52,6 @@ class MetricTester(LaunchTestCase):
     @require_multi_device
     def test_metric_accelerator_multi(self):
         print(f"Found {device_count} devices.")
-        command = self.default_command + [self.test_file_path]
+        cmd = self.default_command + [self.test_file_path]
         with patch_environment(omp_num_threads=1, ACCELERATE_LOG_LEVEL="INFO"):
-            execute_subprocess_async(command, env=os.environ.copy())
+            execute_subprocess_async(cmd, env=os.environ.copy())

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -42,19 +42,23 @@ class MultiDeviceTester(LaunchTestCase):
     @require_multi_device
     def test_multi_device(self):
         print(f"Found {device_count} devices.")
+        cmd = self.default_command + [self.test_file_path]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(self.default_command + [self.test_file_path], env=os.environ.copy())
+            execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_multi_device
     def test_multi_device_ops(self):
         print(f"Found {device_count} devices.")
+        cmd = self.default_command + [self.operation_file_path]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(self.default_command + [self.operation_file_path], env=os.environ.copy())
+            execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_multi_device
     def test_pad_across_processes(self):
+        print(f"Found {device_count} devices.")
+        cmd = self.default_command + [inspect.getfile(self.__class__)]
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(self.default_command + [inspect.getfile(self.__class__)], env=os.environ.copy())
+            execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_non_torch_xla
     @require_multi_gpu
@@ -64,8 +68,9 @@ class MultiDeviceTester(LaunchTestCase):
         when the batch size does not evenly divide the dataset size.
         """
         print(f"Found {device_count} devices, using 2 devices only")
+        cmd = self.get_launch_command(num_processes=2) + [self.data_loop_file_path]
         with patch_environment(omp_num_threads=1, cuda_visible_devices="0,1"):
-            execute_subprocess_async(self.default_command + [self.data_loop_file_path], env=os.environ.copy())
+            execute_subprocess_async(cmd, env=os.environ.copy())
 
     @require_multi_gpu
     @require_pippy
@@ -74,9 +79,9 @@ class MultiDeviceTester(LaunchTestCase):
         Checks the integration with the pippy framework
         """
         print(f"Found {device_count} devices")
-        command = self.get_launch_command(multi_gpu=None, num_processes=device_count)
+        cmd = self.get_launch_command(multi_gpu=True, num_processes=device_count)
         with patch_environment(omp_num_threads=1):
-            execute_subprocess_async(command + [self.pippy_file_path], env=os.environ.copy())
+            execute_subprocess_async(cmd + [self.pippy_file_path], env=os.environ.copy())
 
 
 if __name__ == "__main__":

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -18,7 +18,6 @@ import os
 import random
 import shutil
 import tempfile
-import unittest
 import uuid
 from contextlib import contextmanager
 
@@ -29,7 +28,12 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.test_utils import device_count, execute_subprocess_async, require_non_cpu, require_non_torch_xla
+from accelerate.test_utils import (
+    LaunchTestCase,
+    execute_subprocess_async,
+    require_non_cpu,
+    require_non_torch_xla,
+)
 from accelerate.utils import DistributedType, ProjectConfiguration, set_seed
 
 
@@ -89,7 +93,7 @@ def parameterized_custom_name_func(func, param_num, param):
 
 
 @parameterized_class(("use_safetensors",), [[True], [False]], class_name_func=parameterized_custom_name_func)
-class CheckpointTest(unittest.TestCase):
+class CheckpointTest(LaunchTestCase):
     def check_adam_state(self, state1, state2, distributed_type):
         # For DistributedType.XLA, the `accelerator.save_state` function calls `xm._maybe_convert_to_cpu` before saving.
         # As a result, all tuple values are converted to lists. Therefore, we need to convert them back here.
@@ -373,7 +377,7 @@ class CheckpointTest(unittest.TestCase):
     @require_non_cpu
     @require_non_torch_xla
     def test_map_location(self):
-        cmd = ["torchrun", f"--nproc_per_node={device_count}", inspect.getfile(self.__class__)]
+        cmd = self.default_command + [inspect.getfile(self.__class__)]
         env = os.environ.copy()
         env["USE_SAFETENSORS"] = str(self.use_safetensors)
         env["OMP_NUM_THREADS"] = "1"

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -18,6 +18,7 @@ import os
 import random
 import shutil
 import tempfile
+import unittest
 import uuid
 from contextlib import contextmanager
 
@@ -29,7 +30,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
 from accelerate.test_utils import (
-    LaunchTestCase,
+    DEFAULT_LAUNCH_COMMAND,
     execute_subprocess_async,
     require_non_cpu,
     require_non_torch_xla,
@@ -93,7 +94,7 @@ def parameterized_custom_name_func(func, param_num, param):
 
 
 @parameterized_class(("use_safetensors",), [[True], [False]], class_name_func=parameterized_custom_name_func)
-class CheckpointTest(LaunchTestCase):
+class CheckpointTest(unittest.TestCase):
     def check_adam_state(self, state1, state2, distributed_type):
         # For DistributedType.XLA, the `accelerator.save_state` function calls `xm._maybe_convert_to_cpu` before saving.
         # As a result, all tuple values are converted to lists. Therefore, we need to convert them back here.
@@ -377,7 +378,7 @@ class CheckpointTest(LaunchTestCase):
     @require_non_cpu
     @require_non_torch_xla
     def test_map_location(self):
-        cmd = self.default_command + [inspect.getfile(self.__class__)]
+        cmd = DEFAULT_LAUNCH_COMMAND + [inspect.getfile(self.__class__)]
         env = os.environ.copy()
         env["USE_SAFETENSORS"] = str(self.use_safetensors)
         env["OMP_NUM_THREADS"] = "1"


### PR DESCRIPTION
# What does this PR do?

As `accelerate launch` sets up various environmental variables for users on systems that can freeze tests (e.g. 4090 people) this PR migrates all tests to use `accelerate launch` instead by making a `LaunchTestCase` with a helper to generate the right command arguments. 

This should be inherited and used if any test case wants to run something that would be ran using `torchrun`/`accelerate launch`/etc


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @SunMarc 