### PR TITLE
Add copyright + some ruff lint things

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ extra_quality_checks:
 
 # this target runs checks on all files
 quality:
-	ruff $(check_dirs)
+	ruff check $(check_dirs)
 	ruff format --check $(check_dirs)
 	doc-builder style src/accelerate docs/source --max_len 119 --check_only
 
 # Format source code automatically and check is there are any problems left that need manual fixing
 style:
-	ruff $(check_dirs) --fix
+	ruff check $(check_dirs) --fix
 	ruff format $(check_dirs)
 	doc-builder style src/accelerate docs/source --max_len 119
 	

--- a/benchmarks/measures_util.py
+++ b/benchmarks/measures_util.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import gc
 import threading
 import time

--- a/examples/inference/bert.py
+++ b/examples/inference/bert.py
@@ -75,4 +75,4 @@ end_time = time.time()
 if PartialState().is_last_process:
     output = torch.stack(tuple(output[0]))
     print(f"Time of first pass: {first_batch}")
-    print(f"Average time per batch: {(end_time - start_time)/5}")
+    print(f"Average time per batch: {(end_time - start_time) / 5}")

--- a/examples/inference/gpt2.py
+++ b/examples/inference/gpt2.py
@@ -74,4 +74,4 @@ end_time = time.time()
 if PartialState().is_last_process:
     output = torch.stack(tuple(output[0]))
     print(f"Time of first pass: {first_batch}")
-    print(f"Average time per batch: {(end_time - start_time)/5}")
+    print(f"Average time per batch: {(end_time - start_time) / 5}")

--- a/examples/inference/t5.py
+++ b/examples/inference/t5.py
@@ -86,4 +86,4 @@ end_time = time.time()
 if PartialState().is_last_process:
     output = torch.stack(tuple(output[0]))
     print(f"Time of first pass: {first_batch}")
-    print(f"Average time per batch: {(end_time - start_time)/5}")
+    print(f"Average time per batch: {(end_time - start_time) / 5}")

--- a/examples/multigpu_remote_launcher.py
+++ b/examples/multigpu_remote_launcher.py
@@ -1,3 +1,16 @@
+# Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import argparse
 
 import runhouse as rh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,12 @@ line-length = 119
 target-version = "py38"
 
 [tool.ruff.lint]
