### PR TITLE
fix bnb multi gpu training

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1387,16 +1387,18 @@ class Accelerator:
                     " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."
                     " Therefore you should not specify that you are under any distributed regime in your accelerate config."
                 )
-            current_device = list(model_devices)[0]
-            current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device
+            else:
+                # single device case
+                current_device = list(model_devices)[0]
+                current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device
 
-            if torch.device(current_device_index) != self.device:
-                # if on the first device (GPU 0) we don't care
-                if (self.device.index is not None) or (current_device_index != 0):
-                    raise ValueError(
-                        "You can't train a model that has been loaded in 8-bit precision on a different device than the one "
-                        "you're training on. Make sure you loaded the model on the correct device using for example `device_map={'':torch.cuda.current_device() or device_map={'':torch.xpu.current_device()}"
-                    )
+                if torch.device(current_device_index) != self.device:
+                    # if on the first device (GPU 0) we don't care
+                    if (self.device.index is not None) or (current_device_index != 0):
+                        raise ValueError(
+                            "You can't train a model that has been loaded in 8-bit precision on a different device than the one "
+                            "you're training on. Make sure you loaded the model on the correct device using for example `device_map={'':torch.cuda.current_device() or device_map={'':torch.xpu.current_device()}"
+                        )
 
             if "cpu" in model_devices or "disk" in model_devices:
                 raise ValueError(

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1388,7 +1388,7 @@ class Accelerator:
                     " Therefore you should not specify that you are under any distributed regime in your accelerate config."
                 )
             else:
-                # single device case
+                # single gpu case
                 current_device = list(model_devices)[0]
                 current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device
 
@@ -1400,10 +1400,10 @@ class Accelerator:
                             "you're training on. Make sure you loaded the model on the correct device using for example `device_map={'':torch.cuda.current_device() or device_map={'':torch.xpu.current_device()}"
                         )
 
-            if "cpu" in model_devices or "disk" in model_devices:
-                raise ValueError(
-                    "You can't train a model that has been loaded in 8-bit precision with CPU or disk offload."
-                )
+                if "cpu" in model_devices or "disk" in model_devices:
+                    raise ValueError(
+                        "You can't train a model that has been loaded in 8-bit precision with CPU or disk offload."
+                    )
         elif device_placement and not self.verify_device_map(model):
             model = model.to(self.device)
         if not evaluation_mode:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1401,10 +1401,10 @@ class Accelerator:
                             "you're training on. Make sure you loaded the model on the correct device using for example `device_map={'':torch.cuda.current_device() or device_map={'':torch.xpu.current_device()}"
                         )
 
-                if "cpu" in model_devices or "disk" in model_devices:
-                    raise ValueError(
-                        "You can't train a model that has been loaded in 8-bit precision with CPU or disk offload."
-                    )
+            if "cpu" in model_devices or "disk" in model_devices:
+                raise ValueError(
+                    "You can't train a model that has been loaded in 8-bit precision with CPU or disk offload."
+                )
         elif device_placement and not self.verify_device_map(model):
             model = model.to(self.device)
         if not evaluation_mode:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1389,7 +1389,9 @@ class Accelerator:
                 )
             elif len(model_devices) == 1:
                 current_device = list(model_devices)[0]
-                current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device
+                current_device_index = (
+                    current_device.index if isinstance(current_device, torch.device) else current_device
+                )
 
                 if torch.device(current_device_index) != self.device:
                     # if on the first device (GPU 0) we don't care

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1388,7 +1388,6 @@ class Accelerator:
                     " Therefore you should not specify that you are under any distributed regime in your accelerate config."
                 )
             elif len(model_devices) == 1:
-                # single gpu case
                 current_device = list(model_devices)[0]
                 current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1387,7 +1387,7 @@ class Accelerator:
                     " In order to use 8-bit models that have been loaded across multiple GPUs the solution is to use Naive Pipeline Parallelism."
                     " Therefore you should not specify that you are under any distributed regime in your accelerate config."
                 )
-            else:
+            elif len(model_devices) == 1:
                 # single gpu case
                 current_device = list(model_devices)[0]
                 current_device_index = current_device.index if isinstance(current_device, torch.device) else current_device


### PR DESCRIPTION
# What does this PR do ? 

This PR fixes a bug that users who want to perform multi-gpu training with bnb gets when the first gpu is not used. In this [PR](https://github.com/huggingface/accelerate/pull/1155), you see that we did not allow multi-gpu training before and [all the code after](https://github.com/huggingface/accelerate/pull/1155/files#:~:text=current_device_index%20%3D%20list,.device%3A) that assume that we are in a single gpu setup. Since then, we added the possibility to perform multi-gpu training using naive PP. However, the logic after the multi-gpu check stayed the same as you can see on [main](https://github.com/huggingface/accelerate/blob/6af157ea93dfbace1db88b0fdc7dfb568dfdd5a5/src/accelerate/accelerator.py#L1393) . A quick fix would be to just add an elif statement. 

Fixes https://github.com/huggingface/accelerate/issues/2713 https://github.com/huggingface/accelerate/issues/2429