### PR TITLE
add strict arg to load_checkpoint_and_dispatch

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -508,6 +508,7 @@ def load_checkpoint_and_dispatch(
     skip_keys: Optional[Union[str, List[str]]] = None,
     preload_module_classes: Optional[List[str]] = None,
     force_hooks: bool = False,
+    strict: bool = False,
 ):
     """
     Loads a (potentially sharded) checkpoint inside a model, potentially sending weights to a given device as they are
@@ -554,6 +555,9 @@ def load_checkpoint_and_dispatch(
         force_hooks (`bool`, *optional*, defaults to `False`):
             Whether or not to force device hooks to be attached to the model even if all layers are dispatched to a
             single device.
+        strict (`bool`, *optional*, defaults to `False`):
+            Whether to strictly enforce that the keys in the checkpoint state_dict match the keys of the model's
+            state_dict.
 
     Example:
 
@@ -608,6 +612,7 @@ def load_checkpoint_and_dispatch(
         dtype=dtype,
         offload_state_dict=offload_state_dict,
         offload_buffers=offload_buffers,
+        strict=strict,
     )
     if device_map is None:
         return model


### PR DESCRIPTION
# What does this PR do ?
This PR adds the strict arg in `load_checkpoint_and_dispatch`. We need this since this [PR](https://github.com/huggingface/accelerate/pull/2588) introduced a breaking change in the way to error out when the keys in the checkpoint state_dict do not match the keys of the model's state_dict. 
Fixes https://github.com/huggingface/accelerate/issues/2640#issuecomment-2045579806 cc @yiyixuxu 
maybe worth doing a patch @muellerzr ? There are other issues in diffusers so let's wait a bit if we indeed do a patch. 