### PR TITLE
Support skip_first_batches for XLA

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1088,9 +1088,8 @@ def skip_first_batches(dataloader, num_batches=0):
     """
     Creates a `torch.utils.data.DataLoader` that will efficiently skip the first `num_batches`.
     """
-    is_xla_dataloader = False
-    if is_torch_xla_available() and isinstance(dataloader, MpDeviceLoaderWrapper):
-        is_xla_dataloader = True
+    state = AcceleratorState()
+    if state.distributed_type == DistributedType.XLA:
         device = dataloader.device
         dataloader = dataloader.dataloader
 
@@ -1157,7 +1156,7 @@ def skip_first_batches(dataloader, num_batches=0):
         else:
             dataloader = DataLoader(dataset, batch_sampler=new_batch_sampler, **kwargs)
 
-    if is_xla_dataloader:
+    if state.distributed_type == DistributedType.XLA:
         dataloader = MpDeviceLoaderWrapper(dataloader, device)
 
     return dataloader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -20,7 +20,7 @@ import torch
 from torch.utils.data import BatchSampler, DataLoader, IterableDataset, RandomSampler
 
 from .logging import get_logger
-from .state import AcceleratorState, DistributedType, GradientState, is_torch_xla_available
+from .state import AcceleratorState, DistributedType, GradientState, PartialState, is_torch_xla_available
 from .utils import (
     RNGType,
     broadcast,
@@ -1088,7 +1088,7 @@ def skip_first_batches(dataloader, num_batches=0):
     """
     Creates a `torch.utils.data.DataLoader` that will efficiently skip the first `num_batches`.
     """
-    state = AcceleratorState()
+    state = PartialState()
     if state.distributed_type == DistributedType.XLA:
         device = dataloader.device
         dataloader = dataloader.dataloader


### PR DESCRIPTION
# What does this PR do?

At present, when using the resume_from_checkpoint feature in the Transformers Trainer, it results in an error because `skip_first_batches` does not support `MpDeviceLoaderWrapper` of `XLA`. This PR supports this feature.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr
