### PR TITLE
Expound PartialState docstring

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -117,7 +117,7 @@ class PartialState:
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
             `True` and force the execution on the CPU.
-        **kwargs:
+        kwargs:
             Additional keyword arguments to pass to the relevent `init_process_group` function. Valid `kwargs` can be
             found in [`utils.InitProcessGroupKwargs`]. See the example section for detailed usage.
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -118,8 +118,8 @@ class PartialState:
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
             `True` and force the execution on the CPU.
         **kwargs:
-            Additional keyword arguments to pass to the relevent `init_process_group` function. See the example section
-            for detailed usage. Valid `kwargs` can be found in [`utils.InitProcessGroupKwargs`].
+            Additional keyword arguments to pass to the relevent `init_process_group` function. Valid `kwargs` can be
+            found in [`utils.InitProcessGroupKwargs`]. See the example section for detailed usage.
 
     **Available attributes:**
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -119,7 +119,7 @@ class PartialState:
             `True` and force the execution on the CPU.
         **kwargs:
             Additional keyword arguments to pass to the relevent `init_process_group` function. See the example section
-            for detailed usage.
+            for detailed usage. Valid `kwargs` can be found in [`utils.InitProcessGroupKwargs`].
 
     **Available attributes:**
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -118,13 +118,7 @@ class PartialState:
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
             `True` and force the execution on the CPU.
         **kwargs:
-            Additional keyword arguments to pass to the relevent `init_process_group` function. Generally should be
-            passed in as:
-            ```python
-            from accelerate.utils import InitProcessGroupKwargs
-
-            state = PartialState(**InitProcessGroupKwargs(...).to_kwargs())
-            ```
+            Additional keyword arguments to pass to the relevent `init_process_group` function.
 
     **Available attributes:**
 
@@ -140,6 +134,15 @@ class PartialState:
         - **is_main_process** (`bool`) -- Whether or not the current process is the main one.
         - **is_local_main_process** (`bool`) -- Whether or not the current process is the main one on the local node.
         - **debug** (`bool`) -- Whether or not the current script is being run in debug mode.
+
+    Example:
+    ```python
+    from accelerate.utils import InitProcessGroupKwargs
+
+    # To include `InitProcessGroupKwargs`, init then call `.to_kwargs()`
+    kwargs = InitProcessGroupKwargs(...).to_kwargs()
+    state = PartialState(**kwargs)
+    ```
     """
 
     _shared_state = SharedDict()

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -117,8 +117,7 @@ class PartialState:
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
             `True` and force the execution on the CPU.
-
-        kwargs:
+        kwargs (additional keyword arguments, *optional*):
             Additional keyword arguments to pass to the relevent `init_process_group` function. Valid `kwargs` can be
             found in [`utils.InitProcessGroupKwargs`]. See the example section for detailed usage.
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -115,8 +115,9 @@ class PartialState:
 
     Args:
         cpu (`bool`, *optional*):
-            Whether or not to force the script to execute on CPU. Will ignore GPU available if set to `True` and force
-            the execution on one process only.
+            Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
+            `True`
+             and force the execution on the CPU.
         **kwargs:
             Additional keyword arguments to pass to the relevent `init_process_group` function. Generally should be
             passed in as:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -113,6 +113,19 @@ class PartialState:
     control. Designed to be used when only process control and device execution states are needed. Does *not* need to
     be initialized from `Accelerator`.
 
+    Args:
+        cpu (`bool`, *optional*):
+            Whether or not to force the script to execute on CPU. Will ignore GPU available if set to `True` and force
+            the execution on one process only.
+        **kwargs:
+            Additional keyword arguments to pass to the relevent `init_process_group` function. Generally should be
+            passed in as:
+            ```python
+            from accelerate.utils import InitProcessGroupKwargs
+
+            state = PartialState(**InitProcessGroupKwargs(...).to_kwargs())
+            ```
+
     **Available attributes:**
 
         - **device** (`torch.device`) -- The device to use.

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -116,8 +116,7 @@ class PartialState:
     Args:
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
-            `True`
-             and force the execution on the CPU.
+            `True` and force the execution on the CPU.
         **kwargs:
             Additional keyword arguments to pass to the relevent `init_process_group` function. Generally should be
             passed in as:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -118,7 +118,8 @@ class PartialState:
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
             `True` and force the execution on the CPU.
         **kwargs:
-            Additional keyword arguments to pass to the relevent `init_process_group` function.
+            Additional keyword arguments to pass to the relevent `init_process_group` function. See the example section
+            for detailed usage.
 
     **Available attributes:**
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -117,6 +117,7 @@ class PartialState:
         cpu (`bool`, *optional*):
             Whether or not to force the script to execute on CPU. Will ignore any accelerators available if set to
             `True` and force the execution on the CPU.
+
         kwargs:
             Additional keyword arguments to pass to the relevent `init_process_group` function. Valid `kwargs` can be
             found in [`utils.InitProcessGroupKwargs`]. See the example section for detailed usage.


### PR DESCRIPTION
# What does this PR do?

These merge conflicts are getting *fun*, but it's nice to see more people wanting better uses of `PartialState`!

In this one we explicitly discuss how to use `InitProcessGroupKwargs` with the `PartialState`, which is needed if you want to modify the init outside the `Accelerator`

Closes https://github.com/huggingface/accelerate/issues/2587


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 