### PR TITLE
add custom dtype INT2

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -469,7 +469,7 @@ class CustomDtype(enum.Enum):
 
     FP8 = "fp8"
     INT4 = "int4"
-
+    INT2 = "int2"
 
 # data classes
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -471,6 +471,7 @@ class CustomDtype(enum.Enum):
     INT4 = "int4"
     INT2 = "int2"
 
+
 # data classes
 
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -143,6 +143,8 @@ def dtype_byte_size(dtype: torch.dtype):
     """
     if dtype == torch.bool:
         return 1 / 8
+    elif dtype == CustomDtype.INT2:
+        return 1 / 4
     elif dtype == CustomDtype.INT4:
         return 1 / 2
     elif dtype == CustomDtype.FP8:


### PR DESCRIPTION
# What does this PR do
This PR adds the custom dtype INT2 what will be useful to calculate the memory required for 2bits model for quanto. 