### PR TITLE
Add Upcasting for FSDP in Mixed Precision. Add Concept Guide for FSPD and DeepSpeed. 

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -78,6 +78,8 @@
     title: Executing and deferring jobs
   - local: concept_guides/gradient_synchronization
     title: Gradient synchronization
+  - local: concept_guides/fsdp_and_deepspeed
+    title: FSDP vs DeepSpeed
   - local: concept_guides/low_precision_training
     title: How training in low-precision environments is possible (FP8)
   - local: concept_guides/training_tpu

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -13,82 +13,126 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 -->
 
-# FSDP VS DeepSpeed [DRAFT]
+# Moving between FSDP And DeepSpeed [DRAFT]
 
-🤗 Accelerate integrates two extremely powerful tools for distributed training, namely [Pytorch FSDP](../usage_guides/fsdp.md) and [Microsoft DeepSpeed](../usage_guides/deepspeed.md). It is important to note similarities / differences in order to make an informed choice which framework that will better suit the desired use case.
+🤗 Accelerate offers flexibilty of training frameworks, by integrating two extremely powerful tools for distributed training, namely [Pytorch FSDP](../usage_guides/fsdp.md) and [Microsoft DeepSpeed](../usage_guides/deepspeed.md). The aim fo this article is to draw parallels, as well as to outline potential differences, to empower the user to switch seamlessly between these two frameworks.
 
 <Tip>
-  To switch betwen the frameworks, we recommend 🤗 `accelerate launch`.
+  To switch between the frameworks, we recommend 🤗 `accelerate launch`.
 
