### PR TITLE
Don't manage `PYTORCH_NVML_BASED_CUDA_CHECK` when calling `accelerate.utils.imports.is_cuda_available()`

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -98,7 +98,7 @@ def is_cuda_available():
     Checks if `cuda` is available via an `nvml-based` check which won't trigger the drivers and leave cuda
     uninitialized.
     """
-    pytorch_nvml_based_cuda_check_previous_value = os.getenv("PYTORCH_NVML_BASED_CUDA_CHECK")
+    pytorch_nvml_based_cuda_check_previous_value = os.environ.get("PYTORCH_NVML_BASED_CUDA_CHECK")
     try:
         os.environ["PYTORCH_NVML_BASED_CUDA_CHECK"] = str(1)
         available = torch.cuda.is_available()

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -96,10 +96,19 @@ def is_fp8_available():
 def is_cuda_available():
     """
     Checks if `cuda` is available via an `nvml-based` check which won't trigger the drivers and leave cuda
-    uninitialized. This is similar to setting the environment variable PYTORCH_NVML_BASED_CUDA_CHECK=1.
-    See: https://pytorch.org/docs/stable/notes/cuda.html#device-agnostic-code
+    uninitialized.
     """
-    return torch.cuda._device_count_nvml() > 0
+    pytorch_nvml_based_cuda_check_previous_value = os.getenv("PYTORCH_NVML_BASED_CUDA_CHECK")
+    try:
+        os.environ["PYTORCH_NVML_BASED_CUDA_CHECK"] = str(1)
+        available = torch.cuda.is_available()
+    finally:
+        if pytorch_nvml_based_cuda_check_previous_value:
+            os.environ["PYTORCH_NVML_BASED_CUDA_CHECK"] = pytorch_nvml_based_cuda_check_previous_value
+        else:
+            os.environ.pop("PYTORCH_NVML_BASED_CUDA_CHECK", None)
+
+    return available
 
 
 @lru_cache

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -96,14 +96,10 @@ def is_fp8_available():
 def is_cuda_available():
     """
     Checks if `cuda` is available via an `nvml-based` check which won't trigger the drivers and leave cuda
-    uninitialized.
+    uninitialized. This is similar to setting the environment variable PYTORCH_NVML_BASED_CUDA_CHECK=1.
+    See: https://pytorch.org/docs/stable/notes/cuda.html#device-agnostic-code
     """
-    try:
-        os.environ["PYTORCH_NVML_BASED_CUDA_CHECK"] = str(1)
-        available = torch.cuda.is_available()
-    finally:
-        os.environ.pop("PYTORCH_NVML_BASED_CUDA_CHECK", None)
-    return available
+    return torch.cuda._device_count_nvml() > 0
 
 
 @lru_cache


### PR DESCRIPTION
# What does this PR do?

`PYTORCH_NVML_BASED_CUDA_CHECK=1` will tell PyTorch to use an NVML-based check when determining how many devices are available. That's useful for preventing CUDA initialization when calling `torch.cuda.is_available()`. 

`accelerate.utils.imports.is_cuda_available()` will set that env var and delete it afterwards. This is bad because that env var may be available, so deleting it after the function is called can lead to bugs. We ([Modal](https://modal.com/)) set that env var in some workloads. Calling this function breaks some user programs.

We can restore that env var its previous state after calling this function but I think that it is better to, instead of manipulating that env var, call the torch utility `_device_count_nvml` directly. What do you think?


## Who can review?

@muellerzr tagging you because git blame suggests you were the function author.