### PR TITLE
Fix Wrong use of sync_gradients used to implement sync_each_batch 

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -996,14 +996,14 @@ class Accelerator:
             model.require_backward_grad_sync = old_require_backward_grad_sync
             model.require_forward_param_sync = old_require_forward_param_sync
 
-    def _do_sync(self, force: bool = False):
+    def _do_sync(self):
         "Sets the right `sync_gradients` context and either resets or increases `self.step`"
         if self.gradient_state.sync_with_dataloader and self.gradient_state.end_of_dataloader:
             self.step = 0
             self.gradient_state._set_sync_gradients(True)
         else:
             self.step += 1
-            self.gradient_state._set_sync_gradients(force or ((self.step % self.gradient_state.num_steps) == 0))
+            self.gradient_state._set_sync_gradients((self.step % self.gradient_state.num_steps) == 0)
 
     @property
     def sync_gradients(self):
@@ -1049,12 +1049,21 @@ class Accelerator:
         ...         optimizer.zero_grad()
         ```
         """
-        # sync_each_batch=True will guarantee below that self.sync_gradients=True, therefore
-        # resulting in the nullcontext always being selected.
-        self._do_sync(force=self.gradient_state.plugin_kwargs.get("sync_each_batch", False))
+        self._do_sync()
+
+        allow_gradient_sync = (
+            self.sync_gradients  # must sync if sync gradients need to complete an optimizer step
+            or (
+                # the no_sync context stops the gradients from reducing during distributed training
+                # bringing speedup (potentially at some costs). Here, no_sync can be prevented
+                # by setting sync_each_batch = True.
+                self.use_distributed  # only relevant in distributed settings
+                and self.gradient_state.plugin_kwargs.get("sync_each_batch", False)
+            )
+        )
         with contextlib.ExitStack() as cm_stack:
             for m in models:
-                cm_stack.enter_context(contextlib.nullcontext() if self.sync_gradients else self.no_sync(m))
+                cm_stack.enter_context(contextlib.nullcontext() if allow_gradient_sync else self.no_sync(m))
             yield
 
     @contextmanager

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -295,8 +295,8 @@ def test_gradient_accumulation_with_opt_and_scheduler(
             )
 
         if did_step:
-            opt.zero_grad()  # needs to be guarded by logic as to when we should zero grads
-            ddp_opt.zero_grad()
+            opt.zero_grad()  # flush gradients every accum step
+        ddp_opt.zero_grad()
 
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)

--- a/src/accelerate/test_utils/scripts/test_sync.py
+++ b/src/accelerate/test_utils/scripts/test_sync.py
@@ -267,7 +267,7 @@ def test_gradient_accumulation_with_opt_and_scheduler(
         step_model(model, input, target, accelerator, False)
         opt.step()
 
-        if ((iteration + 1) % 2 == 0) or ((iteration + 1) == len(dataloader)) or sync_each_batch:
+        if ((iteration + 1) % 2 == 0) or ((iteration + 1) == len(dataloader)):
             if split_batches:
                 sched.step()
             else:
@@ -284,19 +284,19 @@ def test_gradient_accumulation_with_opt_and_scheduler(
         assert (
             opt.param_groups[0]["lr"] == ddp_opt.param_groups[0]["lr"]
         ), f'Learning rates found in each optimizer did not align\nopt: {opt.param_groups[0]["lr"]}\nDDP opt: {ddp_opt.param_groups[0]["lr"]}\n'
-        did_step = (((iteration + 1) % 2) == 0) or ((iteration + 1) == len(dataloader)) or sync_each_batch
+        did_step = (((iteration + 1) % 2) == 0) or ((iteration + 1) == len(dataloader))
         if accelerator.num_processes > 1:
             check_model_parameters(
                 model,
                 ddp_model,
-                did_step,
+                did_step or sync_each_batch,  # syncs at each grad_accum interval of if sync_each_batch==True
                 iteration,
-                rtol=1e-3,  # somehow needs a relative tolerance
+                rtol=1e-3,  # needs a relative tolerance due to roundoff errors
             )
 
-        if ((iteration + 1) % 2 == 0) or ((iteration + 1) == len(dataloader)) or sync_each_batch:
+        if did_step:
             opt.zero_grad()  # needs to be guarded by logic as to when we should zero grads
-        ddp_opt.zero_grad()
+            ddp_opt.zero_grad()
 
         # Shuffle ddp_input on each iteration
         torch.manual_seed(1337 + iteration)


### PR DESCRIPTION
# What does this PR do?

As pointed  @Nightmare-n [here](https://github.com/huggingface/transformers/issues/29425#issuecomment-2116574203), the fix of [#29425](https://github.com/huggingface/transformers/issues/29425) was incorrect all this while, due to a misunderstanding of how `sync_gradients` is used to signal also [optimizer step](https://github.com/huggingface/accelerate/blob/main/src/accelerate/optimizer.py#L153).



**Tested On mistralai/Mixtral-8x7B-Instruct-v0.1**:
1. `torch =  2.2.0` , regressed changes to `accelerate = 0.28` (because latest `accelerate` does not support old torch
2. `torch = 2.3` with this PR

In both cases we observed the similar effect of the grad accumulation working on this new fix; the results shown below is from case 1.

![image](https://github.com/huggingface/accelerate/assets/8325951/6c0822ce-3805-4d13-a242-a701d532b3df)


<!-- Remove if not applicable -->

Fixes [#29425](https://github.com/huggingface/transformers/issues/29425), #2531


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @pacman100
- DeepSpeed: @pacman100
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan
- Maintained examples: @muellerzr or @pacman100

 -->

@muellerzr @Nightmare-n