### PR TITLE
Skip deepspeed test

### DIFF
--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -993,7 +993,9 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
 
     def test_peak_memory_usage(self):
         if compare_versions("deepspeed", ">", "0.12.6"):
-            self.skipTest("The test fails when deepspeed>0.12.6. This is something that needs to be fixed on deepspeed library")
+            self.skipTest(
+                "The test fails when deepspeed>0.12.6. This is something that needs to be fixed on deepspeed library"
+            )
 
         self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -992,6 +992,9 @@ class DeepSpeedIntegrationTest(TempDirTestCase):
                 execute_subprocess_async(cmd_stage)
 
     def test_peak_memory_usage(self):
+        if compare_versions("deepspeed", ">", "0.12.6"):
+            self.skipTest("The test fails when deepspeed>0.12.6. This is something that needs to be fixed on deepspeed library")
+
         self.test_file_path = self.test_scripts_folder / "test_peak_memory_usage.py"
         cmd = [
             "accelerate",


### PR DESCRIPTION
# What does this PR do ? 
This PR skips the deepspeed test since it started failing with deepspeed > 0.12.6. This is most probably an issue on deepspeed side cc @pacman100. Let's make sure to not forget about this test :/ . 