### PR TITLE
fix default value for rank size in cpu threads_per_process assignment logic

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1061,7 +1061,8 @@ def _validate_launch_command(args):
         args.num_cpu_threads_per_process = get_int_from_env(["OMP_NUM_THREADS"], 1)
         if args.use_cpu and args.num_processes >= 1 and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
             local_size = get_int_from_env(
-                ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], max(args.num_processes/args.num_machines,1)
+                ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"],
+                max(args.num_processes / args.num_machines, 1)
             )
             threads_per_process = int(psutil.cpu_count(logical=False) / local_size)
             if threads_per_process > 1:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1062,7 +1062,7 @@ def _validate_launch_command(args):
         if args.use_cpu and args.num_processes >= 1 and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
             local_size = get_int_from_env(
                 ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"],
-                max(int(args.num_processes / args.num_machines), 1)
+                max(int(args.num_processes / args.num_machines), 1),
             )
             threads_per_process = int(psutil.cpu_count(logical=False) / local_size)
             if threads_per_process > 1:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1061,7 +1061,7 @@ def _validate_launch_command(args):
         args.num_cpu_threads_per_process = get_int_from_env(["OMP_NUM_THREADS"], 1)
         if args.use_cpu and args.num_processes >= 1 and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
             local_size = get_int_from_env(
-                ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], 1
+                ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"], max(args.num_processes/args.num_machines,1)
             )
             threads_per_process = int(psutil.cpu_count(logical=False) / local_size)
             if threads_per_process > 1:

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1062,7 +1062,7 @@ def _validate_launch_command(args):
         if args.use_cpu and args.num_processes >= 1 and get_int_from_env(["OMP_NUM_THREADS"], 0) == 0:
             local_size = get_int_from_env(
                 ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"],
-                max(args.num_processes / args.num_machines, 1)
+                max(int(args.num_processes / args.num_machines), 1)
             )
             threads_per_process = int(psutil.cpu_count(logical=False) / local_size)
             if threads_per_process > 1:


### PR DESCRIPTION
When a distributed run is launched with `accelerate launch myscript.py` under the hood it launches mpirun. 
The logic that sets the num_of_threads_per_process for good OOB performance relies on the environment variables that are yet unassigned because mpirun is called after the environment variables are read.
```
local_size = get_int_from_env(
                ["MPI_LOCALNRANKS", "OMPI_COMM_WORLD_LOCAL_SIZE", "MV2_COMM_WORLD_LOCAL_SIZE"],
                max(args.num_processes/args.num_machines,1)
            )
threads_per_process = int(psutil.cpu_count(logical=False) / local_size)
```
https://github.com/huggingface/accelerate/blob/cd5698bb324352a80a2a2b5d8bfccf495e14bf6b/src/accelerate/commands/launch.py#L1063 

The solution is to calculate the rank per node assuming total number of processes are equally distributed across the number of machines. 

