### PR TITLE
[tests] use `torch_device` instead of `0` for device check 

### DIFF
--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -803,7 +803,7 @@ class BigModelingTester(unittest.TestCase):
         assert new_model.linear1.weight.device == torch.device("meta")
         assert new_model.linear2.weight.device == torch.device("meta")
         assert new_model.linear3.weight.device == torch.device(torch_device)
-        assert new_model.linear4.weight.device == torch.device(f"{torch_device.split(':')[0]}:1")
+        assert new_model.linear4.weight.device == torch.device(torch_device.replace(":0", ":1"))
 
         output = new_model(x)
         assert torch.allclose(expected, output.cpu(), atol=1e-5)
@@ -855,7 +855,7 @@ class BigModelingTester(unittest.TestCase):
         assert new_model.linear1.linear.weight.device == torch.device("meta")
         assert new_model.linear2.linear.weight.device == torch.device("meta")
         assert new_model.linear3.linear.weight.device == torch.device(torch_device)
-        assert new_model.linear4.linear.weight.device == torch.device(f"{torch_device.split(':')[0]}:1")
+        assert new_model.linear4.linear.weight.device == torch.device(torch_device.replace(":0", ":1"))
 
         output = new_model(x)
         assert torch.allclose(expected, output.cpu(), atol=1e-5)

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -868,8 +868,8 @@ class BigModelingTester(unittest.TestCase):
 
         inputs = torch.randn(3, 4)
         outputs = model1(inputs)
-        assert outputs.device == torch.device(0)
-        assert model1.weight.device == torch.device(0)
+        assert outputs.device == torch.device(torch_device)
+        assert model1.weight.device == torch.device(torch_device)
 
         hook1.offload()
         assert model1.weight.device == torch.device("cpu")
@@ -879,13 +879,13 @@ class BigModelingTester(unittest.TestCase):
         assert model2.weight.device == torch.device("cpu")
 
         outputs = model1(inputs)
-        assert outputs.device == torch.device(0)
-        assert model1.weight.device == torch.device(0)
+        assert outputs.device == torch.device(torch_device)
+        assert model1.weight.device == torch.device(torch_device)
 
         outputs = model2(outputs)
-        assert outputs.device == torch.device(0)
+        assert outputs.device == torch.device(torch_device)
         assert model1.weight.device == torch.device("cpu")
-        assert model2.weight.device == torch.device(0)
+        assert model2.weight.device == torch.device(torch_device)
 
         hook2.offload()
         assert model2.weight.device == torch.device("cpu")

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -323,14 +323,14 @@ class BigModelingTester(unittest.TestCase):
             with self.assertLogs(level="WARNING") as cm:
                 # We want to assert there are no warnings, but the 'assertLogs' method does not support that.
                 # Therefore, we are adding a dummy warning, and then we will assert it is the only warning.
-                model.to(0)
+                model.to(torch_device)
                 logger.warning("Dummy warning")
             self.assertEqual(len(cm.records), 1)
             self.assertIn(
                 "Dummy warning",
                 cm.records[0].message,
             )
-            output_bis = model(x.to(0))
+            output_bis = model(x.to(torch_device))
             assert torch.allclose(expected, output.cpu(), atol=1e-5)
             assert torch.allclose(expected, output_bis.cpu(), atol=1e-5)
 

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -779,7 +779,7 @@ class BigModelingTester(unittest.TestCase):
 
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
         assert new_model.linear1.weight.device == torch.device("meta")
-        assert new_model.linear2.weight.device == torch.device(0)
+        assert new_model.linear2.weight.device == torch.device(torch_device)
 
         output = new_model(x)
         assert torch.allclose(expected, output.cpu(), atol=1e-5)
@@ -802,8 +802,8 @@ class BigModelingTester(unittest.TestCase):
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
         assert new_model.linear1.weight.device == torch.device("meta")
         assert new_model.linear2.weight.device == torch.device("meta")
-        assert new_model.linear3.weight.device == torch.device(0)
-        assert new_model.linear4.weight.device == torch.device(1)
+        assert new_model.linear3.weight.device == torch.device(torch_device)
+        assert new_model.linear4.weight.device == torch.device(f"{torch_device.split(':')[0]}:1")
 
         output = new_model(x)
         assert torch.allclose(expected, output.cpu(), atol=1e-5)
@@ -828,8 +828,8 @@ class BigModelingTester(unittest.TestCase):
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
         assert new_model.linear1.linear.weight.device == torch.device("meta")
         assert new_model.linear2.linear.weight.device == torch.device("meta")
-        assert new_model.linear3.linear.weight.device == torch.device(0)
-        assert new_model.linear4.linear.weight.device == torch.device(0)
+        assert new_model.linear3.linear.weight.device == torch.device(torch_device)
+        assert new_model.linear4.linear.weight.device == torch.device(torch_device)
 
         output = new_model(x)
         assert torch.allclose(expected, output.cpu(), atol=1e-5)
@@ -854,8 +854,8 @@ class BigModelingTester(unittest.TestCase):
         # CPU-offloaded weights are on the meta device while waiting for the forward pass.
         assert new_model.linear1.linear.weight.device == torch.device("meta")
         assert new_model.linear2.linear.weight.device == torch.device("meta")
