### PR TITLE
Fix incorrect gradient clipping behavior when `accelerate config` is used with DeepSpeed

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -279,6 +279,8 @@ def get_cluster_input():
                         float,
                         default=1.0,
                     )
+                else:
+                    deepspeed_config["gradient_clipping"] = 0.0
                 if deepspeed_config["zero_stage"] == 3:
                     deepspeed_config["zero3_save_16bit_model"] = _ask_field(
                         "Do you want to save 16-bit model weights when using ZeRO Stage-3? [yes/NO]: ",


### PR DESCRIPTION
# What does this PR do?

When using DeepSpeed and `accelerate config`, `Do you want to use gradient clipping? [yes/NO]: no` leaves `deepspeed_config["gradient_clipping"]` to `auto`, which defaults DeepSpeed to use a gradient clipping value of `1.0`.

The correct value to specify when disabling gradient clipping should be `0.0`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@pacman100 @muellerzr