### PR TITLE
Refactor affinity and make it stateful

### DIFF
--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -166,6 +166,10 @@ These functionalities check the state of the current working environment includi
 
 When setting up 🤗 Accelerate for the first time, rather than running `accelerate config` [~utils.write_basic_config] can be used as an alternative for quick configuration.
 
+[[autodoc]] utils.set_numa_affinity
+
+[[autodoc]] utils.environment.override_numa_affinity
+
 ## Memory
 
 [[autodoc]] utils.find_executable_batch_size

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -366,9 +366,7 @@ class PartialState:
 
                 if self.device is None:
                     self.device = torch.device("cpu") if cpu else self.default_device
-        self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
-
-        # Set CPU affinity if enabled
+        # Set CPU affinity if enabled, should be part of the state/done once only
         if parse_flag_from_env("ACCELERATE_CPU_AFFINITY", False):
             # Eventually follow syntax here and update for other backends
             if self.device.type == "cuda":
@@ -386,6 +384,7 @@ class PartialState:
                 affinity_list.reverse()  # so core 0 is the 0th element
                 affinity_to_set = [i for i, e in enumerate(affinity_list) if e != 0]
                 os.sched_setaffinity(0, affinity_to_set)
+        self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
     def __repr__(self) -> str:
         return (

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -366,24 +366,24 @@ class PartialState:
 
                 if self.device is None:
                     self.device = torch.device("cpu") if cpu else self.default_device
-        # Set CPU affinity if enabled, should be part of the state/done once only
-        if parse_flag_from_env("ACCELERATE_CPU_AFFINITY", False):
-            # Eventually follow syntax here and update for other backends
-            if self.device.type == "cuda":
-                if not is_pynvml_available():
-                    raise ImportError("To set CPU affinity on CUDA GPUs the pynvml package must be installed.")
-                # The below code is based on https://github.com/NVIDIA/DeepLearningExamples/blob/master/TensorFlow2/LanguageModeling/BERT/gpu_affinity.py
-                nvml.nvmlInit()
-                num_elements = math.ceil(os.cpu_count() / 64)
-                handle = nvml.nvmlDeviceGetHandleByIndex(self.local_process_index)
-                affinity_string = ""
-                for j in nvml.nvmlDeviceGetCpuAffinity(handle, num_elements):
-                    # assume nvml returns list of 64 bit ints
-                    affinity_string = f"{j:064b}{affinity_string}"
-                affinity_list = [int(x) for x in affinity_string]
-                affinity_list.reverse()  # so core 0 is the 0th element
-                affinity_to_set = [i for i, e in enumerate(affinity_list) if e != 0]
-                os.sched_setaffinity(0, affinity_to_set)
+            # Set CPU affinity if enabled, should be part of the state/done once only
+            if parse_flag_from_env("ACCELERATE_CPU_AFFINITY", False):
+                # Eventually follow syntax here and update for other backends
+                if self.device.type == "cuda":
+                    if not is_pynvml_available():
+                        raise ImportError("To set CPU affinity on CUDA GPUs the pynvml package must be installed.")
+                    # The below code is based on https://github.com/NVIDIA/DeepLearningExamples/blob/master/TensorFlow2/LanguageModeling/BERT/gpu_affinity.py
+                    nvml.nvmlInit()
+                    num_elements = math.ceil(os.cpu_count() / 64)
+                    handle = nvml.nvmlDeviceGetHandleByIndex(self.local_process_index)
+                    affinity_string = ""
+                    for j in nvml.nvmlDeviceGetCpuAffinity(handle, num_elements):
+                        # assume nvml returns list of 64 bit ints
+                        affinity_string = f"{j:064b}{affinity_string}"
+                    affinity_list = [int(x) for x in affinity_string]
+                    affinity_list.reverse()  # so core 0 is the 0th element
+                    affinity_to_set = [i for i, e in enumerate(affinity_list) if e != 0]
+                    os.sched_setaffinity(0, affinity_to_set)
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
     def __repr__(self) -> str:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -41,7 +41,6 @@ from .utils import (
     is_mlu_available,
     is_mps_available,
     is_npu_available,
-    is_pynvml_available,
     is_torch_xla_available,
     is_xpu_available,
     parse_choice_from_env,
@@ -59,9 +58,6 @@ if is_mlu_available(check_device=False):
 
 if is_npu_available(check_device=False):
     import torch_npu  # noqa: F401
-
-if is_pynvml_available():
-    pass
 
 logger = logging.getLogger(__name__)
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -365,7 +365,7 @@ class PartialState:
                     self.device = torch.device("cpu") if cpu else self.default_device
             # Set CPU affinity if enabled, should be part of the state/done once only
             if parse_flag_from_env("ACCELERATE_CPU_AFFINITY", False):
-                set_numa_affinity()
+                set_numa_affinity(self.local_process_index)
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
     def __repr__(self) -> str:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -46,6 +46,7 @@ from .utils import (
     is_xpu_available,
     parse_choice_from_env,
     parse_flag_from_env,
+    set_numa_affinity,
 )
 from .utils.dataclasses import SageMakerDistributedType
 
@@ -60,7 +61,7 @@ if is_npu_available(check_device=False):
     import torch_npu  # noqa: F401
 
 if is_pynvml_available():
-    import pynvml as nvml
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -368,22 +369,7 @@ class PartialState:
                     self.device = torch.device("cpu") if cpu else self.default_device
             # Set CPU affinity if enabled, should be part of the state/done once only
             if parse_flag_from_env("ACCELERATE_CPU_AFFINITY", False):
-                # Eventually follow syntax here and update for other backends
-                if self.device.type == "cuda":
-                    if not is_pynvml_available():
-                        raise ImportError("To set CPU affinity on CUDA GPUs the pynvml package must be installed.")
-                    # The below code is based on https://github.com/NVIDIA/DeepLearningExamples/blob/master/TensorFlow2/LanguageModeling/BERT/gpu_affinity.py
-                    nvml.nvmlInit()
-                    num_elements = math.ceil(os.cpu_count() / 64)
-                    handle = nvml.nvmlDeviceGetHandleByIndex(self.local_process_index)
-                    affinity_string = ""
-                    for j in nvml.nvmlDeviceGetCpuAffinity(handle, num_elements):
-                        # assume nvml returns list of 64 bit ints
-                        affinity_string = f"{j:064b}{affinity_string}"
-                    affinity_list = [int(x) for x in affinity_string]
-                    affinity_list.reverse()  # so core 0 is the 0th element
-                    affinity_to_set = [i for i, e in enumerate(affinity_list) if e != 0]
-                    os.sched_setaffinity(0, affinity_to_set)
+                set_numa_affinity()
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 
     def __repr__(self) -> str:

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -59,6 +59,7 @@ from .environment import (
     get_int_from_env,
     parse_choice_from_env,
     parse_flag_from_env,
+    set_numa_affinity,
     str_to_bool,
 )
 from .imports import (

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -180,7 +180,7 @@ def check_fp8_capability():
     return cuda_device_capacity >= (8, 9)
 
 
-def override_numa_affinity(local_process_index: int, verbose: bool = None):
+def override_numa_affinity(local_process_index: int, verbose: Optional[bool] = None) -> None:
     """
     Overrides whatever NUMA affinity is set for the current process. This is very taxing and requires recalculating the
     affinity to set, ideally you should use `utils.environment.set_numa_affinity` instead.
@@ -219,7 +219,7 @@ def override_numa_affinity(local_process_index: int, verbose: bool = None):
 
 
 @lru_cache
-def set_numa_affinity(local_process_index: int, verbose: bool = None):
+def set_numa_affinity(local_process_index: int, verbose: Optional[bool] = None) -> None:
     """
     Assigns the current process to a specific NUMA node. Ideally most efficient when having at least 2 cpus per node.
 

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -231,6 +231,6 @@ def set_numa_affinity(local_process_index: int, verbose: Optional[bool] = None) 
         local_process_index (int):
             The index of the current process on the current server.
         verbose (bool, *optional*):
-            Whether to log out the assignment of each CPU. If `ACCELERATE_DEBUG_MODE` is enabled, will default to True.
+            Whether to print the new cpu cores assignment for each process. If `ACCELERATE_DEBUG_MODE` is enabled, will default to True.
     """
     override_numa_affinity(local_process_index=local_process_index, verbose=verbose)

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -231,6 +231,7 @@ def set_numa_affinity(local_process_index: int, verbose: Optional[bool] = None) 
         local_process_index (int):
             The index of the current process on the current server.
         verbose (bool, *optional*):
-            Whether to print the new cpu cores assignment for each process. If `ACCELERATE_DEBUG_MODE` is enabled, will default to True.
+            Whether to print the new cpu cores assignment for each process. If `ACCELERATE_DEBUG_MODE` is enabled, will
+            default to True.
     """
     override_numa_affinity(local_process_index=local_process_index, verbose=verbose)

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -20,7 +20,7 @@ import subprocess
 import sys
 from functools import lru_cache
 from shutil import which
-from typing import List
+from typing import List, Optional
 
 import torch
 from packaging.version import parse
@@ -189,8 +189,7 @@ def override_numa_affinity(local_process_index: int, verbose: Optional[bool] = N
         local_process_index (int):
             The index of the current process on the current server.
         verbose (bool, *optional*):
-            Whether to print out the assignment of each CPU. If `ACCELERATE_DEBUG_MODE` is enabled, will default to
-            True.
+            Whether to log out the assignment of each CPU. If `ACCELERATE_DEBUG_MODE` is enabled, will default to True.
     """
     if verbose is None:
         verbose = parse_flag_from_env("ACCELERATE_DEBUG_MODE", False)
@@ -198,7 +197,9 @@ def override_numa_affinity(local_process_index: int, verbose: Optional[bool] = N
         from accelerate.utils import is_pynvml_available
 
         if not is_pynvml_available():
-            raise ImportError("To set CPU affinity on CUDA GPUs the pynvml package must be installed.")
+            raise ImportError(
+                "To set CPU affinity on CUDA GPUs the `pynvml` package must be available. (`pip install pynvml`)"
+            )
         import pynvml as nvml
 
         # The below code is based on https://github.com/NVIDIA/DeepLearningExamples/blob/master/TensorFlow2/LanguageModeling/BERT/gpu_affinity.py
@@ -230,7 +231,6 @@ def set_numa_affinity(local_process_index: int, verbose: Optional[bool] = None) 
         local_process_index (int):
             The index of the current process on the current server.
         verbose (bool, *optional*):
-            Whether to print out the assignment of each CPU. If `ACCELERATE_DEBUG_MODE` is enabled, will default to
-            True.
+            Whether to log out the assignment of each CPU. If `ACCELERATE_DEBUG_MODE` is enabled, will default to True.
     """
     override_numa_affinity(local_process_index=local_process_index, verbose=verbose)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -26,7 +26,7 @@ from accelerate import DistributedType, infer_auto_device_map, init_empty_weight
 from accelerate.accelerator import Accelerator
 from accelerate.state import GradientState, PartialState
 from accelerate.test_utils import require_bnb, require_multi_device, require_non_cpu, slow, torch_device
-from accelerate.test_utils.testing import AccelerateTestCase, require_non_torch_xla
+from accelerate.test_utils.testing import AccelerateTestCase, require_cuda, require_non_torch_xla
 from accelerate.utils import patch_environment
 from accelerate.utils.modeling import load_checkpoint_in_model
 
@@ -113,6 +113,14 @@ class AcceleratorTester(AccelerateTestCase):
         assert PartialState._shared_state["device"].type in ["cuda", "mps", "npu", "xpu", "xla"]
         with self.assertRaises(ValueError):
             _ = Accelerator(cpu=True)
+
+    @require_cuda
+    def test_setting_cpu_affinity(self):
+        with patch_environment(accelerate_cpu_affinity=1, accelerate_debug_mode=1):
+            with self.assertLogs("accelerate.utils.environment", level="INFO") as cm:
+                _ = Accelerator()
+                assert any("Assigning" in log for log in cm.output)
+                assert any("cpu cores to process" in log for log in cm.output)
 
     def test_mutable_states(self):
         accelerator = Accelerator()


### PR DESCRIPTION
# What does this PR do?

@stas00 pointed out that the affinity check was being done *every time `PartialState()` was called*. This refactors it into a stateful call when users do `set_numa_affinity`.

This is cached because this check is taxing on the CPU briefly. 

If users want to override it, they can use `accelerate.utils.environment.override_numa_affinity` themselves.

Example usage:

```python
from accelerate.utils import set_numa_affinity

# For GPU 0
set_numa_affinity(0)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @stas00 