-  Simply pass [FSDP and DeepSpeed arguments](../package_reference/cli.md#accelerate-launch) directly to `accelerate launch` or pass `--config_file`. No need for any code instrumentation!
+  Simply pass [FSDP and DeepSpeed arguments](../package_reference/cli#accelerate-launch) directly to `accelerate launch` or pass `--config_file`. No need for any code instrumentation!
 
-  For examplar configurations see [DeepSpeed Config](../usage_guides/deepspeed#accelerate-deepspeed-plugin). and [FSDP Configuration](../usage_guides/fsdp.md#how-it-works-out-of-the-box). 
-  
-
+  Exemplar 🤗 Accelerate configurations can be found here for [DeepSpeed](../usage_guides/deepspeed#accelerate-deepspeed-plugin) and [FSDP](../usage_guides/fsdp#how-it-works-out-of-the-box). 
+ 
 </Tip>
 
 <!--
 The aim of this concept guide is to elucidate similarities/differences with empirical observations and code aspects.  We assume that 🤗 Accelerate is used and configured using the [FSDP and DeepSpeed arguments](../package_reference/cli.md#accelerate-launch). No TPU aspects are discussed. Also we focus only on single-node aspects.
 -->
 
-This article is written with 🤗 Accelerate in mind, for single-node GPU scenarios only. No TPU aspects will be considered.
+This article is written with 🤗 Accelerate in mind, for single-node, multi-GPU, scenarios only. No TPU aspects will be considered.
 
 ## Configuring Various Functionalities
 
-Training parameters are seperated into different GPUs to scale up for large models; this is termed *sharding* in FSDP, and *partioning* in DeepSpeed. Since the terminologies used in FSDP and DeepSpeed are disparate, there are various guides that [reconcile the mapping between FSDP sharding and DeepSpeed ZeRO](../usage_guides/fsdp.md#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). This section aims to reconcile these differences for a 🤗 Accelerate user that desires to use both frameworks in an equivalent manner.
+Model tensors are split into different GPUs in attempt scale up model sizes; this is termed *sharding* in FSDP, and *partitioning* in DeepSpeed. The FSDP sharding strategy and the DeepSpeed ZeRO Stages, are configured by `--fsdp_sharding_strategy`, and `--zero_stage`, respectively.  For example FSDP `FULL_SHARD` maps to DeepSpeed ZeRO stage `3`, see this for a comprehensive [mapping between FSDP sharding and DeepSpeed ZeRO settings](../usage_guides/fsdp#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). There exists a host of other settings besides these two, summarized by similarity in the below table.
 
-In general, DeepSpeed offers more fine-grained control, but may incur extra memory consumption as model and optimizer parameters are always upcasted to `float32`. 
-Below shows a mapping between FSDP and DeepSpeed configuration. 
-Note that to access advanced DeepSpeed configs via `accelerate launch` beyond
-[those exposed by accelerate](../package_reference/cli.md#accelerate-launch), one can link a full DeepSpeed config and pointing to it using the accelerate `deepspeed_config_file`. 
- 
-Configuration | FSDP | DeepSpeed
---|--|--
-sharding/partitioning | `--fsdp_sharding_strategy` | `--zero_stage`
-offload | `--fsdp_offload_params` | `--offload_optimizer_device, --offload_param_device`
-efficient weights loading | `--fsdp_cpu_ram_efficient_loading` | `--zero3_init_flag`
-checkpointing | `--fsdp_state_dict_type` | `--zero3_save_16bit_model`
-pipeline | `--fsdp_backward_prefetch, --fsdp_backward_prefetch` | 
-model | `--fsdp_auto_wrap_policy, --fsdp_transformer_layer_cls_to_wrap` | 
-parameters summoning | `--fsdp_use_orig_params` | 
-parameters syncing | `--fsdp_sync_module_states` | 
-training |  | `--gradient_accumulation_steps, --gradient_clipping`
+Group | Framework | Configuration | Example | Restrictions (if any)
+--|--|--|--|--
+sharding / partitioning | FSDP<br>DeepSpeed | `--fsdp_sharding_strategy`<br>`--zero_stage` | `1` (`FULL_SHARD`) <br>`3` | 
+offload | FSDP<br>DeepSpeed | `--fsdp_offload_params`<br>`--offload_param_device`<br>`--offload_optimizer_device` | `true`<br>`cpu`<br>`cpu` | all or nothing <br><br> 
+model loading | FSDP<br>DeepSpeed | <span style="white-space:nowrap;">`--fsdp_cpu_ram_efficient_loading`</span><br>`--zero3_init_flag` | `true`<br>`true` | <br>only ZeRO 3
+efficient checkpointing | FSDP<br>DeepSpeed | `--fsdp_state_dict_type`<br>`--zero3_save_16bit_model` |  `SHARDED_STATE_DICT`<br>`true` |  <br>only ZeRO 3
+pipeline | FSDP<br><br>DeepSpeed | `--fsdp_forward_prefetch`<br>`--fsdp_backward_prefetch`<br>None | `true`<br>`BACKWARD_PRE` | <br><br>?? check for DS
+model | FSDP<br><br>DeepSpeed |  `--fsdp_auto_wrap_policy`<br><span style="white-space:nowrap;">`--fsdp_transformer_layer_cls_to_wrap`</span><br>None | `TRANSFORMER_BASED_WRAP`<br><Layer Class> |<br>Usually not needed <br>Transparent to user.
+parameters summoning | FSDP<br>DeepSpeed | `--fsdp_use_orig_params`<br>None | `true` | required for `torch.compile`<br>Transparent to user
+parameters syncing | FSDP<br>DeepSpeed | `--fsdp_sync_module_states`<br>None | `true` | <br>?? Need to check
+training | FSDP<br>DeepSpeed | None<br>`--gradient_accumulation_steps`<br>`--gradient_clipping` | <br>`auto`<br>`auto` | Transparent to user
+
+We reiterate again that for all possible settings for the above, refer to [`Accelerate` launch documentation](../package_reference/cli#accelerate-launch).
 
 <Tip>
-    When training transformers, there are some FSDP configuration recommendations that should be followed.
 
-    - set `fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP`, and `fsdp_transformer_layer_cls_to_wrap` not needed for latest `transformers` versions.
-    - when setting `fsdp_cpu_ram_efficient_loading: True`, ensure `fsdp_sync_module_states: True` so that parameters are communicated from main process.
-    - is using `torch.compile` set `fsdp_use_orig_params: True`
+    To access other DeepSpeed configurations, such as mixed precision settings, 
+    one has to link a `deepspeed_config_file`, see [instructions here](../usage_guides/deepspeed#deepspeed-config-file).  
+    
+</Tip>
+
+<!--
+Since the terminologies used in FSDP and DeepSpeed are disparate, there are various guides that [reconcile the mapping between FSDP sharding and DeepSpeed ZeRO](../usage_guides/fsdp#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). This section aims to reconcile these differences for a 🤗 Accelerate user that desires to use both frameworks in an equivalent manner.
+In general, DeepSpeed offers more fine-grained control, but may incur extra memory consumption as model and optimizer parameters are always upcasted to `float32`. 
+-->
+
+<Tip>
+    When using FSDP these are recommendations that should be followed.
+
+    - set `fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP`. Do not set `fsdp_transformer_layer_cls_to_wrap` if using the latest `transformers` versions.
+    - if `fsdp_cpu_ram_efficient_loading: True`, set `fsdp_sync_module_states: True` otherwise the model will not load properly.
+    - when using `torch.compile` set `fsdp_use_orig_params: True`.
 
 </Tip>
 
 <Tip>
-    These are also the DeepSpeed configuration recommendations that should be followed.
+    When using DeepSpeed these are recommendations that should be followed.
 
     - set `gradient_accumulation_steps: "auto"` and `gradient_clipping: "auto"` to automatically pick up values set in [`TrainingArguments`].
 
 </Tip>
 
-## Differences in Training Precisions
+TODO: Consider elaborating on some points ? Maybe a small subsection for each?
+- on checkpoint sharding (DS does not have checkpoint sharding?) Des FSDP save the model in 16 bit also?
+- zero3 init in DS will be automatic if model is above a certain size. More details on this?
+- do I need to talk about bucketing in DS? this is how DS takes care of partitioning in an automatic manner without the wrap policy. Do I need to explain FSDP wrapping causes graph breaks in torch.compile and how this is being resolved?
+- how does DS take care of pipelining? I need to check further.
+- do we need to discuss parameter summoning for DS? maybe not because this is an advanced usage
+- should we discusss activation checkpointing in the configs or is this obvious?
 
+
+## On Data Precision
+
+To discuss the how data precision is handled in both FSDP and Deepspeed, it is instructive to first give a flow of how model parameters are handled in these frameworks. Before the model / optimizer parameters are distributed across GPUs, parameter preparation is involved to first "flatten" them to  one-dimensional [`torch.Tensor`]'s. The implementation of FSDP / DeepSpeed varies in the respect of the `dtype` in which these "flattened" parameters are stored, and there are ramnifications with regards to how [`torch.Optimizer`]'s allocate their `dtypes`'s. The table below outlines the processes for both frameworks; the "Local" column indicates the process occurring at a per-gpu level, therefore any memory overheads by upcasting should be understood to be amortized by the number of gpus used.
+
+<!--
+TODO: for FSDP there are some mixed precision settings like `keep_low_precision_grads`, should we discuss them? NVM, because they way huggingface prepares the model, keep_low_precision_grads will never need to be used
+-->
+
+Process | Local | Framework | Details
+--|--|--|--
+Loading, i.e., [`AutoModel.from_pretrained(..., torch_dtype)`] |  
+Preparation, i.e., creation of "flat params" | ✅ | FSDP<br>DeepSpeed | created in `torch_dtype`.<br> disregards `torch_dtype`, created in `float32`.
+Optimizer initialization | ✅ | FSDP<br>DeepSpeed  | creates parameters in `torch_dtype`<br> creates parameters in `float32`
+Training Step, i.e, forward, backward, reduction | | FSDP<br>DeepSpeed  | follows [`MixedPrecision`](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision)<br> follows `deepspeed_config_file` mixed precision settings.
+Optimizer (Pre-Step) | ✅ | FSDP<br>DeepSpeed | upcasting (if any) to `torch_dtype`<br>upcasted to `float32`
+Optimizer (Actual Step) | ✅ | FSDP<br>DeepSpeed  | occurs in `torch_dtype` <br> occurs in `float32`.
+
+
+<!--
 Both FSDP and DeepSpeed have logic for sharding/partitioning the model / optimizer parameters across GPUs; however there are some differences to be aware of. Both of these
 frameworks will create new [`torch.Tensor`]'s to hold "flattened" parameters, which will be used to instantiate the optimizers in each shard/partition. However since the [`torch.Optimizer`]'s allocate their `dtypes`'s based on the optimized parameters, it is important to note the following:
 
+For FSDP there are two options i) load and train/optimize the model in low precision, or ii) load in full precision and configure [`MixedPrecision`](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision) to have activations / reduction performed in low precision. But for DeepSpeed always load the model in full precision. To summarize:
+-->
+
 <Tip warning={true}>
 
-    FSDP will retain the model's `dtype`; if a model is loaded in `float16`, then that will be the `dtype` of the flattened model parameters, and also that of the optimizer, etc. This will be discussed more clearly below. 
-    
-    DeepSpeed however will always upcast the parameters to `float32`, so even if the model was loaded in `float16`, the optimizer will see `float32` parameters. In other words, DeepSpeed only operates in mixed precision. There is no reason to load in low precision and yet train with DeepSpeed.
+    Therefore when using DeepSpeed, one should always load the model with `torch_dtype=torch.float32`.
 
-    This difference may result in different observations during training.
+    However if the number of GPUs are small, be aware of potentially significant memory overheads due to the "local" upcasting.
 
 </Tip>
 
-For FSDP there are two options i) load and train/optimize the model in low precision, or ii) load in full precision and configure [`MixedPrecision`](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision) to have activations / reduction performed in low precision. But for DeepSpeed always load the model in full precision. To summarize:
+<Tip warning={true}>
 
-Framework | Load Model | Mixed Precision | Flat Params | Forward / Backward | Optimizer
+    With FSDP it is possible to operate the [`torch.Optimizer`] in low precision `torch_dtype`, which may be helpful when using small number of GPUs.
+
+    And if migrating to DeepSpeed from FSDP, be aware that if `torch_dtype` had been previously set to low precision (unnecessarily, see above), it will result in non-equivalent observations since then FSDP will optimize in low precision.
+
+</Tip>
+
+
+To clarify the above table consider the concrete examples below; the optimizer pre- and actual step combined for brevity. Thus to ensure that the same data precisions are used in both FSDP and DeepSpeed, always specify `torch_dtype=torch.float32` while calling [`AutoModel.from_pretrained`].
+
+Framework | Model Loading (`torch_dtype`) | Mixed Precision | Preparation (Local) | Training | Optimizer (Local)
 --|--|--|--|--|--
-FSDP | bf16 | None | bf16 | bf16 | bf16
-FSDP | bf16| fp32 | fp32 | bf16 | fp32
-DeepSpeed   | bf16 | bf16 | fp32 | bf16 | fp32
+FSDP | bf16 | default (none) | bf16 | bf16 | bf16
+FSDP | fp32 | bf16 | fp32 | bf16 | fp32
+DeepSpeed   | fp32 | bf16 | fp32 | bf16 | fp32

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -81,7 +81,7 @@ FSDP only allows *all-or-nothing* offload, but DeepSpeed can offload parameters 
 ### Prefetching
 
 FSDP allows two prefetching configurations `--fsdp_forward_prefetch` and `--fsdp_backward_prefetch` to improve overlap of comms / computation at a cost of extra memory, see [FSDP documentation](https://pytorch.org/docs/stable/fsdp.html). 
-For DeepSpeed, the prefetching is always on, and only certain hyperparams like `stage3_prefetch_bucket_size` [can be configured for Zero3](https://www.deepspeed.ai/docs/config-json/#parameter-offloading); 🤗 [`accelerate`] will set these hyperparams automatically.
+For DeepSpeed, the prefetching is always on, and only certain hyperparams like `stage3_prefetch_bucket_size` [can be configured for Zero3](https://www.deepspeed.ai/docs/config-json/#parameter-offloading); 🤗 `accelerate` will set these hyperparams automatically.
 
 <Tip>
 
@@ -126,7 +126,7 @@ Deepspeed requires explicit `--gradient_accumulation_steps` and `--gradient_clip
 
 <Tip>
 
-    When using DeepSpeed, set `gradient_accumulation_steps: "auto"` and `gradient_clipping: "auto"` to automatically pick up values set in [`TrainingArguments`].
+    When using DeepSpeed, set `gradient_accumulation_steps: "auto"` and `gradient_clipping: "auto"` to automatically pick up values set in the [`Accelerator`] or [`TrainingArguments`] (if using `transformers`).
 
 </Tip>
 
@@ -164,7 +164,7 @@ Optimizer (Actual Step) | ✅ | FSDP<br>DeepSpeed  | occurs in `torch_dtype` <br
 
 <Tip warning={true}>
 
-    With mixed precision, then FSDP and DeepSpeed will upcast in the model preperation step (c.f. table above). But do note that FSDP will then save checkpoints in the upcasted precision; Deepspeed may still save low precision checkpoints if `--zero3_save_16bit_model` is specified.
+    With mixed precision, FSDP and DeepSpeed will upcast in the model preparation step (c.f. table above). But do note that FSDP will then save checkpoints in the upcasted precision; Deepspeed may still save low precision checkpoints if `--zero3_save_16bit_model` is specified.
 
 </Tip>
 

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -175,4 +175,4 @@ Framework | Model Loading (`torch_dtype`) | Mixed Precision | Preparation (Local
 --|--|--|--|--|--
 FSDP | bf16 | default (none) | bf16 | bf16 | bf16
 FSDP | bf16 | bf16 | fp32 | bf16 | fp32
-DeepSpeed   | fp32 | bf16 | fp32 | bf16 | fp32
+DeepSpeed   | bf16 | bf16 | fp32 | bf16 | fp32

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -56,7 +56,7 @@ For detailed descriptions of the above, refer to [🤗 `Accelerate` launch docum
     
 </Tip>
 
-**Checkpointing**
+### Checkpointing
 
 Do note that while FSDP can be configured via `--fsdp_state_dict_type` to save either full / sharded checkpoints.
 
@@ -66,11 +66,11 @@ Do note that while FSDP can be configured via `--fsdp_state_dict_type` to save e
 
 </Tip>
 
-**Offloading**
+### Offloading
 
 FSDP only allows *all-or-nothing* offload, but DeepSpeed can offload parameters and optimizer differently. Furthermore, DeepSpeed also supports [offloading to NVME](https://www.deepspeed.ai/docs/config-json/#parameter-offloading).
 
-**Prefetching**
+### Prefetching
 
 FSDP allows two prefetching configurations `--fsdp_forward_prefetch` and `--fsdp_backward_prefetch` to improve overlap of comms / computation at a cost of extra memory, see [FSDP documentation](https://pytorch.org/docs/stable/fsdp.html). 
 For DeepSpeed, the prefetching is always on, and only certain hyperparams like `stage3_prefetch_bucket_size` [can be configured for Zero3](https://www.deepspeed.ai/docs/config-json/#parameter-offloading); 🤗 [`accelerate`] will set these hyperparams automatically.
@@ -81,7 +81,7 @@ For DeepSpeed, the prefetching is always on, and only certain hyperparams like `
 
 </Tip>
 
-**Model Loading**
+### Model Loading
 
 While FSDP require an explicit `--fsdp_cpu_ram_efficient_loading true` to activate efficient model loading, 🤗 `transformers` will activate the similar feature whenever DeepSpeed Zero3 is used.
 
@@ -91,7 +91,7 @@ While FSDP require an explicit `--fsdp_cpu_ram_efficient_loading true` to activa
 
 </Tip>
 
-**Model**
+### Model
 
 FSDP requires an explicit `--fsdp_auto_wrap_policy` for the algorithm to decide how to schedule the all-gather and reduce-scatter operations. But for DeepSpeed this is transparent to the user.
 
@@ -101,7 +101,7 @@ FSDP requires an explicit `--fsdp_auto_wrap_policy` for the algorithm to decide 
 
 </Tip>
 
-**Parameters Summoning**
+### Parameters Summoning
 
 FSDP requires an explicit `--fsdp_use_orig_params` flag if using `torch.compile`, see [the pytorch documenation](https://pytorch.org/docs/stable/fsdp.html#module-torch.distributed.fsdp). For DeepSpeed this is transparent to the user.
 
@@ -112,7 +112,7 @@ FSDP requires an explicit `--fsdp_use_orig_params` flag if using `torch.compile`
 </Tip>
 
 
-**Training**
+## Training
 
 Deepspeed requires explicit `--gradient_accumulation_steps` and `--gradient_clipping` flags. For FSDP this is transparent to the user.
 

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -33,7 +33,7 @@ This tutorial is for single-node, multi-GPU, scenarios only.
 
 ## Configuring Functionalities
 
-Model tensors are split into different GPUs in attempt scale up model sizes; this is termed *sharding* in FSDP, and *partitioning* in DeepSpeed. FSDP sharding and DeepSpeed ZeRO (partitioning) stages, are configured by `--fsdp_sharding_strategy`, and `--zero_stage`, respectively.  In particular, FSDP `FULL_SHARD` maps to DeepSpeed ZeRO stage `3`; see this [comprehensive mapping between FSDP sharding and DeepSpeed ZeRO settings](../usage_guides/fsdp#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). The below table summarizes and groups similar settings:
+Model tensors are split into different GPUs in an attempt to scale up model sizes; this is termed *sharding* in FSDP, and *partitioning* in DeepSpeed. FSDP sharding and DeepSpeed ZeRO (partitioning) stages are configured by `--fsdp_sharding_strategy`, and `--zero_stage`, respectively.  In particular, FSDP `FULL_SHARD` maps to DeepSpeed ZeRO stage `3`; see this [comprehensive mapping between FSDP sharding and DeepSpeed ZeRO settings](../usage_guides/fsdp#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). The below table summarizes and groups similar settings:
 
 Group | Framework | Configuration | Example | Restrictions (if any)
 --|--|--|--|--

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -15,18 +15,21 @@ rendered properly in your Markdown viewer.
 
 # Moving between FSDP And DeepSpeed (DRAFT)
 
-🤗 Accelerate offers flexibilty of training frameworks, by integrating two extremely powerful tools for distributed training, namely [Pytorch FSDP](../usage_guides/fsdp.md) and [Microsoft DeepSpeed](../usage_guides/deepspeed.md). The aim fo this article is to draw parallels, as well as to outline potential differences, to empower the user to switch seamlessly between these two frameworks.
+🤗 Accelerate offers flexibilty of training frameworks, by integrating two extremely powerful tools for distributed training, namely [Pytorch FSDP](../usage_guides/fsdp.md) and [Microsoft DeepSpeed](../usage_guides/deepspeed.md). The aim of this tutorial is to draw parallels, as well as to outline potential differences, to empower the user to switch seamlessly between these two frameworks.
 
 <Tip>
-  To switch between the frameworks, we recommend 🤗 `accelerate launch`.
 
-  Simply pass [FSDP and DeepSpeed arguments](../package_reference/cli#accelerate-launch) directly to `accelerate launch` or pass `--config_file`. No need for any code instrumentation!
+  To switch between the frameworks, we recommend launching code 🤗 `accelerate launch` passing in the correct config file with `--config_file`, or passing in the respective arguments directly for [FSDP and DeepSpeed](../package_reference/cli#accelerate-launch) .
 
-  Exemplar 🤗 Accelerate configurations can be found here for [DeepSpeed](../usage_guides/deepspeed#accelerate-deepspeed-plugin) and [FSDP](../usage_guides/fsdp#how-it-works-out-of-the-box). 
+  Example 🤗 Accelerate configurations can be found here for [DeepSpeed](../usage_guides/deepspeed#accelerate-deepspeed-plugin) and [FSDP](../usage_guides/fsdp#how-it-works-out-of-the-box), or in the [example zoo under "Launch Configurations"](../usage_guides/explore)
  
 </Tip>
 
-This article is written with 🤗 Accelerate in mind, for single-node, multi-GPU, scenarios only. No TPU aspects will be considered.
+<Tip warning={true}>
+
+This tutorial is for single-node, multi-GPU, scenarios only.
+
+</Tip>
 
 ## Configuring Functionalities
 
@@ -49,7 +52,7 @@ For detailed descriptions of the above, refer to [🤗 `Accelerate` launch docum
 <Tip>
 
     To access other DeepSpeed configurations, such as mixed precision settings, 
-    you need to link a `deepspeed_config_file`, see the [documentation](../usage_guides/deepspeed#deepspeed-config-file).  
+    you need to pass in a `--deepspeed_config_file`, see the [documentation](../usage_guides/deepspeed#deepspeed-config-file).  
     
 </Tip>
 
@@ -59,7 +62,7 @@ Do note that while FSDP can be configured via `--fsdp_state_dict_type` to save e
 
 <Tip>
 
-    For DeepSpeed Zero3, it is recommended to also pass a `--zero3_save_16bit_model true` in the [`Accelerate` launch arguments](../package_reference/cli#accelerate-launch), which conviniently consolidates the model to a single rank and saves; this is the FSDP equivalent of `fsdp_state_dict_type: FULL_STATE_DICT`.
+    For DeepSpeed Zero3, it is recommended to also pass a `--zero3_save_16bit_model true`, which conveniently consolidates the model to a single rank and saves; this is the FSDP equivalent of `fsdp_state_dict_type: FULL_STATE_DICT`.
 
 </Tip>
 

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -1,0 +1,94 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# FSDP VS DeepSpeed [DRAFT]
+
+🤗 Accelerate integrates two extremely powerful tools for distributed training, namely [Pytorch FSDP](../usage_guides/fsdp.md) and [Microsoft DeepSpeed](../usage_guides/deepspeed.md). It is important to note similarities / differences in order to make an informed choice which framework that will better suit the desired use case.
+
+<Tip>
+  To switch betwen the frameworks, we recommend 🤗 `accelerate launch`.
+
+  Simply pass [FSDP and DeepSpeed arguments](../package_reference/cli.md#accelerate-launch) directly to `accelerate launch` or pass `--config_file`. No need for any code instrumentation!
+
+  For examplar configurations see [DeepSpeed Config](../usage_guides/deepspeed#accelerate-deepspeed-plugin). and [FSDP Configuration](../usage_guides/fsdp.md#how-it-works-out-of-the-box). 
+  
+
+</Tip>
+
+<!--
+The aim of this concept guide is to elucidate similarities/differences with empirical observations and code aspects.  We assume that 🤗 Accelerate is used and configured using the [FSDP and DeepSpeed arguments](../package_reference/cli.md#accelerate-launch). No TPU aspects are discussed. Also we focus only on single-node aspects.
+-->
+
+This article is written with 🤗 Accelerate in mind, for single-node GPU scenarios only. No TPU aspects will be considered.
+
+## Configuring Various Functionalities
+
+Training parameters are seperated into different GPUs to scale up for large models; this is termed *sharding* in FSDP, and *partioning* in DeepSpeed. Since the terminologies used in FSDP and DeepSpeed are disparate, there are various guides that [reconcile the mapping between FSDP sharding and DeepSpeed ZeRO](../usage_guides/fsdp.md#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). This section aims to reconcile these differences for a 🤗 Accelerate user that desires to use both frameworks in an equivalent manner.
+
+In general, DeepSpeed offers more fine-grained control, but may incur extra memory consumption as model and optimizer parameters are always upcasted to `float32`. 
+Below shows a mapping between FSDP and DeepSpeed configuration. 
+Note that to access advanced DeepSpeed configs via `accelerate launch` beyond
+[those exposed by accelerate](../package_reference/cli.md#accelerate-launch), one can link a full DeepSpeed config and pointing to it using the accelerate `deepspeed_config_file`. 
+ 
+Configuration | FSDP | DeepSpeed
+--|--|--
+sharding/partitioning | `--fsdp_sharding_strategy` | `--zero_stage`
+offload | `--fsdp_offload_params` | `--offload_optimizer_device, --offload_param_device`
+efficient weights loading | `--fsdp_cpu_ram_efficient_loading` | `--zero3_init_flag`
+checkpointing | `--fsdp_state_dict_type` | `--zero3_save_16bit_model`
+pipeline | `--fsdp_backward_prefetch, --fsdp_backward_prefetch` | 
+model | `--fsdp_auto_wrap_policy, --fsdp_transformer_layer_cls_to_wrap` | 
+parameters summoning | `--fsdp_use_orig_params` | 
+parameters syncing | `--fsdp_sync_module_states` | 
+training |  | `--gradient_accumulation_steps, --gradient_clipping`
+
+<Tip>
+    When training transformers, there are some FSDP configuration recommendations that should be followed.
+
+    - set `fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP`, and `fsdp_transformer_layer_cls_to_wrap` not needed for latest `transformers` versions.
+    - when setting `fsdp_cpu_ram_efficient_loading: True`, ensure `fsdp_sync_module_states: True` so that parameters are communicated from main process.
+    - is using `torch.compile` set `fsdp_use_orig_params: True`
+
+</Tip>
+
+<Tip>
+    These are also the DeepSpeed configuration recommendations that should be followed.
+
+    - set `gradient_accumulation_steps: "auto"` and `gradient_clipping: "auto"` to automatically pick up values set in [`TrainingArguments`].
+
+</Tip>
+
+## Differences in Training Precisions
+
+Both FSDP and DeepSpeed have logic for sharding/partitioning the model / optimizer parameters across GPUs; however there are some differences to be aware of. Both of these
+frameworks will create new [`torch.Tensor`]'s to hold "flattened" parameters, which will be used to instantiate the optimizers in each shard/partition. However since the [`torch.Optimizer`]'s allocate their `dtypes`'s based on the optimized parameters, it is important to note the following:
+
+<Tip warning={true}>
+
+    FSDP will retain the model's `dtype`; if a model is loaded in `float16`, then that will be the `dtype` of the flattened model parameters, and also that of the optimizer, etc. This will be discussed more clearly below. 
+    
+    DeepSpeed however will always upcast the parameters to `float32`, so even if the model was loaded in `float16`, the optimizer will see `float32` parameters. In other words, DeepSpeed only operates in mixed precision. There is no reason to load in low precision and yet train with DeepSpeed.
+
+    This difference may result in different observations during training.
+
+</Tip>
+
+For FSDP there are two options i) load and train/optimize the model in low precision, or ii) load in full precision and configure [`MixedPrecision`](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision) to have activations / reduction performed in low precision. But for DeepSpeed always load the model in full precision. To summarize:
+
+Framework | Load Model | Mixed Precision | Flat Params | Forward / Backward | Optimizer
+--|--|--|--|--|--
+FSDP | bf16 | None | bf16 | bf16 | bf16
+FSDP | bf16| fp32 | fp32 | bf16 | fp32
+DeepSpeed   | bf16 | bf16 | fp32 | bf16 | fp32

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -26,15 +26,11 @@ rendered properly in your Markdown viewer.
  
 </Tip>
 
-<!--
-The aim of this concept guide is to elucidate similarities/differences with empirical observations and code aspects.  We assume that 🤗 Accelerate is used and configured using the [FSDP and DeepSpeed arguments](../package_reference/cli.md#accelerate-launch). No TPU aspects are discussed. Also we focus only on single-node aspects.
--->
-
 This article is written with 🤗 Accelerate in mind, for single-node, multi-GPU, scenarios only. No TPU aspects will be considered.
 
 ## Configuring Functionalities
 
-Model tensors are split into different GPUs in attempt scale up model sizes; this is termed *sharding* in FSDP, and *partitioning* in DeepSpeed. The FSDP sharding strategy and the DeepSpeed ZeRO Stages, are configured by `--fsdp_sharding_strategy`, and `--zero_stage`, respectively.  For example FSDP `FULL_SHARD` maps to DeepSpeed ZeRO stage `3`, see this for a comprehensive [mapping between FSDP sharding and DeepSpeed ZeRO settings](../usage_guides/fsdp#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). There exists a host of other settings besides these two, summarized by similarity in the below table.
+Model tensors are split into different GPUs in attempt scale up model sizes; this is termed *sharding* in FSDP, and *partitioning* in DeepSpeed. FSDP sharding and DeepSpeed ZeRO (partitioning) stages, are configured by `--fsdp_sharding_strategy`, and `--zero_stage`, respectively.  In particular, FSDP `FULL_SHARD` maps to DeepSpeed ZeRO stage `3`; see this [comprehensive mapping between FSDP sharding and DeepSpeed ZeRO settings](../usage_guides/fsdp#mapping-between-fsdp-sharding-strategies-and-deepspeed-zero-stages). The below table summarizes and groups similar settings:
 
 Group | Framework | Configuration | Example | Restrictions (if any)
 --|--|--|--|--
@@ -42,48 +38,53 @@ sharding / partitioning | FSDP<br>DeepSpeed | `--fsdp_sharding_strategy`<br>`--z
 offload | FSDP<br>DeepSpeed | `--fsdp_offload_params`<br>`--offload_param_device`<br>`--offload_optimizer_device` | `true`<br>`cpu`<br>`cpu` | all or nothing <br><br> 
 model loading | FSDP<br>DeepSpeed | <span style="white-space:nowrap;">`--fsdp_cpu_ram_efficient_loading`</span><br>`--zero3_init_flag` | `true`<br>`true` | <br>only ZeRO 3
 efficient checkpointing | FSDP<br>DeepSpeed | `--fsdp_state_dict_type`<br>`--zero3_save_16bit_model` |  `SHARDED_STATE_DICT`<br>`true` |  <br>only ZeRO 3
-pipeline | FSDP<br><br>DeepSpeed | `--fsdp_forward_prefetch`<br>`--fsdp_backward_prefetch`<br>None | `true`<br>`BACKWARD_PRE` | <br><br>?? check for DS
+pipeline | FSDP<br><br>DeepSpeed | `--fsdp_forward_prefetch`<br>`--fsdp_backward_prefetch`<br>None | `true`<br>`BACKWARD_PRE` | <br><br>
 model | FSDP<br><br>DeepSpeed |  `--fsdp_auto_wrap_policy`<br><span style="white-space:nowrap;">`--fsdp_transformer_layer_cls_to_wrap`</span><br>None | `TRANSFORMER_BASED_WRAP`<br><Layer Class> |<br>Usually not needed <br>Transparent to user.
 parameters summoning | FSDP<br>DeepSpeed | `--fsdp_use_orig_params`<br>None | `true` | required for `torch.compile`<br>Transparent to user
-parameters syncing | FSDP<br>DeepSpeed | `--fsdp_sync_module_states`<br>None | `true` | <br>?? Need to check
+parameters syncing | FSDP<br>DeepSpeed | `--fsdp_sync_module_states`<br>None | `true` | 
 training | FSDP<br>DeepSpeed | None<br>`--gradient_accumulation_steps`<br>`--gradient_clipping` | <br>`auto`<br>`auto` | Transparent to user
 
-We reiterate again that for all possible settings for the above, refer to [`Accelerate` launch documentation](../package_reference/cli#accelerate-launch).
+For detailed descriptions of the above, refer to [🤗 `Accelerate` launch documentation](../package_reference/cli#accelerate-launch).
 
 <Tip>
 
     To access other DeepSpeed configurations, such as mixed precision settings, 
-    one has to link a `deepspeed_config_file`, see [instructions here](../usage_guides/deepspeed#deepspeed-config-file).  
+    you need to link a `deepspeed_config_file`, see the [documentation](../usage_guides/deepspeed#deepspeed-config-file).  
     
 </Tip>
 
-<!--
-
-TODO: Consider elaborating on some points ? Maybe a small subsection for each?
-- do I need to talk about bucketing in DS? this is how DS takes care of partitioning in an automatic manner without the wrap policy. Do I need to explain FSDP wrapping causes graph breaks in torch.compile and how this is being resolved?
-- how does DS take care of pipelining? I need to check further.
-- do we need to discuss parameter summoning for DS? maybe not because this is an advanced usage
-- should we discusss activation checkpointing in the configs or is this obvious?
-
--->
-
 **Checkpointing**
 
-While FSDP can be configured via `--fsdp_state_dict_type` to save full / sharded checkpoints, DeepSpeed [saves sharded checkpoints by default](https://deepspeed.readthedocs.io/en/latest/model-checkpointing.html#saving-training-checkpoints).
+Do note that while FSDP can be configured via `--fsdp_state_dict_type` to save either full / sharded checkpoints, but DeepSpeed [only saves sharded checkpoints](https://deepspeed.readthedocs.io/en/latest/model-checkpointing.html#saving-training-checkpoints).
 
 <Tip>
 
-    For DeepSpeed Zero3, it is recommended to also pass a `--zero3_save_16bit_model: true` in the [`Accelerate` launch arguments](../package_reference/cli#accelerate-launch) that is typically faster.
+    For DeepSpeed Zero3, it is recommended to also pass a `--zero3_save_16bit_model true` in the [`Accelerate` launch arguments](../package_reference/cli#accelerate-launch) as this is typically much more efficient.
+
+</Tip>
+
+**Offloading**
+
+FSDP only allows *all-or-nothing* offload, but DeepSpeed can offload parameters and optimizer differently. Furthermore, DeepSpeed also supports [offloading to NVME](https://www.deepspeed.ai/docs/config-json/#parameter-offloading).
+
+**Prefetching**
+
+FSDP allows two prefetching configurations `--fsdp_forward_prefetch` and `--fsdp_backward_prefetch` to improve overlap of comms / computation at a cost of extra memory, see [FSDP documentation](https://pytorch.org/docs/stable/fsdp.html). 
+For DeepSpeed, the prefetching is always on, and only certain hyperparams like `stage3_prefetch_bucket_size` [can be configured for Zero3](https://www.deepspeed.ai/docs/config-json/#parameter-offloading); 🤗 [`accelerate`] will set these hyperparams automatically.
+
+<Tip>
+
+    For FSDP set `fsdp_backward_prefetch: BACKWARD_PRE` for improved throughputs if memory allows.
 
 </Tip>
 
 **Model Loading**
 
-While FSDP require an explicit `--fsdp_cpu_ram_efficient_loading: True` flag to activate efficient model loading, `transformers` will activate the similar feature whenever DeepSpeed Zero3 is used.
+While FSDP require an explicit `--fsdp_cpu_ram_efficient_loading true` to activate efficient model loading, 🤗 `transformers` will activate the similar feature whenever DeepSpeed Zero3 is used.
 
 <Tip>
 
-    For FSDP if you set `fsdp_cpu_ram_efficient_loading: True`, also set `fsdp_sync_module_states: True` otherwise the model will not load properly.
+    For FSDP, whenever setting `--fsdp_cpu_ram_efficient_loading true`, please also set `--fsdp_sync_module_states true`, otherwise the model will not load properly. 
 
 </Tip>
 
@@ -99,11 +100,11 @@ FSDP requires an explicit `--fsdp_auto_wrap_policy` for the algorithm to decide 
 
 **Parameters Summoning**
 
-FSDP requires an explicit `--fsdp_use_orig_params` flag if using `torch.compile`; this is required so [`torch.dynamo`] can properly parse the model. For DeepSpeed this is transparent to the user.
+FSDP requires an explicit `--fsdp_use_orig_params` flag if using `torch.compile`, see [the pytorch documenation](https://pytorch.org/docs/stable/fsdp.html#module-torch.distributed.fsdp). For DeepSpeed this is transparent to the user.
 
 <Tip>
 
-    For FSDP when using `torch.compile` set `fsdp_use_orig_params: True`.
+    For FSDP, when using `torch.compile` please set `fsdp_use_orig_params: True`.
 
 </Tip>
 
@@ -119,13 +120,9 @@ Deepspeed requires explicit `--gradient_accumulation_steps` and `--gradient_clip
 </Tip>
 
 
-## On Data Precision
+## On Differences in Data Precision Handling
 
-To discuss the how data precision is handled in both FSDP and Deepspeed, it is instructive to first give a flow of how model parameters are handled in these frameworks. Before the model / optimizer parameters are distributed across GPUs, parameter preparation is involved to first "flatten" them to  one-dimensional [`torch.Tensor`]'s. The implementation of FSDP / DeepSpeed varies in the respect of the `dtype` in which these "flattened" parameters are stored, and there are ramifications with regards to how [`torch.Optimizer`]'s allocate their `dtypes`'s. The table below outlines the processes for both frameworks; the "Local" column indicates the process occurring at a per-gpu level, therefore any memory overheads by upcasting should be understood to be amortized by the number of gpus used.
-
-<!--
-TODO: for FSDP there are some mixed precision settings like `keep_low_precision_grads`, should we discuss them? NVM, because they way huggingface prepares the model, keep_low_precision_grads will never need to be used
--->
+To discuss the how data precision is handled in both FSDP and Deepspeed, it is instructive to first give a flow of how model parameters are handled in these frameworks. Before the model / optimizer parameters are distributed across GPUs, parameter preparation is involved to first "flatten" them to  one-dimensional [`torch.Tensor`](https://pytorch.org/docs/stable/tensors.html#torch-tensor)'s. The implementation of FSDP / DeepSpeed varies in the respect of the `dtype` in which these "flattened" parameters are stored, and there are ramifications with regards to how [`torch.Optimizer`](https://pytorch.org/docs/stable/optim.html#module-torch.optim)'s allocate their `dtypes`'s. The table below outlines the processes for both frameworks; the "Local" column indicates the process occurring at a per-gpu level, therefore any memory overheads by upcasting should be understood to be amortized by the number of gpus used.
 
 Process | Local | Framework | Details
 --|--|--|--
@@ -136,35 +133,25 @@ Training Step, i.e, forward, backward, reduction | | FSDP<br>DeepSpeed  | follow
 Optimizer (Pre-Step) | ✅ | FSDP<br>DeepSpeed | upcasting (if any) to `torch_dtype`<br>upcasted to `float32`
 Optimizer (Actual Step) | ✅ | FSDP<br>DeepSpeed  | occurs in `torch_dtype` <br> occurs in `float32`.
 
-
-<!--
-Both FSDP and DeepSpeed have logic for sharding/partitioning the model / optimizer parameters across GPUs; however there are some differences to be aware of. Both of these
-frameworks will create new [`torch.Tensor`]'s to hold "flattened" parameters, which will be used to instantiate the optimizers in each shard/partition. However since the [`torch.Optimizer`]'s allocate their `dtypes`'s based on the optimized parameters, it is important to note the following:
-
-For FSDP there are two options i) load and train/optimize the model in low precision, or ii) load in full precision and configure [`MixedPrecision`](https://pytorch.org/docs/stable/fsdp.html#torch.distributed.fsdp.MixedPrecision) to have activations / reduction performed in low precision. But for DeepSpeed always load the model in full precision. To summarize:
--->
-
 <Tip warning={true}>
 
-    Therefore when using DeepSpeed, one should always load the model with `torch_dtype=torch.float32`.
-
-    However if the number of GPUs are small, be aware of potentially significant memory overheads due to the "local" upcasting.
+    Therefore when using DeepSpeed a small number of GPUs, be aware of potentially significant memory overheads due to the upcasting during preperation.
 
 </Tip>
 
 <Tip warning={true}>
 
-    With FSDP it is possible to operate the [`torch.Optimizer`] in low precision `torch_dtype`, which may be helpful when using small number of GPUs.
+    With FSDP, in the absence of mixed precision, it is possible to operate the [`torch.Optimizer`](https://pytorch.org/docs/stable/optim.html#module-torch.optim) in low precision `torch_dtype`, which may be helpful when using small number of GPUs. 
 
-    And if migrating to DeepSpeed from FSDP, be aware that if `torch_dtype` had been previously set to low precision (unnecessarily, see above), it will result in non-equivalent observations since then FSDP will optimize in low precision.
+    On the other hand with mixed precision, then FSDP (like DeepSpeed) will upcast in the model preperation step (c.f. table above).
 
 </Tip>
 
 
-To clarify the above table consider the concrete examples below; the optimizer pre- and actual step combined for brevity. Thus to ensure that the same data precisions are used in both FSDP and DeepSpeed, always specify `torch_dtype=torch.float32` while calling [`AutoModel.from_pretrained`].
+To clarify the above table consider the concrete examples below; the optimizer pre- and actual step combined for brevity. With FSDP it is possible to operate in the two modes shown below, but DeepSpeed can only operate in one.
 
 Framework | Model Loading (`torch_dtype`) | Mixed Precision | Preparation (Local) | Training | Optimizer (Local)
 --|--|--|--|--|--
 FSDP | bf16 | default (none) | bf16 | bf16 | bf16
-FSDP | fp32 | bf16 | fp32 | bf16 | fp32
+FSDP | bf16 | bf16 | fp32 | bf16 | fp32
 DeepSpeed   | fp32 | bf16 | fp32 | bf16 | fp32

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 -->
 
-# Moving between FSDP And DeepSpeed (DRAFT)
+# Moving between FSDP And DeepSpeed
 
 🤗 Accelerate offers flexibilty of training frameworks, by integrating two extremely powerful tools for distributed training, namely [Pytorch FSDP](../usage_guides/fsdp.md) and [Microsoft DeepSpeed](../usage_guides/deepspeed.md). The aim of this tutorial is to draw parallels, as well as to outline potential differences, to empower the user to switch seamlessly between these two frameworks.
 
@@ -53,6 +53,14 @@ For detailed descriptions of the above, refer to [🤗 `Accelerate` launch docum
 
     To access other DeepSpeed configurations, such as mixed precision settings, 
     you need to pass in a `--deepspeed_config_file`, see the [documentation](../usage_guides/deepspeed#deepspeed-config-file).  
+
+    DeepSpeed can be also configured via [`DeepSpeedPlugin`], e.g., `DeepSpeedPlugin.zero_stage` is equivalent of `--zero_stage`, and `DeepSpeedPlugin.hf_ds_config` can be used to pass `--deepeed_config_file.`
+
+</Tip>
+
+<Tip>
+
+    FSDP can be also configured via [`FullyShardedDataParallelPlugin`], e.g., `FullyShardedDataParallelPlugin.sharding_strategy` is equivalent of `--fsdp_sharding_strategy`.
     
 </Tip>
 

--- a/docs/source/concept_guides/fsdp_and_deepspeed.md
+++ b/docs/source/concept_guides/fsdp_and_deepspeed.md
@@ -76,7 +76,7 @@ Do note that while FSDP can be configured via `--fsdp_state_dict_type` to save e
 
 ### Offloading
 
-FSDP only allows *all-or-nothing* offload, but DeepSpeed can offload parameters and optimizer differently. Furthermore, DeepSpeed also supports [offloading to NVME](https://www.deepspeed.ai/docs/config-json/#parameter-offloading).
+FSDP only allows *all-or-nothing* offload (i.e., either offload parameters, gradients, and optimizer, or keep them all in GPU), but DeepSpeed can offload parameters and optimizer differently. Furthermore, DeepSpeed also supports [offloading to NVME](https://www.deepspeed.ai/docs/config-json/#parameter-offloading).
 
 ### Prefetching
 

--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -208,6 +208,10 @@ The following arguments are only useful when `use_fsdp` is passed or Fully Shard
 * `--fsdp_transformer_layer_cls_to_wrap` (`str`) -- Transformer layer class name (case-sensitive) to wrap, e.g, `BertLayer`, `GPTJBlock`, `T5Block` ...
 * `--fsdp_backward_prefetch_policy` (`str`) -- FSDP's backward prefetch policy.
 * `--fsdp_state_dict_type` (`str`) -- FSDP's state dict type.
+* `--fsdp_forward_prefetch` (`str`) -- FSDP forward prefetch.
+* `--fsdp_use_orig_params` (`str`) -- If True, allows non-uniform `requires_grad` mixed in a FSDP unit.
+* `--fsdp_cpu_ram_efficient_loading` (`str`) - If true, only the first process loads the pretrained model checkoint while all other processes have empty weights. When using this, `--fsdp_sync_module_states` needs to True. 
+* `--fsdp_sync_module_states` (`str`) - If true, each individually wrapped FSDP unit will broadcast module parameters from rank 0.
 
 **Megatron-LM Arguments**:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1448,20 +1448,58 @@ class Accelerator:
                             auto_wrap_policy=fsdp_plugin.auto_wrap_policy,
                         )
 
-                # NOTE: do we also need to check trainer.args.bf16 and trainer.args.fp16?
-                # - check the mixed precision setting on the FSDP root wrapper.
-                if model.mixed_precision:
-                    for module in model.module():
-                        if isinstance(module, FSDP):
-                            # module.params will hold a list of FlatParameter's
-                            for param in module.params:
-                                if param.dtype != torch.float32 and param.device != torch.device("meta"):
-                                    # TODO: make the warning issue only once
-                                    warnings.warn("Training FSDP with mixed precision. Upcasting parameters to full precision.")
+                # In the event the model had been loaded in low precision, but
+                # mixed precision had also been activated, then we follow DeepSpeed's
+                # strategy to hold the parameters in full precision.
+                # - assume that trainer.args.bf16 and trainer.args.fp16 are already checked against
+                #   fsdp_plugin.mixed_precision_policy.
+                # - NOTE: we do not check the mixed_precision attribute on the FSDP root wrapper.
+                #   * this attribute will always set by init_utils.init_core_state so its always not None.
+                #   * mixed_precision.param_dtype only regards _fwd_bwd_param_dtype
+                #   * if model is loaded in 16bit, and even if mixed_precision.param_dtype is None,
+                #     we sill want to upcast the flat_param.
+                if self.mixed_precision != "no":  # if mixed precision is set
+                    for module in FSDP.fsdp_modules(model):
+                        # Referencing DeepSpeed Zero3
+                        # - in Init, params are converted to 16bit while partitioning.
+                        # - in accelerator.prepare, deepspeed.initalize is called to:
+                        #   * creates the DeepSpeeedEngine.
+                        #   * since zero_optimization() is True , calls engine._configure_zero_optimizer.
+                        #
+                        # Inside the DeepSpeed Zero3 optimizer configuration, which initalizes
+                        # DeepSpeedZeroOptimizer_Stage3, during which:
+                        #   * trainable_param_groups are obtained from the attached optimizer
+                        #     (already partitioned in 16bit).
+                        #   * then _setup_for_real_optimizer -> _create_fp32_partitions
+                        #     which performs the fp32 upcasting.
 
-                                # upcasting to float32 because we are already using mixed precision
-                                # this should be passthrough if dtype already is float32
-                                param.data = param.data.to(torch.float32)
+                        # To mimick DeepSeepds's casting in FSDP, we look at the (single) FlatParameter held
+                        # within an FSDP wrapper. This FlatParameter will be seen by the optimizer.
+                        #  - even though there is a torch.device('meta') guard below, we
+                        #    expect _init_utils._init_param_handle_from_module to already
+                        #    sync the parameter.
+
+                        if not module._has_params:
+                            continue  # skip if FSDP module not managing parameters
+                        param = module._flat_param
+                        if (
+                            param.dtype != torch.float32
+                            and param.device != torch.device("meta")
+                            and param.requires_grad
+                        ):
+                            # TODO: make the warning issue only once
+                            if self.is_main_process:
+                                warnings.warn(
+                                    f"Upcasting low precision parameters in {module.module.__class__.__name__}, "
+                                    "mixed precision is turned on: "
+                                    f"{','.join(module._flat_param._fqns)}."
+                                )
+
+                            # this works because of FSDP's _runtime_utils.lazy_init.
+                            # Have to be careful not to call anything before this that
+                            # triggers lazy_init (e.g., _is_fsdp_root).
+                            param.data = param.data.to(torch.float32)  # upcasting
+                            module._handle._orig_param_dtype = torch.float32  # update
 
                 # if the previous and current models are same, delete the previous one
                 if len(self._models) > 1 and (self._models[-2] is self._models[-1]):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1511,7 +1511,7 @@ class Accelerator:
 
                         if len(upcasted_log) > 0:
                             warnings.warn(
-                                "FSDP upcast of low precision paramters may affect precision of model checkpoints."
+                                "FSDP upcast of low precision parameters may affect the precision of model checkpoints."
                             )
 
                 # if the previous and current models are same, delete the previous one

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1490,7 +1490,7 @@ class Accelerator:
                         ):
                             # keep log of names_params that was upcasted
                             # NOTE: resorted to this because warnings.simplefilter("once") is somehow not working
-                            name_param_log = (module.module.__class__.__name__, ",".join(module._flat_param._fqns))
+                            name_param_log = (module.module.__class__.__name__, ", ".join(module._flat_param._fqns))
                             if name_param_log not in upcasted_log:
                                 upcasted_log.append(name_param_log)
 
@@ -1507,6 +1507,11 @@ class Accelerator:
                             warnings.warn(
                                 f"Upcasted low precision parameters in {name_log} because mixed precision turned on in FSDP. "
                                 f"Affects: {param_log}."
+                            )
+
+                        if len(upcasted_log) > 0:
+                            warnings.warn(
+                                "FSDP upcast of low precision paramters may affect precision of model checkpoints."
                             )
 
                 # if the previous and current models are same, delete the previous one


### PR DESCRIPTION
# What does this PR do?

This PR address the issues identified in #2624, whereby differences were found between how DeepSpeed (DS) and FSDP handle the sharded parameters during mixed precision. To address this we have:
- added logic in `accelerate.prepare` to upcast the FSDP sharded paramaters, if it has been detected that:
   1. mixed precision has been activated, and,
   2. the sharded parameters are in low precision.
- added concept guide to clarify to how DS and FSDP handles mixed precision. Also to inform that 🤗  Accelerate will upcast FSDP sharded weights.
- added warning to inform user, that if the weights were upcasted, then this will affect the precision in which the checkpoint will be saved. 

In addition to the above, we also:
- int the above mentioned concept guide, clarified the equivalences between DS and FSDP configs, enabling users to better transition between DS/FSDP.
- updated the outdated [accelerate launch cli commands](https://huggingface.co/docs/accelerate/en/package_reference/cli#accelerate-launch).

Checklist:
- [x] test with low mem 
- [x] test with `SHARD_GRAD_OP`
- [x] test with CPU offload
- ~consider the [impacts of fp8 training](https://github.com/huggingface/accelerate/issues/2624#issuecomment-2050404125) suggested by @stas00.~ Update: this has to be done later 

To test and reproduce:
-  get the FSDP/ DS accelerate configurations, and the reproduction script (call it `learning_rate_repro.py`)  [from here](https://github.com/huggingface/accelerate/issues/2624#issue-2225498257).  
- run the script with `accelerate_fspd.yaml` config and without `--bf16` flag; this gets the `bf16` case in the below plot. The script will load the model in `bfloat16` (since `load_model_dtype` was default) and **turn off mixed precision**.
```
    accelerate launch \
        --num_processes 4 \
        --config_file accelerate_fsdp.yaml \
        learning_rate_repro.py  \
          --num_train_epochs 10 \
          --output_dir './results' \
          --per_device_train_batch_size 10 \
          --lr_scheduler_type "linear" \
          --learning_rate 1e-6 \
          --logging_steps 1 \
          --save_strategy 'no' 
```
- run the same adding `--bf16` (this gets `bf16-with-mp` in the plot below). This runs `bfloat16` model in FSDP **with mixed precision**.
- run the same benchmark with a DS `accelerate_ds.yaml` config (here `--bf16` is irrelevant, DS will handle both cases similarly). 

In the plot below, we can see that with the casting logic put in:
- if we detect that the model is in low precision `bfloat16` but mixed precision is turned on (`--bf16`), then we perform the upcasting. Hence we see that the loss curves of DS and FSDP will now be the same with the added casting logic.
- *If the logic was absent*, then we would have observed that FSDP would not converge, regardless if `--bf16` had been supplied or not

**Sample of New Warnings**

We have added some logic to reduce repetitive warnings: 

```
/data/flim/accelerate/src/accelerate/accelerator.py:1492: UserWarning: Upcasting low precision parameters in MistralForCausalLM, mixed precision is turned on: model.embed_tokens.weight,model.norm.weight,lm_head.weight.
  warnings.warn(
/data/flim/accelerate/src/accelerate/accelerator.py:1492: UserWarning: Upcasting low precision parameters in MistralDecoderLayer, mixed precision is turned on: self_attn.q_proj.weight,self_attn.k_proj.weight,self_attn.v_proj.weight,self_attn.o_proj.weight,mlp.gate_proj.weight,mlp.up_proj.weight,mlp.down_proj.weight,input_layernorm.weight,post_attention_layernorm.weight.
  warnings.warn(
```

<!-- ... the second line repeats  X number of times  (once for each layer ...) -->

**Performance of low precision models under FSDP and DS and mixed precision, with the proposed casting fix** 

This was plotted when comparing FSDP (Full Shard) and DeepSpeed (Zero3)
![image](https://github.com/huggingface/accelerate/assets/8325951/15addc48-d8f6-4bfd-8acb-52305d57415c)

This was plotted when comparing FSDP in various modes, namely GradOp and CPUOffload (while full-sharding)
![image](https://github.com/huggingface/accelerate/assets/8325951/c059ec0d-8659-478c-af2f-18dda83b2354)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Tagging @stas00, @muellerzr and @pacman100  first. We can add more reviewers later.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->