### PR TITLE
Custom Types DataLoader

### DIFF
--- a/docs/source/concept_guides/internal_mechanism.md
+++ b/docs/source/concept_guides/internal_mechanism.md
@@ -28,7 +28,7 @@ Then, when calling [`~Accelerator.prepare`], the library:
 - wraps your model(s) in the container adapted for the distributed setup,
 - wraps your optimizer(s) in an [`~optimizer.AcceleratedOptimizer`],
 - wraps your scheduler(s) in an [`~scheduler.AcceleratedScheduler`]
-- creates a new version of your dataloader(s) in a [`~data_loader.DataLoaderShard`] or [`~data_loader.DataLoaderDispatcher`]
+- creates a new version of your dataloader(s) in a [`~data_loader.DataLoaderShard`], [`~data_loader.DataLoaderDispatcher`], or [`~data_loader.CustomTypesDataLoader`]
 
 While the model(s), optimizer(s), and scheduler(s) are just put in simple wrappers, the dataloader(s) are re-created. This is mostly
 because PyTorch does not let the user change the `batch_sampler` of a dataloader once it's been created and the
@@ -42,7 +42,9 @@ The [`~data_loader.DataLoaderShard`] subclasses `DataLoader` to add the followin
 - it puts the batches on the proper device before yielding them (unless you have opted out of
   `device_placement=True`).
   
-The [`~data_loader.DataLoaderDispatcher`] subclasses differs from the [`~data_loader.DataLoaderShard`] in that when iterating through the `DataLoader`, the data is all starting from process 0 and *then* split and sent off to each process rather than it happening at the dataset level.
+The [`~data_loader.DataLoaderDispatcher`] subclass differs from the [`~data_loader.DataLoaderShard`] in that when iterating through the `DataLoader`, the data is all starting from process 0 and *then* split and sent off to each process rather than it happening at the dataset level.
+
+The [`~data_loader.CustomTypesDataLoader`] subclass differs from the [`~data_loader.DataLoaderShard`] and [`~data_loader.DataLoaderDispatcher`] in that it can be used to wrap iterables with custom logic to give users more control over how the dataloader should manipulate the data; the dataloader itself only invokes `__iter__()` and moves the data to the appropriate device.
 
 The random number generator synchronization will by default synchronize:
 

--- a/docs/source/package_reference/torch_wrappers.md
+++ b/docs/source/package_reference/torch_wrappers.md
@@ -27,6 +27,7 @@ when calling [`~Accelerator.prepare`].
 [[autodoc]] data_loader.IterableDatasetShard
 [[autodoc]] data_loader.DataLoaderShard
 [[autodoc]] data_loader.DataLoaderDispatcher
+[[autodoc]] data_loader.CustomTypesDataLoader
 
 ## Optimizers 
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1188,7 +1188,9 @@ class Accelerator:
             elif isinstance(obj, torch.optim.Optimizer):
                 optimizer = self.prepare_optimizer(obj, device_placement=device_placement)
                 return optimizer
