### PR TITLE
Allow for setting deterministic algorithms

### DIFF
--- a/src/accelerate/utils/random.py
+++ b/src/accelerate/utils/random.py
@@ -28,7 +28,7 @@ if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
 
 
-def set_seed(seed: int, device_specific: bool = False):
+def set_seed(seed: int, device_specific: bool = False, determinsitic: bool = False):
     """
     Helper function for reproducible behavior to set the seed in `random`, `numpy`, `torch`.
 
@@ -37,6 +37,8 @@ def set_seed(seed: int, device_specific: bool = False):
             The seed to set.
         device_specific (`bool`, *optional*, defaults to `False`):
             Whether to differ the seed on each device slightly with `self.process_index`.
+        determinsitic (`bool`, *optional*, defaults to `False`):
+            Whether to use deterministic algorithms where available.
     """
     if device_specific:
         seed += AcceleratorState().process_index
@@ -54,6 +56,9 @@ def set_seed(seed: int, device_specific: bool = False):
     # ^^ safe to call this function even if cuda is not available
     if is_torch_xla_available():
         xm.set_rng_state(seed)
+
+    if determinsitic:
+        torch.use_deterministic_algorithms(True)
 
 
 def synchronize_rng_state(rng_type: Optional[RNGType] = None, generator: Optional[torch.Generator] = None):


### PR DESCRIPTION
# What does this PR do?

This PR expands `set_seed` to include `torch.use_deterministic_algorithms` for true reproducability. Comes at a caveat of can slow things down on the GPU dramatically, but improves reproducability. 

PyTorch docs: https://pytorch.org/docs/stable/notes/randomness.html#avoiding-nondeterministic-algorithms

This also is a more global approach rather than `torch.backends.cudnn.deterministic` and should be device agnostic. 

Requested in an internal slack thread: https://huggingface.slack.com/archives/C038TF8B7UZ/p1711016602277049


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 