### PR TITLE
Enable using dash or underscore in CLI

### DIFF
--- a/src/accelerate/commands/accelerate_cli.py
+++ b/src/accelerate/commands/accelerate_cli.py
@@ -12,9 +12,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
-
-from argparse import ArgumentParser
+# limitations under the License
 
 from accelerate.commands.config import get_config_parser
 from accelerate.commands.env import env_command_parser
@@ -22,10 +20,13 @@ from accelerate.commands.estimate import estimate_command_parser
 from accelerate.commands.launch import launch_command_parser
 from accelerate.commands.test import test_command_parser
 from accelerate.commands.tpu import tpu_command_parser
+from accelerate.commands.utils import ArgumentParserWithDashSupport
 
 
 def main():
-    parser = ArgumentParser("Accelerate CLI tool", usage="accelerate <command> [<args>]", allow_abbrev=False)
+    parser = ArgumentParserWithDashSupport(
+        "Accelerate CLI tool", usage="accelerate <command> [<args>]", allow_abbrev=False
+    )
     subparsers = parser.add_subparsers(help="accelerate command helpers")
 
     # Register commands

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -128,10 +128,13 @@ class _CustomHelpAction(argparse._HelpAction):
 
 
 def launch_command_parser(subparsers=None):
+    description = "Launch a python script in a distributed scenario. Arguments can be passed in with either hyphens (`a-b`) or underscores (`a_b`)"
     if subparsers is not None:
-        parser = subparsers.add_parser("launch", add_help=False, allow_abbrev=False)
+        parser = subparsers.add_parser("launch", description=description, add_help=False, allow_abbrev=False)
     else:
-        parser = ArgumentParserWithDashSupport("Accelerate launch command", add_help=False, allow_abbrev=False)
+        parser = ArgumentParserWithDashSupport(
+            "Accelerate launch command", description=description, add_help=False, allow_abbrev=False
+        )
 
     parser.register("action", "help", _CustomHelpAction)
     parser.add_argument("-h", "--help", action="help", help="Show this help message and exit.")

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -28,6 +28,7 @@ import torch
 from accelerate.commands.config import default_config_file, load_config_from_file
 from accelerate.commands.config.config_args import SageMakerConfig
 from accelerate.commands.config.config_utils import DYNAMO_BACKENDS
