### PR TITLE
Auto create dir when merging FSDP weights

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -223,6 +223,7 @@ def _distributed_checkpoint_to_merged_weights(checkpoint_dir: str, save_path: st
     """
     state_dict = {}
     save_path = Path(save_path)
+    save_path.mkdir(exist_ok=True)
     dist_cp_format_utils._load_state_dict(
         state_dict,
         storage_reader=dist_cp.FileSystemReader(checkpoint_dir),


### PR DESCRIPTION
# What does this PR do?

If the merge save_dir does not exist, the accelerate merge-weight will crash after a long time (Weights already merged in memory)
```
$ accelerate merge-weights checkpoint-2000/pytorch_model_fsdp_0/ checkpoint-2000-merged-weight
Traceback (most recent call last):
  File "/home/jobuser/.local/bin/accelerate", line 8, in <module>
    sys.exit(main())
  File "/home/jobuser/.local/lib/python3.10/site-packages/accelerate/commands/accelerate_cli.py", line 48, in main
    args.func(args)
  File "/home/jobuser/.local/lib/python3.10/site-packages/accelerate/commands/merge.py", line 27, in merge_command
    merge_fsdp_weights(
  File "/home/jobuser/.local/lib/python3.10/site-packages/accelerate/utils/fsdp_utils.py", line 270, in merge_fsdp_weights
    save_path = _distributed_checkpoint_to_merged_weights(checkpoint_dir, output_path, safe_serialization)
  File "/home/jobuser/.local/lib/python3.10/site-packages/accelerate/utils/fsdp_utils.py", line 237, in _distributed_checkpoint_to_merged_weights
    save(state_dict, save_path, safe_serialization=safe_serialization)
  File "/home/jobuser/.local/lib/python3.10/site-packages/accelerate/utils/other.py", line 205, in save
    save_func(obj, f)
  File "/home/jobuser/.local/lib/python3.10/site-packages/torch/serialization.py", line 627, in save
    with _open_zipfile_writer(f) as opened_zipfile:
  File "/home/jobuser/.local/lib/python3.10/site-packages/torch/serialization.py", line 501, in _open_zipfile_writer
    return container(name_or_buffer)
  File "/home/jobuser/.local/lib/python3.10/site-packages/torch/serialization.py", line 472, in __init__
    super().__init__(torch._C.PyTorchFileWriter(self.name))
RuntimeError: Parent directory checkpoint-2000-merged-weight does not exist.
```

This PR automatically create the dir if it does not exist


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?
@muellerzr 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->