### PR TITLE
Allow Gradients to be Synced Each Data Batch While Performing Gradient Accumulation

### DIFF
--- a/docs/source/concept_guides/gradient_synchronization.md
+++ b/docs/source/concept_guides/gradient_synchronization.md
@@ -180,4 +180,5 @@ See the example below where we fine-tune Mixtral (47B parameters) on 8 A100-80GB
 | :-------------: | :-----------------: | :-----------------: | :-----------------: 
 mixtral 8x7B      | 69G                 | OOM                 | 69G
 
-Finally, note that disabling `no_sync` means there _will be slowdown_ due the extra data syncs, as explained by the earlier sections of this guide.
+> [!WARNING] 
+> Disabling `no_sync` means there _will be slowdown_ due the extra data syncs, as explained by the earlier sections of this guide.

--- a/docs/source/concept_guides/gradient_synchronization.md
+++ b/docs/source/concept_guides/gradient_synchronization.md
@@ -170,9 +170,9 @@ If you are worried about making sure everything is done properly, we highly reco
 
 ### `no_sync` requires additional GPU memory when using FSDP
 
-Be aware that not syncing gradients can have adverse effects while performing FSDP training. As it has been warned in `torch`, the [`no_sync` context manager for FSDP](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.no_sync) will incur additional memory.
+Be aware that not syncing gradients can have adverse effects while performing FSDP training. As it has been warned in `torch`, the [`no_sync` context manager for FSDP](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.no_sync) will require additional memory.
 
-Therefore in memory intensive situations while using FSDP, we recommend to set `sync_each_batch` to `False` in the [`~utils.GradientAccumulationPlugin`] to disable `no_sync`.
+Therefore in memory intensive situations while using FSDP, we recommend to set `sync_each_batch` to `True` in the [`~utils.GradientAccumulationPlugin`] to disable `no_sync`.
 
 See the example below where we fine-tune Mixtral (47B parameters) on 8 A100-80GB GPUs. We see that even for a modest `gradient_accumulation_steps=2` we quickly go out-of-memory (OOM) if `no_sync` is enabled. Again, this is due to additional memory overheads due to FSDP's `no_sync`. However, if `no_sync` is disabled via `sync_each_batch=True`, then the memory consumption for `gradient_accumulation_steps=16` reverts to that of `gradient_accumulation_steps=1`.
 

--- a/docs/source/concept_guides/gradient_synchronization.md
+++ b/docs/source/concept_guides/gradient_synchronization.md
@@ -167,3 +167,17 @@ As you can see, if you are not careful about how you set up your gradient synchr
 
 If you are worried about making sure everything is done properly, we highly recommend utilizing the [`~Accelerator.accumulate`] function and passing in
 `gradient_accumulation_steps` or `gradient_accumulation_plugin` to the [`Accelerator`] object so Accelerate can handle this for you.
+
+### `no_sync` requires additional GPU memory when using FSDP
+
+Be aware that not syncing gradients can have adverse effects while performing FSDP training. As it has been warned in `torch`, the [`no_sync` context manager for FSDP](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.FullyShardedDataParallel.no_sync) will incur additional memory.
+
+Therefore in memory intensive situations while using FSDP, we recommend to set `sync_each_batch` to `False` in the [`~utils.GradientAccumulationPlugin`] to disable `no_sync`.
+
+See the example below where we fine-tune Mixtral (47B parameters) on 8 A100-80GB GPUs. We see that even for a modest `gradient_accumulation_steps=2` we quickly go out-of-memory (OOM) if `no_sync` is enabled. Again, this is due to additional memory overheads due to FSDP's `no_sync`. However, if `no_sync` is disabled via `sync_each_batch=True`, then the memory consumption for `gradient_accumulation_steps=16` reverts to that of `gradient_accumulation_steps=1`.
+
+| Model           | `no_sync` (accum=1) | `no_sync` (accum=2) | `no_sync` disabled (accum=16)
+| :-------------: | :-----------------: | :-----------------: | :-----------------: 
+mixtral 8x7B      | 69G                 | OOM                 | 69G
+
+Finally, note that disabling `no_sync` means there _will be slowdown_ due the extra data syncs, as explained by the earlier sections of this guide.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1025,7 +1025,7 @@ class Accelerator:
         ...         optimizer.zero_grad()
         ```
         """
-        # sync_each_batch=True will gaurantee below that self.sync_gradients=True, therefore
+        # sync_each_batch=True will guarantee below that self.sync_gradients=True, therefore
         # resulting in the nullcontext always being selected.
         self._do_sync(force=self.gradient_state.plugin_kwargs.get("sync_each_batch", False))
         with contextlib.ExitStack() as cm_stack:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -972,7 +972,7 @@ class Accelerator:
             model.require_backward_grad_sync = old_require_backward_grad_sync
             model.require_forward_param_sync = old_require_forward_param_sync
 
-    def _do_sync(self, force: bool = True):
+    def _do_sync(self, force: bool = False):
         "Sets the right `sync_gradients` context and either resets or increases `self.step`"
         if self.gradient_state.sync_with_dataloader and self.gradient_state.end_of_dataloader:
             self.step = 0
@@ -1025,6 +1025,8 @@ class Accelerator:
         ...         optimizer.zero_grad()
         ```
         """
+        # sync_each_batch=True will gaurantee below that self.sync_gradients=True, therefore
+        # resulting in the nullcontext always being selected.
         self._do_sync(force=self.gradient_state.plugin_kwargs.get("sync_each_batch", False))
         with contextlib.ExitStack() as cm_stack:
             for m in models:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -979,9 +979,7 @@ class Accelerator:
             self.gradient_state._set_sync_gradients(True)
         else:
             self.step += 1
-            self.gradient_state._set_sync_gradients(
-                force or ((self.step % self.gradient_state.num_steps) == 0)
-            )
+            self.gradient_state._set_sync_gradients(force or ((self.step % self.gradient_state.num_steps) == 0))
 
     @property
     def sync_gradients(self):
@@ -1027,7 +1025,7 @@ class Accelerator:
         ...         optimizer.zero_grad()
         ```
         """
