### PR TITLE
Fixed 0MiB bug in convert_file_size_to_int

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -100,7 +100,7 @@ def convert_file_size_to_int(size: Union[int, str]):
     1048576
     ```
     """
-    mem_size = 0
+    mem_size = -1
     err_msg = (
         f"`size` {size} is not in a valid format. Use an integer for bytes, or a string with an unit (like '5.0GB')."
     )
@@ -125,7 +125,7 @@ def convert_file_size_to_int(size: Union[int, str]):
     except ValueError:
         raise ValueError(err_msg)
 
-    if mem_size <= 0:
+    if mem_size < 0:
         raise ValueError(err_msg)
     return mem_size
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -651,6 +651,9 @@ class ModelingUtilsTester(unittest.TestCase):
                 assert loaded_state_dict[param].device == torch.device(device)
 
     def test_convert_file_size(self):
+        result = convert_file_size_to_int("0MB")
+        assert result == 0
+
         result = convert_file_size_to_int("100MB")
         assert result == (100 * (10**6))
 


### PR DESCRIPTION
# What does this PR do?

Fix 0MiB bug converting from string to int 
https://github.com/oobabooga/text-generation-webui/issues/4193
```
02:06:45-485003 INFO     Loading "mistralai_Mistral-7B-Instruct-v0.2"
{'low_cpu_mem_usage': True, 'trust_remote_code': False, 'torch_dtype': torch.float16, 'use_safetensors': None, 'device_map': 'auto', 'max_memory': {0: '6070MiB', 1: '6070MiB', 2: '6070MiB', 3: '6070MiB', 4: '6070MiB', 5: '6070MiB', 6: '0MiB', 7: '0MiB', 'cpu': '99GiB'}}
02:06:49-501273 ERROR    Failed to load the model.
Traceback (most recent call last):
  File "/mnt/nvme/workspace/text-generation-webui/modules/ui_model_menu.py", line 242, in load_model_wrapper
    shared.model, shared.tokenizer = load_model(selected_model, loader)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/modules/models.py", line 87, in load_model
    output = load_func_map[loader](model_name)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/modules/models.py", line 237, in huggingface_loader
    model = LoaderClass.from_pretrained(path_to_model, **params)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/installer_files/env/lib/python3.11/site-packages/transformers/models/auto/auto_factory.py", line 566, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/installer_files/env/lib/python3.11/site-packages/transformers/modeling_utils.py", line 3766, in from_pretrained
    max_memory = get_balanced_memory(
                 ^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/installer_files/env/lib/python3.11/site-packages/accelerate/utils/modeling.py", line 910, in get_balanced_memory
    max_memory = get_max_memory(max_memory)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/installer_files/env/lib/python3.11/site-packages/accelerate/utils/modeling.py", line 791, in get_max_memory
    max_memory[key] = convert_file_size_to_int(max_memory[key])
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/nvme/workspace/text-generation-webui/installer_files/env/lib/python3.11/site-packages/accelerate/utils/modeling.py", line 129, in convert_file_size_to_int
    raise ValueError(err_msg)
ValueError: `size` 0MiB is not in a valid format. Use an integer for bytes, or a string with an unit (like '5.0GB').
```

## Before submitting
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@muellerzr @BenjaminBossan