### PR TITLE
Fix the rng states of sampler's generator to be synchronized for correct sharding of dataset across GPUs

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -901,6 +901,10 @@ def prepare_data_loader(
                 split_batches=split_batches,
             )
         else:
+            if not use_seedable_sampler and hasattr(sampler, "generator"):
+                if sampler.generator is None:
+                    sampler.generator = torch.Generator()
+                synchronized_generator = sampler.generator
             batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler
             new_batch_sampler = BatchSamplerShard(
                 batch_sampler,


### PR DESCRIPTION
# What does this PR do?
1. Fix the rng states of sampler's generator to be synchronized for correct sharding of dataset across GPUs

Example:
1. Code:
```
import torch
from torch.utils.data import default_collate,default_convert, Dataset, DataLoader, BatchSampler, RandomSampler, SequentialSampler
import numpy
import accelerate
from accelerate import Accelerator
from accelerate.utils import set_seed
from accelerate.utils.random import synchronize_rng_state
from accelerate.utils.dataclasses import DistributedType, RNGType
import os
import sys
import platform

class MyDataset(Dataset):
    def __len__(self):
        return 22
    
    def __getitem__(self, index):
#         print("MyDataset __getitem__", index)

        squeeze = False

        if isinstance(index, int):
            index = [index]
            squeeze = True
        elif isinstance(index, slice):
            index = list(range(*index.indices(self.size)))
        else:
            index = list(index)

        batch = [{"index": i, "label": i % 2, "random_augmentation": torch.rand(1).item()} for i in index]
#         print(batch)

        if squeeze:
            batch = batch[0]

        return batch
    

if __name__ == "__main__":
    
    num_workers = 4
    dataset = MyDataset()
    accelerator = Accelerator()
    torch.manual_seed(accelerator.process_index)
    
    accelerator.print("Starting conventional Dataloader with shuffle=False. Eval mode in general")
    loader = DataLoader(dataset, shuffle=False, batch_size=4, num_workers=num_workers)
    loader = accelerator.prepare(loader)
    all_examples = []
    for i, batch in enumerate(loader):
        print(f"{accelerator.process_index} | batch #{i} = {batch}")
        index, label = accelerator.gather_for_metrics((batch["index"], batch["label"]))
        all_examples.extend(index.detach().cpu().numpy().tolist())
        accelerator.print(f"{accelerator.process_index} | gathered batch #{i} | index = {index}, label = {label}")
    accelerator.print(f"{sorted(all_examples)=}")
    accelerator.print("Ending conventional Dataloader with shuffle=False. Eval mode in general")
    accelerator.print()
    accelerator.print()
    
    accelerator.print("Starting conventional Dataloader with shuffle=True")
    loader = DataLoader(dataset, shuffle=True, batch_size=4, num_workers=num_workers)
    loader = accelerator.prepare(loader)
    all_examples = []
    for i, batch in enumerate(loader):
        print(f"{accelerator.process_index} | batch #{i} = {batch}")
        index, label = accelerator.gather_for_metrics((batch["index"], batch["label"]))
        all_examples.extend(index.detach().cpu().numpy().tolist())
        accelerator.print(f"{accelerator.process_index} | gathered batch #{i} | index = {index}, label = {label}")
    accelerator.print(f"{sorted(all_examples)=}")
    accelerator.print("Ending conventional Dataloader with shuffle=True")
    accelerator.print()
    accelerator.print()
    
    accelerator.print("Starting Dataloader with batch_sampler=BatchSampler()")
    sampler = BatchSampler(RandomSampler(dataset), batch_size=4, drop_last=False)
    loader = DataLoader(dataset, batch_sampler=sampler, num_workers=num_workers)
    loader = accelerator.prepare(loader)
    all_examples = []
    for i, batch in enumerate(loader):
        print(f"{accelerator.process_index} | batch #{i} = {batch}")
        index, label = accelerator.gather_for_metrics((batch["index"], batch["label"]))
        all_examples.extend(index.detach().cpu().numpy().tolist())
        accelerator.print(f"{accelerator.process_index} | gathered batch #{i} | index = {index}, label = {label}")
    accelerator.print(f"{sorted(all_examples)=}")
    accelerator.print("Ending Dataloader with batch_sampler=BatchSampler()")
    accelerator.print()
    accelerator.print()
    
    accelerator.print("Starting Dataloader with sampler=BatchSampler()")
    sampler = BatchSampler(RandomSampler(dataset), batch_size=4, drop_last=False)
    loader = DataLoader(dataset, sampler=sampler, batch_size=None, collate_fn=default_collate, num_workers=num_workers)
    loader = accelerator.prepare(loader)
    all_examples = []
    for i, batch in enumerate(loader):
        print(f"{accelerator.process_index} | batch #{i} = {batch}")
        index, label = accelerator.gather_for_metrics((batch["index"], batch["label"]))
        all_examples.extend(index.detach().cpu().numpy().tolist())
        accelerator.print(f"{accelerator.process_index} | gathered batch #{i} | index = {index}, label = {label}")
    accelerator.print(f"{sorted(all_examples)=}")
    accelerator.print("Ending Dataloader with sampler=BatchSampler()")
```

2. Run:
```
accelerate launch --multi_gpu --num_processes 2 temp/dataloader_test.py
```

3. Output logs:
```
Starting conventional Dataloader with shuffle=False. Eval mode in general
0 | batch #0 = {'index': tensor([0, 1, 2, 3], device='cuda:0'), 'label': tensor([0, 1, 0, 1], device='cuda:0'), 'random_augmentation': tensor([0.7821, 0.0536, 0.9888, 0.1949], device='cuda:0', dtype=torch.float64)}
1 | batch #0 = {'index': tensor([4, 5, 6, 7], device='cuda:1'), 'label': tensor([0, 1, 0, 1], device='cuda:1'), 'random_augmentation': tensor([0.5113, 0.2310, 0.6590, 0.7075], device='cuda:1', dtype=torch.float64)}
0 | gathered batch #0 | index = tensor([0, 1, 2, 3, 4, 5, 6, 7], device='cuda:0'), label = tensor([0, 1, 0, 1, 0, 1, 0, 1], device='cuda:0')
1 | batch #1 = {'index': tensor([12, 13, 14, 15], device='cuda:1'), 'label': tensor([0, 1, 0, 1], device='cuda:1'), 'random_augmentation': tensor([0.3023, 0.8598, 0.0777, 0.6678], device='cuda:1', dtype=torch.float64)}
0 | batch #1 = {'index': tensor([ 8,  9, 10, 11], device='cuda:0'), 'label': tensor([0, 1, 0, 1], device='cuda:0'), 'random_augmentation': tensor([0.6938, 0.2980, 0.1669, 0.2847], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #1 | index = tensor([ 8,  9, 10, 11, 12, 13, 14, 15], device='cuda:0'), label = tensor([0, 1, 0, 1, 0, 1, 0, 1], device='cuda:0')
1 | batch #2 = {'index': tensor([20, 21,  0,  1], device='cuda:1'), 'label': tensor([0, 1, 0, 1], device='cuda:1'), 'random_augmentation': tensor([0.4550, 0.6276, 0.2961, 0.1046], device='cuda:1', dtype=torch.float64)}
0 | batch #2 = {'index': tensor([16, 17, 18, 19], device='cuda:0'), 'label': tensor([0, 1, 0, 1], device='cuda:0'), 'random_augmentation': tensor([0.6540, 0.2994, 0.2798, 0.5160], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #2 | index = tensor([16, 17, 18, 19, 20, 21], device='cuda:0'), label = tensor([0, 1, 0, 1, 0, 1], device='cuda:0')
sorted(all_examples)=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
Ending conventional Dataloader with shuffle=False. Eval mode in general


Starting conventional Dataloader with shuffle=True
0 | batch #0 = {'index': tensor([ 8,  6, 19, 18], device='cuda:0'), 'label': tensor([0, 0, 1, 0], device='cuda:0'), 'random_augmentation': tensor([0.6428, 0.8767, 0.2868, 0.8217], device='cuda:0', dtype=torch.float64)}
1 | batch #0 = {'index': tensor([13, 12,  0, 21], device='cuda:1'), 'label': tensor([1, 0, 0, 1], device='cuda:1'), 'random_augmentation': tensor([0.3477, 0.5812, 0.9468, 0.7082], device='cuda:1', dtype=torch.float64)}
0 | gathered batch #0 | index = tensor([ 8,  6, 19, 18, 13, 12,  0, 21], device='cuda:0'), label = tensor([0, 0, 1, 0, 1, 0, 0, 1], device='cuda:0')
1 | batch #1 = {'index': tensor([ 2, 20,  3, 17], device='cuda:1'), 'label': tensor([0, 0, 1, 1], device='cuda:1'), 'random_augmentation': tensor([0.4607, 0.4023, 0.4945, 0.9562], device='cuda:1', dtype=torch.float64)}
0 | batch #1 = {'index': tensor([15,  7,  5,  9], device='cuda:0'), 'label': tensor([1, 1, 1, 1], device='cuda:0'), 'random_augmentation': tensor([0.0631, 0.1480, 0.5031, 0.1961], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #1 | index = tensor([15,  7,  5,  9,  2, 20,  3, 17], device='cuda:0'), label = tensor([1, 1, 1, 1, 0, 0, 1, 1], device='cuda:0')
1 | batch #2 = {'index': tensor([16, 11,  8,  6], device='cuda:1'), 'label': tensor([0, 1, 0, 0], device='cuda:1'), 'random_augmentation': tensor([0.6213, 0.1756, 0.9498, 0.2625], device='cuda:1', dtype=torch.float64)}
0 | batch #2 = {'index': tensor([14, 10,  4,  1], device='cuda:0'), 'label': tensor([0, 0, 0, 1], device='cuda:0'), 'random_augmentation': tensor([0.1110, 0.0218, 0.8730, 0.2692], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #2 | index = tensor([14, 10,  4,  1, 16, 11], device='cuda:0'), label = tensor([0, 0, 0, 1, 0, 1], device='cuda:0')
sorted(all_examples)=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
Ending conventional Dataloader with shuffle=True


Starting Dataloader with batch_sampler=BatchSampler()
1 | batch #0 = {'index': tensor([13, 12,  0, 21], device='cuda:1'), 'label': tensor([1, 0, 0, 1], device='cuda:1'), 'random_augmentation': tensor([0.6874, 0.2763, 0.0351, 0.2464], device='cuda:1', dtype=torch.float64)}
0 | batch #0 = {'index': tensor([ 8,  6, 19, 18], device='cuda:0'), 'label': tensor([0, 0, 1, 0], device='cuda:0'), 'random_augmentation': tensor([0.7514, 0.5174, 0.8544, 0.2775], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #0 | index = tensor([ 8,  6, 19, 18, 13, 12,  0, 21], device='cuda:0'), label = tensor([0, 0, 1, 0, 1, 0, 0, 1], device='cuda:0')
1 | batch #1 = {'index': tensor([ 2, 20,  3, 17], device='cuda:1'), 'label': tensor([0, 0, 1, 1], device='cuda:1'), 'random_augmentation': tensor([0.1724, 0.2674, 0.2993, 0.4871], device='cuda:1', dtype=torch.float64)}
0 | batch #1 = {'index': tensor([15,  7,  5,  9], device='cuda:0'), 'label': tensor([1, 1, 1, 1], device='cuda:0'), 'random_augmentation': tensor([0.1679, 0.6141, 0.1338, 0.5165], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #1 | index = tensor([15,  7,  5,  9,  2, 20,  3, 17], device='cuda:0'), label = tensor([1, 1, 1, 1, 0, 0, 1, 1], device='cuda:0')
1 | batch #2 = {'index': tensor([16, 11,  8,  6], device='cuda:1'), 'label': tensor([0, 1, 0, 0], device='cuda:1'), 'random_augmentation': tensor([0.6530, 0.2832, 0.4021, 0.6125], device='cuda:1', dtype=torch.float64)}
0 | batch #2 = {'index': tensor([14, 10,  4,  1], device='cuda:0'), 'label': tensor([0, 0, 0, 1], device='cuda:0'), 'random_augmentation': tensor([0.3018, 0.2774, 0.3048, 0.7736], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #2 | index = tensor([14, 10,  4,  1, 16, 11], device='cuda:0'), label = tensor([0, 0, 0, 1, 0, 1], device='cuda:0')
sorted(all_examples)=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
Ending Dataloader with batch_sampler=BatchSampler()


Starting Dataloader with sampler=BatchSampler()
1 | batch #0 = {'index': tensor([13, 12,  0, 21], device='cuda:1'), 'label': tensor([1, 0, 0, 1], device='cuda:1'), 'random_augmentation': tensor([0.5130, 0.3116, 0.6127, 0.5772], device='cuda:1', dtype=torch.float64)}
0 | batch #0 = {'index': tensor([ 8,  6, 19, 18], device='cuda:0'), 'label': tensor([0, 0, 1, 0], device='cuda:0'), 'random_augmentation': tensor([0.2295, 0.3469, 0.4031, 0.0229], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #0 | index = tensor([ 8,  6, 19, 18, 13, 12,  0, 21], device='cuda:0'), label = tensor([0, 0, 1, 0, 1, 0, 0, 1], device='cuda:0')
1 | batch #1 = {'index': tensor([ 2, 20,  3, 17], device='cuda:1'), 'label': tensor([0, 0, 1, 1], device='cuda:1'), 'random_augmentation': tensor([0.1195, 0.5409, 0.9639, 0.6952], device='cuda:1', dtype=torch.float64)}
0 | batch #1 = {'index': tensor([15,  7,  5,  9], device='cuda:0'), 'label': tensor([1, 1, 1, 1], device='cuda:0'), 'random_augmentation': tensor([0.9403, 0.9529, 0.5809, 0.5221], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #1 | index = tensor([15,  7,  5,  9,  2, 20,  3, 17], device='cuda:0'), label = tensor([1, 1, 1, 1, 0, 0, 1, 1], device='cuda:0')
1 | batch #2 = {'index': tensor([16, 11,  8,  6], device='cuda:1'), 'label': tensor([0, 1, 0, 0], device='cuda:1'), 'random_augmentation': tensor([0.9050, 0.7603, 0.9795, 0.6661], device='cuda:1', dtype=torch.float64)}
0 | batch #2 = {'index': tensor([14, 10,  4,  1], device='cuda:0'), 'label': tensor([0, 0, 0, 1], device='cuda:0'), 'random_augmentation': tensor([0.4820, 0.9801, 0.8129, 0.6514], device='cuda:0', dtype=torch.float64)}
0 | gathered batch #2 | index = tensor([14, 10,  4,  1, 16, 11], device='cuda:0'), label = tensor([0, 0, 0, 1, 0, 1], device='cuda:0')
sorted(all_examples)=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21]
Ending Dataloader with sampler=BatchSampler()

```