### PR TITLE
Use uv instead of pip install for github CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,7 +49,7 @@ jobs:
         cd ..
         git clone https://github.com/huggingface/transformers
         cd transformers
-        uv pip install .[torch,testing]
+        uv pip install -e .[torch,testing]
 
     - name: Show installed libraries
       run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,17 +32,24 @@ jobs:
       with:
         python-version: 3.8
 
+    - name: Setup uv
+      run: | 
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv .venv
+          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
     - name: Install Accelerate from source
       run: |
-        pip install --upgrade pip
-        pip install -e .
+        uv pip install setuptools
+        uv pip install -e .
     
     - name: Clone and install transformers
       run: |
         cd ..
         git clone https://github.com/huggingface/transformers
         cd transformers
-        pip install .[torch,testing]
+        uv pip install .[torch,testing]
 
     - name: Show installed libraries
       run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,24 +32,17 @@ jobs:
       with:
         python-version: 3.8
 
-    - name: Setup uv
-      run: | 
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv ~/.venv
-          echo "VIRTUAL_ENV=~/.venv" >> $GITHUB_ENV
-          echo "$PWD/.venv/bin" >> $GITHUB_PATH
-
     - name: Install Accelerate from source
       run: |
-        uv pip install setuptools
-        uv pip install -e .
+        pip install --upgrade pip
+        pip install -e .
     
     - name: Clone and install transformers
       run: |
         cd ..
         git clone https://github.com/huggingface/transformers
         cd transformers
-        uv pip install -e .[torch,testing]
+        pip install .[torch,testing]
 
     - name: Show installed libraries
       run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,8 +35,8 @@ jobs:
     - name: Setup uv
       run: | 
           curl -LsSf https://astral.sh/uv/install.sh | sh
-          uv venv .venv
-          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+          uv venv ~/.venv
+          echo "VIRTUAL_ENV=~/.venv" >> $GITHUB_ENV
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
     - name: Install Accelerate from source

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         if [[ ${{ matrix.test-kind }} = test_prod ]]; then uv pip install -e .[test_prod]; fi
         if [[ ${{ matrix.test-kind }} != test_prod ]]; then uv pip install -e .[testing,test_trackers]; fi
-        if [[ ${{ matrix.test-kind }} = test_rest ]]; then uv pip uninstall comet_ml -y; fi
+        if [[ ${{ matrix.test-kind }} = test_rest ]]; then uv pip uninstall comet_ml; fi
         if [[ ${{ matrix.test-kind }} = minimum ]]; then uv pip install torch==1.10.0; fi
         uv pip install pytest-reportlog tabulate setuptools
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,12 +54,13 @@ jobs:
     
     - name: Install the library
       run: |
+        python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
         pip install --upgrade pip
-        if [[ ${{ matrix.test-kind }} = test_prod ]]; then pip install -e .[test_prod]; fi
-        if [[ ${{ matrix.test-kind }} != test_prod ]]; then pip install -e .[testing,test_trackers]; fi
-        if [[ ${{ matrix.test-kind }} = test_rest ]]; then pip uninstall comet_ml -y; fi
-        if [[ ${{ matrix.test-kind }} = minimum ]]; then pip install torch==1.10.0; fi
-        pip install pytest-reportlog tabulate
+        if [[ ${{ matrix.test-kind }} = test_prod ]]; then uv pip install -e .[test_prod]; fi
+        if [[ ${{ matrix.test-kind }} != test_prod ]]; then uv pip install -e .[testing,test_trackers]; fi
+        if [[ ${{ matrix.test-kind }} = test_rest ]]; then uv pip uninstall comet_ml -y; fi
+        if [[ ${{ matrix.test-kind }} = minimum ]]; then uv pip install torch==1.10.0; fi
+        uv pip install pytest-reportlog tabulate
     
     - name: Run Tests
       env: 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,14 +45,6 @@ jobs:
       with:
         python-version: 3.8
     
-    - name: Activate python cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ${{ env.pythonLocation }}
-          ${{ env.HF_HOME }}
-        key: ${{ env.pythonLocation }}-${{ matrix.pytorch-version }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
-
     - name: Setup uv
       run: | 
           curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,11 +52,16 @@ jobs:
           ${{ env.pythonLocation }}
           ${{ env.HF_HOME }}
         key: ${{ env.pythonLocation }}-${{ matrix.pytorch-version }}-${{ matrix.test-kind }}-${{ hashFiles('setup.py') }}
+
+    - name: Setup uv
+      run: | 
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          uv venv .venv
+          echo "VIRTUAL_ENV=.venv" >> $GITHUB_ENV
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
     
     - name: Install the library
       run: |
-        python -m venv /opt/venv && export PATH="/opt/venv/bin:$PATH"
-        pip install --upgrade pip
         if [[ ${{ matrix.test-kind }} = test_prod ]]; then uv pip install -e .[test_prod]; fi
         if [[ ${{ matrix.test-kind }} != test_prod ]]; then uv pip install -e .[testing,test_trackers]; fi
         if [[ ${{ matrix.test-kind }} = test_rest ]]; then uv pip uninstall comet_ml -y; fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,6 @@ on:
       - "examples/**"
       - "setup.py"
     types: [opened, synchronize, reopened]
-  workflow_dispatch:
 
 env:
   HF_HOME: ~/hf_cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - "examples/**"
       - "setup.py"
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 env:
   HF_HOME: ~/hf_cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         if [[ ${{ matrix.test-kind }} != test_prod ]]; then uv pip install -e .[testing,test_trackers]; fi
         if [[ ${{ matrix.test-kind }} = test_rest ]]; then uv pip uninstall comet_ml -y; fi
         if [[ ${{ matrix.test-kind }} = minimum ]]; then uv pip install torch==1.10.0; fi
-        uv pip install pytest-reportlog tabulate
+        uv pip install pytest-reportlog tabulate setuptools
     
     - name: Run Tests
       env: 


### PR DESCRIPTION
# What does this PR do?

Opts for using `uv` instead of `pip install` for the github CI. It's so fast that we don't need to cache anymore, fun fact.

Total time: 

Before: **14m 15s** (~10min on a second commit), taken from https://github.com/huggingface/accelerate/actions/runs/8231938776

After: **6m 30s**, taken from https://github.com/huggingface/accelerate/actions/runs/8238343827

As you can see, *much* of our time is spent on caching (both download and upload of `n` workers, github doesn't like that bandwidth cost)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 