### PR TITLE
Speed up tests by shaving off subprocess when not needed

### DIFF
--- a/src/accelerate/test_utils/__init__.py
+++ b/src/accelerate/test_utils/__init__.py
@@ -15,6 +15,7 @@ from .testing import (
     DEFAULT_LAUNCH_COMMAND,
     are_the_same_tensors,
     assert_exception,
+    capture_call_output,
     device_count,
     execute_subprocess_async,
     get_launch_command,

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -672,10 +672,10 @@ def assert_exception(exception_class: Exception, msg: str = None) -> bool:
     if was_ran:
         raise AssertionError(f"Expected exception of type {exception_class} but ran without issue.")
 
+
 def capture_call_output(func, *args, **kwargs):
     """
-    Takes in a `func` with `args` and `kwargs`
-    and returns the captured stdout as a string
+    Takes in a `func` with `args` and `kwargs` and returns the captured stdout as a string
     """
     captured_output = io.StringIO()
     original_stdout = sys.stdout

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -14,6 +14,7 @@
 
 import asyncio
 import inspect
+import io
 import os
 import shutil
 import subprocess
@@ -670,3 +671,19 @@ def assert_exception(exception_class: Exception, msg: str = None) -> bool:
             assert msg in str(e), f"Expected message '{msg}' to be in exception but got '{str(e)}'"
     if was_ran:
         raise AssertionError(f"Expected exception of type {exception_class} but ran without issue.")
+
+def capture_call_output(func, *args, **kwargs):
+    """
+    Takes in a `func` with `args` and `kwargs`
+    and returns the captured stdout as a string
+    """
+    captured_output = io.StringIO()
+    original_stdout = sys.stdout
+    try:
+        sys.stdout = captured_output
+        func(*args, **kwargs)
+    except Exception as e:
+        raise e
+    finally:
+        sys.stdout = original_stdout
+    return captured_output.getvalue()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,12 +70,11 @@ class AccelerateLauncherTester(unittest.TestCase):
             cls.changed_path.rename(cls.config_path)
 
     def test_no_config(self):
+        args = ["--monitor_interval", "0.1", str(self.test_file_path)]
         if torch.cuda.is_available() and (torch.cuda.device_count() > 1):
-            cmd = get_launch_command(multi_gpu=True)
-        else:
-            cmd = DEFAULT_LAUNCH_COMMAND
-        cmd.append(self.test_file_path)
-        execute_subprocess_async(cmd, env=os.environ.copy())
+            args = ["--multi_gpu"] + args
+        args = self.parser.parse_args(["--monitor_interval", "0.1", str(self.test_file_path)])
+        launch_command(args)
 
     def test_config_compatibility(self):
         invalid_configs = ["fp8", "invalid", "mpi", "sagemaker"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,8 +83,8 @@ class AccelerateLauncherTester(unittest.TestCase):
             if any(invalid_config in str(config) for invalid_config in invalid_configs):
                 continue
             with self.subTest(config_file=config):
-                cmd = get_launch_command(config_file=config) + [self.test_file_path]
-                execute_subprocess_async(cmd)
+                args = self.parser.parse_args(["--config_file", str(config), str(self.test_file_path)])
+                launch_command(args)
 
     def test_invalid_keys(self):
         config_path = self.test_config_path / "invalid_keys.yaml"


### PR DESCRIPTION
# What does this PR do?

As title states, subprocess is slow. Each time we call it adds a whole second or so to the testing suite. This PR removes that (when save/applicable) from our testing suite, and instead does a 1:1 replacement by capturing the `stdout` instead of a func (said func being the equivalent `accelerate.commands.X`. 

Total CPU CI time:

```
Before: 2m53s
After: 2m36s
```

For specific areas:

* `TpuConfigTester`: (10x reduction)
```
Before: 10.77s
After: 0.95s
```
* `AccelerateLauncherTester` (50% reduction)
```
Before: 13.46s
After: 6.99s
```


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @SunMarc 