### PR TITLE
delete CCL env var setting

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -194,12 +194,6 @@ class PartialState:
                                 "DeepSpeed is not available => install it using `pip3 install deepspeed` or build it from source"
                             )
                         from deepspeed import comm as dist
-
-                        if is_xpu_available() and is_ccl_available():
-                            os.environ["CCL_PROCESS_LAUNCHER"] = "none"
-                            os.environ["CCL_LOCAL_SIZE"] = os.environ.get("LOCAL_WORLD_SIZE", "1")
-                            os.environ["CCL_LOCAL_RANK"] = os.environ.get("LOCAL_RANK", "0")
-
                         if not dist.is_initialized():
                             dist.init_distributed(dist_backend=self.backend, auto_mpi_discovery=False, **kwargs)
                         # We need to flag to `use_deepspeed` to be True to override `distributed_type` later
@@ -217,10 +211,6 @@ class PartialState:
                 os.environ["WORLD_SIZE"] = str(dist_information.world_size)
                 os.environ["LOCAL_RANK"] = str(dist_information.local_rank)
                 os.environ["LOCAL_WORLD_SIZE"] = str(dist_information.local_world_size)
-                if self.backend == "ccl" and self.distributed_type == DistributedType.MULTI_XPU:
-                    os.environ["CCL_PROCESS_LAUNCHER"] = "none"
-                    os.environ["CCL_LOCAL_SIZE"] = os.environ["LOCAL_WORLD_SIZE"]
-                    os.environ["CCL_LOCAL_RANK"] = os.environ["LOCAL_RANK"]
                 if not os.environ.get("MASTER_PORT", None):
                     os.environ["MASTER_PORT"] = "29500"
                 if (

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -194,6 +194,7 @@ class PartialState:
                                 "DeepSpeed is not available => install it using `pip3 install deepspeed` or build it from source"
                             )
                         from deepspeed import comm as dist
+
                         if not dist.is_initialized():
                             dist.init_distributed(dist_backend=self.backend, auto_mpi_discovery=False, **kwargs)
                         # We need to flag to `use_deepspeed` to be True to override `distributed_type` later


### PR DESCRIPTION
This PR deletes some CCL environment variable setting. With versions updating of software stack, current torch-CCL don't recommend manually setting these CCL env vars like 'CCL_LOCAL_SIZE', 'CCL_LOCAL_RANK' or 'CCL_PROCESS_LAUNCHER'.

And  `os.environ.get("LOCAL_WORLD_SIZE", "1")
os.environ.get("LOCAL_RANK", "0")`
may not get the correct value. For example, when run fine-tuning with deepspeed on multiple gpus, it will get wrong value and pass them to torchCCL comm backend, which will result in crash. 