### PR TITLE
Quanto compatibility with QBitsTensor

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -404,7 +404,7 @@ def set_module_tensor_to_device(
                     new_value.SCB = new_value.SCB.to("cpu")
                 else:
                     new_value = param_cls(new_value, requires_grad=old_value.requires_grad, **kwargs).to(device)
-            elif param_cls.__name__ in ["QTensor"]:
+            elif param_cls.__name__ in ["QTensor", "QBitsTensor"]:
                 new_value = torch.nn.Parameter(new_value, requires_grad=old_value.requires_grad).to(device)
             else:
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)


### PR DESCRIPTION
# What does this PR
For quanto compatibility with lower bit quantization, we need to check for QBitsTensor class too. 
Related [PR](https://github.com/huggingface/accelerate/pull/2481). 