### PR TITLE
fix cpu omp num threads set

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1043,8 +1043,8 @@ def _validate_launch_command(args):
         defaults is not None and defaults.compute_environment != ComputeEnvironment.AMAZON_SAGEMAKER
     )
     if is_aws_env_disabled and args.num_cpu_threads_per_process is None:
-        args.num_cpu_threads_per_process = get_int_from_env(["OMP_NUM_THREADS"], 0)
-        if args.use_cpu and args.num_processes >= 1 and args.num_cpu_threads_per_process == 0:
+        args.num_cpu_threads_per_process = get_int_from_env(["OMP_NUM_THREADS"], 1)
+        if args.use_cpu and args.num_processes >= 1 and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
             local_size = get_int_from_env(
                 ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
             )

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1043,8 +1043,8 @@ def _validate_launch_command(args):
         defaults is not None and defaults.compute_environment != ComputeEnvironment.AMAZON_SAGEMAKER
     )
     if is_aws_env_disabled and args.num_cpu_threads_per_process is None:
-        args.num_cpu_threads_per_process = 1
-        if args.use_cpu and args.num_processes >= 1:
+        args.num_cpu_threads_per_process = get_int_from_env(["OMP_NUM_THREADS"], 0)
+        if args.use_cpu and args.num_processes >= 1 and args.num_cpu_threads_per_process == 0:
             local_size = get_int_from_env(
                 ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
             )

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -236,7 +236,10 @@ class PartialState:
                 kwargs["rank"] = dist_information.rank
                 kwargs["world_size"] = dist_information.world_size
 
-                if self.distributed_type == DistributedType.MULTI_CPU and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
+                if (
+                    self.distributed_type == DistributedType.MULTI_CPU
+                    and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0
+                ):
                     import psutil
 
                     num_cpu_threads_per_process = int(

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -236,7 +236,7 @@ class PartialState:
                 kwargs["rank"] = dist_information.rank
                 kwargs["world_size"] = dist_information.world_size
 
-                if self.distributed_type == DistributedType.MULTI_CPU and get_int_from_env(["OMP_NUM_THREADS"], 0) > 0:
+                if self.distributed_type == DistributedType.MULTI_CPU and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
                     import psutil
 
                     num_cpu_threads_per_process = int(


### PR DESCRIPTION
Hi @muellerzr 

This PR fixed the cpu num threads set. We should set a default value if the env parameter `OMP_NUM_THREADS` is not set.
Besides, we should keep `OMP_NUM_THREADS` instead of replacing it in `launch.py`. Could you pls review it? Thx!