### PR TITLE
Add huggingface_hub version to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "psutil",
         "pyyaml",
         "torch>=1.10.0",
-        "huggingface_hub",
+        "huggingface_hub>=0.21.0",
         "safetensors>=0.3.1",
     ],
     extras_require=extras,


### PR DESCRIPTION
# What does this PR do?

There is no `huggingface_hub` version in setup.py. It can lead to errors in some installations:

```
from accelerate import init_empty_weights, load_checkpoint_and_dispatch
File "/root/miniconda3/lib/python3.10/site-packages/accelerate/__init__.py", line 16, in <module> 
from .accelerator import Accelerator
File "/root/miniconda3/lib/python3.10/site-packages/accelerate/accelerator.py", line 34, in <module>
from huggingface_hub import split_torch_state_dict_into_shards
ImportError: cannot import name 'split_torch_state_dict_into_shards' from 'huggingface_hub' (/root/miniconda3/lib/python3.10/site-packages/huggingface_hub/__init__.py)
```
`split_torch_state_dict_into_shards` was added in [0.21.0](https://github.com/huggingface/huggingface_hub/releases/tag/v0.21.0) version of `huggingface_hub` library.

## Who can review?

Sorry, I am not sure who should review `setup.py` and installation process.