### PR TITLE
fix sampler serialization

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -120,8 +120,7 @@ def save_accelerator_state(
         from .data_loader import IterableDatasetShard, SeedableRandomSampler
 
         if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = getattr(dataloader.sampler, "sampler", None)
-
+            sampler = dataloader.get_sampler()
             if isinstance(sampler, SeedableRandomSampler):
                 save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
         logger.info(f"Sampler state for dataloader {i} saved in {output_sampler_file}")
@@ -227,10 +226,9 @@ def load_accelerator_state(
         from .data_loader import IterableDatasetShard, SeedableRandomSampler
 
         if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = getattr(dataloader.sampler, "sampler", None)
-
+            sampler = dataloader.get_sampler()
             if isinstance(sampler, SeedableRandomSampler):
-                dataloader.sampler.sampler = torch.load(input_sampler_file)
+                sampler = dataloader.set_sampler(torch.load(input_sampler_file))
     logger.info("All dataloader sampler states loaded successfully")
 
     # GradScaler state

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -120,7 +120,7 @@ def save_accelerator_state(
         from .data_loader import IterableDatasetShard, SeedableRandomSampler
 
         if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.sampler.sampler
+            sampler = getattr(dataloader.sampler, "sampler", None)
 
             if isinstance(sampler, SeedableRandomSampler):
                 save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
@@ -227,7 +227,7 @@ def load_accelerator_state(
         from .data_loader import IterableDatasetShard, SeedableRandomSampler
 
         if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.sampler.sampler
+            sampler = getattr(dataloader.sampler, "sampler", None)
 
             if isinstance(sampler, SeedableRandomSampler):
                 dataloader.sampler.sampler = torch.load(input_sampler_file)


### PR DESCRIPTION
# What does this PR do ?
This PR fixes an issue with sampler serialization. The sampler do not necessarily have a sampler attribute. I think this is only the case when the sampler is a `SeedableRandomSampler`. To fix the issue, we create a getter and setter function to get the sample of the dataloader. 

### Example of failing script 
You need to use num_processes >= 2 :

```python 
from typing import Iterator
from torch.utils.data import IterableDataset,DataLoader
from accelerate import Accelerator, DataLoaderConfiguration

class FooSet(IterableDataset):
    def __iter__(self) -> Iterator:
        for i in range(100):
            yield i

dset = FooSet()
dloader = DataLoader(dset, batch_size=1)

dataloader_config = DataLoaderConfiguration(dispatch_batches=False, split_batches=False)

ac = Accelerator(
    dataloader_config = dataloader_config
)

dloader = ac.prepare(dloader)
# print(dloader)
for data in dloader:
    ac.print(data)
    # This will fail saying that dataloader.sampler.sampler do not exist
    ac.save_state('test_checkpoint')
```

Fixes https://github.com/huggingface/accelerate/issues/2718