### PR TITLE
Check if hub down

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   check-hf-status:
     runs-on: ubuntu-latest
-      steps:
+    steps:
     - uses: actions/checkout@v3.1.0
     - name: Set up python 3.8
       uses: actions/setup-python@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,30 @@ env:
   IS_GITHUB_CI: "1"
 
 jobs:
+  check-hf-status:
+    runs-on: ubuntu-latest
+      steps:
+    - uses: actions/checkout@v3.1.0
+    - name: Set up python 3.8
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+    
+    - name: Install the library
+      run: |
+        pip install --upgrade pip
+        pip install -e .
+        pip install pytest-reportlog tabulate pytest
+
+    - name: Check status
+      run: |
+        make test_hub_status
+
+    - name: Generate Report
+      if: always()
+      run: |
+        python utils/log_reports.py >> $GITHUB_STEP_SUMMARY
+
   run-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,15 @@ style:
 	doc-builder style src/accelerate docs/source --max_len 119
 	
 # Run tests for the library
+test_hub_status:
+	python -m pytest -s -v ./tests/test_hub_status.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_hub_status.log",)
+
 test_big_modeling:
 	python -m pytest -s -v ./tests/test_big_modeling.py ./tests/test_modeling_utils.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_big_modeling.log",)
 
 test_core:
 	python -m pytest -s -v ./tests/ --ignore=./tests/test_examples.py --ignore=./tests/deepspeed --ignore=./tests/test_big_modeling.py \
-	--ignore=./tests/fsdp --ignore=./tests/test_cli.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_core.log",)
+	--ignore=./tests/fsdp --ignore=./tests/test_cli.py --ignore=./tests/test_hub_status.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_core.log",)
 
 test_cli:
 	python -m pytest -s -v ./tests/test_cli.py $(if $(IS_GITHUB_CI),--report-log "$(PYTORCH_VERSION)_cli.log",)

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -10,6 +10,7 @@ from .testing import (
     require_bnb,
     require_cpu,
     require_cuda,
+    require_hub_online,
     require_huggingface_suite,
     require_mps,
     require_multi_device,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -15,18 +15,18 @@
 import asyncio
 import inspect
 import os
-import requests
 import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
-from functools import partial, lru_cache
+from functools import lru_cache, partial
 from pathlib import Path
 from typing import List, Union
 from unittest import mock
 
+import requests
 import torch
 
 import accelerate
@@ -73,18 +73,21 @@ def get_backend():
 
 torch_device, device_count, memory_allocated_func = get_backend()
 
+
 @lru_cache
 def is_hub_online():
     """
     Checks if the huggingface_hub is online
     """
     response = requests.get("https://huggingface.co/api")
-    if r.status_code != 200:
+    if response.status_code != 200:
         return False
     return True
 
+
 if not is_hub_online():
-    os.environ['HF_HUB_OFFLINE']=1
+    os.environ["HF_HUB_OFFLINE"] = 1
+
 
 def get_launch_command(**kwargs) -> list:
     """
@@ -197,7 +200,8 @@ def require_huggingface_suite(test_case):
     Decorator marking a test that requires transformers and datasets. These tests are skipped when they are not.
     """
     return unittest.skipUnless(
-        is_transformers_available() and is_datasets_available() and is_hub_online(), "test requires the Hugging Face suite"
+        is_transformers_available() and is_datasets_available() and is_hub_online(),
+        "test requires the Hugging Face suite",
     )(test_case)
 
 

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -205,6 +205,16 @@ def require_huggingface_suite(test_case):
     )(test_case)
 
 
