### PR TITLE
add third-party device prefix to `execution_device`  

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -360,6 +360,14 @@ def dispatch_model(
     # in the unique device and the user can decide where to dispatch the model.
     # If the model is quantized, we always force-dispatch the model
     if (len(set(device_map.values())) > 1) or is_bnb_quantized or force_hooks:
+        for name, device in device_map.items():
+            if is_npu_available() and isinstance(device, int):
+                device_map[name] = f"npu:{device}"
+            if is_mlu_available() and isinstance(device, int):
+                device_map[name] = f"mlu:{device}"
+            if is_xpu_available() and isinstance(device, int):
+                device_map[name] = f"xpu:{device}"
+
         if main_device is None:
             if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {"cpu", "disk"}:
                 main_device = "cpu"

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -360,14 +360,6 @@ def dispatch_model(
     # in the unique device and the user can decide where to dispatch the model.
     # If the model is quantized, we always force-dispatch the model
     if (len(set(device_map.values())) > 1) or is_bnb_quantized or force_hooks:
-        for name, device in device_map.items():
-            if is_npu_available() and isinstance(device, int):
-                device_map[name] = f"npu:{device}"
-            if is_mlu_available() and isinstance(device, int):
-                device_map[name] = f"mlu:{device}"
-            if is_xpu_available() and isinstance(device, int):
-                device_map[name] = f"xpu:{device}"
-
         if main_device is None:
             if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {"cpu", "disk"}:
                 main_device = "cpu"

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -164,10 +164,7 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             if is_npu_available():
                 if isinstance(device, int):
                     device = f"npu:{device}"
-            else:
-                raise error
-        except Exception as error:
-            if is_xpu_available():
+            elif is_xpu_available():
                 if isinstance(device, int):
                     device = f"xpu:{device}"
             else:


### PR DESCRIPTION
## What does this PR do?
The following code fails on XPU:
```python
import torch
import requests
from PIL import Image
from transformers import Blip2ForConditionalGeneration, Blip2Processor

def prepare_img():
    url = "https://huggingface.co/hf-internal-testing/blip-test-image/resolve/main/demo.jpg"
    image = Image.open(requests.get(url, stream=True).raw)
    return image

processor = Blip2Processor.from_pretrained("Salesforce/blip2-flan-t5-xl")
device_map = {
    "query_tokens": 0,
    "vision_model": 0,
    "language_model": 1,
    "language_projection": 0,
    "qformer": 0,
}

model = Blip2ForConditionalGeneration.from_pretrained(
    "Salesforce/blip2-flan-t5-xl", torch_dtype=torch.float16, device_map=device_map
)
image = prepare_img()
inputs = processor(images=image, return_tensors="pt").to("xpu:0", dtype=torch.float16)

predictions = model.generate(**inputs)
```
Error:
```bash
Traceback (most recent call last):
  File "/soft/fanli/transformers/fanli.py", line 83, in <module>
    predictions = model.generate(**inputs)
  File "/home/fan/anaconda3/envs/pytest/lib/python3.9/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/soft/fanli/transformers/src/transformers/models/blip_2/modeling_blip_2.py", line 1800, in generate
    image_embeds = self.vision_model(pixel_values, return_dict=True).last_hidden_state
  File "/home/fan/anaconda3/envs/pytest/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1518, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/fan/anaconda3/envs/pytest/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1527, in _call_impl
    return forward_call(*args, **kwargs)
  File "/soft/fanli/accelerate/src/accelerate/hooks.py", line 161, in new_forward
    args, kwargs = module._hf_hook.pre_forward(module, *args, **kwargs)
  File "/soft/fanli/accelerate/src/accelerate/hooks.py", line 356, in pre_forward
    return send_to_device(args, self.execution_device), send_to_device(
  File "/soft/fanli/accelerate/src/accelerate/utils/operations.py", line 180, in send_to_device
    return honor_type(
  File "/soft/fanli/accelerate/src/accelerate/utils/operations.py", line 81, in honor_type
    return type(obj)(generator)
  File "/soft/fanli/accelerate/src/accelerate/utils/operations.py", line 181, in <genexpr>
    tensor, (send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys) for t in tensor)
  File "/soft/fanli/accelerate/src/accelerate/utils/operations.py", line 168, in send_to_device
    raise error
  File "/soft/fanli/accelerate/src/accelerate/utils/operations.py", line 158, in send_to_device
    return tensor.to(device, non_blocking=non_blocking)
  File "/home/fan/anaconda3/envs/pytest/lib/python3.9/site-packages/torch/cuda/__init__.py", line 289, in _lazy_init
    raise AssertionError("Torch not compiled with CUDA enabled")
AssertionError: Torch not compiled with CUDA enabled
```
This is because the device values in `execution_device` don't take the third-party devices into account. This PR fixed this issue by adding the missing deivice-specific prefix to `execution_device`. 

## Who can review?
 @muellerzr @pacman100
