### PR TITLE
fix comet ml test

### DIFF
--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -224,6 +224,8 @@ class CometMLTest(unittest.TestCase):
             if "metric" in j.keys():
                 if j["metric"]["metricName"] == key:
                     return j["metric"]["metricValue"]
+            if j.get("key", None) == key:
+                return j["value"]
 
     def test_init_trackers(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the comet ml test that is failing on the CI. The issue is that there is a breaking change in their latest version. The payload structure is not the same anymore: 
old version: 
`'{"payload":{"local_timestamp":1716817708970,"log_other":{"key":"my_text","val":"some_value"},"message_id":20},"type":"ws_msg"}'`
new version:
`'{"payload":{"key":"my_text","message_id":20,"value":"some_value"},"type":"log_other"}'`

This seems intentional on comet-ml side, so O'm fixing how we parse the results. 
