### PR TITLE
fix bug when getting the real accelerator's device number

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -990,14 +990,14 @@ def get_balanced_memory(
     max_memory = get_max_memory(max_memory)
 
     if is_npu_available():
-        expected_device_type = "npu"
+        expected_device_count = torch.npu.device_count()
     elif is_mlu_available():
-        expected_device_type = "mlu"
+        expected_device_count = torch.mlu.device_count()
     elif is_xpu_available():
-        expected_device_type = "xpu"
+        expected_device_count = torch.xpu.device_count()
     else:
-        expected_device_type = "cuda"
-    num_devices = len([d for d in max_memory if torch.device(d).type == expected_device_type and max_memory[d] > 0])
+        expected_device_count = torch.cuda.device_count()
+    num_devices = len([d for d in max_memory if d != "cpu" and int(d) < expected_device_count and max_memory[d] > 0])
 
     if num_devices == 0:
         return max_memory

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -990,20 +990,10 @@ def get_balanced_memory(
     max_memory = get_max_memory(max_memory)
 
     if is_npu_available():
-        expected_device_count = torch.npu.device_count()
-    elif is_mlu_available():
-        expected_device_count = torch.mlu.device_count()
-    elif is_xpu_available():
-        expected_device_count = torch.xpu.device_count()
+        expected_device_type = "npu"
     else:
-        expected_device_count = torch.cuda.device_count()
-    num_devices = len(
-        [
-            d
-            for d in max_memory
-            if d not in ["mps", "cpu", "disk"] and int(d) < expected_device_count and max_memory[d] > 0
-        ]
-    )
+        expected_device_type = "cuda"
+    num_devices = len([d for d in max_memory if torch.device(d).type == expected_device_type and max_memory[d] > 0])
 
     if num_devices == 0:
         return max_memory

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -997,7 +997,13 @@ def get_balanced_memory(
         expected_device_count = torch.xpu.device_count()
     else:
         expected_device_count = torch.cuda.device_count()
-    num_devices = len([d for d in max_memory if d != "cpu" and int(d) < expected_device_count and max_memory[d] > 0])
+    num_devices = len(
+        [
+            d
+            for d in max_memory
+            if d not in ["mps", "cpu", "disk"] and int(d) < expected_device_count and max_memory[d] > 0
+        ]
+    )
 
     if num_devices == 0:
         return max_memory


### PR DESCRIPTION
## What does this PR do?
This PR is a follow-up fix for PR #2826  and I want to correct my statement in that PR that torch.device(d).type == "xpu" is enough to check the xpu device just like the case in npu and mlu. This was my mistake. In fact, `torch.device(0).type` will always return "cuda" on XPU as can be seen from the [pytorch code](https://github.com/pytorch/pytorch/blob/main/c10/core/Device.cpp#L45) and from the [pytorch offical doc](https://pytorch.org/docs/stable/tensor_attributes.html#torch-device) at least for now. But we are working on a PR to support it in the future pytorch version. Also for NPU path, I think torch.device(0).type` will return `cuda` as can be seen [here](https://github.com/Ascend/pytorch/issues/16).

In addition, users might pass device id that exceeds the available device count. For this case, we will not count that incorrect id to `num_devices` when calculating the balanced memory. So this PR actually fixes 2 issues:
- `num_devices` for non-cuda devices will always be 0
- `num_devices` will include device index that is larger than the available device number


## Who can review?
@SunMarc and @muellerzr
