### PR TITLE
Deprecate tqdm args + slight logic tweaks

### DIFF
--- a/src/accelerate/utils/tqdm.py
+++ b/src/accelerate/utils/tqdm.py
@@ -33,7 +33,7 @@ def tqdm(*args, main_process_only: bool = True, **kwargs):
     """
     if not is_tqdm_available():
         raise ImportError("Accelerate's `tqdm` module requires `tqdm` to be installed. Please run `pip install tqdm`.")
-    if isinstance(args[0], bool):
+    if len(args) > 0 and isinstance(args[0], bool):
         warnings.warn(
             f"Passing `{args[0]}` as the first argument to Accelerate's `tqdm` wrapper is deprecated "
             "and will be removed in v0.33.0. Please use the `main_process_only` keyword argument instead.",

--- a/src/accelerate/utils/tqdm.py
+++ b/src/accelerate/utils/tqdm.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import warnings
+
 from .imports import is_tqdm_available
 
 
@@ -31,7 +33,15 @@ def tqdm(*args, main_process_only: bool = True, **kwargs):
     """
     if not is_tqdm_available():
         raise ImportError("Accelerate's `tqdm` module requires `tqdm` to be installed. Please run `pip install tqdm`.")
-    disable = False
-    if main_process_only:
+    if isinstance(args[0], bool):
+        warnings.warn(
+            f"Passing `{args[0]}` as the first argument to Accelerate's `tqdm` wrapper is deprecated "
+            "and will be removed in v0.33.0. Please use the `main_process_only` keyword argument instead.",
+            FutureWarning,
+        )
+        main_process_only = args[0]
+        args = args[1:]
+    disable = kwargs.pop("disable", False)
+    if main_process_only and not disable:
         disable = PartialState().local_process_index != 0
     return _tqdm(*args, **kwargs, disable=disable)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -405,14 +405,8 @@ class UtilsTester(unittest.TestCase):
             valid_env_items = convert_dict_to_env_variables(env)
         assert valid_env_items == ["ACCELERATE_DEBUG_MODE=1\n", "OTHER_ENV=2\n"]
 
-
-class TqdmTester(unittest.TestCase):
-    def test_tqdm(self):
-        expected = [0, 1, 2]
-        assert list(tqdm(range(3), main_process_only=True)) == expected
-        assert list(tqdm(main_process_only=True, iterable=range(3))) == expected
-
-        assert list(tqdm(range(3), main_process_only=False)) == expected
-        assert list(tqdm(main_process_only=False, iterable=range(3))) == expected
-
-        assert list(tqdm(range(3))) == expected
+    def test_tqdm_deprecation(self):
+        with pytest.warns(FutureWarning) as cm:
+            tqdm(True, range(3), disable=True)
+        assert "Passing `True` as the first argument to" in cm.pop().message.args[0]
+        tqdm(range(3), main_process_only=True, disable=True)


### PR DESCRIPTION
# What does this PR do?

This PR is a follow-up to https://github.com/huggingface/accelerate/pull/2654, specifically it:

1. Writes a new test to check that the deprecation is flagged
2. Changes the logic slightly to check if users are passing in `disable` explicitly as a kwarg. We should be respecting this if so


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc or @BenjaminBossan 