### PR TITLE
Guard stateful objects

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -133,6 +133,18 @@ class PartialState:
     """
 
     _shared_state = SharedDict()
+    _known_attrs = [
+        "_cpu",
+        "_mixed_precision",
+        "backend",
+        "debug",
+        "device",
+        "distributed_type",
+        "fork_launched",
+        "local_process_index",
+        "num_processes",
+        "process_index",
+    ]
 
     def __init__(self, cpu: bool = False, **kwargs):
         self.__dict__ = self._shared_state
@@ -805,8 +817,8 @@ class PartialState:
             # If not found, give a more contextualized answer
             raise AttributeError(
                 f"`PartialState` object has no attribute `{name}`. "
-                "This can happen if the state was reset and using an old reference. "
-                "If you are using an `Accelerator`, make sure to re-initialize it."
+                "This can happen if `PartialState._reset_state()` was called and "
+                "an `Accelerator` or `PartialState` was not reinitialized."
             )
 
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -811,11 +811,12 @@ class PartialState:
             return torch.device("cpu")
 
     def __getattribute__(self, name: str):
-        if name not in self._known_attrs:
-            return object.__getattribute__(self, name)
+        obj_getattr = object.__getattribute__
+        if name not in obj_getattr(self, "_known_attrs"):
+            return obj_getattr(self, name)
         else:
             try:
-                return object.__getattribute__(self, name)
+                return obj_getattr(self, name)
             except AttributeError:
                 # If not found, give a more contextualized answer
                 raise AttributeError(
@@ -1095,11 +1096,12 @@ class AcceleratorState:
         PartialState().print(*args, **kwargs)
 
     def __getattribute__(self, name: str):
-        if name not in self._known_attrs:
-            return object.__getattribute__(self, name)
+        obj_getattr = object.__getattribute__
+        if name not in obj_getattr(self, "_known_attrs"):
+            return obj_getattr(self, name)
         else:
             try:
-                return object.__getattribute__(self, name)
+                return obj_getattr(self, name)
             except AttributeError:
                 # If not found, give a more contextualized answer
                 raise AttributeError(

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -797,6 +797,18 @@ class PartialState:
         else:
             return torch.device("cpu")
 
+    def __getattr__(self, name: str):
+        try:
+            # First try the normal way
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            # If not found, give a more contextualized answer
+            raise AttributeError(
+                f"`PartialState` object has no attribute `{name}`. "
+                "This can happen if the state was reset and using an old reference. "
+                "If you are using an `Accelerator`, make sure to re-initialize it."
+            )
+
 
 class AcceleratorState:
     """
@@ -1059,6 +1071,19 @@ class AcceleratorState:
 
     def print(self, *args, **kwargs):
         PartialState().print(*args, **kwargs)
+
+    def __getattr__(self, name: str):
+        try:
+            # First try the normal way
+            return object.__getattribute__(self, name)
+        except AttributeError:
+            # If not found, give a more contextualized answer
+            # adjust err message
+            raise AttributeError(
+                f"`AcceleratorState` object has no attribute `{name}`. "
+                "This can happen if the state was reset and using an old reference. "
+                "If you are using an `Accelerator`, make sure to re-initialize it."
+            )
 
 
 class GradientState:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -813,13 +813,16 @@ class PartialState:
         try:
             # First try the normal way
             return object.__getattribute__(self, name)
-        except AttributeError:
-            # If not found, give a more contextualized answer
-            raise AttributeError(
-                f"`PartialState` object has no attribute `{name}`. "
-                "This can happen if `PartialState._reset_state()` was called and "
-                "an `Accelerator` or `PartialState` was not reinitialized."
-            )
+        except AttributeError as e:
+            if name in self._known_attrs:
+                # If not found, give a more contextualized answer
+                raise AttributeError(
+                    f"`PartialState` object has no attribute `{name}`. "
+                    "This happens if `PartialState._reset_state()` was called and "
+                    "an `Accelerator` or `PartialState` was not reinitialized."
+                )
+            else:
+                raise e
 
 
 class AcceleratorState:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -810,20 +810,17 @@ class PartialState:
         else:
             return torch.device("cpu")
 
-    def __getattribute__(self, name: str):
-        obj_getattr = object.__getattribute__
-        if name not in obj_getattr(self, "_known_attrs"):
-            return obj_getattr(self, name)
-        else:
-            try:
-                return obj_getattr(self, name)
-            except AttributeError:
-                # If not found, give a more contextualized answer
-                raise AttributeError(
-                    f"`PartialState` object has no attribute `{name}`. "
-                    "This happens if `PartialState._reset_state()` was called and "
-                    "an `Accelerator` or `PartialState` was not reinitialized."
-                )
+    def __getattr__(self, name: str):
+        # By this point we know that no attributes of `self` contain `name`,
+        # so we just modify the error message
+        if name in self._known_attrs:
+            raise AttributeError(
+                f"`PartialState` object has no attribute `{name}`. "
+                "This happens if `PartialState._reset_state()` was called and "
+                "an `Accelerator` or `PartialState` was not reinitialized."
+            )
+        # Raise a typical AttributeError
+        raise AttributeError(f"'PartialState' object has no attribute '{name}'")
 
 
 class AcceleratorState:
@@ -1095,20 +1092,17 @@ class AcceleratorState:
     def print(self, *args, **kwargs):
         PartialState().print(*args, **kwargs)
 
-    def __getattribute__(self, name: str):
-        obj_getattr = object.__getattribute__
-        if name not in obj_getattr(self, "_known_attrs"):
-            return obj_getattr(self, name)
-        else:
-            try:
-                return obj_getattr(self, name)
-            except AttributeError:
-                # If not found, give a more contextualized answer
-                raise AttributeError(
-                    f"`AcceleratorState` object has no attribute `{name}`. "
-                    "This happens if `AcceleratorState._reset_state()` was called and "
-                    "an `Accelerator` or `PartialState` was not reinitialized."
-                )
+    def __getattr__(self, name: str):
+        # By this point we know that no attributes of `self` contain `name`,
+        # so we just modify the error message
+        if name in self._known_attrs:
+            raise AttributeError(
+                f"`AcceleratorState` object has no attribute `{name}`. "
+                "This happens if `AcceleratorState._reset_state()` was called and "
+                "an `Accelerator` or `PartialState` was not reinitialized."
+            )
+        # Raise a typical AttributeError
+        raise AttributeError(f"'AcceleratorState' object has no attribute '{name}'")
 
 
 class GradientState:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -815,7 +815,7 @@ class PartialState:
             return object.__getattribute__(self, name)
         else:
             try:
-                attr = object.__getattribute__(self, name)
+                return object.__getattribute__(self, name)
             except AttributeError:
                 # If not found, give a more contextualized answer
                 raise AttributeError(
@@ -823,7 +823,6 @@ class PartialState:
                     "This happens if `PartialState._reset_state()` was called and "
                     "an `Accelerator` or `PartialState` was not reinitialized."
                 )
-        return attr
 
 
 class AcceleratorState:
@@ -1100,7 +1099,7 @@ class AcceleratorState:
             return object.__getattribute__(self, name)
         else:
             try:
-                attr = object.__getattribute__(self, name)
+                return object.__getattribute__(self, name)
             except AttributeError:
                 # If not found, give a more contextualized answer
                 raise AttributeError(
@@ -1108,7 +1107,6 @@ class AcceleratorState:
                     "This happens if `AcceleratorState._reset_state()` was called and "
                     "an `Accelerator` or `PartialState` was not reinitialized."
                 )
-        return attr
 
 
 class GradientState:

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -699,8 +699,10 @@ def test_reinstantiated_state():
     # Then call `reset_state`, breaking the state existing in the accelerator
     AcceleratorState._reset_state()
     # Now try and prepare a simple model, should raise the custom error early
-    with pytest.raises(AttributeError, match="This can happen if the state was reset and using an old reference."):
+    with pytest.raises(AttributeError) as cm:
         accelerator.prepare(simple_model)
+    assert "`AcceleratorState` object has no attribute" in str(cm.value.args[0])
+    assert "This happens if `AcceleratorState._reset_state()`" in str(cm.value.args[0])
 
 
 def main():

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
 from torch.utils.data import DataLoader, Dataset
 
@@ -690,6 +691,18 @@ def test_trigger():
     assert accelerator.check_trigger() is False
 
 
+def test_reinstantiated_state():
+    AcceleratorState._reset_state()
+    simple_model = torch.nn.Linear(1, 1)
+    # First define an accelerator
+    accelerator = Accelerator()
+    # Then call `reset_state`, breaking the state existing in the accelerator
+    AcceleratorState._reset_state()
+    # Now try and prepare a simple model, should raise the custom error early
+    with pytest.raises(AttributeError, match="This can happen if the state was reset and using an old reference."):
+        accelerator.prepare(simple_model)
+
+
 def main():
     accelerator = Accelerator()
     state = accelerator.state
@@ -754,6 +767,10 @@ def main():
     if state.local_process_index == 0:
         print("\n**Breakpoint trigger test**")
     test_trigger()
+
+    if state.local_process_index == 0:
+        print("\n**Test reinstantiated state**")
+    test_reinstantiated_state()
 
 
 if __name__ == "__main__":

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -107,14 +107,22 @@ class AcceleratorTester(AccelerateTestCase):
             assert accelerator.use_seedable_sampler is False
 
     def test_state_after_reset(self):
