### PR TITLE
Add log message for RTX 4000 series when performing multi-gpu inference with device_map

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -31,6 +31,7 @@ from .hooks import (
 )
 from .utils import (
     OffloadedWeightsLoader,
+    check_cuda_p2p_ib_support,
     check_device_map,
     extract_submodules_state_dict,
     find_tied_parameters,
@@ -463,6 +464,11 @@ def dispatch_model(
         else:
             model.cuda = add_warning(model.cuda, model)
 
+        # Check if we are using multi-gpus with RTX 4000 series
+        use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
+        if use_multi_gpu and not check_cuda_p2p_ib_support():
+            logger.info("RTX 4000 series have issues with P2P. This can affect the multi-gpu inference when using accelerate device_map."
+                        "Please make sure to update your driver to the latest version")
     else:
         device = list(device_map.values())[0]
         # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -467,9 +467,10 @@ def dispatch_model(
         # Check if we are using multi-gpus with RTX 4000 series
         use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
         if use_multi_gpu and not check_cuda_p2p_ib_support():
-            logger.info("RTX 4000 series have issues with P2P. This can affect the multi-gpu inference when using accelerate device_map."
-                        "Please make sure to update your driver to the latest version"
-                        )
+            logger.info(
+                "RTX 4000 series have issues with P2P. This can affect the multi-gpu inference when using accelerate device_map."
+                "Please make sure to update your driver to the latest version"
+            )
     else:
         device = list(device_map.values())[0]
         # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -468,8 +468,9 @@ def dispatch_model(
         use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
         if use_multi_gpu and not check_cuda_p2p_ib_support():
             logger.warning(
-                "RTX 4000 series have issues with P2P. This can affect the multi-gpu inference when using accelerate device_map."
-                "Please make sure to update your driver to the latest version"
+                "We've detected an older driver with an RTX 4000 series GPU. These drivers have issues with P2P. "
+                "This can affect the multi-gpu inference when using accelerate device_map."
+                "Please make sure to update your driver to the latest version which resolves this."
             )
     else:
         device = list(device_map.values())[0]

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -467,7 +467,7 @@ def dispatch_model(
         # Check if we are using multi-gpus with RTX 4000 series
         use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
         if use_multi_gpu and not check_cuda_p2p_ib_support():
-            logger.info(
+            logger.warning(
                 "RTX 4000 series have issues with P2P. This can affect the multi-gpu inference when using accelerate device_map."
                 "Please make sure to update your driver to the latest version"
             )

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -468,7 +468,8 @@ def dispatch_model(
         use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
         if use_multi_gpu and not check_cuda_p2p_ib_support():
             logger.info("RTX 4000 series have issues with P2P. This can affect the multi-gpu inference when using accelerate device_map."
-                        "Please make sure to update your driver to the latest version")
+                        "Please make sure to update your driver to the latest version"
+                        )
     else:
         device = list(device_map.values())[0]
         # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).


### PR DESCRIPTION
# What does this PR do ?
This PR adds a message for users with RTX 4000 when using multi-gpu inference with device_map. 
Maybe we can do a better check by looking at the driver version but I need to dig into that a little bit. 
Needed [here](https://github.com/huggingface/diffusers/pull/6857) 
cc @sayakpaul 