### PR TITLE
Introduce stateful dataloader (alternative)

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2038,6 +2038,7 @@ class Accelerator:
             slice_fn_for_dispatch=slice_fn_for_dispatch,
             use_seedable_sampler=self.use_seedable_sampler,
             non_blocking=self.non_blocking,
+            stateful=self.dataloader_config.stateful,
         )
         self._dataloaders.append(prepared_data_loader)
         return prepared_data_loader
@@ -3481,7 +3482,7 @@ class Accelerator:
         ...     ...
         ```
         """
-        return skip_first_batches(dataloader, num_batches=num_batches)
+        return skip_first_batches(dataloader, num_batches=num_batches, stateful=self.dataloader_config.stateful)
 
     def __deepcopy__(self, memo):
         logger.info("Deep copying the `Accelerator` object, note that this will point to the same original object.")

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -466,6 +466,9 @@ class DataLoaderShard(DataLoaderStateMixin):
         # Delegate attribute access to the internal instance
         return getattr(self._dataloader, name)
 
+    def __len__(self):
+        return len(self._dataloader)
+
     def __iter__(self):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.synchronized_generator)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -779,7 +779,7 @@ class DataLoaderDispatcher(DataLoaderStateMixin):
             self.dataset.set_epoch(epoch)
 
     def __len__(self):
-        whole_length = super().__len__()
+        whole_length = self._dataloader.__len__()
         if self.split_batches:
             return whole_length
         elif self._drop_last:

--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -39,6 +39,7 @@ from .testing import (
     require_single_gpu,
     require_single_xpu,
     require_torch_min_version,
+    require_torchdata,
     require_torchvision,
     require_tpu,
     require_xpu,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -52,6 +52,7 @@ from ..utils import (
     is_timm_available,
     is_torch_version,
     is_torch_xla_available,
+    is_torchdata_available,
     is_torchvision_available,
     is_transformers_available,
     is_triton_available,
@@ -402,6 +403,13 @@ def require_import_timer(test_case):
     installed
     """
     return unittest.skipUnless(is_import_timer_available(), "test requires tuna interpreter")(test_case)
+
+
+def require_torchdata(test_case):
+    """
+    Decorator marking a test that requires torchdata installed. These tests are skipped when tuna isn't installed
+    """
+    return unittest.skipUnless(is_torchdata_available(), "test requires torchdata")(test_case)
 
 
 _atleast_one_tracker_available = (

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -107,6 +107,7 @@ from .imports import (
     is_tensorboard_available,
     is_timm_available,
     is_torch_xla_available,
+    is_torchdata_available,
     is_torchvision_available,
     is_transformer_engine_available,
     is_transformers_available,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -720,6 +720,10 @@ class DataLoaderConfiguration:
             " prepared dataloader has `pin_memory` set to `True` to work properly."
         },
     )
+    stateful: bool = field(
+        default=False,
+        metadata={"help": "If set to `True`, the dataloader prepared by the Accelerator will be stateful."},
+    )
 
 
 @dataclass

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -177,6 +177,15 @@ def is_deepspeed_available():
     return _is_package_available("deepspeed")
 
 
+def is_torchdata_available():
+    package_exists = _is_package_available("torchdata")
+    if not package_exists:
+        return False
+    import torchdata
+
+    return hasattr(torchdata, "stateful_dataloader") and hasattr(torchdata.stateful_dataloader, "StatefulDataLoader")
+
+
 def is_pippy_available():
     package_exists = _is_package_available("pippy", "torchpippy")
     if package_exists:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -410,11 +410,10 @@ class StatefulDataLoaderTester(unittest.TestCase):
     def test_init(self):
         Accelerator()
 
-        dataloader = DataLoaderShard(range(16), batch_size=4, stateful=True)
-        assert isinstance(dataloader._dataloader, StatefulDataLoader)
-
-        dataloader = DataLoaderDispatcher(range(16), batch_size=4, stateful=True)
-        assert isinstance(dataloader._dataloader, StatefulDataLoader)
+        for dl_type in [DataLoaderShard, DataLoaderDispatcher]:
+            for dl_type in [DataLoaderShard, DataLoaderDispatcher]:
+                dataloader = dl_type(range(16), batch_size=4, stateful=True)
+                assert isinstance(dataloader._dataloader, StatefulDataLoader)
 
     def test_grab_state(self):
         Accelerator()


### PR DESCRIPTION
# What does this PR do?

This PR is an alternative to https://github.com/huggingface/accelerate/pull/2895 which uses composition in the end to be a pinch less "magical". Since we're also using composition, if we eventually want any "base iterable" type of loader to be compatible/use these methods, as long as the underlying assumption is they behave like `DataLoader`'s, this logic could scale.

Fixes https://github.com/huggingface/accelerate/issues/2859


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @BenjaminBossan @byi8220