### PR TITLE
Fixup `free_memory` to deal with garbage collection

### DIFF
--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -248,7 +248,7 @@ def training_function(config, args):
         # Use accelerator.print to print only on the main process.
         test_predictions.append(torch.cat(fold_predictions, dim=0))
         # We now need to release all our memory and get rid of the current model, optimizer, etc
-        accelerator.free_memory()
+        model, optimizer = accelerator.free_memory(model, optimizer)
     # New Code #
     # Finally we check the accuracy of our folded results:
     test_references = torch.cat(test_references, dim=0)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3054,9 +3054,10 @@ class Accelerator:
         self._models = []
         self._dataloaders = []
         # Deepspeed needs a bit more prep
-        if self.deepspeed_engine_wrapped is not None:
-            self.deepspeed_engine_wrapped.destroy()
-        self.deepspeed_engine_wrapped = None
+        if hasattr(self, "deepspeed_engine_wrapped"):
+            if self.deepspeed_engine_wrapped is not None:
+                self.deepspeed_engine_wrapped.destroy()
+            self.deepspeed_engine_wrapped = None
         self.step = 0
         return objects
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3053,6 +3053,9 @@ class Accelerator:
         self._optimizers = []
         self._models = []
         self._dataloaders = []
+        # Deepspeed needs a bit more prep
+        if self.deepspeed_engine_wrapped is not None:
+            self.deepspeed_engine_wrapped.destroy()
         self.deepspeed_engine_wrapped = None
         self.step = 0
         return objects

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3057,7 +3057,7 @@ class Accelerator:
         if hasattr(self, "deepspeed_engine_wrapped"):
             if self.deepspeed_engine_wrapped is not None:
                 self.deepspeed_engine_wrapped.destroy()
-        self.deepspeed_engine_wrapped = None
+            self.deepspeed_engine_wrapped = None
         self.step = 0
         return objects
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3054,7 +3054,7 @@ class Accelerator:
         self._dataloaders = []
         self.deepspeed_engine_wrapped = None
         self.step = 0
-        release_memory(*objects)
+        return release_memory(*objects)
 
     def clear(self, *objects):
         """
@@ -3072,7 +3072,7 @@ class Accelerator:
         >>> model, optimizer, scheduler = accelerator.clear(model, optimizer, scheduler)
         ```
         """
-        self.free_memory(*objects)
+        return self.free_memory(*objects)
 
     def _get_named_parameters(self, *args):
         named_parameters = {}

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3126,16 +3126,16 @@ class Accelerator:
         >>> model, optimizer, scheduler = accelerator.free_memory(model, optimizer, scheduler)
         ```
         """
+        # Deepspeed needs a bit more prep that should be done first
+        if hasattr(self, "deepspeed_engine_wrapped"):
+            if self.deepspeed_engine_wrapped is not None:
+                self.deepspeed_engine_wrapped.engine.destroy()
+            self.deepspeed_engine_wrapped = None
         objects = release_memory(*objects)
         self._schedulers = []
         self._optimizers = []
         self._models = []
         self._dataloaders = []
-        # Deepspeed needs a bit more prep
-        if hasattr(self, "deepspeed_engine_wrapped"):
-            if self.deepspeed_engine_wrapped is not None:
-                self.deepspeed_engine_wrapped.destroy()
-            self.deepspeed_engine_wrapped = None
         self.step = 0
         return objects
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3048,13 +3048,14 @@ class Accelerator:
         >>> model, optimizer, scheduler = accelerator.free_memory(model, optimizer, scheduler)
         ```
         """
+        objects = release_memory(*objects)
         self._schedulers = []
         self._optimizers = []
         self._models = []
         self._dataloaders = []
         self.deepspeed_engine_wrapped = None
         self.step = 0
-        return release_memory(*objects)
+        return objects
 
     def clear(self, *objects):
         """

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3057,7 +3057,7 @@ class Accelerator:
         if hasattr(self, "deepspeed_engine_wrapped"):
             if self.deepspeed_engine_wrapped is not None:
                 self.deepspeed_engine_wrapped.destroy()
-            self.deepspeed_engine_wrapped = None
+        self.deepspeed_engine_wrapped = None
         self.step = 0
         return objects
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3032,7 +3032,7 @@ class Accelerator:
             for index, obj in enumerate(self._custom_objects):
                 load_custom_state(obj, input_dir, index)
 
-    def free_memory(self):
+    def free_memory(self, *objects):
         """
         Will release all references to the internal objects stored and call the garbage collector. You should call this
         method between two trainings with different models/optimizers. Also will reset `Accelerator.step` to 0.
@@ -3045,8 +3045,7 @@ class Accelerator:
         >>> accelerator = Accelerator()
         >>> model, optimizer, scheduler = ...
         >>> model, optimizer, scheduler = accelerator.prepare(model, optimizer, scheduler)
-        >>> accelerator.free_memory()
-        >>> del model, optimizer, scheduler
+        >>> model, optimizer, scheduler = accelerator.free_memory(model, optimizer, scheduler)
         ```
         """
         self._schedulers = []
@@ -3055,9 +3054,9 @@ class Accelerator:
         self._dataloaders = []
         self.deepspeed_engine_wrapped = None
         self.step = 0
-        release_memory()
+        release_memory(*objects)
 
-    def clear(self):
+    def clear(self, *objects):
         """
         Alias for [`Accelerate.free_memory`], releases all references to the internal objects stored and call the
         garbage collector. You should call this method between two trainings with different models/optimizers.
@@ -3070,11 +3069,10 @@ class Accelerator:
         >>> accelerator = Accelerator()
         >>> model, optimizer, scheduler = ...
         >>> model, optimizer, scheduler = accelerator.prepare(model, optimizer, scheduler)
-        >>> accelerator.free_memory()
-        >>> del model, optimizer, scheduler
+        >>> model, optimizer, scheduler = accelerator.clear(model, optimizer, scheduler)
         ```
         """
-        self.free_memory()
+        self.free_memory(*objects)
 
     def _get_named_parameters(self, *args):
         named_parameters = {}

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -212,7 +212,8 @@ class AcceleratorTester(AccelerateTestCase):
         assert len(accelerator._optimizers) == 0
         assert len(accelerator._schedulers) == 0
         assert len(accelerator._dataloaders) == 0
-        assert free_cpu_ram_after < free_cpu_ram_before
+        # The less-than comes *specifically* from CUDA CPU things/won't be present on CPU builds
+        assert free_cpu_ram_after <= free_cpu_ram_before
 
     @require_non_torch_xla
     def test_env_var_device(self):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -17,6 +17,7 @@ import pickle
 import tempfile
 from unittest.mock import patch
 
+import psutil
 import pytest
 import torch
 from parameterized import parameterized
@@ -197,13 +198,21 @@ class AcceleratorTester(AccelerateTestCase):
     def test_free_memory_dereferences_prepared_components(self):
         accelerator = Accelerator()
         model, optimizer, scheduler, train_dl, valid_dl = create_components()
-        accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
-        accelerator.free_memory()
+        free_cpu_ram_before = psutil.virtual_memory().available // 1024 // 1024
+        model, optimizer, scheduler, train_dl, valid_dl = accelerator.prepare(
+            model, optimizer, scheduler, train_dl, valid_dl
+        )
+        model, optimizer, scheduler, train_dl, valid_dl = accelerator.free_memory(
+            model, optimizer, scheduler, train_dl, valid_dl
+        )
+
+        free_cpu_ram_after = psutil.virtual_memory().available // 1024 // 1024
 
         assert len(accelerator._models) == 0
         assert len(accelerator._optimizers) == 0
         assert len(accelerator._schedulers) == 0
         assert len(accelerator._dataloaders) == 0
+        assert free_cpu_ram_after < free_cpu_ram_before
 
     @require_non_torch_xla
     def test_env_var_device(self):


### PR DESCRIPTION
# What does this PR do?

Tweaks `Accelerator.free_memory` to take in `*objects` and return `*objects`. This is because we need to fully replace the values, doing just `del` doesn't *actually* help as much as it should. 

Solves https://github.com/huggingface/accelerate/issues/2715, graph:

Solves https://github.com/huggingface/transformers/issues/28178

![image](https://github.com/huggingface/accelerate/assets/7831895/a60b8054-1fce-4a12-bf1a-00f087b58eac)

(Weird read, I know, I think it's because they delay the reading of the computer for a few seconds). But I think because the graphs are identical that's **good**

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 