### PR TITLE
add bnb test marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,8 @@ exclude = [
 "os.getenv".msg = "Use os.environ instead"
 "os.putenv".msg = "Use os.environ instead"
 "os.unsetenv".msg = "Use os.environ instead"
+
+[tool.pytest.ini_options]
+markers = [
+    "bnb: select bitsandbytes integration tests; `pytest -m bnb`",
+]

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -255,7 +255,15 @@ def require_bnb(test_case):
     """
     Decorator marking a test that requires bitsandbytes. These tests are skipped when they are not.
     """
-    return unittest.skipUnless(is_bnb_available(), "test requires the bitsandbytes library")(test_case)
+    if is_bnb_available():
+        try:
+            import pytest
+
+            return pytest.mark.bnb(test_case)
+        except ImportError:
+            return test_case
+    else:
+        return unittest.skip("test requires the bitsandbytes library")(test_case)
 
 
 def require_tpu(test_case):


### PR DESCRIPTION
Small utility to easily all tests that require bnb..

Unfortunately I'm on my Intel box right now and also don't have a fully functioning dev setup for accelerate. I think this should work as is, but be sure to give it a quick spin, as I can't execute the tests in my current setup.