+from accelerate.commands.utils import ArgumentParserWithDashSupport
 from accelerate.state import get_int_from_env
 from accelerate.utils import (
     ComputeEnvironment,
@@ -130,7 +131,7 @@ def launch_command_parser(subparsers=None):
     if subparsers is not None:
         parser = subparsers.add_parser("launch", add_help=False, allow_abbrev=False)
     else:
-        parser = argparse.ArgumentParser("Accelerate launch command", add_help=False, allow_abbrev=False)
+        parser = ArgumentParserWithDashSupport("Accelerate launch command", add_help=False, allow_abbrev=False)
 
     parser.register("action", "help", _CustomHelpAction)
     parser.add_argument("-h", "--help", action="help", help="Show this help message and exit.")

--- a/src/accelerate/commands/utils.py
+++ b/src/accelerate/commands/utils.py
@@ -1,0 +1,90 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+
+
+class ArgumentParserWithDashSupport(argparse.ArgumentParser):
+    """
+    argparse subclass that allows for seamless use of `--a-b` or `--a_b` style arguments automatically.
+
+    Based on the implementation here:
+    https://stackoverflow.com/questions/53527387/make-argparse-treat-dashes-and-underscore-identically
+    """
+
+    def _parse_optional(self, arg_string):
+        # Conditions to not change anything/it's a positional:
+        # - Empty string, positional
+        # - Doesn't start with a prefix
+        # - Single character
+        if (not arg_string) or (arg_string[0] not in self.prefix_chars) or (len(arg_string) == 1):
+            return None
+
+        option_tuples = self._get_option_tuples(arg_string)
+
+        # If multiple matches, it was ambigous, raise an error
+        if len(option_tuples) > 1:
+            options = ", ".join([option_string for _, option_string, _ in option_tuples])
+            self.error(f"ambiguous option: {arg_string} could match {options}")
+
+        # If exactly one match, return it
+        elif len(option_tuples) == 1:
+            (option_tuple,) = option_tuples
+            return option_tuple
+
+        # If not found, but looks like a negative number, probably posisional
+        if self._negative_number_matcher.match(arg_string) and not self._has_negative_number_optionals:
+            return None
+
+        # If it has a space, probably positional
+        if " " in arg_string:
+            return None
+
+        # Otherwise meant to be optional though no such option,
+        # but could be valid in a subparser so just return it
+        return None, arg_string, None
+
+    def _get_option_tuples(self, option_string):
+        result = []
+        explicit_arg = None
+        if "=" in option_string:
+            option_prefix, explicit_arg = option_string.split("=", 1)
+        else:
+            option_prefix = option_string
+        # Assuming it's a perfect match
+        if option_prefix in self._option_string_actions:
+            action = self._option_string_actions[option_prefix]
+            result.append((action, option_prefix, explicit_arg))
+        else:
+            # Imperfect match, have to go dig
+            chars = self.prefix_chars
+            if option_string[0] in chars and option_string[1] not in chars:
+                # short option: if single character, can be concatenated with arguments
+                short_option_prefix = option_string[:2]
+                short_explicit_arg = option_string[2:]
+                if short_option_prefix in self._option_string_actions:
+                    action = self._option_string_actions[short_option_prefix]
+                    result.append((action, short_option_prefix, short_explicit_arg))
+
+            # Finally check for `-` vs `_`
+            underscored = {k.replace("-", "_"): k for k in self._option_string_actions}
+            option_prefix = option_prefix.replace("-", "_")
+            if option_prefix in underscored:
+                action = self._option_string_actions[underscored[option_prefix]]
+                result.append((action, underscored[option_prefix], explicit_arg))
+            elif self.allow_abbrev:
+                for option_string in underscored:
+                    if option_string.startswith(option_prefix):
+                        action = self._option_string_actions[underscored[option_string]]
+                        result.append((action, underscored[option_string], explicit_arg))
+        return result

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,7 @@ import torch
 from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
+from accelerate.commands.launch import launch_command_parser
 from accelerate.test_utils import execute_subprocess_async
 from accelerate.test_utils.testing import (
     DEFAULT_LAUNCH_COMMAND,
@@ -97,6 +98,50 @@ class AccelerateLauncherTester(unittest.TestCase):
         cmd = ["python", self.notebook_launcher_path]
         with patch_environment(omp_num_threads=1, accelerate_num_processes=2):
             run_command(cmd, env=os.environ.copy())
+
+
+class LaunchArgTester(unittest.TestCase):
+    """
+    Test cases revolving around the CLI wrappers
+    """
+
+    def test_hiphen(self):
+        # Try a little from each cluster
+        parser = launch_command_parser()
+        args = ["--config-file", "test.yaml", "test.py"]
+        result = parser.parse_args(args)
+        assert result.config_file == "test.yaml"
+
+        args = ["--multi-gpu", "--num-processes", "4", "test.py"]
+        result = parser.parse_args(args)
+        assert result.multi_gpu is True
+        assert result.num_processes == 4
+        # And use a mix
+        args = ["--multi-gpu", "--use-deepspeed", "--use-fsdp", "--num_processes", "4", "test.py"]
+        result = parser.parse_args(args)
+        assert result.multi_gpu is True
+        assert result.use_deepspeed is True
+        assert result.use_fsdp is True
+        assert result.num_processes == 4
+
+    def test_underscore(self):
+        # Try a little from each cluster
+        parser = launch_command_parser()
+        args = ["--config_file", "test.yaml", "test.py"]
+        result = parser.parse_args(args)
+        assert result.config_file == "test.yaml"
+
+        args = ["--multi_gpu", "--num_processes", "4", "test.py"]
+        result = parser.parse_args(args)
+        assert result.multi_gpu is True
+        assert result.num_processes == 4
+        # And use a mix
+        args = ["--multi_gpu", "--use_deepspeed", "--use_fsdp", "--num-processes", "4", "test.py"]
+        result = parser.parse_args(args)
+        assert result.multi_gpu is True
+        assert result.use_deepspeed is True
+        assert result.use_fsdp is True
+        assert result.num_processes == 4
 
 
 class TpuConfigTester(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

This PR adds a pinch of magic for users that are used to doing `--a-b` with arguments that pass-through to things such as `torchrun`, accelerate can process those if we have them defined ourselves already.

E.g. a user can do:
```bash
accelerate launch --no_python --multi_gpu --num_processes 8 --monitor_interval=1 ./trampoline.sh python3 -c "print('hello')"
```
**OR**:
```bash
accelerate launch --no-python --multi-gpu --num-processes 8 --monitor-interval=1 ./trampoline.sh python3 -c "print('hello')"
```

Fixes https://github.com/huggingface/accelerate/issues/2241

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan, @stas00 (for your future sanity 😄 )