### PR TITLE
🍻 Add static typing

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -179,9 +179,7 @@ _use_seedable_sampler = object()
 
 # Type hinting
 T_split_between_processes = TypeVar("T_split_between_processes", bound=Union[Sequence, dict, torch.Tensor])
-Ts_prepare = TypeVarTuple(
-    name="Ts_prepare",
-)
+Ts_prepare = TypeVarTuple(name="Ts_prepare")
 T_Module = TypeVar("T_Module", bound=torch.nn.Module)
 T_DataLoader = TypeVar("T_DataLoader", bound=torch.utils.data.DataLoader)
 T_Optimizer = TypeVar("T_Optimizer", bound=torch.optim.Optimizer)

--- a/src/accelerate/utils/typing.py
+++ b/src/accelerate/utils/typing.py
@@ -1,0 +1,15 @@
+from typing import Callable, Optional, ParamSpec, TypeVar
+
+
+T = TypeVar("T")
+P = ParamSpec("P")
+
+
+def take_annotation_from(this: Callable[P, Optional[T]]) -> Callable[[Callable], Callable[P, Optional[T]]]:
+    def decorator(real_function: Callable) -> Callable[P, Optional[T]]:
+        def new_function(*args: P.args, **kwargs: P.kwargs) -> Optional[T]:
+            return real_function(*args, **kwargs)
+
+        return new_function
+
+    return decorator


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Add strong typing to `Accelerator` methods.

It's super annoying to loose your typing when using `accelerate` wrapper.

Here is some typing that are preserved with this PR:

`accelerator.split_between_processes` is typed
```python
with accelerator.split_between_processes(["A", "B", "C"]) as inputs:
    reveal_type(inputs)  # E: list[str]
```
`accelerator.print` is typed, all the print *args are passed
```python
accelerator.print("Hello world!", file=...) # all the `print` args are passed
```

`accelerator.prepare` is typed, output types exactly match input type. Same for `accelerator.prepare_model`, `accelerator.prepare_optimizer` and `accelerator.prepare_scheduler`, `accelerator.unwrap_model`
```python
model2, optimizer2, scheduler2, = accelerator.prepare(model, optimizer, scheduler)

model2 = accelerator.prepare_model(model)
optimizer2 = accelerator.prepare_optimizer(optimizer)
scheduler2 = accelerator.prepare_scheduler(scheduler)
```

`accelerator.gather`, `accelerator.pad_across_processes` and `accelerator.reduce` are also typed

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->