### PR TITLE
Improve deepspeed env gen

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -723,8 +723,6 @@ def deepspeed_launcher(args):
 
     if not is_deepspeed_available():
         raise ImportError("DeepSpeed is not installed => run `pip3 install deepspeed` or build it from source.")
-    else:
-        from deepspeed.launcher.runner import DEEPSPEED_ENVIRONMENT_NAME
 
     cmd, current_env = prepare_deepspeed_cmd_env(args)
     if not check_cuda_p2p_ib_support():
@@ -740,7 +738,7 @@ def deepspeed_launcher(args):
             logger.warning(message)
 
     if args.num_machines > 1 and args.deepspeed_multinode_launcher != DEEPSPEED_MULTINODE_LAUNCHERS[1]:
-        with open(DEEPSPEED_ENVIRONMENT_NAME, "a") as f:
+        with open(".deepspeed_env", "a") as f:
             valid_env_items = convert_dict_to_env_variables(current_env)
             if len(valid_env_items) > 1:
                 f.writelines(valid_env_items)

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -36,6 +36,7 @@ from accelerate.utils import (
     PrepareForLaunch,
     _filter_args,
     check_cuda_p2p_ib_support,
+    convert_dict_to_env_variables,
     is_bf16_available,
     is_deepspeed_available,
     is_mlu_available,
@@ -722,6 +723,8 @@ def deepspeed_launcher(args):
 
     if not is_deepspeed_available():
         raise ImportError("DeepSpeed is not installed => run `pip3 install deepspeed` or build it from source.")
+    else:
+        from deepspeed.launcher.runner import DEEPSPEED_ENVIRONMENT_NAME
 
     cmd, current_env = prepare_deepspeed_cmd_env(args)
     if not check_cuda_p2p_ib_support():
@@ -737,11 +740,10 @@ def deepspeed_launcher(args):
             logger.warning(message)
 
     if args.num_machines > 1 and args.deepspeed_multinode_launcher != DEEPSPEED_MULTINODE_LAUNCHERS[1]:
-        with open(".deepspeed_env", "a") as f:
-            for key, value in current_env.items():
-                if ";" in value or " " in value:
-                    continue
-                f.write(f"{key}={value}\n")
+        with open(DEEPSPEED_ENVIRONMENT_NAME, "a") as f:
+            valid_env_items = convert_dict_to_env_variables(current_env)
+            if len(valid_env_items) > 1:
+                f.writelines(valid_env_items)
 
         process = subprocess.Popen(cmd, env=current_env)
         process.wait()

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -55,6 +55,7 @@ from .environment import (
     are_libraries_initialized,
     check_cuda_p2p_ib_support,
     check_fp8_capability,
+    convert_dict_to_env_variables,
     get_int_from_env,
     parse_choice_from_env,
     parse_flag_from_env,

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import platform
 import subprocess
@@ -21,6 +22,34 @@ from typing import List
 
 import torch
 from packaging.version import parse
+
+
+logger = logging.getLogger(__name__)
+
+
+def convert_dict_to_env_variables(current_env: dict):
+    """
+    Verifies that all keys and values in `current_env` do not contain illegal keys or values, and returns a list of
+    strings as the result.
+
+    Example:
+    ```python
+    >>> from accelerate.utils.environment import verify_env
+
+    >>> env = {"ACCELERATE_DEBUG_MODE": "1", "BAD_ENV_NAME": "<mything", "OTHER_ENV": "2"}
+    >>> valid_env_items = verify_env(env)
+    >>> print(valid_env_items)
+    ["ACCELERATE_DEBUG_MODE=1\n", "OTHER_ENV=2\n"]
+    ```
+    """
+    forbidden_chars = [";", "\n", "<", ">", " "]
+    valid_env_items = []
+    for key, value in current_env.items():
+        if all(char not in (key + value) for char in forbidden_chars) and len(key) >= 1 and len(value) >= 1:
+            valid_env_items.append(f"{key}={value}\n")
+        else:
+            logger.warning(f"WARNING: Skipping {key}={value} as it contains forbidden characters or missing values.")
+    return valid_env_items
 
 
 def str_to_bool(value) -> int:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -31,6 +31,7 @@ from accelerate.utils import (
     CannotPadNestedTensorWarning,
     check_os_kernel,
     clear_environment,
+    convert_dict_to_env_variables,
     convert_outputs_to_fp32,
     convert_to_fp32,
     extract_model_from_parallel,
@@ -355,3 +356,9 @@ class UtilsTester(unittest.TestCase):
         self.assertFalse(is_namedtuple((1, 2)))
         self.assertFalse(is_namedtuple("hey"))
         self.assertFalse(is_namedtuple(object()))
+
+    def test_convert_dict_to_env_variables(self):
+        env = {"ACCELERATE_DEBUG_MODE": "1", "BAD_ENV_NAME": "<mything", "OTHER_ENV": "2"}
+        with self.assertLogs("accelerate.utils.environment", level="WARNING"):
+            valid_env_items = convert_dict_to_env_variables(env)
+        assert valid_env_items == ["ACCELERATE_DEBUG_MODE=1\n", "OTHER_ENV=2\n"]


### PR DESCRIPTION
# What does this PR do?

This PR improves the deepspeed env file generation by making sure any bad flags include a warning that they are being strict. 

```
Avoid trailing newline and avoid writing some other characters that would break reading in this file.

DeepSpeed [code](https://github.com/microsoft/DeepSpeed/blob/688239e3f24f7ba11d3fe90bbe9670b7a61e5440/deepspeed/launcher/runner.py#L560) that reads from this file is naive and thus requires strict narrowing of legal key=value lines.
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@pacman100 