### PR TITLE
Add missing docs for two KwargsHandlers

### DIFF
--- a/docs/source/package_reference/kwargs.md
+++ b/docs/source/package_reference/kwargs.md
@@ -42,6 +42,14 @@ related to distributed training or mixed precision are created.
 
 [[autodoc]] InitProcessGroupKwargs
 
+## ‎TorchDynamoPlugin
+
+[[autodoc]] ‎TorchDynamoPlugin
+
+## ‎GradientAccumulationPlugin
+
+[[autodoc]] ‎GradientAccumulationPlugin
+
 ## KwargsHandler
 
 [[autodoc]] utils.KwargsHandler


### PR DESCRIPTION
TorchDynamoPlugin and ‎GradientAccumulationPlugin were not included in the documentation.

@muellerzr