### PR TITLE
Improve test speeds by up to 30% in multi-gpu settings

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -99,7 +99,7 @@ def get_launch_command(**kwargs) -> list:
     return command
 
 
-DEFAULT_LAUNCH_COMMAND = get_launch_command(num_processes=device_count)
+DEFAULT_LAUNCH_COMMAND = get_launch_command(num_processes=device_count, monitor_interval=0.1)
 
 
 def parse_flag_from_env(key, default=False):


### PR DESCRIPTION
# What does this PR do?

@stas00 and Nikita (sorry don't know your gh handle!) and I were investigating why `accelerate launch` is *so slow* during tests.

Turns out pytorch isn't respecting the `monitor_interval` default of 0.1 for *some reason* and it's being set to 5 seconds instead. So, magically do that and the `test_multigpu.py` is sped up by 30% (`33.40s` -> `23.29s`) and `test_core` was sped up by 25% (`102.23s (0:01:42)` -> `76.94s (0:01:16)`

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @stas00 