### PR TITLE
Megatron plugin can support NPU

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -899,7 +899,6 @@ class AcceleratorState:
                         fsdp_plugin.set_mixed_precision(self._mixed_precision)
                     self.fsdp_plugin = fsdp_plugin
                 if os.environ.get("ACCELERATE_USE_MEGATRON_LM", "false") == "true" and self.distributed_type not in [
-                    DistributedType.MULTI_NPU,
                     DistributedType.MULTI_XPU,
                 ]:
                     self.distributed_type = DistributedType.MEGATRON_LM


### PR DESCRIPTION
We are using accelerate's megatron plugin on the NPU.

Specifically, there are two scenarios:
1. After we `import torch_npu`, `torch.cuda.is_available()` is False, which is the `MULTI_NPU` branch.
2. When we `import transfer_to_npu from torch_npu.contrib`, `torch.cuda.is_available()` is True, which is the `MULTI_GPU` branch.

Therefore, in fact, accelerate's megatron plugin supports both `MULTI_GPU` and `MULTI_NPU` scenarios.