### PR TITLE
Fix test_script.py on TPU v2/v3

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -872,9 +872,9 @@ def prepare_data_loader(
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(dataloader.sampler, RandomSampler) and state.distributed_type == DistributedType.XLA:
         # isinstance(dataloader.sampler, RandomSampler) indicates the original dataloader has `shuffle` enabled.
-        generator=torch.Generator().manual_seed(42)
-        dataloader.generator=generator
-        dataloader.sampler.generator=generator
+        generator = torch.Generator().manual_seed(42)
+        dataloader.generator = generator
+        dataloader.sampler.generator = generator
     if isinstance(sampler, RandomSampler) and use_seedable_sampler:
         # When iterating through the dataloader during distributed processes
         # we want to ensure that on each process we are iterating through the same

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -971,8 +971,6 @@ def prepare_data_loader(
         else:
             dataloader.batch_sampler.sampler = sampler
     if state.distributed_type == DistributedType.XLA:
-        # dataloader.generator=torch.Generator().manual_seed(42)
-        # dataloader.batch_sampler
         return MpDeviceLoaderWrapper(dataloader, device)
     return dataloader
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -871,9 +871,10 @@ def prepare_data_loader(
     else:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     if isinstance(dataloader.sampler, RandomSampler) and state.distributed_type == DistributedType.XLA:
-        seed=torch.Generator().manual_seed(42)
-        dataloader.generator=seed
-        dataloader.sampler.generator=seed
+        # isinstance(dataloader.sampler, RandomSampler) indicates the original dataloader has `shuffle` enabled.
+        generator=torch.Generator().manual_seed(42)
+        dataloader.generator=generator
+        dataloader.sampler.generator=generator
     if isinstance(sampler, RandomSampler) and use_seedable_sampler:
         # When iterating through the dataloader during distributed processes
         # we want to ensure that on each process we are iterating through the same

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -823,10 +823,6 @@ def prepare_data_loader(
 
     </Tip>
     """
-    if getattr(dataloader, 'shuffle', False) and state.distributed_type == DistributedType.XLA:
-        seed=torch.Generator().manual_seed(42)
-        dataloader.generator=seed
-        dataloader.sampler.generator=seed
     if dispatch_batches is None:
         if not put_on_device:
             dispatch_batches = False
@@ -874,6 +870,10 @@ def prepare_data_loader(
         sampler = getattr(dataloader.sampler, "sampler", None)
     else:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
+    if isinstance(dataloader.sampler, RandomSampler) and state.distributed_type == DistributedType.XLA:
+        seed=torch.Generator().manual_seed(42)
+        dataloader.generator=seed
+        dataloader.sampler.generator=seed
     if isinstance(sampler, RandomSampler) and use_seedable_sampler:
         # When iterating through the dataloader during distributed processes
         # we want to ensure that on each process we are iterating through the same

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -887,7 +887,6 @@ def prepare_data_loader(
         generator = torch.Generator().manual_seed(42)
         dataloader.generator = generator
         dataloader.sampler.generator = generator
-        dataloader.batch_sampler.sampler = dataloader.sampler
     # No change if no multiprocess
     if (num_processes != 1 or state.distributed_type == DistributedType.MEGATRON_LM) and not dispatch_batches:
         if isinstance(new_dataset, IterableDataset):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -823,6 +823,10 @@ def prepare_data_loader(
 
     </Tip>
     """
+    if getattr(dataloader, 'shuffle', False) and state.distributed_type == DistributedType.XLA:
+        seed=torch.Generator().manual_seed(42)
+        dataloader.generator=seed
+        dataloader.sampler.generator=seed
     if dispatch_batches is None:
         if not put_on_device:
             dispatch_batches = False
@@ -967,6 +971,8 @@ def prepare_data_loader(
         else:
             dataloader.batch_sampler.sampler = sampler
     if state.distributed_type == DistributedType.XLA:
+        # dataloader.generator=torch.Generator().manual_seed(42)
+        # dataloader.batch_sampler
         return MpDeviceLoaderWrapper(dataloader, device)
     return dataloader
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -160,7 +160,7 @@ class PartialState:
             elif is_torch_xla_available() and not cpu:
                 self.distributed_type = DistributedType.XLA
                 self.device = xm.xla_device()
-                xm.set_replication(self.device, [self.device])
+                xm.set_replication(self.device, xm.get_xla_supported_devices())
                 self.num_processes = xm.xrt_world_size()
                 self.process_index = xm.get_ordinal()
                 if is_torch_xla_available(check_is_tpu=True):

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -211,7 +211,9 @@ def dl_preparation_check():
     if state.process_index == 0:
         print("Non-shuffled dataloader passing.")
 
+    # xw32: fails here.
     dl = DataLoader(range(length), batch_size=8, shuffle=True)
+    #dl = DataLoader(range(length), batch_size=8, shuffle=True, generator=torch.Generator().manual_seed(42))
     dl = prepare_data_loader(dl, state.device, state.num_processes, state.process_index, put_on_device=True)
     result = []
     for batch in dl:

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -211,9 +211,7 @@ def dl_preparation_check():
     if state.process_index == 0:
         print("Non-shuffled dataloader passing.")
 
-    # xw32: fails here.
     dl = DataLoader(range(length), batch_size=8, shuffle=True)
-    #dl = DataLoader(range(length), batch_size=8, shuffle=True, generator=torch.Generator().manual_seed(42))
     dl = prepare_data_loader(dl, state.device, state.num_processes, state.process_index, put_on_device=True)
     result = []
     for batch in dl:


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/accelerate/issues/2479

- This PR fix the dataloader test: The same test `accelerate test` succeeds on TPU v4 but fails on v2/v3. The reason why it fails on TPU v2/v3 is multithreading. TPU v2/v3 involves multithreading: there are 4 processes and 8 TPU devices on the TPU v3-8, and each process spawns 2 threads for each device respectively. However TPU v4 and further TPU generations doesn't use multithreading. On TPU v2/v3, due to multithreading, we need to explicitly set the seed on each thread. Otherwise, each thread will permute the dataset indices in a different way and therefore generate the duplicate indices as shown in the gh issue. This PR explicitly set the `generator` for each thread and fix the test failure.
- This PR also fix a `xm.set_replication` issue for TPU v2/v3.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->