### PR TITLE
Add ignore_unexpected_keys arg to load_checkpoint_in_model()

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1616,6 +1616,7 @@ def load_checkpoint_in_model(
     keep_in_fp32_modules: List[str] = None,
     offload_8bit_bnb: bool = False,
     strict: bool = False,
+    ignore_unexpected_keys: bool = False,
 ):
     """
     Loads a (potentially sharded) checkpoint inside a model, potentially sending weights to a given device as they are
@@ -1656,6 +1657,8 @@ def load_checkpoint_in_model(
         strict (`bool`, *optional*, defaults to `False`):
             Whether to strictly enforce that the keys in the checkpoint state_dict match the keys of the model's
             state_dict.
+        ignore_unexpected_keys (`bool`, *optional*, defaults to `False`):
+            Whether to log warning for unexpected keys in checkpoint state_dict. Applicable for quantized models.
 
     """
     if offload_8bit_bnb:
@@ -1813,7 +1816,7 @@ def load_checkpoint_in_model(
         del loaded_checkpoint
         gc.collect()
 
-    if not strict and len(unexpected_keys) > 0:
+    if not strict and not ignore_unexpected_keys and len(unexpected_keys) > 0:
         logger.warning(
             f"Some weights of the model checkpoint at {checkpoint} were not used when"
             f" initializing {model.__class__.__name__}: {unexpected_keys}. This may or may not be an issue - make sure that the checkpoint does not have unnecessary parameters, or that the model definition correctly corresponds to the checkpoint."


### PR DESCRIPTION
# What does this PR do?

Do not output gigantic amount of warning output to console when loading a quantized model where the layers are replaced by QuantLinear as in [GPTQModel](https://github.com/modelcloud/GPTQModel) library (fork of AutoGPTQ). AutoGPTQ also has similar problem. 

This is not a bug fix but an end-user usability issue. As example when `GPTQModel.from_quantized()` load a quantized Qwen2MoE model, where there is massive amount of layers and experts, you get like hundreds to thousands of virtual lines of unexpected_keys warning pushed to the console/log.

To fix this, I added `ignore_unexpected_keys` property to loader method. Not sure this was the best way to do it.  Let me know if there is a better way around this. 

This needs to be fixed because users think this is a bug. It is not a bug but the warning verbosity is so great that it becomes a bug in user's perspective. Imagine yourself as a user and presented with several hundreds screen lines of warning on your terminal. 

For a quantized model, the warnings should not there in the first place and should only be printed in debug mode. This toggle allow that manual control.

TEST
* [X] PASSED: Tested true/false + strict=false

@muellerzr @BenjaminBossan @SunMarc