### PR TITLE
P2P Works on 4090s!*

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -468,13 +468,13 @@ def dispatch_model(
             model.cuda = add_warning(model.cuda, model)
 
         # Check if we are using multi-gpus with RTX 4000 series
-        use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
-        if use_multi_gpu and not check_cuda_p2p_ib_support():
-            logger.warning(
-                "We've detected an older driver with an RTX 4000 series GPU. These drivers have issues with P2P. "
-                "This can affect the multi-gpu inference when using accelerate device_map."
-                "Please make sure to update your driver to the latest version which resolves this."
-            )
+        # use_multi_gpu = len([device for device in set(device_map.values()) if device not in ("cpu", "disk")]) > 1
+        # if use_multi_gpu and not check_cuda_p2p_ib_support():
+        #     logger.warning(
+        #         "We've detected an older driver with an RTX 4000 series GPU. These drivers have issues with P2P. "
+        #         "This can affect the multi-gpu inference when using accelerate device_map."
+        #         "Please make sure to update your driver to the latest version which resolves this."
+        #     )
     else:
         device = list(device_map.values())[0]
         # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -31,7 +31,6 @@ from .hooks import (
 )
 from .utils import (
     OffloadedWeightsLoader,
-    check_cuda_p2p_ib_support,
     check_device_map,
     extract_submodules_state_dict,
     find_tied_parameters,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -35,7 +35,6 @@ from accelerate.utils import (
     DistributedType,
     PrepareForLaunch,
     _filter_args,
-    check_cuda_p2p_ib_support,
     convert_dict_to_env_variables,
     is_bf16_available,
     is_deepspeed_available,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -687,17 +687,17 @@ def multi_gpu_launcher(args):
     import torch.distributed.run as distrib_run
 
     current_env = prepare_multi_gpu_env(args)
-    if not check_cuda_p2p_ib_support():
-        message = "Using RTX 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
-        warn = False
-        if "NCCL_P2P_DISABLE" not in current_env:
-            current_env["NCCL_P2P_DISABLE"] = "1"
-            warn = True
-        if "NCCL_IB_DISABLE" not in current_env:
-            current_env["NCCL_IB_DISABLE"] = "1"
-            warn = True
-        if warn:
-            logger.warning(message)
+    # if not check_cuda_p2p_ib_support():
+    #     message = "Using RTX 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
+    #     warn = False
+    #     if "NCCL_P2P_DISABLE" not in current_env:
+    #         current_env["NCCL_P2P_DISABLE"] = "1"
+    #         warn = True
+    #     if "NCCL_IB_DISABLE" not in current_env:
+    #         current_env["NCCL_IB_DISABLE"] = "1"
+    #         warn = True
+    #     if warn:
+    #         logger.warning(message)
 
     debug = getattr(args, "debug", False)
     args = _filter_args(
@@ -727,17 +727,17 @@ def deepspeed_launcher(args):
         from deepspeed.launcher.runner import DEEPSPEED_ENVIRONMENT_NAME
 
     cmd, current_env = prepare_deepspeed_cmd_env(args)
-    if not check_cuda_p2p_ib_support():
-        message = "Using RTX 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
-        warn = False
-        if "NCCL_P2P_DISABLE" not in current_env:
-            current_env["NCCL_P2P_DISABLE"] = "1"
-            warn = True
-        if "NCCL_IB_DISABLE" not in current_env:
-            current_env["NCCL_IB_DISABLE"] = "1"
-            warn = True
-        if warn:
-            logger.warning(message)
+    # if not check_cuda_p2p_ib_support():
+    #     message = "Using RTX 4000 series which doesn't support faster communication speedups. Ensuring P2P and IB communications are disabled."
+    #     warn = False
+    #     if "NCCL_P2P_DISABLE" not in current_env:
+    #         current_env["NCCL_P2P_DISABLE"] = "1"
+    #         warn = True
+    #     if "NCCL_IB_DISABLE" not in current_env:
+    #         current_env["NCCL_IB_DISABLE"] = "1"
+    #         warn = True
+    #     if warn:
+    #         logger.warning(message)
 
     if args.num_machines > 1 and args.deepspeed_multinode_launcher != DEEPSPEED_MULTINODE_LAUNCHERS[1]:
         with open(DEEPSPEED_ENVIRONMENT_NAME, "a") as f:

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -29,7 +29,6 @@ from .utils import (
     DistributedType,
     DynamoBackend,
     GradientAccumulationPlugin,
-    check_cuda_p2p_ib_support,
     check_fp8_capability,
     get_ccl_version,
     get_cpu_distributed_information,

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -284,14 +284,14 @@ class PartialState:
             if parse_flag_from_env("ACCELERATE_CPU_AFFINITY", False):
                 set_numa_affinity(self.local_process_index)
 
-            # Check for old RTX 4000's that can't use P2P or IB and are on old drivers
-            if self.device.type == "cuda" and not check_cuda_p2p_ib_support():
-                if "NCCL_P2P_DISABLE" not in os.environ or "NCCL_IB_DISABLE" not in os.environ:
-                    raise NotImplementedError(
-                        "Using RTX 4000 series doesn't support faster communication broadband via P2P or IB. "
-                        'Please set `NCCL_P2P_DISABLE="1"` and `NCCL_IB_DISABLE="1" or use `accelerate launch` which '
-                        "will do this automatically."
-                    )
+            # # Check for old RTX 4000's that can't use P2P or IB and are on old drivers
+            # if self.device.type == "cuda" and not check_cuda_p2p_ib_support():
+            #     if "NCCL_P2P_DISABLE" not in os.environ or "NCCL_IB_DISABLE" not in os.environ:
+            #         raise NotImplementedError(
+            #             "Using RTX 4000 series doesn't support faster communication broadband via P2P or IB. "
+            #             'Please set `NCCL_P2P_DISABLE="1"` and `NCCL_IB_DISABLE="1" or use `accelerate launch` which '
+            #             "will do this automatically."
+            #         )
         # Important: This should be the *only* code outside of `self.initialized!`
         self.fork_launched = parse_flag_from_env("FORK_LAUNCHED", 0)
 


### PR DESCRIPTION
# What does this PR do?

For the weekend/testing, this PR allows people to try out P2P comms by fully disabling accelerate's baked-in limiter (due to old driver hangs).

Thanks to `tinygrad`, we now have open-source fixes for these drivers, which you can find here: https://github.com/tinygrad/open-gpu-kernel-modules

If you want to play with this while we work towards closer checks for this (if that's even possible), you can install accelerate with:

```bash
pip install git+https://github.com/huggingface/accelerate@unfreeze-4090
```

Testing speeds: TBD


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 