+preview = true
 ignore-init-module-imports = true
 extend-select = [
     "B009", # static getattr
     "B010", # static setattr
+    "CPY", # Copyright
     "E", # PEP8 errors
     "F", # PEP8 formatting
     "I", # Import sorting

--- a/src/accelerate/__init__.py
+++ b/src/accelerate/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 __version__ = "0.28.0.dev0"
 
 from .accelerator import Accelerator

--- a/src/accelerate/commands/__init__.py
+++ b/src/accelerate/commands/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/accelerate/commands/menu/__init__.py
+++ b/src/accelerate/commands/menu/__init__.py
@@ -1,1 +1,14 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from .selection_menu import BulletMenu

--- a/src/accelerate/commands/menu/keymap.py
+++ b/src/accelerate/commands/menu/keymap.py
@@ -16,7 +16,6 @@
 Utilities relating to parsing raw characters from the keyboard, based on https://github.com/bchao1/bullet
 """
 
-
 import os
 import string
 import sys

--- a/src/accelerate/commands/menu/selection_menu.py
+++ b/src/accelerate/commands/menu/selection_menu.py
@@ -15,6 +15,7 @@
 """
 Main driver for the selection menu, based on https://github.com/bchao1/bullet
 """
+
 import builtins
 import sys
 

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -1,3 +1,16 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import math
 from types import MethodType
 from typing import Any, Dict, List, Optional, Tuple, Union

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from .testing import (
     DEFAULT_LAUNCH_COMMAND,
     are_the_same_tensors,

--- a/src/accelerate/test_utils/scripts/__init__.py
+++ b/src/accelerate/test_utils/scripts/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/accelerate/test_utils/scripts/external_deps/__init__.py
+++ b/src/accelerate/test_utils/scripts/external_deps/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/accelerate/test_utils/scripts/external_deps/test_checkpointing.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_checkpointing.py
@@ -181,7 +181,7 @@ def training_function(config, args):
         accelerator.print("resumed checkpoint performance:", accuracy)
         accelerator.print("resumed checkpoint's scheduler's lr:", lr_scheduler.get_lr()[0])
         accelerator.print("resumed optimizers's lr:", optimizer.param_groups[0]["lr"])
-        with open(os.path.join(args.output_dir, f"state_{starting_epoch-1}.json")) as f:
+        with open(os.path.join(args.output_dir, f"state_{starting_epoch - 1}.json")) as f:
             resumed_state = json.load(f)
             assert resumed_state["accuracy"] == accuracy, "Accuracy mismatch, loading from checkpoint failed"
             assert (

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -113,8 +113,8 @@ def generate_predictions(model, dataloader, accelerator):
 def test_torch_metrics(
     accelerator: Accelerator, num_samples=82, dispatch_batches=False, split_batches=False, batch_size=16
 ):
-    model, ddp_model, dataloader = get_basic_setup(accelerator, num_samples, batch_size)
-    logits, targs = generate_predictions(ddp_model, dataloader, accelerator)
+    _, ddp_model, dataloader = get_basic_setup(accelerator, num_samples, batch_size)
+    logits, _ = generate_predictions(ddp_model, dataloader, accelerator)
     assert (
         len(logits) == num_samples
     ), f"Unexpected number of inputs:\n    Expected: {num_samples}\n    Actual: {len(logits)}"

--- a/src/accelerate/test_utils/scripts/test_cli.py
+++ b/src/accelerate/test_utils/scripts/test_cli.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import torch
 
 

--- a/src/accelerate/test_utils/scripts/test_notebook.py
+++ b/src/accelerate/test_utils/scripts/test_notebook.py
@@ -1,4 +1,20 @@
-# Test file to ensure that in general certain situational setups for notebooks work.
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Test file to ensure that in general certain situational setups for notebooks work.
+"""
+
 import os
 
 from pytest import raises

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from .constants import (
     MODEL_NAME,
     OPTIMIZER_NAME,

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -781,9 +781,9 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 
     def test_ds_config_assertions(self):
         ambiguous_env = self.dist_env.copy()
-        ambiguous_env["ACCELERATE_CONFIG_DS_FIELDS"] = (
-            "gradient_accumulation_steps,gradient_clipping,zero_stage,offload_optimizer_device,offload_param_device,zero3_save_16bit_model,mixed_precision"
-        )
+        ambiguous_env[
+            "ACCELERATE_CONFIG_DS_FIELDS"
+        ] = "gradient_accumulation_steps,gradient_clipping,zero_stage,offload_optimizer_device,offload_param_device,zero3_save_16bit_model,mixed_precision"
 
         with mockenv_context(**ambiguous_env):
             with self.assertRaises(ValueError) as cm:

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -354,10 +354,10 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 )
                 assert accelerator.deepspeed_config["zero_allow_untested_optimizer"]
                 assert accelerator.deepspeed_config["train_batch_size"], 16
-                assert type(model) == DeepSpeedEngine
-                assert type(optimizer) == DeepSpeedOptimizerWrapper
-                assert type(lr_scheduler) == AcceleratedScheduler
-                assert type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper
+                assert type(model) is DeepSpeedEngine
+                assert type(optimizer) is DeepSpeedOptimizerWrapper
+                assert type(lr_scheduler) is AcceleratedScheduler
+                assert type(accelerator.deepspeed_engine_wrapped) is DeepSpeedEngineWrapper
 
         elif optim_type == DS_OPTIMIZER and scheduler_type == DS_SCHEDULER:
             # Test DeepSpeed optimizer + DeepSpeed scheduler
@@ -411,10 +411,10 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, dummy_optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                 )
-                assert type(model) == DeepSpeedEngine
-                assert type(optimizer) == DeepSpeedOptimizerWrapper
-                assert type(lr_scheduler) == DeepSpeedSchedulerWrapper
-                assert type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper
+                assert type(model) is DeepSpeedEngine
+                assert type(optimizer) is DeepSpeedOptimizerWrapper
+                assert type(lr_scheduler) is DeepSpeedSchedulerWrapper
+                assert type(accelerator.deepspeed_engine_wrapped) is DeepSpeedEngineWrapper
 
         elif optim_type == CUSTOM_OPTIMIZER and scheduler_type == DS_SCHEDULER:
             # Test custom optimizer + DeepSpeed scheduler
