### PR TITLE
clear memory after offload

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -21,6 +21,7 @@ import torch.nn as nn
 from .state import PartialState
 from .utils import (
     PrefixedDataset,
+    clear_device_cache,
     find_device,
     named_module_tensors,
     send_to_device,
@@ -695,6 +696,7 @@ class CpuOffload(ModelHook):
     def pre_forward(self, module, *args, **kwargs):
         if self.prev_module_hook is not None:
             self.prev_module_hook.offload()
+            clear_device_cache()
         module.to(self.execution_device)
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -21,12 +21,12 @@ import torch.nn as nn
 from .state import PartialState
 from .utils import (
     PrefixedDataset,
-    clear_device_cache,
     find_device,
     named_module_tensors,
     send_to_device,
     set_module_tensor_to_device,
 )
+from .utils.memory import clear_device_cache
 from .utils.modeling import get_non_persistent_buffers
 from .utils.other import recursive_getattr
 

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -223,7 +223,7 @@ if is_megatron_lm_available():
     from .megatron_lm import prepare_model_optimizer_scheduler as megatron_lm_prepare_model_optimizer_scheduler
     from .megatron_lm import prepare_optimizer as megatron_lm_prepare_optimizer
     from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
-from .memory import clear_device_cache, find_executable_batch_size, release_memory
+from .memory import find_executable_batch_size, release_memory
 from .other import (
     check_os_kernel,
     clean_state_dict_for_safetensors,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -223,7 +223,7 @@ if is_megatron_lm_available():
     from .megatron_lm import prepare_model_optimizer_scheduler as megatron_lm_prepare_model_optimizer_scheduler
     from .megatron_lm import prepare_optimizer as megatron_lm_prepare_optimizer
     from .megatron_lm import prepare_scheduler as megatron_lm_prepare_scheduler
-from .memory import find_executable_batch_size, release_memory
+from .memory import clear_device_cache, find_executable_batch_size, release_memory
 from .other import (
     check_os_kernel,
     clean_state_dict_for_safetensors,

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -23,7 +23,14 @@ import inspect
 
 import torch
 
-from .imports import is_mlu_available, is_mps_available, is_musa_available, is_npu_available, is_xpu_available
+from .imports import (
+    is_cuda_available,
+    is_mlu_available,
+    is_mps_available,
+    is_musa_available,
+    is_npu_available,
+    is_xpu_available,
+)
 
 
 def clear_device_cache(garbage_collection=False):
@@ -44,7 +51,7 @@ def clear_device_cache(garbage_collection=False):
         torch.npu.empty_cache()
     elif is_mps_available(min_version="2.0"):
         torch.mps.empty_cache()
-    else:
+    elif is_cuda_available():
         torch.cuda.empty_cache()
 
 


### PR DESCRIPTION
# What does this PR do ? 

This PR clears the memory in `CpuOffload` after we offload the previous module to the `cpu` ( used a lot in `cpu_offload_with_hook` ). This helps a lot with cpu offloading in diffusers as this is more efficient with the VRAM usage.

cc @sayakpaul 