### PR TITLE
[`fsdp`] Allow `set_auto_wrap_policy` without any split modules

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1144,11 +1144,12 @@ class FullyShardedDataParallelPlugin:
                 ).split(",")
                 transformer_cls_to_wrap = set()
                 for layer_class in transformer_cls_names_to_wrap:
-                    transformer_cls = FullyShardedDataParallelPlugin.get_module_class_from_name(model, layer_class)
-                    if transformer_cls is None:
-                        raise Exception("Could not find the transformer layer class to wrap in the model.")
-                    else:
-                        transformer_cls_to_wrap.add(transformer_cls)
+                    if layer_class:
+                        transformer_cls = FullyShardedDataParallelPlugin.get_module_class_from_name(model, layer_class)
+                        if transformer_cls is None:
+                            raise Exception("Could not find the transformer layer class to wrap in the model.")
+                        else:
+                            transformer_cls_to_wrap.add(transformer_cls)
 
                 self.auto_wrap_policy = functools.partial(
                     transformer_auto_wrap_policy,

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -140,6 +140,24 @@ class FSDPPluginIntegration(AccelerateTestCase):
             assert "Could not find the transformer layer class to wrap in the model." in str(cm.exception)
 
         env = self.dist_env.copy()
+        env["FSDP_AUTO_WRAP_POLICY"] = "TRANSFORMER_BASED_WRAP"
+        original_no_split_modules = model._no_split_modules
+        model._no_split_modules = []
+        with mockenv_context(**env):
+            fsdp_plugin = FullyShardedDataParallelPlugin()
+            fsdp_plugin.set_auto_wrap_policy(model)
+            assert fsdp_plugin.auto_wrap_policy is not None
+        model._no_split_modules = original_no_split_modules
+
+        env = self.dist_env.copy()
+        env["FSDP_AUTO_WRAP_POLICY"] = "TRANSFORMER_BASED_WRAP"
+        env["FSDP_TRANSFORMER_CLS_TO_WRAP"] = ""
+        with mockenv_context(**env):
+            fsdp_plugin = FullyShardedDataParallelPlugin()
+            fsdp_plugin.set_auto_wrap_policy(model)
+            assert fsdp_plugin.auto_wrap_policy is not None
+
+        env = self.dist_env.copy()
         env["FSDP_AUTO_WRAP_POLICY"] = "SIZE_BASED_WRAP"
         env["FSDP_MIN_NUM_PARAMS"] = "0"
         with mockenv_context(**env):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Details
If `_no_split_modules` is `None` or an empty list, then `default_transformer_cls_names_to_wrap` becomes an empty string: `""`. Then, `transformer_cls_names_to_wrap` calls `.split(",")` on that potentially empty string, resulting in `[""]` as the list of transformer class names that should be wrapped. We loop over these class names, and obviously the empty string can't be found within the model. This results in `raise Exception("Could not find the transformer layer class to wrap in the model.")` when `model._no_split_modules = []` and the auto wrap policy is `TRANSFORMER_BASED_WRAP`.

This PR updates this surprising behaviour to ignore the "empty class name" case.

I encountered this issue when subclassing the `transformers` `Trainer` for Sentence Transformers. I realise that it's possible that in doing so, the bug may have actually been on my side, so apologies if that is the case.

## Who can review?

cc @pacman100

- Tom Aarsen