### PR TITLE
Fix broken PiPPy IR and PipelineStage imports

### DIFF
--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -28,8 +28,15 @@ from .utils import (
 )
 
 
-if is_pippy_available():
+pippy_version = is_pippy_available()
+
+if pippy_version == "0.1.1-0.2.0":
+    from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+    from pippy.PipelineStage import PipelineStage
+    split_point_class = PipeSplitWrapper.SplitPoint
+elif pippy_version == ">0.2.0":
     from pippy import Pipe, PipelineStage, SplitPoint, annotate_split_points
+    split_point_class = SplitPoint
 
 
 def generate_device_map(model, num_processes: int = 1, no_split_module_classes=None, max_memory: dict = None):
@@ -84,7 +91,7 @@ def build_pipeline(model, split_points, args, kwargs, num_chunks):
     """
     # We need to annotate the split points in the model for PiPPy
     state = PartialState()
-    annotate_split_points(model, {split_point: SplitPoint.BEGINNING for split_point in split_points})
+    annotate_split_points(model, {split_point: split_point_class.BEGINNING for split_point in split_points})
     found_batch_size = find_pippy_batch_size(args, kwargs)
     if found_batch_size != num_chunks:
         if args is not None:

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -29,7 +29,8 @@ from .utils import (
 
 
 if is_pippy_available():
-    from pippy import Pipe, SplitPoint, annotate_split_points, PipelineStage
+    from pippy import Pipe, PipelineStage, SplitPoint, annotate_split_points
+
 
 def generate_device_map(model, num_processes: int = 1, no_split_module_classes=None, max_memory: dict = None):
     """

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -29,9 +29,7 @@ from .utils import (
 
 
 if is_pippy_available():
-    from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
-    from pippy.PipelineStage import PipelineStage
-
+    from pippy import Pipe, SplitPoint, annotate_split_points, PipelineStage
 
 def generate_device_map(model, num_processes: int = 1, no_split_module_classes=None, max_memory: dict = None):
     """
@@ -85,7 +83,7 @@ def build_pipeline(model, split_points, args, kwargs, num_chunks):
     """
     # We need to annotate the split points in the model for PiPPy
     state = PartialState()
-    annotate_split_points(model, {split_point: PipeSplitWrapper.SplitPoint.BEGINNING for split_point in split_points})
+    annotate_split_points(model, {split_point: SplitPoint.BEGINNING for split_point in split_points})
     found_batch_size = find_pippy_batch_size(args, kwargs)
     if found_batch_size != num_chunks:
         if args is not None:

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -28,15 +28,12 @@ from .utils import (
 )
 
 
-pippy_version = is_pippy_available()
-
-if pippy_version == "0.1.1-0.2.0":
-    from pippy.IR import Pipe, PipeSplitWrapper, annotate_split_points
+if is_pippy_available(max_version="0.2.0"):
+    from pippy.IR import Pipe, annotate_split_points
+    from pippy.IR import PipeSplitWrapper as SplitPoint
     from pippy.PipelineStage import PipelineStage
-    split_point_class = PipeSplitWrapper.SplitPoint
-elif pippy_version == ">0.2.0":
+elif is_pippy_available():
     from pippy import Pipe, PipelineStage, SplitPoint, annotate_split_points
-    split_point_class = SplitPoint
 
 
 def generate_device_map(model, num_processes: int = 1, no_split_module_classes=None, max_memory: dict = None):
@@ -91,7 +88,7 @@ def build_pipeline(model, split_points, args, kwargs, num_chunks):
     """
     # We need to annotate the split points in the model for PiPPy
     state = PartialState()
-    annotate_split_points(model, {split_point: split_point_class.BEGINNING for split_point in split_points})
+    annotate_split_points(model, {split_point: SplitPoint.BEGINNING for split_point in split_points})
     found_batch_size = find_pippy_batch_size(args, kwargs)
     if found_batch_size != num_chunks:
         if args is not None:

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -372,7 +372,7 @@ def require_pippy(test_case):
     """
     Decorator marking a test that requires pippy installed. These tests are skipped when pippy isn't installed
     """
-    return unittest.skipUnless(is_pippy_available(), "test requires pippy")(test_case)
+    return unittest.skipUnless(bool(is_pippy_available()), "test requires pippy")(test_case)
 
 
 _atleast_one_tracker_available = (

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -372,7 +372,7 @@ def require_pippy(test_case):
     """
     Decorator marking a test that requires pippy installed. These tests are skipped when pippy isn't installed
     """
-    return unittest.skipUnless(bool(is_pippy_available()), "test requires pippy")(test_case)
+    return unittest.skipUnless(is_pippy_available(), "test requires pippy")(test_case)
 
 
 _atleast_one_tracker_available = (

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -177,7 +177,10 @@ def is_pippy_available():
     package_exists = _is_package_available("pippy", "torchpippy")
     if package_exists:
         pippy_version = version.parse(importlib.metadata.version("torchpippy"))
-        return compare_versions(pippy_version, ">", "0.1.1")
+        if compare_versions(pippy_version, ">", "0.1.1") and compare_versions(pippy_version, "<=", "0.2.0"):
+            return "0.1.1-0.2.0"
+        elif compare_versions(pippy_version, ">", "0.2.0"):
+            return ">0.2.0"
     return False
 
 

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -173,14 +173,14 @@ def is_deepspeed_available():
     return _is_package_available("deepspeed")
 
 
-def is_pippy_available():
+def is_pippy_available(max_version=None):
     package_exists = _is_package_available("pippy", "torchpippy")
     if package_exists:
         pippy_version = version.parse(importlib.metadata.version("torchpippy"))
-        if compare_versions(pippy_version, ">", "0.1.1") and compare_versions(pippy_version, "<=", "0.2.0"):
-            return "0.1.1-0.2.0"
-        elif compare_versions(pippy_version, ">", "0.2.0"):
-            return ">0.2.0"
+        min_version = compare_versions(pippy_version, ">", "0.1.1")
+        if max_version is not None:
+            return compare_versions(pippy_version, "=<", max_version) and min_version
+        return min_version
     return False
 
 


### PR DESCRIPTION
# What does this PR do?
Updates the PiPPy imports to not use the private _IR and _PipelineStage modules

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr 