### PR TITLE
Change dataloader send_to_device calls to non-blocking

### DIFF
--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -93,6 +93,9 @@ accelerator = Accelerator()
 > [!WARNING]
 > This step is *optional* but it is considered best practice to allow Accelerate to handle device placement. You could also deactivate automatic device placement by passing `device_placement=False` when initializing the [`Accelerator`]. If you want to explicitly place objects on a device with `.to(device)`, make sure you use `accelerator.device` instead. For example, if you create an optimizer before placing a model on `accelerator.device`, training fails on a TPU.
 
+> [!WARNING]
+> Accelerate does not use non-blocking transfers by default for its automatic device placement, which can result in potentially unwanted CUDA synchronizations.  You can enable non-blocking transfers by passing a `DataLoaderConfiguration` with `non_blocking=True` set as the `dataloader_config` when initializing the [`Accelerator`].  As usual, non-blocking transfers will only work if the dataloader also has `pin_memory=True` set.  Be wary that using non-blocking transfers from GPU to CPU may cause incorrect results if it results in CPU operations being performed on non-ready tensors.
+
 ```py
 device = accelerator.device
 ```

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -94,7 +94,7 @@ accelerator = Accelerator()
 > This step is *optional* but it is considered best practice to allow Accelerate to handle device placement. You could also deactivate automatic device placement by passing `device_placement=False` when initializing the [`Accelerator`]. If you want to explicitly place objects on a device with `.to(device)`, make sure you use `accelerator.device` instead. For example, if you create an optimizer before placing a model on `accelerator.device`, training fails on a TPU.
 
 > [!WARNING]
-> Accelerate does not use non-blocking transfers by default for its automatic device placement, which can result in potentially unwanted CUDA synchronizations.  You can enable non-blocking transfers by passing a `DataLoaderConfiguration` with `non_blocking=True` set as the `dataloader_config` when initializing the [`Accelerator`].  As usual, non-blocking transfers will only work if the dataloader also has `pin_memory=True` set.  Be wary that using non-blocking transfers from GPU to CPU may cause incorrect results if it results in CPU operations being performed on non-ready tensors.
+> Accelerate does not use non-blocking transfers by default for its automatic device placement, which can result in potentially unwanted CUDA synchronizations.  You can enable non-blocking transfers by passing a [`~utils.dataclasses.DataLoaderConfiguration`] with `non_blocking=True` set as the `dataloader_config` when initializing the [`Accelerator`].  As usual, non-blocking transfers will only work if the dataloader also has `pin_memory=True` set.  Be wary that using non-blocking transfers from GPU to CPU may cause incorrect results if it results in CPU operations being performed on non-ready tensors.
 
 ```py
 device = accelerator.device

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -562,6 +562,10 @@ class Accelerator:
         return self.dataloader_config.use_seedable_sampler
 
     @property
+    def non_blocking(self):
+        return self.dataloader_config.non_blocking
+
+    @property
     def project_dir(self):
         return self.project_configuration.project_dir
 
@@ -1926,6 +1930,7 @@ class Accelerator:
             even_batches=self.even_batches,
             slice_fn_for_dispatch=slice_fn_for_dispatch,
             use_seedable_sampler=self.use_seedable_sampler,
+            non_blocking=self.non_blocking,
         )
         self._dataloaders.append(prepared_data_loader)
         return prepared_data_loader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -580,7 +580,7 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
         _drop_last: bool = False,
         _non_blocking: bool = False,
         slice_fn=None,
-        **kwargs
+        **kwargs,
     ):
         shuffle = False
         if is_torch_version(">=", "1.11.0"):
@@ -824,7 +824,7 @@ def prepare_data_loader(
             algorithms but ensures results will be the *exact* same. Should be paired with `set_seed()` at every
             `self.set_epoch`
         non_blocking (`bool`, *optional*, defaults to `False`):
-            If set to `True`, dataloader will utilize non-blocking host-to-device transfers.  If the dataloader has
+            If set to `True`, dataloader will utilize non-blocking host-to-device transfers. If the dataloader has
             `pin_memory` set to `True`, this will help to increase overlap between data transfer and computations.
 
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -458,7 +458,7 @@ class DataLoaderShard(DataLoader, DataLoaderStateMixin):
             try:
                 # But we still move it to the device so it is done before `StopIteration` is reached
                 if self.device is not None:
-                    current_batch = send_to_device(current_batch, self.device)
+                    current_batch = send_to_device(current_batch, self.device, non_blocking=True)
                 next_batch = next(dataloader_iter)
                 if batch_index >= self.skip_batches:
                     yield current_batch
@@ -660,7 +660,7 @@ class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
             if self.state.process_index != 0:
                 # Initialize tensors on other processes than process 0.
                 batch = initialize_tensors(batch_info[0])
-            batch = send_to_device(batch, self.state.device)
+            batch = send_to_device(batch, self.state.device, non_blocking=True)
             # Broadcast the batch before splitting it.
             batch = broadcast(batch, from_process=0)
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -524,6 +524,14 @@ class DataLoaderConfiguration:
             "multiple different seeds to compare. Should also be ran with [`~utils.set_seed`] for the best results."
         },
     )
+    non_blocking: bool = field(
+        default=False,
+        metadata={
+            "help": "If set to `True`, the dataloader prepared by the Accelerator will utilize non-blocking host-to-device"
+            " transfers, allowing for better overlap between dataloader communication and computation.  Requires that the"
+            " prepared dataloader has `pin_memory` set to `True` to work properly."
+        },
+    )
 
 
 @dataclass

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -528,7 +528,7 @@ class DataLoaderConfiguration:
         default=False,
         metadata={
             "help": "If set to `True`, the dataloader prepared by the Accelerator will utilize non-blocking host-to-device"
-            " transfers, allowing for better overlap between dataloader communication and computation.  Requires that the"
+            " transfers, allowing for better overlap between dataloader communication and computation.  Recommended that the"
             " prepared dataloader has `pin_memory` set to `True` to work properly."
         },
     )


### PR DESCRIPTION
# What does this PR do?

Currently, it seems that even with pinned memory enabled on the dataloader, iterating over the dataloader causes a cudaStreamSynchronize call:

![image](https://github.com/huggingface/accelerate/assets/1313496/1e356748-49fb-46e0-b812-fec77e598ef1)

This is a devastating hit to performance if you are trying to overlap any other asynchronous transfers with your computations (such as offloading optimizer/EMA states), since it appears to be waiting for all async transfers to complete before continuing.

Setting these operations to be non-blocking, as well as using pinned memory for the dataloader, gets rid of the offending call:
![image](https://github.com/huggingface/accelerate/assets/1313496/4876b3cb-de20-46f4-ac6d-b7cadf6e1507)
(the timescale is very different here, this one is a fraction of a millisecond whereas the previous screenshot highlights a period of roughly one entire second)

With this, the tensors should only get forcibly synced when they are about to be used, and other non-blocking transfers will be left alone.  When I made this change, I had a noticeable speedup in my training loop where I am offloading an EMA state (3s/it -> 2.5s/it).

This also shouldn't cause issues when not using pinned memory.  It will just do a normal synchronous transfer as before.  The `send_to_device` utility function also has handling built in for any case where `Tensor.to()` does not accept `non_blocking` as an argument for whatever reason.  There shouldn't be any downsides to this change, as a result, so I don't see any reason to leave it as anything but a fixed value of True.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

- Core parts of the library: @muellerzr @BenjaminBossan