@@ -445,11 +445,11 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
                 model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
                     model, optimizer, train_dataloader, eval_dataloader, dummy_lr_scheduler
                 )
-                assert type(model) == DeepSpeedEngine
-                assert type(optimizer) == DeepSpeedOptimizerWrapper
-                assert type(lr_scheduler) == DeepSpeedSchedulerWrapper
-                assert type(accelerator.deepspeed_engine_wrapped) == DeepSpeedEngineWrapper
-        elif optim_type == DS_OPTIMIZER and scheduler_type == CUSTOM_SCHEDULER:
+                assert type(model) is DeepSpeedEngine
+                assert type(optimizer) is DeepSpeedOptimizerWrapper
+                assert type(lr_scheduler) is DeepSpeedSchedulerWrapper
+                assert type(accelerator.deepspeed_engine_wrapped) is DeepSpeedEngineWrapper
+        elif optim_type == DS_OPTIMIZER and scheduler_type is CUSTOM_SCHEDULER:
             # Test deepspeed optimizer + custom scheduler
             deepspeed_plugin = DeepSpeedPlugin(hf_ds_config=self.ds_config_file[ZERO2])
             with mockenv_context(**self.dist_env):
@@ -781,9 +781,9 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 
     def test_ds_config_assertions(self):
         ambiguous_env = self.dist_env.copy()
-        ambiguous_env[
-            "ACCELERATE_CONFIG_DS_FIELDS"
-        ] = "gradient_accumulation_steps,gradient_clipping,zero_stage,offload_optimizer_device,offload_param_device,zero3_save_16bit_model,mixed_precision"
+        ambiguous_env["ACCELERATE_CONFIG_DS_FIELDS"] = (
+            "gradient_accumulation_steps,gradient_clipping,zero_stage,offload_optimizer_device,offload_param_device,zero3_save_16bit_model,mixed_precision"
+        )
 
         with mockenv_context(**ambiguous_env):
             with self.assertRaises(ValueError) as cm:
@@ -992,8 +992,8 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                     ]
                 )
                 for i in range(3):
-                    if f"stage_{i+1}" in spec:
-                        cmd_stage.extend([f"--zero_stage={i+1}"])
+                    if f"stage_{i + 1}" in spec:
+                        cmd_stage.extend([f"--zero_stage={i + 1}"])
                         break
                 cmd_stage.extend(
                     [

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import os
 import pickle

--- a/tests/test_sagemaker.py
+++ b/tests/test_sagemaker.py
@@ -1,3 +1,16 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import unittest
 from dataclasses import dataclass
 

--- a/tests/xla_spawn.py
+++ b/tests/xla_spawn.py
@@ -24,7 +24,6 @@ Inspired by https://github.com/pytorch/pytorch/blob/master/torch/distributed/lau
 
 """
 
-
 import importlib
 import sys
 from argparse import REMAINDER, ArgumentParser

--- a/utils/log_reports.py
+++ b/utils/log_reports.py
@@ -1,3 +1,16 @@
+# Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import json
 import os
 from datetime import date

--- a/utils/stale.py
+++ b/utils/stale.py
@@ -15,6 +15,7 @@
 Script to close stale issue. Taken in part from the AllenNLP repository.
 https://github.com/allenai/allennlp.
 """
+
 import os
 from datetime import datetime as dt
 from datetime import timezone


### PR DESCRIPTION
# What does this PR do?

This PR adds a rule to the `ruff` formatter that allows for checking the presence of a copyright notice at the top of the file, adds said copyrights with the right year (file was introduced), and also fixes a few lint things I found when running on 0.3.0 (note I'm not unpinning 0.3.0, and verified that these rules etc still work on 0.2.1)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 