### PR TITLE
Fix sagemaker config

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -79,6 +79,7 @@ class BaseConfig:
     mixed_precision: str
     use_cpu: bool
     debug: bool
+    enable_cpu_affinity: bool
 
     def to_dict(self):
         result = self.__dict__
@@ -182,7 +183,6 @@ class ClusterConfig(BaseConfig):
     rdzv_backend: Optional[str] = "static"
     same_network: Optional[bool] = False
     main_training_function: str = "main"
-    enable_cpu_affinity: bool = False
 
     # args for deepspeed_plugin
     deepspeed_config: dict = None


### PR DESCRIPTION
# What does this PR do?

Puts `enable_cpu_affinity` down a level so sagemaker can work.

We already have checks to verify if we should call cpu_affinity, so its safe to do (and will default to `False` if they didn't pass it in)

Fixes https://github.com/huggingface/accelerate/issues/2744


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 