-        self._do_sync(force=self.gradient_state.plugin_kwargs.get('sync_each_batch', False))
+        self._do_sync(force=self.gradient_state.plugin_kwargs.get("sync_each_batch", False))
         with contextlib.ExitStack() as cm_stack:
             for m in models:
                 cm_stack.enter_context(contextlib.nullcontext() if self.sync_gradients else self.no_sync(m))

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -23,7 +23,7 @@ from torch.utils.data import DataLoader
 from accelerate.accelerator import Accelerator
 from accelerate.state import GradientState
 from accelerate.test_utils import RegressionDataset, RegressionModel
-from accelerate.utils import DistributedType, is_torch_version, set_seed
+from accelerate.utils import DistributedType, set_seed
 
 
 def check_model_parameters(model_a, model_b, did_step, iteration, **kwargs):
@@ -205,13 +205,12 @@ def test_distributed_sync_multiple_fwd(accelerator):
 
 
 def test_gradient_accumulation(split_batches=False, dispatch_batches=False, sync_each_batch=False):
-
     from accelerate.accelerator import GradientAccumulationPlugin
+
     accelerator = Accelerator(
-        split_batches=split_batches, dispatch_batches=dispatch_batches, 
-        gradient_accumulation_plugin=GradientAccumulationPlugin(
-            num_steps=2, sync_each_batch=sync_each_batch
-        )
+        split_batches=split_batches,
+        dispatch_batches=dispatch_batches,
+        gradient_accumulation_plugin=GradientAccumulationPlugin(num_steps=2, sync_each_batch=sync_each_batch),
     )
     # Test that context manager behaves properly
     model, ddp_model, dataloader = get_training_setup(accelerator)
