### PR TITLE
change `is_main_process` to `on_main_process`

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -33,7 +33,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
     def _should_log(main_process_only):
         "Check if log should be performed"
         state = PartialState()
-        return not main_process_only or (main_process_only and state.is_main_process)
+        return not main_process_only or (main_process_only and state.on_main_process)
 
     def log(self, level, msg, *args, **kwargs):
         """


### PR DESCRIPTION
## What does this PR do?
This PR fixes the following failing test:
```bash
pytest -rA tests/test_accelerator.py::AcceleratorTester::test_accelerator_bnb_multi_device
```
Error Log:
```bash
src/accelerate/accelerator.py:520: in __init__
    check_os_kernel()
src/accelerate/utils/other.py:349: in check_os_kernel
    logger.warning(msg, main_process_only=True)
/usr/lib/python3.10/logging/__init__.py:1847: in warning
    self.log(WARNING, msg, *args, **kwargs)
src/accelerate/logging.py:61: in log
    if self._should_log(main_process_only):
src/accelerate/logging.py:36: in _should_log
    return not main_process_only or (main_process_only and state.is_main_process)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError('`PartialState` object has no attribute `distributed_type`. This happens if `PartialState._reset_stat...nd an `Accelerator` or `PartialState` was not reinitialized.') raised in repr()] PartialState object at 0x7f7718aaf5e0>
name = 'is_main_process'

    def __getattr__(self, name: str):
        # By this point we know that no attributes of `self` contain `name`,
        # so we just modify the error message
        if name in self._known_attrs:
            raise AttributeError(
                f"`PartialState` object has no attribute `{name}`. "
                "This happens if `PartialState._reset_state()` was called and "
                "an `Accelerator` or `PartialState` was not reinitialized."
            )
        # Raise a typical AttributeError
>       raise AttributeError(f"'PartialState' object has no attribute '{name}'")
E       AttributeError: 'PartialState' object has no attribute 'is_main_process'. Did you mean: 'on_main_process'?

src/accelerate/state.py:802: AttributeError
========================================================== short test summary info ===========================================================
FAILED tests/test_accelerator.py::AcceleratorTester::test_accelerator_bnb_multi_device - AttributeError: 'PartialState' object has no attribute 'is_main_process'. Did you mean: 'on_main_process'?
```

After Fix:

```bash
========================================================== short test summary info ===========================================================
PASSED tests/test_accelerator.py::AcceleratorTester::test_accelerator_bnb_multi_device
======================================================= 1 passed, 2 warnings in 6.07s ========================================================
```

@muellerzr 