### PR TITLE
Fix link typo

### DIFF
--- a/docs/source/usage_guides/big_modeling.md
+++ b/docs/source/usage_guides/big_modeling.md
@@ -52,7 +52,7 @@ will attempt to fill all the space in your GPU(s), then loading them to the CPU,
 
 <Tip>
 
-For more details on designing your own device map, see this section of the [concept guide](../concept_guide/big_model_inference#designing-a-device-map)
+For more details on designing your own device map, see this section of the [concept guide](../concept_guides/big_model_inference#designing-a-device-map)
 
 </Tip>
 


### PR DESCRIPTION
# What does this PR do?
This PR fixes a small typo in the big model inference docs. 