### PR TITLE
[tests] enable XPU backend for `test_zero3_integration`

### DIFF
--- a/src/accelerate/test_utils/scripts/external_deps/test_zero3_integration.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_zero3_integration.py
@@ -14,7 +14,7 @@
 
 import torch.distributed
 
-from accelerate.test_utils import require_huggingface_suite
+from accelerate.test_utils import require_huggingface_suite, torch_device
 from accelerate.utils import is_transformers_available
 
 
@@ -27,7 +27,8 @@ GPT2_TINY = "sshleifer/tiny-gpt2"
 
 @require_huggingface_suite
 def init_torch_dist_then_launch_deepspeed():
-    torch.distributed.init_process_group(backend="nccl")
+    backend = "ccl" if torch_device == "xpu" else "nccl"
+    torch.distributed.init_process_group(backend=backend)
     deepspeed_config = {
         "zero_optimization": {
             "stage": 3,


### PR DESCRIPTION
## What does this PR do?
```bash
python -m pytest -rA -k "test_zero3_integration" tests/deepspeed
```
The command above gives the following error: 
```bash
E           Traceback (most recent call last):
E             File "/home/fanli/workspace/accelerate/src/accelerate/test_utils/scripts/external_deps/test_zero3_integration.py", line 52, in <module>
E               main()
E             File "/home/fanli/workspace/accelerate/src/accelerate/test_utils/scripts/external_deps/test_zero3_integration.py", line 48, in main
E               init_torch_dist_then_launch_deepspeed()
E             File "/home/fanli/workspace/accelerate/src/accelerate/test_utils/scripts/external_deps/test_zero3_integration.py", line 30, in init_torch_dist_then_launch_deepspeed
E               torch.distributed.init_process_group(backend="nccl")
E             File "/home/fanli/miniforge3/envs/acc-ut-ww23/lib/python3.9/site-packages/torch/distributed/c10d_logger.py", line 75, in wrapper
E               return func(*args, **kwargs)
E             File "/home/fanli/miniforge3/envs/acc-ut-ww23/lib/python3.9/site-packages/torch/distributed/c10d_logger.py", line 89, in wrapper
E               func_return = func(*args, **kwargs)
E             File "/home/fanli/miniforge3/envs/acc-ut-ww23/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py", line 1312, in init_process_group
E               default_pg, _ = _new_process_group_helper(
E             File "/home/fanli/miniforge3/envs/acc-ut-ww23/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py", line 1513, in _new_process_group_helper
E               raise RuntimeError("Distributed package doesn't have NCCL built in")
E           RuntimeError: Distributed package doesn't have NCCL built in
E           /home/fanli/miniforge3/envs/acc-ut-ww23/lib/python3.9/site-packages/torch/distributed/distributed_c10d.py:613: UserWarning: Attempted to get default timeout for nccl backend, but NCCL support is not compiled
E             warnings.warn("Attempted to get default timeout for nccl backend, but NCCL support is not compiled")
```

Pls let me know if I need to add support for other devices as well. @muellerzr @SunMarc 