### PR TITLE
Block AMP for MPS device 

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -457,7 +457,7 @@ class Accelerator:
             and self.distributed_type not in (DistributedType.DEEPSPEED, DistributedType.MEGATRON_LM)
         ):
             self.native_amp = True
-            if self.device.type not in ("xpu", "cuda", "mps", "npu", "xla", "mlu") or is_torch_xla_available(
+            if self.device.type not in ("xpu", "cuda", "npu", "xla", "mlu") or is_torch_xla_available(
                 check_is_tpu=True
             ):
                 raise ValueError(f"fp16 mixed precision requires a GPU (not {self.device.type!r}).")

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -179,6 +179,8 @@ def is_bf16_available(ignore_tpu=False):
         return not ignore_tpu
     if is_cuda_available():
         return torch.cuda.is_bf16_supported()
+    if is_mps_available():
+        return False
     return True
 
 


### PR DESCRIPTION
# What does this PR do ? 
This PR fixes the support of AMP with mps. It was never supported in the first place. When this [PR](https://github.com/pytorch/pytorch/pull/99272) from pytorch gets merged, we can revert this PR. However, one can safely load a model in bf16 or fp16 with mps device with the latest torch. 

Fixes https://github.com/huggingface/accelerate/issues/2693