### PR TITLE
Require safetensors>=0.4.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         "pyyaml",
         "torch>=1.10.0",
         "huggingface_hub>=0.21.0",
-        "safetensors>=0.3.1",
+        "safetensors>=0.4.3",
     ],
     extras_require=extras,
     classifiers=[


### PR DESCRIPTION
# What does this PR do?

Fixes #2939

Changes made in `accelerate` PR https://github.com/huggingface/accelerate/pull/2875 require passing the arg `device` into `safetensors.torch.load_model`. This was not supported until after the `safetensors` PR https://github.com/huggingface/safetensors/pull/449 which is contained starting from release `v0.4.3`

Note: `conda` does not contain this release yet.