### PR TITLE
Fix `is_train_batch_min` type in DeepSpeedPlugin

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -682,7 +682,7 @@ class DeepSpeedPlugin:
         default=None,
         metadata={"help": "Possible options are 0,1,2,3; Default will be taken from environment variable"},
     )
-    is_train_batch_min: str = field(
+    is_train_batch_min: bool = field(
         default=True,
         metadata={"help": "If both train & eval dataloaders are specified, this will decide the train_batch_size"},
     )


### PR DESCRIPTION
**PR Description**:

Fixes the data type of `is_train_batch_min` in `DeepSpeedPlugin` from `str` to `bool`, ensuring correct usage as a boolean flag.

**Fixes**: N/A

**Tests**: Existing tests apply; no new tests needed.

**Documentation**: Not affected.