### PR TITLE
Allow "auto" for gradient clipping in YAML

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -722,9 +722,12 @@ class DeepSpeedPlugin:
             self.gradient_accumulation_steps = int(gas) if gas.isdigit() else gas
 
         if self.gradient_clipping is None:
-            gradient_clipping = os.environ.get("ACCELERATE_GRADIENT_CLIPPING", "none")
-            if gradient_clipping != "none":
+            gradient_clipping = os.environ.get("ACCELERATE_GRADIENT_CLIPPING", "auto")
+            # isdigit doesn't work for floats so using try/except
+            try:
                 self.gradient_clipping = float(gradient_clipping)
+            except ValueError:
+                self.gradient_clipping = gradient_clipping
 
         if self.zero_stage is None:
             self.zero_stage = int(os.environ.get("ACCELERATE_DEEPSPEED_ZERO_STAGE", 2))


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

If we have `gradient_clipping: auto` in the DeepSpeed config inside an Accelerate config, the code currently fails with:
```
Traceback (most recent call last):
  File "/root/workspace/lora/tmp.py", line 3, in <module>
    args = TrainingArguments(
  File "<string>", line 124, in __init__
  File "/usr/local/lib/python3.10/dist-packages/transformers/training_args.py", line 1828, in __post_init__
    self.deepspeed_plugin = DeepSpeedPlugin()
  File "<string>", line 14, in __init__
  File "/usr/local/lib/python3.10/dist-packages/accelerate/utils/dataclasses.py", line 727, in __post_init__
    self.gradient_clipping = float(gradient_clipping)
ValueError: could not convert string to float: 'auto'
```

This can be reproduced running `accelerate launch --config_file my_config.yaml script.py` with `script.py` being
```py
from transformers import TrainingArguments, Trainer, AutoModel

args = TrainingArguments(
    output_dir="/tmp/test",
    max_grad_norm=0.5,
)

trainer = Trainer(
    model=AutoModel.from_pretrained("bert-base-uncased"),
    args=args,
)
```
and `my_config.yaml` is
```yaml
compute_environment: LOCAL_MACHINE
debug: false
deepspeed_config:
  gradient_accumulation_steps: 1
  gradient_clipping: auto
  offload_optimizer_device: none
  offload_param_device: none
  zero3_init_flag: true
  zero3_save_16bit_model: true
  zero_stage: 3
distributed_type: DEEPSPEED
downcast_bf16: 'no'
machine_rank: 0
main_training_function: main
mixed_precision: bf16
num_machines: 1
num_processes: 8
rdzv_backend: static
same_network: true
tpu_env: []
tpu_use_cluster: false
tpu_use_sudo: false
use_cpu: false
```

This PR fixes this issue by checking if the given value can actually be casted to float.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->