### PR TITLE
Update link to dynamo/compile doc

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -369,7 +369,7 @@ class ComputeEnvironment(str, enum.Enum):
 
 class DynamoBackend(str, BaseEnum):
     """
-    Represents a dynamo backend (see https://github.com/pytorch/torchdynamo).
+    Represents a dynamo backend (see https://pytorch.org/docs/stable/torch.compiler.html).
 
     Values:
 


### PR DESCRIPTION
# What does this PR do?

[pytorch/torchdynamo](https://github.com/pytorch/torchdynamo ) has moved to [pytorch/pytorch](https://github.com/pytorch/pytorch/tree/main/torch/_dynamo) and relevant doc is now at https://pytorch.org/docs/stable/torch.compiler.html.

This µPR updates the link in the `DynamoBackend` docstring to save you one click :).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?


## Who can review?

@muellerzr 