### PR TITLE
Fix access error for torch.mps when using torch==1.13.1 on macOS

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -63,7 +63,7 @@ def get_backend():
     elif is_cuda_available():
         return "cuda", torch.cuda.device_count(), torch.cuda.memory_allocated
     elif is_mps_available():
-        return "mps", 1, torch.mps.current_allocated_memory() if hasattr(torch, "mps") else 0
+        return "mps", 1, (torch.mps.current_allocated_memory() if hasattr(torch, "mps") else 0)
     elif is_mlu_available():
         return "mlu", torch.mlu.device_count(), torch.mlu.memory_allocated
     elif is_npu_available():

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -63,7 +63,7 @@ def get_backend():
     elif is_cuda_available():
         return "cuda", torch.cuda.device_count(), torch.cuda.memory_allocated
     elif is_mps_available():
-        return "mps", 1, torch.mps.current_allocated_memory()
+        return "mps", 1, torch.mps.current_allocated_memory() if hasattr(torch, "mps") else 0
     elif is_mlu_available():
         return "mlu", torch.mlu.device_count(), torch.mlu.memory_allocated
     elif is_npu_available():

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -60,7 +60,8 @@ def release_memory(*objects):
     elif is_npu_available():
         torch.npu.empty_cache()
     elif is_mps_available():
-        torch.mps.empty_cache()
+        if hasattr(torch, "mps"):
+            torch.mps.empty_cache()
     else:
         torch.cuda.empty_cache()
     return objects


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

When I run `accelerate` using `torch==1.13.1` on my macbook, I get:

```
        elif is_mps_available():
>           torch.mps.empty_cache()
E           AttributeError: module 'torch' has no attribute 'mps'
```

You can see the `torch.mps` module and the functions backing `torch.mps.empty_cache()` and `torch.mps.current_allocated_memory()` were not added until torch 2.0.0, whereas MPS support was added in 1.12.1:

https://github.com/pytorch/pytorch/blob/v1.13.1/torch/mps/__init__.py
https://github.com/pytorch/pytorch/blob/v1.13.1/torch/_C/__init__.pyi.in

So it is not safe to just use `is_mps_available()` to know if you can access `torch.mps`, you actually have to check if it exists before accessing it. There are plenty of other places where `is_mps_available()` is used and `torch.mps` is not accessed, so I don't think we should change its definition.

Ideally, `accelerate` would commit to running at least one 1.13.1 mac CI build, although I know it may not be feasible. The conditions I added appear to cover every access of `torch.mps`, but without the build, it seems likely there will be additional regressions.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?

## Who can review?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->

@muellerzr
@amyeroberts 