### PR TITLE
allow gather_for_metrics to be more flexible

### DIFF
--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -124,7 +124,7 @@ To perform distributed evaluation, pass your validation dataloader to the [`~Acc
 validation_dataloader = accelerator.prepare(validation_dataloader)
 ```
 
-Each device in your distributed setup only receives a part of the evaluation data, which means you should group your predictions together with the [`~Accelerator.gather_for_metrics`] method. This method requires all tensors to be the same size on each process, so if your tensors have different sizes on each process (for instance when dynamically padding to the maximum length in a batch), you should use the [`~Accelerator.pad_across_processes`] method to pad you tensor to the largest size across processes.
+Each device in your distributed setup only receives a part of the evaluation data, which means you should group your predictions together with the [`~Accelerator.gather_for_metrics`] method. This method requires all tensors to be the same size on each process, so if your tensors have different sizes on each process (for instance when dynamically padding to the maximum length in a batch), you should use the [`~Accelerator.pad_across_processes`] method to pad you tensor to the largest size across processes. Note that the tensors needs to be 1D and that we concatenate the tensors along the first dimension. 
 
 ```python
 for inputs, targets in validation_dataloader:
@@ -133,6 +133,11 @@ for inputs, targets in validation_dataloader:
     all_predictions, all_targets = accelerator.gather_for_metrics((predictions, targets))
     # Example of use with a *Datasets.Metric*
     metric.add_batch(all_predictions, all_targets)
+```
+
+For more complex cases (e.g. 2D tensors, don't want to concatenate tensors, dict of 3D tensors), you can pass `use_gather_object=True`. This will return the list of objects after gathering. Note that using it with GPU tensors is not well supported and inefficient.
+```python
+all_predictions, all_targets = accelerator.gather_for_metrics((predictions, targets), use_gather_object=True)
 ```
 
 > [!TIP]

--- a/docs/source/quicktour.md
+++ b/docs/source/quicktour.md
@@ -135,10 +135,7 @@ for inputs, targets in validation_dataloader:
     metric.add_batch(all_predictions, all_targets)
 ```
 
-For more complex cases (e.g. 2D tensors, don't want to concatenate tensors, dict of 3D tensors), you can pass `use_gather_object=True`. This will return the list of objects after gathering. Note that using it with GPU tensors is not well supported and inefficient.
-```python
-all_predictions, all_targets = accelerator.gather_for_metrics((predictions, targets), use_gather_object=True)
-```
+For more complex cases (e.g. 2D tensors, don't want to concatenate tensors, dict of 3D tensors), you can pass `use_gather_object=True` in `gather_for_metrics`. This will return the list of objects after gathering. Note that using it with GPU tensors is not well supported and inefficient.
 
 > [!TIP]
 > Data at the end of a dataset may be duplicated so the batch can be equally divided among all workers. The [`~Accelerator.gather_for_metrics`] method automatically removes the duplicated data to calculate a more accurate metric.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2296,7 +2296,7 @@ class Accelerator:
                         "The used dataset had no length, returning gathered tensors. You should drop the remainder yourself."
                     )
                     return data
-                elif self.gradient_state.remainder > 0 and self.distributed_type != DistributedType.NO:
+                elif self.gradient_state.remainder > 0:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
                         return tensor[: self.gradient_state.remainder]

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2299,6 +2299,7 @@ class Accelerator:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
                         return tensor[: self.gradient_state.remainder]
+
                     if use_gather_oject:
                         # gather_object put the objects in a list
                         return _adjust_samples(data)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2243,7 +2243,7 @@ class Accelerator:
         """
         return gather(tensor)
 
-    def gather_for_metrics(self, input_data, use_gather_oject=False):
+    def gather_for_metrics(self, input_data, use_gather_object=False):
         """
         Gathers `input_data` and potentially drops duplicates in the last batch if on a distributed system. Should be
         used for gathering the inputs and targets for metric calculation.
@@ -2280,7 +2280,7 @@ class Accelerator:
         except TypeError:
             all_tensors = False
 
-        use_gather_oject = use_gather_oject or not all_tensors
+        use_gather_oject = use_gather_object or not all_tensors
 
         if use_gather_oject:
             data = gather_object(input_data)
@@ -2301,7 +2301,7 @@ class Accelerator:
                     def _adjust_samples(tensor):
                         return tensor[: self.gradient_state.remainder]
 
-                    if use_gather_oject:
+                    if use_gather_object:
                         # gather_object put the objects in a list
                         return _adjust_samples(data)
                     else:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2243,7 +2243,7 @@ class Accelerator:
         """
         return gather(tensor)
 
-    def gather_for_metrics(self, input_data, use_gather_object=False):
+    def gather_for_metrics(self, input_data, use_gather_oject=False):
         """
         Gathers `input_data` and potentially drops duplicates in the last batch if on a distributed system. Should be
         used for gathering the inputs and targets for metric calculation.
@@ -2279,7 +2279,7 @@ class Accelerator:
         except TypeError:
             all_tensors = False
 
-        use_gather_oject = use_gather_object or not all_tensors
+        use_gather_oject = use_gather_oject or not all_tensors
 
         if use_gather_oject:
             data = gather_object(input_data)
@@ -2298,11 +2298,6 @@ class Accelerator:
                 elif self.gradient_state.remainder > 0 and self.distributed_type != DistributedType.NO:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
-                        if tensor.dim > 1 and not use_gather_object:
-                            logger.warning_once("You are using `gather_for_metrics` on a tensor that is not 1D."
-                                                "This is not supported and you might get unexpected results with the last batch."
-                                                "As an alternative, you can pass `use_gather_object=True` in `gather_for_metrics`"
-                                                "or drop the last batch.")
                         return tensor[: self.gradient_state.remainder]
 
                     if use_gather_oject:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2252,9 +2252,10 @@ class Accelerator:
             input (`torch.Tensor`, `object`, a nested tuple/list/dictionary of `torch.Tensor`, or a nested tuple/list/dictionary of `object`):
                 The tensors or objects for calculating metrics across all processes
             use_gather_object(`bool`):
-                Whether to use or not gather_object instead of gather. This flag can be useful for gathering tensors with different sizes
-                that we don't want to pad and concatenate along the first dimension. Using it with GPU tensors is not well supported and inefficient as
-                it incurs GPU -> CPU transfer since tensors would be pickled.
+                Whether to use or not gather_object instead of gather. This flag can be useful for gathering tensors
+                with different sizes that we don't want to pad and concatenate along the first dimension. Using it with
+                GPU tensors is not well supported and inefficient as it incurs GPU -> CPU transfer since tensors would
+                be pickled.
 
         Example:
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2280,9 +2280,9 @@ class Accelerator:
         except TypeError:
             all_tensors = False
 
-        use_gather_oject = use_gather_object or not all_tensors
+        use_gather_object = use_gather_object or not all_tensors
 
-        if use_gather_oject:
+        if use_gather_object:
             data = gather_object(input_data)
         else:
             data = self.gather(input_data)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2243,7 +2243,7 @@ class Accelerator:
         """
         return gather(tensor)
 
-    def gather_for_metrics(self, input_data):
+    def gather_for_metrics(self, input_data, use_gather_oject=False):
         """
         Gathers `input_data` and potentially drops duplicates in the last batch if on a distributed system. Should be
         used for gathering the inputs and targets for metric calculation.
@@ -2251,6 +2251,10 @@ class Accelerator:
         Args:
             input (`torch.Tensor`, `object`, a nested tuple/list/dictionary of `torch.Tensor`, or a nested tuple/list/dictionary of `object`):
                 The tensors or objects for calculating metrics across all processes
+            use_gather_oject(`bool`):
+                Whether to use or not gather_object instead of gather. This flag can be useful for gathering tensors with different sizes
+                that we don't want to pad and concatenate along the first dimension. Using it with GPU tensors is not well supported and inefficient as
+                it incurs GPU -> CPU transfer since tensors would be pickled.
 
         Example:
 
@@ -2275,7 +2279,9 @@ class Accelerator:
         except TypeError:
             all_tensors = False
 
-        if not all_tensors:
+        use_gather_oject = use_gather_oject or not all_tensors
+
+        if use_gather_oject:
             data = gather_object(input_data)
         else:
             data = self.gather(input_data)
@@ -2289,12 +2295,15 @@ class Accelerator:
                         "The used dataset had no length, returning gathered tensors. You should drop the remainder yourself."
                     )
                     return data
-                elif self.gradient_state.remainder > 0:
+                elif self.gradient_state.remainder > 0 and self.distributed_type != DistributedType.NO:
                     # Last batch needs to be truncated on distributed systems as it contains additional samples
                     def _adjust_samples(tensor):
                         return tensor[: self.gradient_state.remainder]
-
-                    return recursively_apply(_adjust_samples, data)
+                    if use_gather_oject:
+                        # gather_object put the objects in a list
+                        return _adjust_samples(data)
+                    else:
+                        return recursively_apply(_adjust_samples, data)
                 else:  # remainder is 0
                     # no remainder even though at end of dataloader, so nothing to do.
                     return data

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2252,10 +2252,10 @@ class Accelerator:
             input (`torch.Tensor`, `object`, a nested tuple/list/dictionary of `torch.Tensor`, or a nested tuple/list/dictionary of `object`):
                 The tensors or objects for calculating metrics across all processes
             use_gather_object(`bool`):
-                Whether to forcibly use gather_object instead of gather (which is already done if all objects passed do not contain tensors). This flag can be useful for gathering tensors
-                with different sizes that we don't want to pad and concatenate along the first dimension. Using it with
-                GPU tensors is not well supported and inefficient as it incurs GPU -> CPU transfer since tensors would
-                be pickled.
+                Whether to forcibly use gather_object instead of gather (which is already done if all objects passed do
+                not contain tensors). This flag can be useful for gathering tensors with different sizes that we don't
+                want to pad and concatenate along the first dimension. Using it with GPU tensors is not well supported
+                and inefficient as it incurs GPU -> CPU transfer since tensors would be pickled.
 
         Example:
 


### PR DESCRIPTION
# What does this PR do ? 
This Pr makes `gather_for_metrics` more flexible when it comes to tensors. We introduce `use_gather_object` flag that enable users to gather object even if the input data is composed of tensors only. This is useful in the case the tensors have different sizes and we don't wanna end up padding all tensors to the same shape/size as it might be a bit complicated afterwards. Note that this is not very efficient for tensors on GPU. Also, we make sure that we do not adjust the sample when we are not in distributed setup. 

cc [qubvel](https://github.com/qubvel) could you try your use case by setting `use_gather_object = True` ? 

Fixes https://github.com/huggingface/transformers/issues/30357

## Example where we should use `gather_object` instead of `gather` in `gather_for_metrics`

```python
import torch
import random
from torch.utils.data import DataLoader, Dataset
from accelerate import Accelerator


class Dataset(Dataset):
    def __init__(self, size):
        self.size = size

    def __len__(self):
        return self.size

    def __getitem__(self, idx):
        return {"boxes": torch.rand(idx, 4)}


dataloader = DataLoader(Dataset(5), batch_size=4, collate_fn=lambda x: x)
accelerator = Accelerator()
dataloader = accelerator.prepare(dataloader)

for i, batch in enumerate(dataloader):
    #skip until the last batch
    if i != len(dataloader) - 1:
        continue
    
    print("Batch before gather:", [x["boxes"].shape for x in batch])
    gathered_batch = accelerator.gather_for_metrics(batch, use_gather_object=True)
    print("Batch after gather: ", [x["boxes"].shape for x in gathered_batch])

```

With two processes, we get: 
```
Batch before gather: [torch.Size([0, 4]), torch.Size([1, 4]), torch.Size([2, 4]), torch.Size([3, 4])]
Batch before gather: [torch.Size([4, 4]), torch.Size([0, 4]), torch.Size([1, 4]), torch.Size([2, 4])]
Batch after gather:  [torch.Size([0, 4]), torch.Size([1, 4]), torch.Size([2, 4]), torch.Size([3, 4]), torch.Size([4, 4])]
Batch after gather:  [torch.Size([0, 4]), torch.Size([1, 4]), torch.Size([2, 4]), torch.Size([3, 4]), torch.Size([4, 4])]
```