+def require_hub_online(test_case):
+    """
+    Decorator marking a test that requires the huggingface hub be online. These tests are skipped when it is not.
+    """
+    return unittest.skipUnless(
+        is_hub_online(),
+        "test requires Hub be online, currently it is down!",
+    )(test_case)
+
+
 def require_transformers(test_case):
     """
     Decorator marking a test that requires transformers. These tests are skipped when they are not.

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -205,7 +205,7 @@ def require_huggingface_suite(test_case):
     )(test_case)
 
 
-def require_hub_online(test_case):
+def require_huggingface_online(test_case):
     """
     Decorator marking a test that requires the huggingface hub be online. These tests are skipped when it is not.
     """

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -86,7 +86,7 @@ def is_hub_online():
 
 
 if not is_hub_online():
-    os.environ["HF_HUB_OFFLINE"] = 1
+    os.environ["HF_HUB_OFFLINE"] = "1"
 
 
 def get_launch_command(**kwargs) -> list:

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -15,13 +15,14 @@
 import asyncio
 import inspect
 import os
+import requests
 import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 from contextlib import contextmanager
-from functools import partial
+from functools import partial, lru_cache
 from pathlib import Path
 from typing import List, Union
 from unittest import mock
@@ -72,6 +73,18 @@ def get_backend():
 
 torch_device, device_count, memory_allocated_func = get_backend()
 
+@lru_cache
+def is_hub_online():
+    """
+    Checks if the huggingface_hub is online
+    """
+    response = requests.get("https://huggingface.co/api")
+    if r.status_code != 200:
+        return False
+    return True
+
+if not is_hub_online():
+    os.environ['HF_HUB_OFFLINE']=1
 
 def get_launch_command(**kwargs) -> list:
     """
@@ -184,7 +197,7 @@ def require_huggingface_suite(test_case):
     Decorator marking a test that requires transformers and datasets. These tests are skipped when they are not.
     """
     return unittest.skipUnless(
-        is_transformers_available() and is_datasets_available(), "test requires the Hugging Face suite"
+        is_transformers_available() and is_datasets_available() and is_hub_online(), "test requires the Hugging Face suite"
     )(test_case)
 
 

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -205,7 +205,7 @@ def require_huggingface_suite(test_case):
     )(test_case)
 
 
-def require_huggingface_online(test_case):
+def require_hub_online(test_case):
     """
     Decorator marking a test that requires the huggingface hub be online. These tests are skipped when it is not.
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,6 +25,7 @@ from accelerate.test_utils.testing import (
     DEFAULT_LAUNCH_COMMAND,
     get_launch_command,
     path_in_accelerate_package,
+    require_hub_online,
     require_multi_device,
     require_timm,
     require_transformers,
@@ -234,6 +235,7 @@ class TpuConfigTester(unittest.TestCase):
         )
 
 
+@require_hub_online
 class ModelEstimatorTester(unittest.TestCase):
     """
     Test case for checking the output of `accelerate estimate-memory` is correct.

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -27,6 +27,7 @@ from accelerate.test_utils.examples import compare_against_test
 from accelerate.test_utils.testing import (
     TempDirTestCase,
     get_launch_command,
+    require_huggingface_suite,
     require_multi_gpu,
     require_pippy,
     require_trackers,
@@ -136,6 +137,7 @@ class ExampleDifferenceTests(unittest.TestCase):
 
 
 @mock.patch.dict(os.environ, {"TESTING_MOCKED_DATALOADERS": "1"})
+@require_huggingface_suite
 class FeatureExamplesTests(TempDirTestCase):
     clear_on_setup = False
 

--- a/tests/test_hub_status.py
+++ b/tests/test_hub_status.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from accelerate.test_utils import is_hub_online
+from accelerate.test_utils.testing import is_hub_online
 
 
 class HooksModelTester(unittest.TestCase):

--- a/tests/test_hub_status.py
+++ b/tests/test_hub_status.py
@@ -1,0 +1,27 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from accelerate.test_utils import is_hub_online
+
+
+class HooksModelTester(unittest.TestCase):
+    "Simple tester that checks if the Hub is online or not"
+
+    def test_hub_online(self):
+        self.assertTrue(
+            is_hub_online(),
+            "Hub is offline! This test will fail until the hub is back online. Relevent tests will be skipped.",
+        )

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -27,6 +27,7 @@ from accelerate.test_utils import (
     execute_subprocess_async,
     get_launch_command,
     path_in_accelerate_package,
+    require_huggingface_suite,
     require_multi_device,
     require_multi_gpu,
     require_non_torch_xla,
@@ -76,6 +77,7 @@ class MultiDeviceTester(unittest.TestCase):
 
     @require_multi_gpu
     @require_pippy
+    @require_huggingface_suite
     def test_pippy(self):
         """
         Checks the integration with the pippy framework


### PR DESCRIPTION
# What does this PR do?

Adds a decorator to the test utils that will skip tests if we find the Hub is down automatically to avoid red CI in the case of an outtage