### PR TITLE
Fix slowdown on init with `device_map="auto"`

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -26,8 +26,13 @@ import torch
 from .imports import is_mlu_available, is_mps_available, is_npu_available, is_xpu_available
 
 
-def clear_device_cache():
-    gc.collect()
+def clear_device_cache(garbage_collection=False):
+    """
+    Clears the device cache by calling `torch.{backend}.empty_cache`. Can also run `gc.collect()`, but do note that
+    this is a *considerable* slowdown and should be used sparingly.
+    """
+    if garbage_collection:
+        gc.collect()
 
     if is_xpu_available():
         torch.xpu.empty_cache()
@@ -67,7 +72,7 @@ def release_memory(*objects):
         objects = list(objects)
     for i in range(len(objects)):
         objects[i] = None
-    clear_device_cache()
+    clear_device_cache(garbage_collection=True)
     return objects
 
 
@@ -123,7 +128,7 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
 
     def decorator(*args, **kwargs):
         nonlocal batch_size
-        clear_device_cache()
+        clear_device_cache(garbage_collection=True)
         params = list(inspect.signature(function).parameters.keys())
         # Guard against user error
         if len(params) < (len(args) + 1):
@@ -139,7 +144,7 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                 return function(batch_size, *args, **kwargs)
             except Exception as e:
                 if should_reduce_batch_size(e):
-                    clear_device_cache()
+                    clear_device_cache(garbage_collection=True)
                     batch_size //= 2
                 else:
                     raise


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/accelerate/pull/2857 introduced using `gc.collect()` as part of the `clear_device_cache`. This is *very* slow to do and increases the time to load models exponentially when using `device_map="auto"` (e.g. `llama-3-8B` went from 6.663s to 37.535s).

This PR adds a `garbage_collection` flag which is `False` by default.

Fixes https://github.com/huggingface/accelerate/issues/2911


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 