-            elif isinstance(obj, torch.utils.data.DataLoader) or (self.dataloader_config.custom_types and isinstance(obj, Iterable)):
+            elif isinstance(obj, torch.utils.data.DataLoader) or (
+                self.dataloader_config.custom_types and isinstance(obj, Iterable)
+            ):
                 return self.prepare_data_loader(
                     obj,
                     device_placement=device_placement,
@@ -1996,15 +1998,21 @@ class Accelerator:
         return tuple(result)
 
     def prepare_data_loader(
-        self, data_loader: torch.utils.data.DataLoader, device_placement=None, slice_fn_for_dispatch=None, custom_types: bool = False, custom_type_batch_size=None,
+        self,
+        data_loader: Union[torch.utils.data.DataLoader, Iterable],
+        device_placement=None,
+        slice_fn_for_dispatch=None,
+        custom_types: bool = False,
+        custom_type_batch_size: int = None,
     ):
         """
         Prepares a PyTorch DataLoader for training in any distributed setup. It is recommended to use
         [`Accelerator.prepare`] instead.
 
         Args:
-            data_loader (`torch.utils.data.DataLoader`):
-                A vanilla PyTorch DataLoader to prepare
+            data_loader (`Union[torch.utils.data.DataLoader, Iterable]`):
+                A vanilla PyTorch DataLoader to prepare, or a custom Iterable to be wrapped in a dataloader if
+                `custom_types`=True.
             device_placement (`bool`, *optional*):
                 Whether or not to place the batches on the proper device in the prepared dataloader. Will default to
                 `self.device_placement`.
@@ -2012,6 +2020,11 @@ class Accelerator:
                 If passed, this function will be used to slice tensors across `num_processes`. Will default to
                 [`~utils.slice_tensors`]. This argument is used only when `dispatch_batches` is set to `True` and will
                 be ignored otherwise.
+            custom_types (`bool`, , *optional*`,  defaults to `False`):
+                Whether or not the data_loader arg is a custom type, or a vanilla dataloader wrapped around an instance
+                of a custom iterable type.
+            custom_type_batch_size (`int`, *optional*):
+                Batch size to be used if custom_types=`True`.
 
         Example:
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -566,14 +566,17 @@ if is_torch_xla_available():
 
 class CustomTypesDataLoader(DataLoader, DataLoaderStateMixin):
     """
-    Subclass of a PyTorch `DataLoader` that can handle custom iterable types as long as they yield
-    things that can be converted to PyTorch tensors.
+    Subclass of a PyTorch `DataLoader` that can handle custom iterable types as long as they yield things that can be
+    converted to PyTorch tensors.
     """
+
     def __init__(self, data_or_loader, batch_size=None, device=None, _non_blocking: bool = False, **kwargs):
         if isinstance(data_or_loader, DataLoader):
             data = data_or_loader.dataset
             if batch_size is not None and batch_size != data_or_loader.batch_size:
-                raise ValueError("provided custom types batch size conflicts with the batch size of wrapped dataloader")
+                raise ValueError(
+                    "provided custom types batch size conflicts with the batch size of wrapped dataloader"
+                )
             batch_size = data_or_loader.batch_size
         else:
             if batch_size is None:
@@ -588,15 +591,18 @@ class CustomTypesDataLoader(DataLoader, DataLoaderStateMixin):
         if isinstance(iter_type, IterableDataset):
             return iter_type
         # If it isn't, we create a thin wrapper to make it into one
+
         class WrappedIterable(IterableDataset):
             def __iter__(self):
                 return iter(iter_type)
+
         return WrappedIterable()
 
     def __iter__(self):
         # Iterate through the data; if the device is configured, move the data to it
         for batch in super().__iter__():
-            yield(send_to_device(batch, self.device, non_blocking=self._non_blocking))
+            yield (send_to_device(batch, self.device, non_blocking=self._non_blocking))
+
 
 class DataLoaderDispatcher(DataLoader, DataLoaderStateMixin):
     """
@@ -910,9 +916,10 @@ def prepare_data_loader(
             If set to `True`, dataloader will utilize non-blocking host-to-device transfers. If the dataloader has
             `pin_memory` set to `True`, this will help to increase overlap between data transfer and computations.
         custom_types (`bool`, *optional*, defaults to `False`):
-            If set to True, dataloader will accept custom_types that yield values that can be
-            converted to Torch tensors. If True, the value of `dispatch_batches` and `split_batches`
-            will be ignored.
+            If set to `True`, dataloader will accept custom_types that yield values that can be converted to Torch
+            tensors. If `True`, the value of `dispatch_batches` and `split_batches` will be ignored.
+        custom_type_batch_size (`int`, *optional*):
+            Batch size to be used if custom_types=`True` for custom iterables not already wrapped by a dataloader.
 
     Returns:
         `torch.utils.data.dataloader.DataLoader`: A new data loader that will yield the portion of the batches
@@ -925,7 +932,9 @@ def prepare_data_loader(
     </Tip>
     """
     if custom_types:
-        return CustomTypesDataLoader(dataloader, batch_size=custom_type_batch_size, non_blocking=non_blocking, device=device)
+        return CustomTypesDataLoader(
+            dataloader, batch_size=custom_type_batch_size, non_blocking=non_blocking, device=device
+        )
 
     if dispatch_batches is None:
         if not put_on_device:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -724,15 +724,15 @@ class DataLoaderConfiguration:
         default=False,
         metadata={
             "help": "If set to `True`, the data prepared by the Accelerator may wrap custom iterables, as long as it"
-            " yields types that can be converted into torch tensors. If `True`, the values of `split_batches` and" 
+            " yields types that can be converted into torch tensors. If `True`, the values of `split_batches` and"
             " `dispatch_batches` will not be used."
-        }
+        },
     )
     custom_type_batch_size: int = field(
         default=None,
         metadata={
-            "help": "Value to be used for the batch size of custom_types. Only used if `custom_types` is `True`."
-        }
+            "help": "Value to be used for the batch size of wrapped custom iterables. Only used if `custom_types` is `True`."
+        },
     )
 
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -720,6 +720,20 @@ class DataLoaderConfiguration:
             " prepared dataloader has `pin_memory` set to `True` to work properly."
         },
     )
+    custom_types: bool = field(
+        default=False,
+        metadata={
+            "help": "If set to `True`, the data prepared by the Accelerator may wrap custom iterables, as long as it"
+            " yields types that can be converted into torch tensors. If `True`, the values of `split_batches` and" 
+            " `dispatch_batches` will not be used."
+        }
+    )
+    custom_type_batch_size: int = field(
+        default=None,
+        metadata={
+            "help": "Value to be used for the batch size of custom_types. Only used if `custom_types` is `True`."
+        }
+    )
 
 
 @dataclass

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -32,6 +32,7 @@ from accelerate.data_loader import (
 )
 from accelerate.utils import DataLoaderConfiguration
 
+
 class RandomIterableDataset(IterableDataset):
     # For testing, an iterable dataset of random length
     def __init__(self, p_stop=0.01, max_length=1000):
@@ -405,8 +406,10 @@ class DataLoaderTester(unittest.TestCase):
         class MyCustomType:
             def __init__(self):
                 self.data = data
+
             def __iter__(self):
                 return iter(self.data)
+
         return MyCustomType()
 
     @staticmethod
@@ -419,10 +422,12 @@ class DataLoaderTester(unittest.TestCase):
                 assert batch.tolist() == expected_batch
                 assert batch.device.type == device
 
-    @parameterized.expand([
-        ("nested under dataloader wrapper", True),
-        ("without nested dataloader wrapper", False),
-    ])
+    @parameterized.expand(
+        [
+            ("nested under dataloader wrapper", True),
+            ("without nested dataloader wrapper", False),
+        ]
+    )
     def test_custom_types_dataloader(self, _, wrap_with_dataloader):
         device = "cuda"
         custom_iterable = self._get_custom_iterable(data=list(range(8)))
@@ -432,13 +437,15 @@ class DataLoaderTester(unittest.TestCase):
         else:
             kwargs = {"batch_size": 4}
         dataloader = CustomTypesDataLoader(custom_iterable, device=device, **kwargs)
-        expected_batches = [[0,1,2,3], [4,5,6,7]]
+        expected_batches = [[0, 1, 2, 3], [4, 5, 6, 7]]
         self.check_custom_types_iterable(dataloader, expected_batches, device)
 
-    @parameterized.expand([
-        ("nested under dataloader wrapper", True),
-        ("without nested dataloader wrapper", False),
-    ])
+    @parameterized.expand(
+        [
+            ("nested under dataloader wrapper", True),
+            ("without nested dataloader wrapper", False),
+        ]
+    )
     def test_custom_types_via_prepare(self, _, wrap_with_dataloader):
         device = "cuda"
         batch_size = 4
@@ -449,10 +456,10 @@ class DataLoaderTester(unittest.TestCase):
             custom_iterable = DataLoader(custom_iterable, batch_size=batch_size)
         else:
             # Otherwise we need to specify it through the dataloader config
-            dataloader_config.custom_type_batch_size=batch_size
+            dataloader_config.custom_type_batch_size = batch_size
         accelerator = Accelerator(dataloader_config=dataloader_config)
         dataloader = accelerator.prepare(custom_iterable)
-        expected_batches = [[0,1,2,3], [4,5,6,7]]
+        expected_batches = [[0, 1, 2, 3], [4, 5, 6, 7]]
         self.check_custom_types_iterable(dataloader, expected_batches, device)
 
     def test_prepare_custom_types_dataloader_is_idempotent(self):
@@ -466,7 +473,9 @@ class DataLoaderTester(unittest.TestCase):
     def test_prepare_custom_types_dataloader_conflicting_batch_sizes(self):
         # Ensure we can't pass a batch size for custom types and a wrapped
         # dataloader unless the batch sizes are the same value
-        accelerator = Accelerator(dataloader_config=DataLoaderConfiguration(custom_types=True, custom_type_batch_size=2))
+        accelerator = Accelerator(
+            dataloader_config=DataLoaderConfiguration(custom_types=True, custom_type_batch_size=2)
+        )
         dataloader = DataLoader(self._get_custom_iterable(data=list(range(8))), batch_size=4)
         with pytest.raises(ValueError):
             accelerator.prepare(dataloader)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -20,6 +20,7 @@ from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 from accelerate import Accelerator
 from accelerate.data_loader import (
     BatchSamplerShard,
+    CustomTypesDataLoader,
     DataLoaderDispatcher,
     DataLoaderShard,
     IterableDatasetShard,
@@ -396,3 +397,15 @@ class DataLoaderTester(unittest.TestCase):
         # Test it also works on the second iteration
         for idx, _ in enumerate(dataloader):
             assert dataloader.end_of_dataloader == (idx == 3)
+
+    def test_custom_types_dataloader(self):
+        class MyCustomType:
+            def __init__(self, data):
+                self.data = data
+            def __iter__(self):
+                return iter(self.data)
+
+        dataloader = CustomTypesDataLoader(MyCustomType(data=list(range(8))), batch_size=4)
+        # Ensure that we can iterate over the custom type without any problems
+        assert [t.tolist() for t in dataloader] == [[0, 1, 2, 3], [4, 5, 6, 7]]
+        # TODO: device placement

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -405,7 +405,13 @@ class DataLoaderTester(unittest.TestCase):
             def __iter__(self):
                 return iter(self.data)
 
-        dataloader = CustomTypesDataLoader(MyCustomType(data=list(range(8))), batch_size=4)
-        # Ensure that we can iterate over the custom type without any problems
-        assert [t.tolist() for t in dataloader] == [[0, 1, 2, 3], [4, 5, 6, 7]]
-        # TODO: device placement
+        device = "cuda"
+        dataloader = CustomTypesDataLoader(MyCustomType(data=list(range(8))), device=device, batch_size=4)
+        expected_batches = [[0,1,2,3], [4,5,6,7]]
+        # Ensure that we have 2 batches and can iterate over the custom type multiple times
+        assert len(expected_batches) == len(list(dataloader))
+        for _ in range(2):
+            for batch, expected_batch in zip(dataloader, expected_batches):
+                # And that each time we get the expected tensor on the device we specified
+                assert batch.tolist() == expected_batch
+                assert batch.device.type == device


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/accelerate/issues/2975

This PR adds a `CustomTypesDataLoader`, which allows for the passing of custom iterable types (either under a PyTorch DataLoader, which would normally throw a TypeError once you start to iterate over it, or directly) to the Accelerator state's device. This adds two args to the `DataLoaderConfiguration` class:
- `custom_types: bool`; indicates whether or not an instance of this class should be created when `prepare()` is invoked  on a dataloader or iterable type
- `custom_type_batch_size: int`; batch size to be used for the `CustomTypesDataLoader`; if the iterable is already held under a PyTorch dataloader, this is optional, and the batch size will be pulled off of the data loader.

Minimal example:
```python
from accelerate import Accelerator
from accelerate.utils import DataLoaderConfiguration

class MyIterableType:
    def __init__(self, data):
        self.data = data
    
    def __iter__(self):
        return iter(self.data)

some_iterable = MyIterableType(list(range(16)))
accelerator = Accelerator(dataloader_config=DataLoaderConfiguration(custom_types=True, custom_type_batch_size=4))

# Passing DataLoader(some_iterable, batch_size=4) 
# would also be fine - if passed in this way, we could omit custom_type_batch_size
custom_type_loader = accelerator.prepare(some_iterable)
for batch in custom_type_loader:
    print(batch)
```
Running with `export ACCELERATE_TORCH_DEVICE=cuda` provides the following output:
```
tensor([0, 1, 2, 3], device='cuda:0')
tensor([4, 5, 6, 7], device='cuda:0')
tensor([ 8,  9, 10, 11], device='cuda:0')
tensor([12, 13, 14, 15], device='cuda:0')
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr @BenjaminBossan @SunMarc