### PR TITLE
Trigger `weights_only=True` by default for all compatible objects

### DIFF
--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -215,7 +215,7 @@ These include general utilities that should be used when working in parallel.
 
 [[autodoc]] utils.save
 
-[[autodoc]] utils.load
+[[autodoc]] utils.torch_load_maybe_weights_only
 
 [[autodoc]] utils.wait_for_everyone
 

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -215,6 +215,8 @@ These include general utilities that should be used when working in parallel.
 
 [[autodoc]] utils.save
 
+[[autodoc]] utils.load
+
 [[autodoc]] utils.wait_for_everyone
 
 

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -215,7 +215,7 @@ These include general utilities that should be used when working in parallel.
 
 [[autodoc]] utils.save
 
-[[autodoc]] utils.torch_load_maybe_weights_only
+[[autodoc]] utils.load
 
 [[autodoc]] utils.wait_for_everyone
 

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -268,7 +268,7 @@ def load_accelerator_state(
 
     # Random states
     try:
-        states = load(input_dir.joinpath(f"{RNG_STATE_NAME}_{process_index}.pkl"), weights_only=False)
+        states = load(input_dir.joinpath(f"{RNG_STATE_NAME}_{process_index}.pkl"), weights_only=True)
         if "step" in states:
             override_attributes["step"] = states["step"]
         random.setstate(states["random_state"])

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -35,12 +35,14 @@ from .utils import (
     is_mlu_available,
     is_torch_xla_available,
     is_xpu_available,
+    load,
     save,
 )
 
 
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
+
 
 from .logging import get_logger
 from .state import PartialState
@@ -217,7 +219,7 @@ def load_accelerator_state(
         else:
             # Load with torch
             input_model_file = input_dir.joinpath(f"{MODEL_NAME}{ending}.bin")
-            state_dict = torch.load(input_model_file, map_location=map_location)
+            state_dict = load(input_model_file, map_location=map_location, weights_only=True)
             model.load_state_dict(state_dict, **load_model_func_kwargs)
     logger.info("All model weights loaded successfully")
 
@@ -225,7 +227,7 @@ def load_accelerator_state(
     for i, opt in enumerate(optimizers):
         optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
         input_optimizer_file = input_dir.joinpath(optimizer_name)
-        optimizer_state = torch.load(input_optimizer_file, map_location=map_location)
+        optimizer_state = load(input_optimizer_file, map_location=map_location, weights_only=True)
         optimizers[i].load_state_dict(optimizer_state)
     logger.info("All optimizer states loaded successfully")
 
@@ -233,7 +235,8 @@ def load_accelerator_state(
     for i, scheduler in enumerate(schedulers):
         scheduler_name = f"{SCHEDULER_NAME}.bin" if i == 0 else f"{SCHEDULER_NAME}_{i}.bin"
         input_scheduler_file = input_dir.joinpath(scheduler_name)
-        scheduler.load_state_dict(torch.load(input_scheduler_file))
+        scheduler_state = load(input_scheduler_file, weights_only=True)
+        scheduler.load_state_dict(scheduler_state)
     logger.info("All scheduler states loaded successfully")
 
     for i, dataloader in enumerate(dataloaders):
@@ -245,24 +248,27 @@ def load_accelerator_state(
         if isinstance(dataloader.dataset, IterableDatasetShard):
             sampler = dataloader.get_sampler()
             if isinstance(sampler, SeedableRandomSampler):
-                sampler = dataloader.set_sampler(torch.load(input_sampler_file))
+                sampler = dataloader.set_sampler(torch.load(input_sampler_file, weights_only=True))
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)
             if input_dataloader_state_dict_file.exists():
-                state_dict = torch.load(input_dataloader_state_dict_file)
+                state_dict = torch.load(input_dataloader_state_dict_file, weights_only=True)
                 dataloader.load_state_dict(state_dict)
+                sampler_state = load(input_sampler_file, weights_only=True)
+                sampler = dataloader.set_sampler(sampler_state)
     logger.info("All dataloader sampler states loaded successfully")
 
     # GradScaler state
     if scaler is not None:
         input_scaler_file = input_dir.joinpath(SCALER_NAME)
-        scaler.load_state_dict(torch.load(input_scaler_file))
+        scaler_state = load(input_scaler_file, weights_only=True)
+        scaler.load_state_dict(scaler_state)
         logger.info("GradScaler state loaded successfully")
 
     # Random states
     try:
-        states = torch.load(input_dir.joinpath(f"{RNG_STATE_NAME}_{process_index}.pkl"))
+        states = load(input_dir.joinpath(f"{RNG_STATE_NAME}_{process_index}.pkl"), weights_only=False)
         if "step" in states:
             override_attributes["step"] = states["step"]
         random.setstate(states["random_state"])
@@ -295,8 +301,9 @@ def save_custom_state(obj, path, index: int = 0, save_on_each_node: bool = False
 
 def load_custom_state(obj, path, index: int = 0):
     """
-    Loads the state of `obj` at `{path}/custom_checkpoint_{index}.pkl`
+    Loads the state of `obj` at `{path}/custom_checkpoint_{index}.pkl`. Will always set `weights_only=False` when
+    loading the state.
     """
     load_location = f"{path}/custom_checkpoint_{index}.pkl"
     logger.info(f"Loading the state of {get_pretty_name(obj)} from {load_location}")
-    obj.load_state_dict(torch.load(load_location, map_location="cpu"))
+    obj.load_state_dict(load(load_location, map_location="cpu", weights_only=False))

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -248,14 +248,14 @@ def load_accelerator_state(
         if isinstance(dataloader.dataset, IterableDatasetShard):
             sampler = dataloader.get_sampler()
             if isinstance(sampler, SeedableRandomSampler):
-                sampler = dataloader.set_sampler(torch.load(input_sampler_file, weights_only=True))
+                sampler = dataloader.set_sampler(load(input_sampler_file))
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)
             if input_dataloader_state_dict_file.exists():
-                state_dict = torch.load(input_dataloader_state_dict_file, weights_only=True)
+                state_dict = load(input_dataloader_state_dict_file)
                 dataloader.load_state_dict(state_dict)
-                sampler_state = load(input_sampler_file, weights_only=True)
+                sampler_state = load(input_sampler_file)
                 sampler = dataloader.set_sampler(sampler_state)
     logger.info("All dataloader sampler states loaded successfully")
 

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -43,7 +43,6 @@ from .utils import (
 if is_torch_xla_available():
     import torch_xla.core.xla_model as xm
 
-
 from .logging import get_logger
 from .state import PartialState
 
@@ -219,7 +218,7 @@ def load_accelerator_state(
         else:
             # Load with torch
             input_model_file = input_dir.joinpath(f"{MODEL_NAME}{ending}.bin")
-            state_dict = load(input_model_file, map_location=map_location, weights_only=True)
+            state_dict = load(input_model_file, map_location=map_location)
             model.load_state_dict(state_dict, **load_model_func_kwargs)
     logger.info("All model weights loaded successfully")
 
@@ -227,7 +226,7 @@ def load_accelerator_state(
     for i, opt in enumerate(optimizers):
         optimizer_name = f"{OPTIMIZER_NAME}.bin" if i == 0 else f"{OPTIMIZER_NAME}_{i}.bin"
         input_optimizer_file = input_dir.joinpath(optimizer_name)
-        optimizer_state = load(input_optimizer_file, map_location=map_location, weights_only=True)
+        optimizer_state = load(input_optimizer_file, map_location=map_location)
         optimizers[i].load_state_dict(optimizer_state)
     logger.info("All optimizer states loaded successfully")
 
@@ -235,7 +234,7 @@ def load_accelerator_state(
     for i, scheduler in enumerate(schedulers):
         scheduler_name = f"{SCHEDULER_NAME}.bin" if i == 0 else f"{SCHEDULER_NAME}_{i}.bin"
         input_scheduler_file = input_dir.joinpath(scheduler_name)
-        scheduler_state = load(input_scheduler_file, weights_only=True)
+        scheduler_state = load(input_scheduler_file)
         scheduler.load_state_dict(scheduler_state)
     logger.info("All scheduler states loaded successfully")
 
@@ -262,13 +261,13 @@ def load_accelerator_state(
     # GradScaler state
     if scaler is not None:
         input_scaler_file = input_dir.joinpath(SCALER_NAME)
-        scaler_state = load(input_scaler_file, weights_only=True)
+        scaler_state = load(input_scaler_file)
         scaler.load_state_dict(scaler_state)
         logger.info("GradScaler state loaded successfully")
 
     # Random states
     try:
-        states = load(input_dir.joinpath(f"{RNG_STATE_NAME}_{process_index}.pkl"), weights_only=True)
+        states = load(input_dir.joinpath(f"{RNG_STATE_NAME}_{process_index}.pkl"))
         if "step" in states:
             override_attributes["step"] = states["step"]
         random.setstate(states["random_state"])

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -254,8 +254,6 @@ def load_accelerator_state(
             if input_dataloader_state_dict_file.exists():
                 state_dict = load(input_dataloader_state_dict_file)
                 dataloader.load_state_dict(state_dict)
-                sampler_state = load(input_sampler_file)
-                sampler = dataloader.set_sampler(sampler_state)
     logger.info("All dataloader sampler states loaded successfully")
 
     # GradScaler state

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -249,15 +249,13 @@ from .other import (
     extract_model_from_parallel,
     get_pretty_name,
     is_port_in_use,
+    load,
     merge_dicts,
     patch_environment,
     recursive_getattr,
     save,
     wait_for_everyone,
     write_basic_config,
-)
-from .other import (
-    torch_load_maybe_weights_only as load,
 )
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
 from .torch_xla import install_xla

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -118,6 +118,7 @@ from .imports import (
     is_transformers_available,
     is_triton_available,
     is_wandb_available,
+    is_weights_only_available,
     is_xpu_available,
 )
 from .modeling import (
@@ -248,6 +249,7 @@ from .other import (
     extract_model_from_parallel,
     get_pretty_name,
     is_port_in_use,
+    load,
     merge_dicts,
     patch_environment,
     recursive_getattr,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -249,13 +249,15 @@ from .other import (
     extract_model_from_parallel,
     get_pretty_name,
     is_port_in_use,
-    load,
     merge_dicts,
     patch_environment,
     recursive_getattr,
     save,
     wait_for_everyone,
     write_basic_config,
+)
+from .other import (
+    torch_load_maybe_weights_only as load,
 )
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
 from .torch_xla import install_xla

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -451,3 +451,8 @@ def is_weights_only_available():
     # Weights only with allowlist was added in 2.4.0
     # ref: https://github.com/pytorch/pytorch/pull/124331
     return is_torch_version(">=", "2.4.0")
+
+
+def is_numpy_available(min_version="1.25.0"):
+    numpy_version = parse(importlib.metadata.version("numpy"))
+    return compare_versions(numpy_version, ">=", min_version)

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -445,6 +445,8 @@ def deepspeed_required(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
 def is_weights_only_available():
     # Weights only with allowlist was added in 2.4.0
     # ref: https://github.com/pytorch/pytorch/pull/124331

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -446,4 +446,6 @@ def deepspeed_required(func):
 
     return wrapper
 def is_weights_only_available():
-    return is_torch_version(">=", "2.0.0")
+    # Weights only with allowlist was added in 2.4.0
+    # ref: https://github.com/pytorch/pytorch/pull/124331
+    return is_torch_version(">=", "2.4.0")

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -445,3 +445,5 @@ def deepspeed_required(func):
         return func(*args, **kwargs)
 
     return wrapper
+def is_weights_only_available():
+    return is_torch_version(">=", "2.0.0")

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -35,6 +35,7 @@ from .constants import FSDP_PYTORCH_VERSION
 from .dataclasses import DistributedType
 from .imports import (
     is_deepspeed_available,
+    is_numpy_available,
     is_torch_distributed_available,
     is_torch_xla_available,
     is_weights_only_available,
@@ -223,8 +224,10 @@ TORCH_SAFE_GLOBALS = [
     # The following are needed for the RNG states
     encode,
     np.dtype,
-    np.dtypes.UInt32DType,
 ]
+
+if is_numpy_available("1.25.0"):
+    TORCH_SAFE_GLOBALS.append(np.dtypes.UInt32DType)
 
 
 def load(f, map_location=None, **kwargs):

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -223,7 +223,7 @@ TORCH_SAFE_GLOBALS = [
     # The following are needed for the RNG states
     encode,
     np.dtype,
-    np.dtypes.UInt32Dtype,
+    np.dtypes.UInt32DType,
 ]
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -227,7 +227,7 @@ TORCH_SAFE_GLOBALS = [
 ]
 
 
-def torch_load_maybe_weights_only(f, map_location=None, **kwargs):
+def load(f, map_location=None, **kwargs):
     """
     Compatible drop-in replacement of `torch.load()` which allows for `weights_only` to be used if `torch` version is
     2.4.0 or higher. Otherwise will ignore the kwarg.

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -244,15 +244,17 @@ def torch_load_maybe_weights_only(f, map_location=None, **kwargs):
     """
     try:
         if is_weights_only_available():
+            old_safe_globals = torch.serialization.get_safe_globals()
             if "weights_only" not in kwargs:
                 kwargs["weights_only"] = True
-            torch.serialization.add_safe_globals(TORCH_SAFE_GLOBALS)
+            torch.serialization.add_safe_globals(TORCH_SAFE_GLOBALS + old_safe_globals)
         else:
             kwargs.pop("weights_only", None)
         loaded_obj = torch.load(f, map_location=map_location, **kwargs)
     finally:
         if is_weights_only_available():
             torch.serialization.clear_safe_globals()
+            torch.serialization.add_safe_globals(old_safe_globals)
     return loaded_obj
 
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -250,14 +250,15 @@ def load(f, map_location=None, **kwargs):
             old_safe_globals = torch.serialization.get_safe_globals()
             if "weights_only" not in kwargs:
                 kwargs["weights_only"] = True
-            torch.serialization.add_safe_globals(TORCH_SAFE_GLOBALS + old_safe_globals)
+            torch.serialization.add_safe_globals(TORCH_SAFE_GLOBALS)
         else:
             kwargs.pop("weights_only", None)
         loaded_obj = torch.load(f, map_location=map_location, **kwargs)
     finally:
         if is_weights_only_available():
             torch.serialization.clear_safe_globals()
-            torch.serialization.add_safe_globals(old_safe_globals)
+            if old_safe_globals:
+                torch.serialization.add_safe_globals(old_safe_globals)
     return loaded_obj
 
 


### PR DESCRIPTION
# What does this PR do?

Sets `weights_only=True` by default when using `torch.save()` for all compatible objects:

* Model weights
* Optimizer states
* DataLoader states
* Scheduler states

The only one that we can't do right now are the random states, since the numpy random states will raise an exception if we add the right classes for safe loading:

```
Traceback (most recent call last):
  File "/home/zach/work/accelerate/test.py", line 24, in <module>
    _ = load(p / "r2.pkl", weights_only=True)
  File "/home/zach/work/accelerate/src/accelerate/utils/other.py", line 245, in load
    loaded_obj = torch.load(f, map_location=map_location, **kwargs)
  File "/home/zach/miniconda3/envs/accelerate/lib/python3.10/site-packages/torch/serialization.py", line 1096, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source.
 Please file an issue with the following so that we can make `weights_only=True` compatible with your use case: WeightsUnpickler error: Can only build Tensor, parameter or OrderedDict objects, but got <class 'numpy.dtypes.UInt32DType'>
```

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 