### PR TITLE
Add small util to enable FSDP offloading quickly

### DIFF
--- a/docs/source/package_reference/fsdp.md
+++ b/docs/source/package_reference/fsdp.md
@@ -15,6 +15,10 @@ rendered properly in your Markdown viewer.
 
 # Utilities for Fully Sharded Data Parallelism
 
+[[autodoc]] utils.enable_fsdp_ram_efficient_loading
+
+[[autodoc]] utils.disable_fsdp_ram_efficient_loading
+
 [[autodoc]] utils.merge_fsdp_weights
 
 [[autodoc]] utils.FullyShardedDataParallelPlugin

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -188,7 +188,15 @@ if is_deepspeed_available():
     )
 
 from .bnb import has_4bit_bnb_layers, load_and_quantize_model
-from .fsdp_utils import load_fsdp_model, load_fsdp_optimizer, merge_fsdp_weights, save_fsdp_model, save_fsdp_optimizer
+from .fsdp_utils import (
+    disable_fsdp_ram_efficient_loading,
+    enable_fsdp_ram_efficient_loading,
+    load_fsdp_model,
+    load_fsdp_optimizer,
+    merge_fsdp_weights,
+    save_fsdp_model,
+    save_fsdp_optimizer,
+)
 from .launch import (
     PrepareForLaunch,
     _filter_args,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1300,7 +1300,7 @@ class FullyShardedDataParallelPlugin:
             "for reduced memory usage. Defaults to `False`"
         },
     )
-    ram_efficient_loading: bool = field(
+    cpu_ram_efficient_loading: bool = field(
         default=None,
         metadata={
             "help": "If True, only the first process loads the pretrained model checkoint while all other processes have empty weights. "
@@ -1399,12 +1399,12 @@ class FullyShardedDataParallelPlugin:
                 str_to_bool(os.environ.get(env_prefix + "ACTIVATION_CHECKPOINTING", "False")) == 1
             )
 
-        if self.ram_efficient_loading is None:
-            self.ram_efficient_loading = (
-                str_to_bool(os.environ.get(env_prefix + "RAM_EFFICIENT_LOADING", "False")) == 1
+        if self.cpu_ram_efficient_loading is None:
+            self.cpu_ram_efficient_loading = (
+                str_to_bool(os.environ.get(env_prefix + "CPU_RAM_EFFICIENT_LOADING", "False")) == 1
             )
 
-        if self.ram_efficient_loading and not self.sync_module_states:
+        if self.cpu_ram_efficient_loading and not self.sync_module_states:
             warnings.warn(
                 "sync_module_states cannot be False since efficient cpu ram loading enabled. "
                 "Setting sync_module_states to True."

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -27,6 +27,23 @@ from .versions import is_torch_version
 logger = get_logger(__name__)
 
 
+def enable_fsdp_ram_efficient_loading():
+    """
+    Enables RAM efficient loading of Hugging Face models for FSDP in the environment.
+    """
+    # Sets values for `transformers.modeling_utils.is_fsdp_enabled`
+    if "ACCELERATE_USE_FSDP" not in os.environ:
+        os.environ["ACCELERATE_USE_FSDP"] = "True"
+    os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"] = "True"
+
+
+def disable_fsdp_ram_efficient_loading():
+    """
+    Disables RAM efficient loading of Hugging Face models for FSDP in the environment.
+    """
+    os.environ["FSDP_CPU_RAM_EFFICIENT_LOADING"] = "False"
+
+
 def _get_model_state_dict(model, adapter_only=False):
     if adapter_only and is_peft_model(model):
         from peft import get_peft_model_state_dict

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -43,7 +43,7 @@ from accelerate.utils.constants import (
     FSDP_STATE_DICT_TYPE,
 )
 from accelerate.utils.dataclasses import FullyShardedDataParallelPlugin
-from accelerate.utils.fsdp_utils import enable_fsdp_ram_efficient_loading
+from accelerate.utils.fsdp_utils import disable_fsdp_ram_efficient_loading, enable_fsdp_ram_efficient_loading
 from accelerate.utils.other import patch_environment
 
 
@@ -273,6 +273,10 @@ class FSDPPluginIntegration(AccelerateTestCase):
         fsdp_plugin = FullyShardedDataParallelPlugin()
         assert fsdp_plugin.cpu_ram_efficient_loading is True
         assert os.environ.get("FSDP_CPU_RAM_EFFICIENT_LOADING") == "True"
+        disable_fsdp_ram_efficient_loading()
+        fsdp_plugin = FullyShardedDataParallelPlugin()
+        assert fsdp_plugin.cpu_ram_efficient_loading is False
+        assert os.environ.get("FSDP_CPU_RAM_EFFICIENT_LOADING") == "False"
 
 
 # Skip this test when TorchXLA is available because accelerate.launch does not support TorchXLA FSDP.

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -267,7 +267,6 @@ class FSDPPluginIntegration(AccelerateTestCase):
             fsdp_plugin = FullyShardedDataParallelPlugin(cpu_offload=flag)
             assert fsdp_plugin.cpu_offload == CPUOffload(offload_params=flag)
 
-    @require_huggingface_suite
     def test_cpu_ram_efficient_loading(self):
         enable_fsdp_ram_efficient_loading()
         fsdp_plugin = FullyShardedDataParallelPlugin()

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -30,7 +30,6 @@ from accelerate.test_utils.testing import (
     get_launch_command,
     path_in_accelerate_package,
     require_fsdp,
-    require_huggingface_suite,
     require_multi_device,
     require_non_cpu,
     require_non_torch_xla,


### PR DESCRIPTION
# What does this PR do?

Enables users to quickly do:
```python
from accelerate.utils import enable_fsdp_ram_efficient_loading
enable_fsdp_ram_efficient_loading()

model = AutoModel.from_*
```

(Also some tests got commented out when I was toying with things, hence the odd diff)

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 

## Other info

Note that we have `self.ram_efficient_loading` in the FSDP Plugin. For clarity it should be `cpu_ram_efficient_loading` and also this was only added in the prior PR, so it's fine. 