### PR TITLE
[DO NOT MERGE] add all level buffer support when computing infer_auto_device_map

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1228,7 +1228,11 @@ def infer_auto_device_map(
                 # -> split, we replace the module studied by its children + parameters
                 if verbose:
                     print(f"Splitting {name}.")
-                modules_children = list(module.named_parameters(recurse=False)) + list(module.named_buffers(recurse=False)) + modules_children
+                modules_children = (
+                    list(module.named_parameters(recurse=False))
+                    + list(module.named_buffers(recurse=False))
+                    + modules_children
+                )
                 modules_to_treat = [(f"{name}.{n}", v) for n, v in modules_children] + modules_to_treat
                 # Update the max layer size.
                 max_layer_size, max_layer_names = get_max_layer_size(
@@ -1295,7 +1299,11 @@ def infer_auto_device_map(
 
                     if verbose:
                         print(f"Splitting {tied_module_name}.")
-                    tied_module_children = list(tied_module.named_parameters(recurse=False)) + list(module.named_buffers(recurse=False)) + tied_module_children
+                    tied_module_children = (
+                        list(tied_module.named_parameters(recurse=False))
+                        + list(module.named_buffers(recurse=False))
+                        + tied_module_children
+                    )
                     tied_module_children = [(f"{tied_module_name}.{n}", v) for n, v in tied_module_children]
                     tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n == tied_module_name][0]
 


### PR DESCRIPTION
# What does this PR do ?
This PR adds all level support when computing `infer_auto_device_map`. This is especially important for persistant buffer that are in the state_dict. If we don't attribute a device to those buffers, we will get error in transformers when we try to load the `state_dict`. We might hit edge cases with cpu and disk offload.
Usually buffers are defined in a `nn.Module` that don't have other children modules. However, in a model such as RecurrentGemmaModel, `normalize` buffer is defined at the level of the model. So when we have model = RecurrentGemmaForCausalLM, the persistent buffer is defined there at this location `model.model.normalize` but `model.model` have children modules such as `layers`. 
cc @ArthurZucker 

Another solution would be to just use non persistant buffer all the time for these cases 
-> This is the solution that we are going with for now. We can merge this PR if it makes sense later. 