### PR TITLE
Correct loading of models with shared tensors when using accelerator.load_state()

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -18,7 +18,7 @@ from typing import List
 
 import numpy as np
 import torch
-from safetensors.torch import load_file
+from safetensors.torch import load_file, load_model
 from torch.cuda.amp import GradScaler
 
 from .utils import (
@@ -196,12 +196,12 @@ def load_accelerator_state(
         ending = f"_{i}" if i > 0 else ""
         input_model_file = input_dir.joinpath(f"{SAFE_MODEL_NAME}{ending}.safetensors")
         if input_model_file.exists():
-            state_dict = load_file(input_model_file, device=str(map_location))
+            load_model(model, input_model_file, device=str(map_location), **load_model_func_kwargs)
         else:
             # Load with torch
             input_model_file = input_dir.joinpath(f"{MODEL_NAME}{ending}.bin")
             state_dict = torch.load(input_model_file, map_location=map_location)
-        models[i].load_state_dict(state_dict, **load_model_func_kwargs)
+            model.load_state_dict(state_dict, **load_model_func_kwargs)
     logger.info("All model weights loaded successfully")
 
     # Optimizer states

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -18,7 +18,7 @@ from typing import List
 
 import numpy as np
 import torch
-from safetensors.torch import load_file, load_model
+from safetensors.torch import load_model
 from torch.cuda.amp import GradScaler
 
 from .utils import (

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -66,7 +66,7 @@ class ModelForTest(torch.nn.Module):
 
 
 def get_signature(model):
-    return sum((param.abs().sum().item() for param in model.parameters()))
+    return sum(param.abs().sum().item() for param in model.parameters())
 
 
 def load_random_weights(model):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -31,6 +31,7 @@ from accelerate.test_utils.testing import AccelerateTestCase, require_cuda, requ
 from accelerate.utils import patch_environment
 from accelerate.utils.modeling import get_state_dict_from_offload, load_checkpoint_in_model
 
+
 class ModelWithTiedWeights(torch.nn.Module):
     def __init__(self):
         super().__init__()
@@ -39,12 +40,9 @@ class ModelWithTiedWeights(torch.nn.Module):
         self.linear2.weight = self.linear1.weight
         self.linear2.bias = self.linear1.bias
 
-        # need to add this for compliance with other methods
-        self.weight = self.linear1.weight
-        self.bias = self.linear1.bias
-
     def forward(self, x):
         return self.linear2(self.linear1(x))
+
 
 def create_components(tied_weights=False):
     model = ModelWithTiedWeights() if tied_weights else torch.nn.Linear(2, 4)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -31,9 +31,23 @@ from accelerate.test_utils.testing import AccelerateTestCase, require_cuda, requ
 from accelerate.utils import patch_environment
 from accelerate.utils.modeling import get_state_dict_from_offload, load_checkpoint_in_model
 
+class ModelWithTiedWeights(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear1 = torch.nn.Linear(2, 4)
+        self.linear2 = torch.nn.Linear(4, 2)
+        self.linear2.weight = self.linear1.weight
+        self.linear2.bias = self.linear1.bias
 
-def create_components():
-    model = torch.nn.Linear(2, 4)
+        # need to add this for compliance with other methods
+        self.weight = self.linear1.weight
+        self.bias = self.linear1.bias
+
+    def forward(self, x):
+        return self.linear2(self.linear1(x))
+
+def create_components(tied_weights=False):
+    model = ModelWithTiedWeights() if tied_weights else torch.nn.Linear(2, 4)
     optimizer = torch.optim.AdamW(model.parameters(), lr=1.0)
     scheduler = torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=0.01, steps_per_epoch=2, epochs=1)
     train_dl = DataLoader(TensorDataset(torch.tensor([1, 2, 3])))
@@ -54,11 +68,14 @@ class ModelForTest(torch.nn.Module):
 
 
 def get_signature(model):
-    return (model.weight.abs().sum() + model.bias.abs().sum()).item()
+    return sum((param.abs().sum().item() for param in model.parameters()))
 
 
 def load_random_weights(model):
-    state = torch.nn.Linear(*tuple(model.weight.T.shape)).state_dict()
+    if isinstance(model, torch.nn.Linear):
+        state = torch.nn.Linear(*tuple(model.weight.T.shape)).state_dict()
+    elif isinstance(model, ModelWithTiedWeights):
+        state = ModelWithTiedWeights().state_dict()
     model.load_state_dict(state)
 
 
@@ -66,6 +83,7 @@ def parameterized_custom_name_func(func, param_num, param):
     # customize the test name generator function as we want both params to appear in the sub-test
     # name, as by default it shows only the first param
     param_based_name = "use_safetensors" if param.args[0] is True else "use_pytorch"
+    param_based_name += "_tied_weights" if (len(param.args) == 2 and param.args[1] is True) else ""
     return f"{func.__name__}_{param_based_name}"
 
 
@@ -230,10 +248,10 @@ class AcceleratorTester(AccelerateTestCase):
             accelerator = Accelerator()
             assert str(accelerator.state.device) == "cuda:64"
 
-    @parameterized.expand((True, False), name_func=parameterized_custom_name_func)
-    def test_save_load_model(self, use_safetensors):
+    @parameterized.expand([(True, True), (True, False), (False, False)], name_func=parameterized_custom_name_func)
+    def test_save_load_model(self, use_safetensors, tied_weights):
         accelerator = Accelerator()
-        model, optimizer, scheduler, train_dl, valid_dl = create_components()
+        model, optimizer, scheduler, train_dl, valid_dl = create_components(tied_weights)
         accelerator.prepare(model, optimizer, scheduler, train_dl, valid_dl)
 
         model_signature = get_signature(model)


### PR DESCRIPTION
# What does this PR do?

I would run into problems with PyTorch's _load_state_dict_ complaining about missing keys. These keys belonged to shared tensors. These shared keys are intentionally omitted by the safetensors library. To load a model correctly, one has to use safetensor's _load_model_ function instead of the default _load_state_dict_ function (described [here](https://huggingface.co/docs/safetensors/torch_shared_tensors)). This was previously not done when using the _load_state_ function of the _Accelerator_.


Fixes # (issue)
I think this issue might be relevant as they also report problems when loading with _accelerator.load_state_.
https://github.com/huggingface/accelerate/issues/2155

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc