### PR TITLE
Fix stacklevel in `logging` to log the actual user call site (instead of the call site inside the logger wrapper) of log functions

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -54,6 +54,8 @@ class MultiProcessAdapter(logging.LoggerAdapter):
             )
         main_process_only = kwargs.pop("main_process_only", True)
         in_order = kwargs.pop("in_order", False)
+        # set `stacklevel` to exclude ourself in `Logger.findCaller()` while respecting user's choice
+        kwargs.setdefault("stacklevel", 2)
 
         if self.isEnabledFor(level):
             if self._should_log(main_process_only):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,91 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import inspect
+import logging
+import os
+
+import pytest
+
+from accelerate import Accelerator
+from accelerate.logging import get_logger
+
+
+def current_lineno() -> int:
+    # A simple helper that returns the lineno of its call-site.
+    caller_frame = inspect.currentframe().f_back
+    caller_info = inspect.getframeinfo(caller_frame)
+    return caller_info.lineno
+
+
+class CustomLogger(logging.LoggerAdapter):
+    # Mocks a user-defined custom logger wrapper that sets `stacklevel=3`.
+    def log(self, level, msg, *args, **kwargs):
+        # E.g. the user wants to modify `stacklevel`, `accelerate.logging`
+        # should respect the user's `stacklevel`. For the specific value
+        # of `3`, calling `CustomLogger.log()`, etc., should log that callsite,
+        # rather than the callsite of the following `self.logger.log()`.
+        kwargs["stacklevel"] = 3
+        self.logger.log(level, msg, *args, **kwargs)
+
+
+@pytest.fixture(scope="module")
+def accelerator():
+    return Accelerator()
+
+
+@pytest.mark.usefixtures("accelerator")
+def test_log_stack(caplog):
+    logger = get_logger(__name__)
+    logging.basicConfig(
+        format="%(filename)s:%(name)s:%(lineno)s:%(funcName)s - %(message)s",
+        datefmt="%m/%d %H:%M:%S",
+    )
+
+    message = "Test"
+    lineno = current_lineno() + 1  # the next line is the actual callsite
+    logger.warning(message)
+
+    assert len(caplog.records) == 1
+    rec = caplog.records[0]
+    assert rec.levelname == logging.getLevelName(logging.WARNING)
+    assert rec.filename == os.path.basename(__file__)
+    assert rec.name == __name__
+    assert rec.lineno == lineno
+    assert rec.funcName == test_log_stack.__name__
+    assert rec.message == message
+
+
+@pytest.mark.usefixtures("accelerator")
+def test_custom_stacklevel(caplog):
+    wrapped_logger = get_logger(__name__)
+    logging.basicConfig(
+        format="%(filename)s:%(name)s:%(lineno)s:%(funcName)s - %(message)s",
+        datefmt="%m/%d %H:%M:%S",
+    )
+    logger = CustomLogger(wrapped_logger, {})
+
+    message = "Test"
+    lineno = current_lineno() + 1  # the next line is the actual callsite
+    logger.warning(message)
+
+    # `CustomLogger.log` set custom `stacklevel=3`, so `logger.warning` should
+    # log its callsite (rather than those of the `warpped_logger`).
+    assert len(caplog.records) == 1
+    rec = caplog.records[0]
+    assert rec.levelname == logging.getLevelName(logging.WARNING)
+    assert rec.filename == os.path.basename(__file__)
+    assert rec.name == __name__
+    assert rec.lineno == lineno
+    assert rec.funcName == test_custom_stacklevel.__name__
+    assert rec.message == message


### PR DESCRIPTION
# Fix `stacklevel` in `logging`

Fixes #2114

Currently, `accelerate.logging` does not correctly log the *user* call site of log functions such as `.log()` and `.info()`. Consider the following example modified from issue #2114:

```python
import logging

from accelerate import Accelerator
from accelerate.logging import get_logger
from rich.logging import RichHandler

logger = get_logger(__name__)

if __name__ == "__main__":
    accelerator = Accelerator()
    logging.basicConfig(
        format="%(filename)s:%(name)s:%(lineno)s - %(message)s",
        datefmt="%m/%d %H:%M:%S",
        level=logging.INFO,
        handlers=[RichHandler(show_time=True, show_level=True, show_path=True)],
    )
    logger.info("Test")
```

In its current state, the above script shows something like

```
05/01 19:26:22 INFO     logging.py:__main__:61 - Test
```

The calling site of the logging function `.info()` is incorrectly shown as [line 61](https://github.com/huggingface/accelerate/blob/232ebd159a3ff37a1089fbd4e7fc85ee915508ee/src/accelerate/logging.py#L61) of `accelerate.logging.MultiProcessAdapter.log`, which is the calling site inside the logger wrapper `MultiProcessAdapter`. This happens because the `stacklevel` argument of the logging function is set to its default value `1`, which shows the calling site of the wrapped logger's `.log()`. See the [docs](https://docs.python.org/3/library/logging.html#logging.Logger.debug) of Python `logging` for more details of what `stacklevel` means.

There exists a simple fix to the above issue: modify `stacklevel` in `MultiProcessAdapter.log` to `2` (skip `MultiProcessAdapter.log` in the calling stack), unless the users explicitly provide their own `stacklevel`. This fix is summarized as one line of additional code:

```python
kwargs.setdefault("stacklevel", 2)
```

After applying the above fix, the script mentioned earlier prints the correct message (`test_logging.py` is the script's name):

```
05/01 19:27:00 INFO     test_logging.py:__main__:17 - Test
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification). **No. This PR is a bug fix and contains no API change.**
- [ ] Did you write any new necessary tests? **No. This PR is a simple fix that does not change any expected behavior.**


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->

@kiyoon @BenjaminBossan