+        # Verifies that custom getattr errors will be thrown
+        # if the state is reset, but only if trying to
+        # get expected attributes
         state = PartialState()
         assert state.num_processes > 0
-        state._reset_state()
+
+        with self.assertRaises(AttributeError) as cm:
+            state.someotherthing
+        assert "'PartialState' object has no attribute" in str(cm.exception)
+        assert "This happens if `PartialState._reset_state()`" not in str(cm.exception)
+
         with self.assertRaises(AttributeError) as cm:
             state._reset_state()
             state.num_processes
         assert "`PartialState` object has no attribute" in str(cm.exception)
-        assert "This can happen if `PartialState._reset_state()`" in str(cm.exception)
+        assert "This happens if `PartialState._reset_state()`" in str(cm.exception)
 
     @require_non_cpu
     def test_accelerator_can_be_reinstantiated(self):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -106,7 +106,7 @@ class AcceleratorTester(AccelerateTestCase):
             assert "use_seedable_sampler" in deprecation_warning
             assert accelerator.use_seedable_sampler is False
 
-    def test_state_after_reset(self):
+    def test_partial_state_after_reset(self):
         # Verifies that custom getattr errors will be thrown
         # if the state is reset, but only if trying to
         # get expected attributes
@@ -123,6 +123,30 @@ class AcceleratorTester(AccelerateTestCase):
             state.num_processes
         assert "`PartialState` object has no attribute" in str(cm.exception)
         assert "This happens if `PartialState._reset_state()`" in str(cm.exception)
+
+        state.someotherthing = "MyValue"
+        assert state.someotherthing == "MyValue"
+
+    def test_accelerator_state_after_reset(self):
+        # Verifies that custom getattr errors will be thrown
+        # if the state is reset, but only if trying to
+        # get expected attributes
+        accelerator = Accelerator()
+        assert accelerator.num_processes > 0
+
+        with self.assertRaises(AttributeError) as cm:
+            accelerator.state.someotherthing
+        assert "'AcceleratorState' object has no attribute" in str(cm.exception)
+        assert "This happens if `AcceleratorState._reset_state()`" not in str(cm.exception)
+
+        with self.assertRaises(AttributeError) as cm:
+            accelerator.state._reset_state()
+            accelerator.num_processes
+        assert "`AcceleratorState` object has no attribute" in str(cm.exception)
+        assert "This happens if `AcceleratorState._reset_state()`" in str(cm.exception)
+
+        accelerator.state.someotherthing = "MyValue"
+        assert accelerator.state.someotherthing == "MyValue"
 
     @require_non_cpu
     def test_accelerator_can_be_reinstantiated(self):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -106,6 +106,16 @@ class AcceleratorTester(AccelerateTestCase):
             assert "use_seedable_sampler" in deprecation_warning
             assert accelerator.use_seedable_sampler is False
 
+    def test_state_after_reset(self):
+        state = PartialState()
+        assert state.num_processes > 0
+        state._reset_state()
+        with self.assertRaises(AttributeError) as cm:
+            state._reset_state()
+            state.num_processes
+        assert "`PartialState` object has no attribute" in str(cm.exception)
+        assert "This can happen if `PartialState._reset_state()`" in str(cm.exception)
+
     @require_non_cpu
     def test_accelerator_can_be_reinstantiated(self):
         _ = Accelerator()


### PR DESCRIPTION
# What does this PR do?

This PR is the second half of solving https://github.com/huggingface/accelerate/issues/2564

The issue boils down to:

1. The user defines a `PartialState`/creates an `Accelerator`
2. The user then calls `_reset_state()` themselves
3. The user then calls subsequent functions in `Accelerator`.

That instance will still point to our reset/broken `PartialState`, and so a better error needs to be raised that contextualizes what's going on early:

```python
Traceback (most recent call last):
  File "/home/zach/test.py", line 11, in <module>
    _ = accelerator.prepare(model)
  File "/home/zach/accelerate/accelerate/src/accelerate/accelerator.py", line 1230, in prepare
    if self.distributed_type == DistributedType.DEEPSPEED:
  File "/home/zach/accelerate/accelerate/src/accelerate/accelerator.py", line 515, in distributed_type
    return self.state.distributed_type
  File "/home/zach/accelerate/accelerate/src/accelerate/state.py", line 1082, in __getattr__
    raise AttributeError(
AttributeError: `AcceleratorState` object has no attribute `distributed_type`. This can happen if the state was reset and using an old reference. If you are using an `Accelerator`, make sure to re-initialize it.
```

Fixes https://github.com/huggingface/accelerate/issues/2564


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 