### PR TITLE
optimize get_module_leaves speed

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -928,6 +928,7 @@ def load_offloaded_weights(model, index, offload_folder):
         weight = load_offloaded_weight(tensor_file, metadata)
         set_module_tensor_to_device(model, param_name, "cpu", value=weight, fp16_statistics=fp16_statistics)
 
+
 def get_module_leaves(module_sizes):
     module_children = {}
     for module in module_sizes:
@@ -935,9 +936,9 @@ def get_module_leaves(module_sizes):
             continue
         parent = module.rsplit(".", 1)[0]
         module_children[parent] = module_children.get(parent, 0) + 1
-    
     leaves = [module for module in module_sizes if module_children.get(module, 0) == 0]
     return leaves
+
 
 def get_balanced_memory(
     model: nn.Module,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -936,7 +936,7 @@ def get_module_leaves(module_sizes):
             continue
         parent = module.rsplit(".", 1)[0]
         module_children[parent] = module_children.get(parent, 0) + 1
-    leaves = [module for module in module_sizes if module_children.get(module, 0) == 0]
+    leaves = [module for module in module_sizes if module_children.get(module, 0) == 0 and module != ""]
     return leaves
 
 


### PR DESCRIPTION
### Background
When I try to inference deepseek-v2 with transformers:

```python
import torch
from transformers import AutoTokenizer, AutoModelForCausalLM, GenerationConfig

model_name = "deepseek-ai/DeepSeek-V2"
tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
# `max_memory` should be set based on your devices
max_memory = {i: "75GB" for i in range(8)}
# `device_map` cannot be set to `auto`
model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True, device_map="sequential", torch_dtype=torch.bfloat16, max_memory=max_memory, attn_implementation="eager")
model.generation_config = GenerationConfig.from_pretrained(model_name)
model.generation_config.pad_token_id = model.generation_config.eos_token_id

text = "An attention function can be described as mapping a query and a set of key-value pairs to an output, where the query, keys, values, and output are all vectors. The output is"
inputs = tokenizer(text, return_tensors="pt")
outputs = model.generate(**inputs.to(model.device), max_new_tokens=100)

result = tokenizer.decode(outputs[0], skip_special_tokens=True)
print(result)

```



I found that program with stuck...

### Solve
In fact, the stuck appearing [here](https://github.com/huggingface/accelerate/blob/main/src/accelerate/utils/modeling.py#L1041) . 

![图片](https://github.com/huggingface/accelerate/assets/35585791/a4e7d689-babb-438b-8e67-79aff155e9ba)

For DeepSeek V2, the length of `module_sizes` is 68185, and the code here has a complexity of O(N^2) (where `N = module_sizes`), which requires a very long time to execute, giving the illusion of being stuck. This PR optimizes the code to have a complexity of O(N), allowing it to quickly reach the stage of loading the large model. The inference results on an 8xA800 machine are also normal after this optimization.

![img_v3_02an_91e8f57c-fb20-415f-84e8-8effc882f8bg](https://github.com/huggingface/accelerate/assets/35585791/51143b54-9fc0-4c4d-8e13-5b7c62e93d1a)
