### PR TITLE
Remove out-dated xpu device check code in `get_balanced_memory`

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -957,13 +957,14 @@ def get_balanced_memory(
     max_memory = get_max_memory(max_memory)
 
     if is_npu_available():
-        num_devices = len([d for d in max_memory if torch.device(d).type == "npu" and max_memory[d] > 0])
+        expected_device_type = "npu"
     elif is_mlu_available():
-        num_devices = len([d for d in max_memory if torch.device(d).type == "mlu" and max_memory[d] > 0])
+        expected_device_type = "mlu"
     elif is_xpu_available():
-        num_devices = len([d for d in max_memory if torch.device(d).type == "xpu" and max_memory[d] > 0])
+        expected_device_type = "xpu"
     else:
-        num_devices = len([d for d in max_memory if torch.device(d).type == "cuda" and max_memory[d] > 0])
+        expected_device_type = "cuda"
+    num_devices = len([d for d in max_memory if torch.device(d).type == expected_device_type and max_memory[d] > 0])
 
     if num_devices == 0:
         return max_memory

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -961,17 +961,7 @@ def get_balanced_memory(
     elif is_mlu_available():
         num_devices = len([d for d in max_memory if torch.device(d).type == "mlu" and max_memory[d] > 0])
     elif is_xpu_available():
-        num_devices = len(
-            [
-                d
-                for d in max_memory
-                if (
-                    d != "cpu"
-                    and (torch.device(d).type == "xpu" or torch.xpu.get_device_properties(d).dev_type == "gpu")
-                )
-                and max_memory[d] > 0
-            ]
-        )
+        num_devices = len([d for d in max_memory if torch.device(d).type == "xpu" and max_memory[d] > 0])
     else:
         num_devices = len([d for d in max_memory if torch.device(d).type == "cuda" and max_memory[d] > 0])
 


### PR DESCRIPTION
## What does this PR do?
This PR removes the outdated and unnecessary code of xpu device check in the following code snippet
```python
if (
                    d != "cpu"
                    and (torch.device(d).type == "xpu" or torch.xpu.get_device_properties(d).dev_type == "gpu")
                )
```
The reasons are 
- If torch.xpu.get_device_properties(d) works, torch.device(d).type will always be "xpu"
- If torch.device(d).type == "xpu", `d` will definitively not be "cpu"

`torch.device(d).type == "xpu"` is enough to check xpu device just like the case in MLU and  NPU.

## Who can review?
@SunMarc and @muellerzr