### PR TITLE
Fix typo on warning str: "on the meta device device" -> "on the meta device"

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -434,7 +434,7 @@ def dispatch_model(
         )
         if len(offloaded_devices_str) > 0:
             logger.warning(
-                f"Some parameters are on the meta device device because they were offloaded to the {offloaded_devices_str}."
+                f"Some parameters are on the meta device because they were offloaded to the {offloaded_devices_str}."
             )
 
         # Attaching the hook may break tied weights, so we retie them


### PR DESCRIPTION
Fixes #2996

# What does this PR do?

This fixes a typo on a warning string [(link to the line)](https://github.com/huggingface/accelerate/blob/d982751aecc020a58a5583473eabe8d281f5f114/src/accelerate/big_modeling.py#L437).
Typo: "Some parameters are on the meta device device" -> "Some parameters are on the meta **device**"

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Relevant people:

- Big modeling: @SunMarc