### PR TITLE
Drop torch re-imports in npu and mlu paths

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -343,7 +343,6 @@ def is_mlu_available(check_device=False):
     if importlib.util.find_spec("torch_mlu") is None:
         return False
 
-    import torch
     import torch_mlu  # noqa: F401
 
     if check_device:
@@ -359,10 +358,9 @@ def is_mlu_available(check_device=False):
 @lru_cache
 def is_npu_available(check_device=False):
     "Checks if `torch_npu` is installed and potentially if a NPU is in the environment"
-    if importlib.util.find_spec("torch") is None or importlib.util.find_spec("torch_npu") is None:
+    if importlib.util.find_spec("torch_npu") is None:
         return False
 
-    import torch
     import torch_npu  # noqa: F401
 
     if check_device:


### PR DESCRIPTION
That's a follow up to cleanup the code in npu and mlu paths. Noted here: https://github.com/huggingface/accelerate/pull/2825#discussion_r1638310778

`import torch` is actually done file-wise and is not needed: https://github.com/huggingface/accelerate/blob/3b5a00e048f4393398d8ea8c4f468857f595f039/src/accelerate/utils/imports.py#L21

**CAVEAT:** I don't have HW to verify npu and mlu paths with tests.

CC: @SunMarc, @muellerzr
