### PR TITLE
[docs] Missing functions from API

### DIFF
--- a/docs/source/package_reference/accelerator.md
+++ b/docs/source/package_reference/accelerator.md
@@ -20,3 +20,7 @@ The [`Accelerator`] is the main class for enabling distributed training on any t
 ## Accelerator[[api]]
 
 [[autodoc]] Accelerator
+
+## Utilities
+
+[[autodoc]] accelerate.utils.gather_object


### PR DESCRIPTION
Adds missing functions like `gather_object` which is in a separate file `accelerate/utils/operations.py` rather than the main `accelerate/accelerator.py`. This results in `gather_object` not being documented because the `[[autodoc]]` tag couldn't find it in `accelerate/accelerator.py`.