### PR TITLE
Fix duplicate environment variable check in multi-cpu condition

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -238,7 +238,7 @@ class PartialState:
 
                 if (
                     self.distributed_type == DistributedType.MULTI_CPU
-                    and get_int_from_env(["OMP_NUM_THREADS", "OMP_NUM_THREADS"], 0) > 0
+                    and get_int_from_env(["OMP_NUM_THREADS"], 0) > 0
                 ):
                     import psutil
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -236,10 +236,7 @@ class PartialState:
                 kwargs["rank"] = dist_information.rank
                 kwargs["world_size"] = dist_information.world_size
 
-                if (
-                    self.distributed_type == DistributedType.MULTI_CPU
-                    and get_int_from_env(["OMP_NUM_THREADS"], 0) > 0
-                ):
+                if self.distributed_type == DistributedType.MULTI_CPU and get_int_from_env(["OMP_NUM_THREADS"], 0) > 0:
                     import psutil
 
                     num_cpu_threads_per_process = int(


### PR DESCRIPTION
## What does this PR do?

This PR corrects the environment variable check for `DistributedType.MULTI_CPU` in `accelerate/state.py`. Previously, the variable `OMP_NUM_THREADS` was duplicated. This update ensures that only one variable exists.