-        assert new_model.linear3.linear.weight.device == torch.device(0)
-        assert new_model.linear4.linear.weight.device == torch.device(1)
+        assert new_model.linear3.linear.weight.device == torch.device(torch_device)
+        assert new_model.linear4.linear.weight.device == torch.device(f"{torch_device.split(':')[0]}:1")
 
         output = new_model(x)
         assert torch.allclose(expected, output.cpu(), atol=1e-5)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -165,22 +165,22 @@ class HooksModelTester(unittest.TestCase):
         add_hook_to_module(model.linear1, AlignDevicesHook(execution_device=0))
         add_hook_to_module(model.batchnorm, AlignDevicesHook(execution_device=0))
         add_hook_to_module(model.linear2, AlignDevicesHook(execution_device=1))
-
-        assert model.linear1.weight.device == torch.device(0)
-        assert model.batchnorm.weight.device == torch.device(0)
-        assert model.batchnorm.running_mean.device == torch.device(0)
-        assert model.linear2.weight.device == torch.device(1)
+        
+        assert model.linear1.weight.device == torch.device(torch_device)
+        assert model.batchnorm.weight.device == torch.device(torch_device)
+        assert model.batchnorm.running_mean.device == torch.device(torch_device)
+        assert model.linear2.weight.device == torch.device(f"{torch_device.split(':')[0]}:1")
 
         # We can still make a forward pass. The input does not need to be on any particular device
         x = torch.randn(2, 3)
         output = model(x)
-        assert output.device == torch.device(1)
+        assert output.device == torch.device(f"{torch_device.split(':')[0]}:1")
 
         # We can add a general hook to put back output on same device as input.
         add_hook_to_module(model, AlignDevicesHook(io_same_device=True))
         x = torch.randn(2, 3).to(torch_device)
         output = model(x)
-        assert output.device == torch.device(0)
+        assert output.device == torch.device(torch_device)
 
     def test_align_devices_as_cpu_offload(self):
         model = ModelForTest()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -165,16 +165,16 @@ class HooksModelTester(unittest.TestCase):
         add_hook_to_module(model.linear1, AlignDevicesHook(execution_device=0))
         add_hook_to_module(model.batchnorm, AlignDevicesHook(execution_device=0))
         add_hook_to_module(model.linear2, AlignDevicesHook(execution_device=1))
-        
+
         assert model.linear1.weight.device == torch.device(torch_device)
         assert model.batchnorm.weight.device == torch.device(torch_device)
         assert model.batchnorm.running_mean.device == torch.device(torch_device)
-        assert model.linear2.weight.device == torch.device(f"{torch_device.split(':')[0]}:1")
+        assert model.linear2.weight.device == torch.device(torch_device.replace(":0", ":1"))
 
         # We can still make a forward pass. The input does not need to be on any particular device
         x = torch.randn(2, 3)
         output = model(x)
-        assert output.device == torch.device(f"{torch_device.split(':')[0]}:1")
+        assert output.device == torch.device(torch_device.replace(":0", ":1"))
 
         # We can add a general hook to put back output on same device as input.
         add_hook_to_module(model, AlignDevicesHook(io_same_device=True))


### PR DESCRIPTION
## What does this PR do?
Below is the rest result for `tests/test_big_modeling.py::BigModelingTester::test_cpu_offload_with_hook` on XPU:
```bash
===================================================== test session starts =====================================================
platform linux -- Python 3.9.0, pytest-8.0.0, pluggy-1.5.0
rootdir: /home/fanli/workspace/accelerate
plugins: subtests-0.12.1, excel-1.6.0, env-1.1.3, xdist-3.6.1
collected 1 item                                                                                                              

tests/test_big_modeling.py F                                                                                            [100%]

========================================================== FAILURES ===========================================================
________________________________________ BigModelingTester.test_cpu_offload_with_hook _________________________________________

self = <test_big_modeling.BigModelingTester testMethod=test_cpu_offload_with_hook>

    @require_non_cpu
    def test_cpu_offload_with_hook(self):
        model1 = torch.nn.Linear(4, 5)
        model1, hook1 = cpu_offload_with_hook(model1)
        assert model1.weight.device == torch.device("cpu")
    
        inputs = torch.randn(3, 4)
        outputs = model1(inputs)
>       assert outputs.device == torch.device(0)
E       AssertionError: assert device(type='xpu', index=0) == device(type='cuda', index=0)
E        +  where device(type='xpu', index=0) = tensor([[ 0.4093, -0.1815,  0.2612,  1.4389,  0.2595],\n        [ 1.0791,  0.4252, -0.6515,  1.2890,  0.9664],\n        [-0.2314, -0.8029,  0.6100,  0.4829, -0.0271]], device='xpu:0',\n       grad_fn=<AddmmBackward0>).device
E        +  and   device(type='cuda', index=0) = <class 'torch.device'>(0)
E        +    where <class 'torch.device'> = torch.device

tests/test_big_modeling.py:871: AssertionError
```
Not sure why these tests got passed on NPU (PR #2602), but I think the fix in this PR is the right one. 

@SunMarc and @muellerzr