### PR TITLE
Add feature to allow redirecting std streams into log files when using torchrun as the launcher. 

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -304,7 +304,6 @@ def launch_command_parser(subparsers=None):
         help="Tee std streams into a log file and also to console.",
     )
     distributed_args.add_argument(
-        "--log-dir",
         "--log_dir",
         type=str,
         default=None,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -304,6 +304,16 @@ def launch_command_parser(subparsers=None):
         help="Tee std streams into a log file and also to console.",
     )
     distributed_args.add_argument(
+        "--log-dir",
+        "--log_dir",
+        type=str,
+        default=None,
+        help=(
+            "Base directory to use for log files when using torchrun/torch.distributed.run as launcher. "
+            "Use with --tee to redirect std streams info log files."
+        ),
+    )
+    distributed_args.add_argument(
         "--role",
         type=str,
         default="default",


### PR DESCRIPTION

# What does this PR do?

This pull request aims to enable the `accelerate launch` to redirect std streams into log files. 
When I am using torchrun to launch the training scripts, I am able to use --log-dir and --tee to redirect all streams into log files to help debugging. But when I use `accelerate launch`, even though the backend launcher is torchrun, I was unable to achieve that. Thus I would like to add a `--log-dir/--log_dir` argument near the `--tee` argument to improving the logging capability of `accelerate launch`. It's just a few lines of code but it does make debugging much easier when running multi-node training.

Thanks!

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr Hi Mueller, this pull request is an addition to the command line interface code. Please review the PR. Thanks!
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->