### PR TITLE
Upgrade huggingface's megatron to nvidia's megatron when use MegatronLMPlugin

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1739,12 +1739,9 @@ class Accelerator:
             else:
                 result.append(obj)
 
-        if model is not None:
-            model = megatron_lm_prepare_model(self)
-        if optimizer is not None:
-            optimizer = megatron_lm_prepare_optimizer(self, model)
-        if scheduler is not None:
-            scheduler = megatron_lm_prepare_scheduler(self, optimizer, scheduler)
+        model = megatron_lm_prepare_model(self)
+        optimizer = megatron_lm_prepare_optimizer(self, model)
+        scheduler = megatron_lm_prepare_scheduler(self, optimizer, scheduler)
 
         if model is not None:
             model = MegatronEngine(self, model, optimizer, scheduler)

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -37,6 +37,7 @@ from .dataclasses import (
     SageMakerDistributedType,
     TensorInformation,
     TorchDynamoPlugin,
+    add_model_config_to_megatron_parser,
 )
 from .environment import (
     are_libraries_initialized,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -182,7 +182,7 @@ from .megatron_lm import (
 )
 from .megatron_lm import initialize as megatron_lm_initialize
 from .megatron_lm import prepare_data_loader as megatron_lm_prepare_data_loader
-from .megatron_lm import prepare_model as megatron_lm_prepare_model
+from .megatron_lm import prepare_model_optimizer_scheduler as megatron_lm_prepare_model_optimizer_scheduler
 from .megatron_lm import prepare_optimizer as megatron_lm_prepare_optimizer
 from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
 from .memory import find_executable_batch_size, release_memory

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1322,6 +1322,14 @@ class MegatronLMPlugin:
         default=None,
         metadata={"help": "Custom prepare model function."},
     )
+    custom_megatron_datasets_provider_function: Optional[Callable] = field(
+        default=None,
+        metadata={"help": "Custom megatron train_valid_test datasets provider function."},
+    )
+    custom_get_batch_function: Optional[Callable] = field(
+        default=None,
+        metadata={"help": "Custom get batch function."},
+    )
 
     # remaining args such as enabling Alibi/ROPE positional embeddings,
     # wandb logging, Multi-Query Attention, etc.

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1388,87 +1388,15 @@ class MegatronLMPlugin:
             self.megatron_lm_default_args.update(self.other_megatron_args)
 
     def set_network_size_args(self, model, batch_data=None):
