### PR TITLE
destroy process group in `end_training`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2694,9 +2694,9 @@ class Accelerator:
         >>> accelerator.end_training()
         ```
         """
-        with self.on_main_process():
-            for tracker in self.trackers:
-                tracker.finish()
+        for tracker in self.trackers:
+            tracker.finish()
+
         if torch.distributed.is_initialized():
             # needed when using torch.distributed.init_process_group
             torch.distributed.destroy_process_group()

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2680,7 +2680,7 @@ class Accelerator:
 
     def end_training(self):
         """
-        Runs any special end training behaviors, such as stopping trackers on the main process only or destoying all process.
+        Runs any special end training behaviors, such as stopping trackers on the main process only or destoying process group.
         Should always be called at the end of your script if using experiment tracking.
 
         Example:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2680,8 +2680,8 @@ class Accelerator:
 
     def end_training(self):
         """
-        Runs any special end training behaviors, such as stopping trackers on the main process only or destoying process group.
-        Should always be called at the end of your script if using experiment tracking.
+        Runs any special end training behaviors, such as stopping trackers on the main process only or destoying
+        process group. Should always be called at the end of your script if using experiment tracking.
 
         Example:
 


### PR DESCRIPTION
# What does this PR do ?

With the latest version of torch, when we use multi-gpu, torch will trigger a warning asking us to call `destoy_process_group()`. This PR fixes this by adding that in end_training method. Note that this function needs to be called on all process. 

For trackers, we are already only executing the methods on the main process. See [here](https://github.com/huggingface/accelerate/blob/851cf3435135d4be28a7569e61fb7c9466d68291/src/accelerate/tracking.py#L108). So it should be safe to remove the on_main_process decorator in the end_training method. 
However, I see for [WandBTracker](https://github.com/huggingface/accelerate/blob/851cf3435135d4be28a7569e61fb7c9466d68291/src/accelerate/tracking.py#L289) that `main_process_only = False`. Is there a specific reason @muellerzr ? 
