### PR TITLE
Update modeling.py by adding try-catch section to skip the unavailable devices

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -811,7 +811,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                     _ = torch.tensor(0, device=torch.device("npu", i))
                     max_memory.append({i: torch.npu.mem_get_info(i)[0]})
                 except Exception:
-                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
         elif is_mlu_available():
             for i in range(torch.mlu.device_count()):
@@ -819,7 +819,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                     _ = torch.tensor(0, device=torch.device("mlu", i))
                     max_memory.append({i: torch.mlu.mem_get_info(i)[0]})
                 except Exception:
-                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
         elif is_xpu_available():
             for i in range(torch.xpu.device_count()):
@@ -827,7 +827,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                     _ = torch.tensor(0, device=torch.device("xpu", i))
                     max_memory.append({i: torch.xpu.max_memory_allocated(i)})
                 except Exception:
-                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
         else:
             for i in range(torch.cuda.device_count()):
@@ -835,7 +835,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                     _ = torch.tensor([0], device=i)
                     max_memory.append({i: torch.cuda.mem_get_info(i)[0]})
                 except Exception:
-                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
         # allocate everything in the mps device as the RAM is shared
         if is_mps_available():

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -803,27 +803,40 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     import psutil
 
     if max_memory is None:
-        if not (torch.cuda.is_available() or is_npu_available() or is_mlu_available() or is_xpu_available()):
-            max_memory = {}
-
-        else:
-            # Make sure CUDA is initialized on each GPU to have the right memory info.
-            if is_npu_available():
-                for i in range(torch.npu.device_count()):
+        max_memory = {}
+        # Make sure CUDA is initialized on each GPU to have the right memory info.
+        if is_npu_available():
+            for i in range(torch.npu.device_count()):
+                try:
                     _ = torch.tensor(0, device=torch.device("npu", i))
-                max_memory = {i: torch.npu.mem_get_info(i)[0] for i in range(torch.npu.device_count())}
-            elif is_mlu_available():
-                for i in range(torch.mlu.device_count()):
+                    max_memory.append({i: torch.npu.mem_get_info(i)[0]})
+                except Exception:
+                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    continue
+        elif is_mlu_available():
+            for i in range(torch.mlu.device_count()):
+                try:
                     _ = torch.tensor(0, device=torch.device("mlu", i))
-                max_memory = {i: torch.mlu.mem_get_info(i)[0] for i in range(torch.mlu.device_count())}
-            elif is_xpu_available():
-                for i in range(torch.xpu.device_count()):
+                    max_memory.append({i: torch.mlu.mem_get_info(i)[0]})
+                except Exception:
+                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    continue
+        elif is_xpu_available():
+            for i in range(torch.xpu.device_count()):
+                try:
                     _ = torch.tensor(0, device=torch.device("xpu", i))
-                max_memory = {i: torch.xpu.max_memory_allocated(i) for i in range(torch.xpu.device_count())}
-            else:
-                for i in range(torch.cuda.device_count()):
+                    max_memory.append({i: torch.xpu.max_memory_allocated(i)})
+                except Exception:
+                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    continue
+        else:
+            for i in range(torch.cuda.device_count()):
+                try:
                     _ = torch.tensor([0], device=i)
-                max_memory = {i: torch.cuda.mem_get_info(i)[0] for i in range(torch.cuda.device_count())}
+                    max_memory.append({i: torch.cuda.mem_get_info(i)[0]})
+                except Exception:
+                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
+                    continue
         # allocate everything in the mps device as the RAM is shared
         if is_mps_available():
             max_memory["mps"] = psutil.virtual_memory().available


### PR DESCRIPTION
# What does this PR do?
In the current implementation of the library, when deploying tensor operations across multiple GPU devices, the program attempts to initialize a tensor on each device and get maximum available memory. 
```
def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None):
        ...
                for i in range(torch.cuda.device_count()):
                    _ = torch.tensor([0], device=i)
                max_memory = {i: torch.cuda.mem_get_info(i)[0] for i in range(torch.cuda.device_count())}
```
However, this approach leads to an error and terminates the program if it encounters a GPU that is unavailable(memory fully occupied or device damaged). 

For example, this error will occur when one of the devices is fully occupied:
```
RuntimeError: CUDA error: out of memory
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
```
To address this issue, I propose a modification to the logic for determining the maximum available memory on GPUs. Specifically, I have introduced a try-except block around the tensor deployment operation. 
```
            for i in range(torch.cuda.device_count()):
                try:
                    _ = torch.tensor([0], device=i)
                    max_memory.append({i: torch.cuda.mem_get_info(i)[0]})
                except Exception:
                    logger.warning(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                    continue
```
If an error occurs due to the unavailability of a GPU, the code will now catch the exception and continue checking the next available GPU. This change ensures that the program gracefully skips over unavailable GPUs and only utilizes those that are operational.

This adjustment is intended to improve the library's usability in multi-devices.  I am open to any suggestions or further improvements from the community.

Thank you for watching this : )

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @
 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
 -->

I apologize, as I am uncertain about whom to tag. Perhaps @muellerzr or @pacman100 can review this. thx