-        # Check if the model is either BERT, GPT or T5 else raise error
-        # set 'num_layers', 'hidden_size', 'num_attention_heads', 'max_position_embeddings'
-        if "megatron-bert" in model.config.model_type.lower():
-            model_type_name = "bert"
-            num_layers = model.config.num_hidden_layers
-            hidden_size = model.config.hidden_size
-            num_attention_heads = model.config.num_attention_heads
-            max_position_embeddings = model.config.max_position_embeddings
-            num_labels = model.config.num_labels
-            orig_vocab_size = model.config.vocab_size
-            if "maskedlm" in model.__class__.__name__.lower():
-                pretraining_flag = True
-            if self.seq_length is not None:
-                if self.encoder_seq_length is not None:
-                    warnings.warn("Both `seq_length` and `encoder_seq_length` are set. Using `encoder_seq_length`.")
-                self.seq_length = self.encoder_seq_length
-            elif self.encoder_seq_length is not None:
-                self.seq_length = self.encoder_seq_length
-            elif batch_data is not None:
-                self.seq_length = batch_data["input_ids"].shape[1]
-            else:
-                self.seq_length = max_position_embeddings
-            self.megatron_lm_default_args["seq_length"] = self.seq_length
-        elif "gpt2" in model.config.model_type.lower():
-            model_type_name = "gpt"
-            num_layers = model.config.n_layer
-            hidden_size = model.config.n_embd
-            num_attention_heads = model.config.n_head
-            max_position_embeddings = model.config.n_positions
-            orig_vocab_size = model.config.vocab_size
-            pretraining_flag = True
-            if self.seq_length is not None:
-                if self.decoder_seq_length is not None:
-                    warnings.warn("Both `seq_length` and `decoder_seq_length` are set. Using `decoder_seq_length`.")
-                self.seq_length = self.decoder_seq_length
-            elif self.decoder_seq_length is not None:
-                self.seq_length = self.decoder_seq_length
-            elif batch_data is not None:
-                self.seq_length = batch_data["input_ids"].shape[1]
-            else:
-                self.seq_length = max_position_embeddings
-            self.megatron_lm_default_args["seq_length"] = self.seq_length
-            self.megatron_lm_default_args["return_logits"] = self.return_logits
-            self.megatron_lm_default_args["tokenizer_type"] = "GPT2BPETokenizer"
-        elif "t5" in model.config.model_type.lower():
-            model_type_name = "t5"
-            num_layers = model.config.num_layers
-            hidden_size = model.config.d_model
-            num_attention_heads = model.config.num_heads
-            max_position_embeddings = model.config.n_positions if hasattr(model.config, "n_positions") else 1024
-            orig_vocab_size = model.config.vocab_size
-            pretraining_flag = True
-            if self.encoder_seq_length is None:
-                if batch_data is not None:
-                    self.encoder_seq_length = batch_data["input_ids"].shape[1]
-                else:
-                    self.encoder_seq_length = max_position_embeddings
-            if self.decoder_seq_length is None:
-                if batch_data is not None:
-                    self.decoder_seq_length = batch_data["labels"].shape[1]
-                else:
-                    self.decoder_seq_length = max_position_embeddings
-
-            self.megatron_lm_default_args["encoder_seq_length"] = self.encoder_seq_length
-            self.megatron_lm_default_args["decoder_seq_length"] = self.decoder_seq_length
-        else:
-            raise ValueError(
-                "🤗 Accelerate Megatron-LM integration supports only BERT, GPT and T5 model. "
-                "Please check the model you are using is one of those."
-            )
-
-        self.megatron_lm_default_args["model_type_name"] = model_type_name
-        self.megatron_lm_default_args["num_layers"] = num_layers
-        self.megatron_lm_default_args["hidden_size"] = hidden_size
-        self.megatron_lm_default_args["num_attention_heads"] = num_attention_heads
-        self.megatron_lm_default_args["max_position_embeddings"] = max_position_embeddings
-        self.megatron_lm_default_args["pretraining_flag"] = pretraining_flag
-        self.megatron_lm_default_args["orig_vocab_size"] = orig_vocab_size
-        self.megatron_lm_default_args["model_return_dict"] = model.config.return_dict
-        if model_type_name == "bert":
-            self.megatron_lm_default_args["num_labels"] = num_labels
+        model_config_type = model.config.model_type.lower()
+        for model_type in MODEL_CONFIGS_TO_MEGATRON_PARSERS.keys():
+            if model_type in model_config_type:
+                MODEL_CONFIGS_TO_MEGATRON_PARSERS[model_type](self, model, batch_data)
+                return
+        raise ValueError(
+            f"Accelerate Megatron-LM integration not supports {model_config_type} model. "
+            "You can add your own model config parser."
+        )
 
     def set_mixed_precision(self, mixed_precision):
         if mixed_precision == "fp16":
@@ -1543,6 +1471,114 @@ class MegatronLMPlugin:
                 self.megatron_lm_default_args[key] = True
             elif key.startswith("no_log_"):
                 self.megatron_lm_default_args[key.replace("no_", "")] = True
