### PR TITLE
Allow for force unwrapping

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -90,7 +90,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive
         model = model.module
 
     if recursive:
-
+        # This is needed in cases such as using FSDPv2 on XLA
         def _recursive_unwrap(module):
             if hasattr(module, "module"):
                 unwrapped_module = _recursive_unwrap(module.module)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -92,6 +92,8 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive
     if recursive:
         # This is needed in cases such as using FSDPv2 on XLA
         def _recursive_unwrap(module):
+            # Wrapped modules are standardly wrapped as `module`, similar to the cases earlier
+            # with DDP, DataParallel, DeepSpeed, and FSDP
             if hasattr(module, "module"):
                 unwrapped_module = _recursive_unwrap(module.module)
             else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -210,7 +210,7 @@ class UtilsTester(unittest.TestCase):
     @require_huggingface_suite
     def test_extract_model_recursive_fsdpv2(self):
         # Specifically tests for FSDPv2 extraction
-        # repored in https://github.com/huggingface/transformers/pull/29780
+        # reported in https://github.com/huggingface/transformers/pull/29780
         xr.use_spmd()
         from transformers import AutoModelForCausalLM
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -217,6 +217,7 @@ class UtilsTester(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained("gpt2")
         orig_state_dict_keys = list(model.state_dict().keys())
         num_devices = xr.global_runtime_device_count()
+        # Set environment for FSDPv2 to be active
         xs.set_global_mesh(xs.Mesh(np.array(range(num_devices)), (num_devices, 1), axis_names=("fsdp", "tensor")))
 
         def nested_wrap(model):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import numpy as np
 import os
 import pickle
 import tempfile
@@ -20,19 +21,13 @@ from collections import UserDict, namedtuple
 from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
 
-import numpy as np
 import pytest
 import torch
 from torch import nn
 
+from accelerate.big_modeling import init_empty_weights
 from accelerate.state import PartialState
-from accelerate.test_utils.testing import (
-    require_cuda,
-    require_huggingface_suite,
-    require_non_torch_xla,
-    require_torch_min_version,
-    require_tpu,
-)
+from accelerate.test_utils.testing import require_cuda, require_tpu, require_huggingface_suite, require_non_torch_xla, require_torch_min_version
 from accelerate.test_utils.training import RegressionModel
 from accelerate.utils import (
     CannotPadNestedTensorWarning,
@@ -53,7 +48,6 @@ from accelerate.utils import (
     send_to_device,
 )
 from accelerate.utils.operations import is_namedtuple
-
 
 if is_torch_xla_available():
     import torch_xla.distributed.spmd as xs
@@ -213,7 +207,6 @@ class UtilsTester(unittest.TestCase):
         # repored in https://github.com/huggingface/transformers/pull/29780
 
         from transformers import AutoModelForCausalLM
-
         model = AutoModelForCausalLM.from_pretrained("gpt2")
         orig_state_dict_keys = list(model.state_dict().keys())
         num_devices = xr.global_runtime_device_count()
@@ -224,9 +217,11 @@ class UtilsTester(unittest.TestCase):
             wrapped_layer = FSDPv2(layer)
             model.model.wte = wrapped_layer
             return model
-
+        
         wrapped_model = nested_wrap(model)
-        for original_key, new_key in zip(orig_state_dict_keys, wrapped_model.state_dict().keys()):
+        unwrapped_model = extract_model_from_parallel(wrapped_model)
+        unwrapped_state_dict_keys = list(unwrapped_model.state_dict().keys())
+        for original_key, new_key in zip(orig_state_dict_keys, unwrapped_state_dict_keys):
             assert original_key == new_key, f"Keys did not align: {original_key} != {new_key}"
 
     @require_torch_min_version(version="2.0")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,12 +20,19 @@ from collections import UserDict, namedtuple
 from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
 
+import numpy as np
 import pytest
 import torch
 from torch import nn
 
 from accelerate.state import PartialState
-from accelerate.test_utils.testing import require_cuda, require_non_torch_xla, require_torch_min_version
+from accelerate.test_utils.testing import (
+    require_cuda,
+    require_huggingface_suite,
+    require_non_torch_xla,
+    require_torch_min_version,
+    require_tpu,
+)
 from accelerate.test_utils.training import RegressionModel
 from accelerate.utils import (
     CannotPadNestedTensorWarning,
@@ -36,6 +43,7 @@ from accelerate.utils import (
     convert_to_fp32,
     extract_model_from_parallel,
     find_device,
+    is_torch_xla_available,
     listify,
     pad_across_processes,
     pad_input_tensors,
@@ -46,6 +54,11 @@ from accelerate.utils import (
 )
 from accelerate.utils.operations import is_namedtuple
 
+
+if is_torch_xla_available():
+    import torch_xla.distributed.spmd as xs
+    import torch_xla.runtime as xr
+    from torch_xla.experimental.spmd_fully_sharded_data_parallel import SpmdFullyShardedDataParallel as FSDPv2
 
 ExampleNamedTuple = namedtuple("ExampleNamedTuple", "a b c")
 
@@ -192,6 +205,29 @@ class UtilsTester(unittest.TestCase):
         model_unwrapped = extract_model_from_parallel(distributed_model)
 
         assert model == model_unwrapped
+
+    @require_tpu
+    @require_huggingface_suite
+    def test_extract_model_recursive_fsdpv2(self):
+        # Specifically tests for FSDPv2 extraction
+        # repored in https://github.com/huggingface/transformers/pull/29780
+
+        from transformers import AutoModelForCausalLM
+
+        model = AutoModelForCausalLM.from_pretrained("gpt2")
+        orig_state_dict_keys = list(model.state_dict().keys())
+        num_devices = xr.global_runtime_device_count()
+        xs.set_global_mesh(xs.Mesh(np.array(range(num_devices)), (num_devices, 1), axis_names=("fsdp", "tensor")))
+
+        def nested_wrap(model):
+            layer = model.model.wte
+            wrapped_layer = FSDPv2(layer)
+            model.model.wte = wrapped_layer
+            return model
+
+        wrapped_model = nested_wrap(model)
+        for original_key, new_key in zip(orig_state_dict_keys, wrapped_model.state_dict().keys()):
+            assert original_key == new_key, f"Keys did not align: {original_key} != {new_key}"
 
     @require_torch_min_version(version="2.0")
     def test_dynamo_extract_model(self):


### PR DESCRIPTION
# What does this PR do?

There are cases when we need to unwrap *far more* than just what is done natively in Accelerate, such as when we have TPUs/SPMD.

This PR expands `extract_model_from_parallel` to support situations such as using XLA's `FSDPv2`.

Alternative to https://github.com/huggingface/transformers/pull/29780, which we can upstream to transformers by just using `recursive=True`


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @shub-kris 

We can't test it on TPUs since we don't have our runners, but @shub-kris tested this himself :) 