### PR TITLE
Remove extra double-dash in error message

### DIFF
--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -329,7 +329,7 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict
     if need_port_check and is_port_in_use(main_process_port):
         raise ConnectionError(
             f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
-            "Please specify a different port (such as using the `----main_process_port` flag or specifying a different `main_process_port` in your config file)"
+            "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
             " and rerun your script. To automatically use the next open port (on a single node), you can set this to `0`."
         )
 


### PR DESCRIPTION
Error message should read `--main_process_port`, not `----main_process_port`.  Users who copy and paste the message as it was, will get this error message:
```
Accelerate CLI tool: error: unrecognized arguments: ----main_process_port
```

# What does this PR do?
See above. It fixes a typo in the error message printed when there is a process port mismatch


Fixes # (issue)

N/A

## Before submitting
- [x ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr  may be interested as this is a CLI issue