+
+
+MODEL_CONFIGS_TO_MEGATRON_PARSERS = {}
+
+
+def add_model_config_to_megatron_parser(model_type: str):
+    def add_model_config_parser_helper(func):
+        def wrapper(*args, **kwargs):
+            return func(*args, **kwargs)
+        MODEL_CONFIGS_TO_MEGATRON_PARSERS[model_type] = func
+        return wrapper
+    return add_model_config_parser_helper
+
+
+@add_model_config_to_megatron_parser('megatron-bert')
+def parse_bert_config(megatron_lm_plugin, model, batch_data):
+    model_type_name = "bert"
+    num_layers = model.config.num_hidden_layers
+    hidden_size = model.config.hidden_size
+    num_attention_heads = model.config.num_attention_heads
+    max_position_embeddings = model.config.max_position_embeddings
+    num_labels = model.config.num_labels
+    orig_vocab_size = model.config.vocab_size
+    if "maskedlm" in model.__class__.__name__.lower():
+        pretraining_flag = True
+    if megatron_lm_plugin.seq_length is not None:
+        if megatron_lm_plugin.encoder_seq_length is not None:
+            warnings.warn("Both `seq_length` and `encoder_seq_length` are set. Using `encoder_seq_length`.")
+        megatron_lm_plugin.seq_length = megatron_lm_plugin.encoder_seq_length
+    elif megatron_lm_plugin.encoder_seq_length is not None:
+        megatron_lm_plugin.seq_length = megatron_lm_plugin.encoder_seq_length
+    elif batch_data is not None:
+        megatron_lm_plugin.seq_length = batch_data["input_ids"].shape[1]
+    else:
+        megatron_lm_plugin.seq_length = max_position_embeddings
+    megatron_lm_plugin.megatron_lm_default_args["seq_length"] = megatron_lm_plugin.seq_length
+    megatron_lm_plugin.megatron_lm_default_args["model_type_name"] = model_type_name
+    megatron_lm_plugin.megatron_lm_default_args["num_layers"] = num_layers
+    megatron_lm_plugin.megatron_lm_default_args["hidden_size"] = hidden_size
+    megatron_lm_plugin.megatron_lm_default_args["num_attention_heads"] = num_attention_heads
+    megatron_lm_plugin.megatron_lm_default_args["max_position_embeddings"] = max_position_embeddings
+    megatron_lm_plugin.megatron_lm_default_args["pretraining_flag"] = pretraining_flag
+    megatron_lm_plugin.megatron_lm_default_args["orig_vocab_size"] = orig_vocab_size
+    megatron_lm_plugin.megatron_lm_default_args["model_return_dict"] = model.config.return_dict
+    megatron_lm_plugin.megatron_lm_default_args["num_labels"] = num_labels
+
+
+@add_model_config_to_megatron_parser('gpt2')
+def parse_gpt2_config(megatron_lm_plugin, model, batch_data):
+    model_type_name = "gpt"
+    num_layers = model.config.n_layer
+    hidden_size = model.config.n_embd
+    num_attention_heads = model.config.n_head
+    max_position_embeddings = model.config.n_positions
+    orig_vocab_size = model.config.vocab_size
+    pretraining_flag = True
+    if megatron_lm_plugin.seq_length is not None:
+        if megatron_lm_plugin.decoder_seq_length is not None:
+            warnings.warn("Both `seq_length` and `decoder_seq_length` are set. Using `decoder_seq_length`.")
+        megatron_lm_plugin.seq_length = megatron_lm_plugin.decoder_seq_length
+    elif megatron_lm_plugin.decoder_seq_length is not None:
+        megatron_lm_plugin.seq_length = megatron_lm_plugin.decoder_seq_length
+    elif batch_data is not None:
+        megatron_lm_plugin.seq_length = batch_data["input_ids"].shape[1]
+    else:
+        megatron_lm_plugin.seq_length = max_position_embeddings
+    megatron_lm_plugin.megatron_lm_default_args["seq_length"] = megatron_lm_plugin.seq_length
+    megatron_lm_plugin.megatron_lm_default_args["return_logits"] = megatron_lm_plugin.return_logits
+    megatron_lm_plugin.megatron_lm_default_args["tokenizer_type"] = "GPT2BPETokenizer"
+    megatron_lm_plugin.megatron_lm_default_args["model_type_name"] = model_type_name
+    megatron_lm_plugin.megatron_lm_default_args["num_layers"] = num_layers
+    megatron_lm_plugin.megatron_lm_default_args["hidden_size"] = hidden_size
+    megatron_lm_plugin.megatron_lm_default_args["num_attention_heads"] = num_attention_heads
+    megatron_lm_plugin.megatron_lm_default_args["max_position_embeddings"] = max_position_embeddings
+    megatron_lm_plugin.megatron_lm_default_args["pretraining_flag"] = pretraining_flag
+    megatron_lm_plugin.megatron_lm_default_args["orig_vocab_size"] = orig_vocab_size
+    megatron_lm_plugin.megatron_lm_default_args["model_return_dict"] = model.config.return_dict
+
+
+@add_model_config_to_megatron_parser('t5')
+def parse_t5_config(megatron_lm_plugin, model, batch_data):
+    model_type_name = "t5"
+    num_layers = model.config.num_layers
+    hidden_size = model.config.d_model
+    num_attention_heads = model.config.num_heads
+    max_position_embeddings = model.config.n_positions if hasattr(model.config, "n_positions") else 1024
+    orig_vocab_size = model.config.vocab_size
+    pretraining_flag = True
+    if megatron_lm_plugin.encoder_seq_length is None:
+        if batch_data is not None:
+            megatron_lm_plugin.encoder_seq_length = batch_data["input_ids"].shape[1]
+        else:
+            megatron_lm_plugin.encoder_seq_length = max_position_embeddings
+    if megatron_lm_plugin.decoder_seq_length is None:
+        if batch_data is not None:
+            megatron_lm_plugin.decoder_seq_length = batch_data["labels"].shape[1]
+        else:
+            megatron_lm_plugin.decoder_seq_length = max_position_embeddings
+    megatron_lm_plugin.megatron_lm_default_args["encoder_seq_length"] = megatron_lm_plugin.encoder_seq_length
+    megatron_lm_plugin.megatron_lm_default_args["decoder_seq_length"] = megatron_lm_plugin.decoder_seq_length
+    megatron_lm_plugin.megatron_lm_default_args["model_type_name"] = model_type_name
+    megatron_lm_plugin.megatron_lm_default_args["num_layers"] = num_layers
+    megatron_lm_plugin.megatron_lm_default_args["hidden_size"] = hidden_size
+    megatron_lm_plugin.megatron_lm_default_args["num_attention_heads"] = num_attention_heads
+    megatron_lm_plugin.megatron_lm_default_args["max_position_embeddings"] = max_position_embeddings
+    megatron_lm_plugin.megatron_lm_default_args["pretraining_flag"] = pretraining_flag
+    megatron_lm_plugin.megatron_lm_default_args["orig_vocab_size"] = orig_vocab_size
+    megatron_lm_plugin.megatron_lm_default_args["model_return_dict"] = model.config.return_dict
 
 
 @dataclass

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1480,12 +1480,14 @@ def add_model_config_to_megatron_parser(model_type: str):
     def add_model_config_parser_helper(func):
         def wrapper(*args, **kwargs):
             return func(*args, **kwargs)
