### PR TITLE
[tests] fix bug in `test_tracking.ClearMLTest`

### DIFF
--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -270,7 +270,7 @@ class ClearMLTest(TempDirTestCase, MockingTestCase):
     def setUp(self):
         super().setUp()
         # ClearML offline session location is stored in CLEARML_CACHE_DIR
-        self.add_mocks(mock.patch.dict(os.environ, {"CLEARML_CACHE_DIR": self.tmpdir}))
+        self.add_mocks(mock.patch.dict(os.environ, {"CLEARML_CACHE_DIR": str(self.tmpdir)}))
 
     @staticmethod
     def _get_offline_dir(accelerator):


### PR DESCRIPTION
## What does this PR do?
This PR fixes the following failed test:
```bash
(accelerate) root@150f3b602a91:/workspace/code# python -m pytest -rA -k "ClearMLTest" tests
============================================================ test session starts =============================================================
platform linux -- Python 3.9.19, pytest-8.0.0, pluggy-1.5.0
rootdir: /workspace/code
plugins: subtests-0.12.1, xdist-3.6.1, hydra-core-1.3.2, anyio-4.2.0
collected 334 items / 329 deselected / 5 selected                                                                                            

tests/test_tracking.py FFFFF                                                                                                           [100%]

================================================================== FAILURES ==================================================================
_______________________________________________________ ClearMLTest.test_init_trackers _______________________________________________________

self = <test_tracking.ClearMLTest testMethod=test_init_trackers>

    def setUp(self):
        super().setUp()
        # ClearML offline session location is stored in CLEARML_CACHE_DIR
>       self.add_mocks(mock.patch.dict(os.environ, {"CLEARML_CACHE_DIR": self.tmpdir}))

tests/test_tracking.py:273: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/conda/envs/accelerate/lib/python3.9/site-packages/accelerate/test_utils/testing.py:472: in add_mocks
    m.start()
/opt/conda/envs/accelerate/lib/python3.9/unittest/mock.py:1842: in start
    result = self.__enter__()
/opt/conda/envs/accelerate/lib/python3.9/unittest/mock.py:1788: in __enter__
    self._patch_dict()
/opt/conda/envs/accelerate/lib/python3.9/unittest/mock.py:1813: in _patch_dict
    in_dict.update(values)
/opt/conda/envs/accelerate/lib/python3.9/_collections_abc.py:941: in update
    self[key] = other[key]
/opt/conda/envs/accelerate/lib/python3.9/os.py:684: in __setitem__
    value = self.encodevalue(value)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

value = PosixPath('/tmp/tmpmtomihfy')

    def encode(value):
        if not isinstance(value, str):
>           raise TypeError("str expected, not %s" % type(value).__name__)
E           TypeError: str expected, not PosixPath

/opt/conda/envs/accelerate/lib/python3.9/os.py:756: TypeError
```

The error message says that the value for `os.environ` should be a string rather than a PosixPath object. But self.tmpdir from `TempDirTestCase` is not a string. So we need to turn it to string. 