@@ -247,13 +246,15 @@ def test_gradient_accumulation(split_batches=False, dispatch_batches=False, sync
     GradientState._reset_state()
 
 
-def test_gradient_accumulation_with_opt_and_scheduler(split_batches=False, dispatch_batches=False, sync_each_batch=False):
+def test_gradient_accumulation_with_opt_and_scheduler(
+    split_batches=False, dispatch_batches=False, sync_each_batch=False
+):
     from accelerate.accelerator import GradientAccumulationPlugin
+
     accelerator = Accelerator(
-        split_batches=split_batches, dispatch_batches=dispatch_batches, 
-        gradient_accumulation_plugin=GradientAccumulationPlugin(
-            num_steps=2, sync_each_batch=sync_each_batch
-        )
+        split_batches=split_batches,
+        dispatch_batches=dispatch_batches,
+        gradient_accumulation_plugin=GradientAccumulationPlugin(num_steps=2, sync_each_batch=sync_each_batch),
     )
     # Test that context manager behaves properly
     model, opt, sched, dataloader, ddp_model, ddp_opt, ddp_sched = get_training_setup(accelerator, True)
@@ -263,7 +264,7 @@ def test_gradient_accumulation_with_opt_and_scheduler(split_batches=False, dispa
         input, target = accelerator.gather((ddp_input, ddp_target))
         input, target = input.to(accelerator.device), target.to(accelerator.device)
         # Perform our initial ground truth step in non "DDP"
-        model.train() # is this needed?
+        model.train()  # is this needed?
         ddp_model.train()
         step_model(model, input, target, accelerator, False)
         opt.step()
@@ -288,11 +289,15 @@ def test_gradient_accumulation_with_opt_and_scheduler(split_batches=False, dispa
         did_step = (((iteration + 1) % 2) == 0) or ((iteration + 1) == len(dataloader)) or sync_each_batch
         if accelerator.num_processes > 1:
             check_model_parameters(
-                model, ddp_model, did_step, iteration, rtol=1e-3,  # somehow needs a relative tolerance
+                model,
+                ddp_model,
+                did_step,
+                iteration,
+                rtol=1e-3,  # somehow needs a relative tolerance
             )
 
         if ((iteration + 1) % 2 == 0) or ((iteration + 1) == len(dataloader)) or sync_each_batch:
-            opt.zero_grad() # needs to be guarded by logic as to when we should zero grads
+            opt.zero_grad()  # needs to be guarded by logic as to when we should zero grads
         ddp_opt.zero_grad()
 
         # Shuffle ddp_input on each iteration

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -616,6 +616,7 @@ class GradientAccumulationPlugin(KwargsHandler):
         },
     )
 
+
 @dataclass
 class TorchDynamoPlugin(KwargsHandler):
     """

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -585,6 +585,9 @@ class GradientAccumulationPlugin(KwargsHandler):
             `True` if the used scheduler was not adjusted for gradient accumulation.
         sync_with_dataloader (`bool`, *optional*, defaults to `True`):
             Whether to synchronize setting the gradients when at the end of the dataloader.
+        sync_each_batch (`bool`, *optional*, defaults to `False`):
+                Whether to synchronize setting the gradients at each data batch. Seting to `True` may reduce memory
+                requirements when using gradient accumulation with distributed training, at expense of speed.
 
     Example:
 
@@ -612,7 +615,7 @@ class GradientAccumulationPlugin(KwargsHandler):
     sync_each_batch: bool = field(
         default=False,
         metadata={
-            "help": "Whether to synchronize setting the gradients at each data batch. Seting to `True` may reduce memory requirements (especially with distributed training) at expense of speed."
+            "help": "Whether to synchronize setting the gradients at each data batch. Seting to `True` may reduce memory requirements when using gradient accumulation with distributed training, at expense of speed."
         },
     )
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -585,7 +585,7 @@ class GradientAccumulationPlugin(KwargsHandler):
             `True` if the used scheduler was not adjusted for gradient accumulation.
         sync_with_dataloader (`bool`, *optional*, defaults to `True`):
             Whether to synchronize setting the gradients when at the end of the dataloader.
-        sync_each_batch (`bool`, *optional*, defaults to `False`):
+        sync_each_batch (`bool`, *optional*):
                 Whether to synchronize setting the gradients at each data batch. Seting to `True` may reduce memory
                 requirements when using gradient accumulation with distributed training, at expense of speed.
 
@@ -615,7 +615,7 @@ class GradientAccumulationPlugin(KwargsHandler):
     sync_each_batch: bool = field(
         default=False,
         metadata={
-            "help": "Whether to synchronize setting the gradients at each data batch. Seting to `True` may reduce memory requirements when using gradient accumulation with distributed training, at expense of speed."
+            "help": "Whether to synchronize setting the gradients at each data batch. Setting to `True` may reduce memory requirements when using gradient accumulation with distributed training, at expense of speed."
         },
     )
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -609,7 +609,12 @@ class GradientAccumulationPlugin(KwargsHandler):
             "help": "Whether to synchronize setting the gradients when at the end of the dataloader. Should only be set to `False` if you know what you're doing."
         },
     )
-
+    sync_each_batch: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to synchronize setting the gradients at each data batch. Seting to `True` may reduce memory requirements (especially with distributed training) at expense of speed."
+        },
+    )
 
 @dataclass
 class TorchDynamoPlugin(KwargsHandler):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/huggingface/transformers/issues/29425

This PR adds in logic to allow `no_sync` to be disabled in `accelerate`, in particular, so that memory can be saved whilst performing FSDP training. See details in the above linked issue.
- Introduced new  argument `GradientAccumulationPlugin.sync_each_batch`, when set will cause gradients to be synced each data batch, regardless of what the setting of `gradient_accumulation_steps` is.
- Introduced a `force` flag into `_do_sync`. This flag is set to `True` during `accumulate`, if `GradientAccumulationPlugin.sync_each_batch` has been configured to `True. 
- Updated tests `tests/test_grad_sync.py::SyncScheduler::test_gradient_sync_gpu_mult` and `test_gradient_sync_gpu`.
   - update test utilities `test_gradient_accumulation` and `test_gradient_accumulation_with_opt_and_scheduler` in [tests/test_grad_sync.py](https://github.com/fabianlim/accelerate/blob/feature-disable-no-sync/src/accelerate/test_utils/scripts/test_sync.py) to take in `sync_each_batch` that will test each case where the flag is set `True` or `False`


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->