+
         MODEL_CONFIGS_TO_MEGATRON_PARSERS[model_type] = func
         return wrapper
+
     return add_model_config_parser_helper
 
 
-@add_model_config_to_megatron_parser('megatron-bert')
+@add_model_config_to_megatron_parser("megatron-bert")
 def parse_bert_config(megatron_lm_plugin, model, batch_data):
     model_type_name = "bert"
     num_layers = model.config.num_hidden_layers
@@ -1518,7 +1520,7 @@ def parse_bert_config(megatron_lm_plugin, model, batch_data):
     megatron_lm_plugin.megatron_lm_default_args["num_labels"] = num_labels
 
 
-@add_model_config_to_megatron_parser('gpt2')
+@add_model_config_to_megatron_parser("gpt2")
 def parse_gpt2_config(megatron_lm_plugin, model, batch_data):
     model_type_name = "gpt"
     num_layers = model.config.n_layer
@@ -1550,7 +1552,7 @@ def parse_gpt2_config(megatron_lm_plugin, model, batch_data):
     megatron_lm_plugin.megatron_lm_default_args["model_return_dict"] = model.config.return_dict
 
 
-@add_model_config_to_megatron_parser('t5')
+@add_model_config_to_megatron_parser("t5")
 def parse_t5_config(megatron_lm_plugin, model, batch_data):
     model_type_name = "t5"
     num_layers = model.config.num_layers

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -191,12 +191,7 @@ def is_megatron_lm_available():
     if str_to_bool(os.environ.get("ACCELERATE_USE_MEGATRON_LM", "False")) == 1:
         package_exists = importlib.util.find_spec("megatron") is not None
         if package_exists:
-            try:
-                megatron_version = parse(importlib.metadata.version("megatron-lm"))
-                return compare_versions(megatron_version, ">=", "2.2.0")
-            except Exception as e:
-                warnings.warn(f"Parse Megatron version failed. Exception:{e}")
-                return False
+            return True
 
 
 def is_transformers_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -20,7 +20,6 @@ from functools import lru_cache
 
 import torch
 from packaging import version
-from packaging.version import parse
 
 from .environment import parse_flag_from_env, str_to_bool
 from .versions import compare_versions, is_torch_version

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -1029,8 +1029,8 @@ class MegatronEngine(torch.nn.Module):
         args = get_args()
         timers = get_timers()
 
+        data_chunks = []
         if len(batch_data) > 0:
-            data_chunks = []
             if args.num_micro_batches > 1:
                 for i in range(0, args.num_micro_batches):
                     data_chunks.append(


### PR DESCRIPTION
#2390 
I want to use accelerate with megatron, and I do many changes in nvidia's megatron framework.
But when I use MegatronLMPlugin, it is using huggingface's megatron and it is not maintaining now. 
This pr upgrades huggingface's megatron to nvidia's megatron, so we will don't need to maintain huggingface's megatron. And I can also use my changes in nvidia's megatron framework.

By the way, we will use `pip install --no-use-pep517 -e .` to install nvidia's megatron.