### PR TITLE
Add Elastic Launch Support to `notebook_launcher`

### DIFF
--- a/docs/source/basic_tutorials/notebook.md
+++ b/docs/source/basic_tutorials/notebook.md
@@ -430,6 +430,17 @@ args = (model, "fp16", 42, 64)
 notebook_launcher(training_loop, args, num_processes=8)
 ```
 
+To launch the training process with elasticity, enabling fault tolerance, you can use the `elastic_launch` feature provided by PyTorch. This requires setting additional parameters such as `rdzv_backend` and `max_restarts`. Here is an example of how to use `notebook_launcher` with elastic capabilities:
+
+```python
+notebook_launcher(
+    training_loop,
+    args,
+    num_processes=2,
+    max_restarts=3
+)
+```
+
 As it's running it will print the progress as well as state how many devices you ran on. This tutorial was ran with two GPUs:
 
 ```python out

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -217,7 +217,8 @@ def notebook_launcher(
                 launcher = PrepareForLaunch(function, distributed_type="MULTI_GPU")
                 print(f"Launching training on {num_processes} GPUs.")
                 try:
-                    rdzv_conf = rdzv_conf or {}
+                    if rdvz_conf is None:
+                        rdvz_conf = {}
                     if rdzv_backend == "static":
                         rdzv_conf["rank"] = node_rank
                         if not rdzv_endpoint:

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -217,8 +217,8 @@ def notebook_launcher(
                 launcher = PrepareForLaunch(function, distributed_type="MULTI_GPU")
                 print(f"Launching training on {num_processes} GPUs.")
                 try:
-                    if rdvz_conf is None:
-                        rdvz_conf = {}
+                    if rdzv_conf is None:
+                        rdzv_conf = {}
                     if rdzv_backend == "static":
                         rdzv_conf["rank"] = node_rank
                         if not rdzv_endpoint:

--- a/src/accelerate/test_utils/scripts/test_notebook.py
+++ b/src/accelerate/test_utils/scripts/test_notebook.py
@@ -16,8 +16,11 @@ Test file to ensure that in general certain situational setups for notebooks wor
 """
 
 import os
+import time
+from multiprocessing import Queue
 
-from pytest import raises
+from pytest import mark, raises
+from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
 from accelerate import PartialState, notebook_launcher
 from accelerate.test_utils import require_bnb
@@ -29,11 +32,60 @@ def basic_function():
     print(f"PartialState:\n{PartialState()}")
 
 
+def tough_nut_function(queue: Queue):
+    if queue.empty():
+        return
+    trial = queue.get()
+    if trial > 0:
+        queue.put(trial - 1)
+        raise RuntimeError("The nut hasn't cracked yet! Try again.")
+
+    print(f"PartialState:\n{PartialState()}")
+
+
+def bipolar_sleep_function(sleep_sec: int):
+    state = PartialState()
+    if state.process_index % 2 == 0:
+        raise RuntimeError("I'm an even process. I don't like to sleep.")
+    else:
+        time.sleep(sleep_sec)
+
+
 NUM_PROCESSES = int(os.environ.get("ACCELERATE_NUM_PROCESSES", 1))
 
 
 def test_can_initialize():
     notebook_launcher(basic_function, (), num_processes=NUM_PROCESSES)
+
+
+@mark.skipif(NUM_PROCESSES < 2, reason="Need at least 2 processes to test static rendezvous backends")
+def test_static_rdzv_backend():
+    notebook_launcher(basic_function, (), num_processes=NUM_PROCESSES, rdzv_backend="static")
+
+
+@mark.skipif(NUM_PROCESSES < 2, reason="Need at least 2 processes to test c10d rendezvous backends")
+def test_c10d_rdzv_backend():
+    notebook_launcher(basic_function, (), num_processes=NUM_PROCESSES, rdzv_backend="c10d")
+
+
+@mark.skipif(NUM_PROCESSES < 2, reason="Need at least 2 processes to test fault tolerance")
+def test_fault_tolerant(max_restarts: int = 3):
+    queue = Queue()
+    queue.put(max_restarts)
+    notebook_launcher(tough_nut_function, (queue,), num_processes=NUM_PROCESSES, max_restarts=max_restarts)
+
+
+@mark.skipif(NUM_PROCESSES < 2, reason="Need at least 2 processes to test monitoring")
+def test_monitoring(monitor_interval: float = 0.01, sleep_sec: int = 100):
+    start_time = time.time()
+    with raises(ChildFailedError, match="I'm an even process. I don't like to sleep."):
+        notebook_launcher(
+            bipolar_sleep_function,
+            (sleep_sec,),
+            num_processes=NUM_PROCESSES,
+            monitor_interval=monitor_interval,
+        )
+    assert time.time() - start_time < sleep_sec, "Monitoring did not stop the process in time."
 
 
 @require_bnb
@@ -47,6 +99,14 @@ def test_problematic_imports():
 def main():
     print("Test basic notebook can be ran")
     test_can_initialize()
+    print("Test static rendezvous backend")
+    test_static_rdzv_backend()
+    print("Test c10d rendezvous backend")
+    test_c10d_rdzv_backend()
+    print("Test fault tolerant")
+    test_fault_tolerant()
+    print("Test monitoring")
+    test_monitoring()
     if is_bnb_available():
         print("Test problematic imports (bnb)")
         test_problematic_imports()


### PR DESCRIPTION
# What does this PR do?

This PR enhances the `notebook_launcher` function by adding support for elastic launch, enabling fault tolerance. Previously, elastic launch was only supported when using the `accelerate` or `torchrun` CLI command. With this update, users can now launch custom training loops with elastic capabilities directly from a Python script.

The implementation draws on most of the launching code from [PyTorch's launcher API](https://github.com/pytorch/pytorch/blob/91bf952d10e9524a9b078900d9807efa5d252f5c/torch/distributed/launcher/api.py). Variable names and default values are chosen to align with Accelerate CLI standards.

Key features introduced:
- Parameters such as `rdzv_backend`, `rdzv_endpoint`, `rdzv_conf`, `rdzv_id`, `max_restarts`, and `monitor_interval` are added to `notebook_launcher`.
- Documentation is updated to reflect these changes.
- New tests are added to ensure functionality, including fault tolerance and monitoring.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a [link](https://discuss.huggingface.co/t/feature-request-elastic-launch-support-in-notebook-launcher/87042?u=younghwan235t8960u) to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?