### PR TITLE
Add FP8 docker images

### DIFF
--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -38,7 +38,9 @@ jobs:
         with:
           file: docker/accelerate-cpu/Dockerfile
           push: true
-          tags: huggingface/accelerate:cpu-release-${{ needs.get-version.outputs.version }}
+          tags: |
+            huggingface/accelerate:cpu-release-${{ needs.get-version.outputs.version }}
+            huggingface/accelerate:cpu
 
   version-cuda:
     name: "Latest Accelerate GPU [version]"
@@ -59,7 +61,9 @@ jobs:
         with:
           file: docker/accelerate-gpu/Dockerfile
           push: true
-          tags: huggingface/accelerate:gpu-release-${{needs.get-version.outputs.version}}
+          tags: |
+            huggingface/accelerate:gpu-release-${{needs.get-version.outputs.version}}
+            huggingface/accelerate:gpu
 
   version-cuda-deepspeed:
     name: "Latest Accelerate GPU DeepSpeed [version]"
@@ -80,5 +84,29 @@ jobs:
         with:
           file: docker/accelerate-gpu-deepspeed/Dockerfile
           push: true
-          tags: huggingface/accelerate:gpu-deepspeed-release-${{needs.get-version.outputs.version}}
+          tags: |
+            huggingface/accelerate:gpu-deepspeed-release-${{needs.get-version.outputs.version}}
+            huggingface/accelerate:gpu-deepspeed
 
+  version-cuda-fp8-transformerengine:
+    name: "Latest Accelerate GPU FP8 TransformerEngine [version]"
+    runs-on:
+      group: aws-g6-4xlarge-plus
+    needs: get-version
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/accelerate-gpu/Dockerfile
+          push: true
+          tags: |
+            huggingface/accelerate:gpu-fp8-transformerengine-release-${{needs.get-version.outputs.version}}
+            huggingface/accelerate:gpu-fp8-transformerengine

--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -38,9 +38,7 @@ jobs:
         with:
           file: docker/accelerate-cpu/Dockerfile
           push: true
-          tags: |
-            huggingface/accelerate:cpu-release-${{ needs.get-version.outputs.version }}
-            huggingface/accelerate:cpu
+          tags: huggingface/accelerate:cpu-release-${{ needs.get-version.outputs.version }}
 
   version-cuda:
     name: "Latest Accelerate GPU [version]"
@@ -61,9 +59,7 @@ jobs:
         with:
           file: docker/accelerate-gpu/Dockerfile
           push: true
-          tags: |
-            huggingface/accelerate:gpu-release-${{needs.get-version.outputs.version}}
-            huggingface/accelerate:gpu
+          tags: huggingface/accelerate:gpu-release-${{needs.get-version.outputs.version}}
 
   version-cuda-deepspeed:
     name: "Latest Accelerate GPU DeepSpeed [version]"
@@ -84,9 +80,7 @@ jobs:
         with:
           file: docker/accelerate-gpu-deepspeed/Dockerfile
           push: true
-          tags: |
-            huggingface/accelerate:gpu-deepspeed-release-${{needs.get-version.outputs.version}}
-            huggingface/accelerate:gpu-deepspeed
+          tags: huggingface/accelerate:gpu-deepspeed-release-${{needs.get-version.outputs.version}}
 
   version-cuda-fp8-transformerengine:
     name: "Latest Accelerate GPU FP8 TransformerEngine [version]"
@@ -107,6 +101,4 @@ jobs:
         with:
           file: docker/accelerate-gpu/Dockerfile
           push: true
-          tags: |
-            huggingface/accelerate:gpu-fp8-transformerengine-release-${{needs.get-version.outputs.version}}
-            huggingface/accelerate:gpu-fp8-transformerengine
+          tags: huggingface/accelerate:gpu-fp8-transformerengine-release-${{needs.get-version.outputs.version}}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -107,6 +107,4 @@ jobs:
         with:
           file: benchmarks/fp8/Dockerfile
           push: true
-          tags: |
-            huggingface/accelerate:gpu-fp8-transformerengine-nightly
-            huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ env.date }}
+          tags: huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ env.date }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -61,8 +61,8 @@ jobs:
             huggingface/accelerate:gpu-nightly
             huggingface/accelerate:gpu-nightly-${{ env.date }}
 
-  latest-cuda-deepspeed:
-    name: "Latest Accelerate GPU DeepSpeed [dev]"
+  latest-cuda-fp8-transformerengine:
+    name: "Latest Accelerate GPU FP8 TransformerEngine [dev]"
     runs-on:
       group: aws-g6-4xlarge-plus
     steps:
@@ -80,9 +80,8 @@ jobs:
       - name: Build and Push GPU
         uses: docker/build-push-action@v4
         with:
-          file: docker/accelerate-gpu-deepspeed/Dockerfile
+          file: benchmarks/fp8/Dockerfile
           push: true
           tags: |
-            huggingface/accelerate:gpu-deepspeed-nightly
-            huggingface/accelerate:gpu-deepspeed-nightly-${{ env.date }}
-
+            huggingface/accelerate:gpu-fp8-transformerengine-nightly
+            huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ env.date }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -61,8 +61,8 @@ jobs:
             huggingface/accelerate:gpu-nightly
             huggingface/accelerate:gpu-nightly-${{ env.date }}
 
-  latest-deepspeed:
-    name: "Latest Accelerate GPU Deepspeed [dev]"
+  latest-cuda-deepspeed:
+    name: "Latest Accelerate GPU DeepSpeed [dev]"
     runs-on:
       group: aws-g6-4xlarge-plus
     steps:

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -61,6 +61,31 @@ jobs:
             huggingface/accelerate:gpu-nightly
             huggingface/accelerate:gpu-nightly-${{ env.date }}
 
+  latest-deepspeed:
+    name: "Latest Accelerate GPU Deepspeed [dev]"
+    runs-on:
+      group: aws-g6-4xlarge-plus
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/accelerate-gpu-deepspeed/Dockerfile
+          push: true
+          tags: |
+            huggingface/accelerate:gpu-deepspeed-nightly
+            huggingface/accelerate:gpu-deepspeed-nightly-${{ env.date }}
+
   latest-cuda-fp8-transformerengine:
     name: "Latest Accelerate GPU FP8 TransformerEngine [dev]"
     runs-on:

--- a/benchmarks/fp8/README.md
+++ b/benchmarks/fp8/README.md
@@ -15,6 +15,8 @@ To run them, it's recommended to use a docker image (see the attached `Dockerfil
 
 ## Running:
 
+There are official Docker images located at `huggingface/accelerate:gpu-fp8-transformerengine-nightly` which can be used.
+
 You can run all scripts using the core `accelerate launch` command without any `accelerate config` being needed.
 
 For single GPU, run it via `python`:

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,7 @@ huggingface/accelerate:{accelerator}-{nightly,release}
 * `cpu`: Comes compiled off of `python:3.9-slim` and is designed for non-CUDA based workloads.
 * More to come soon
 * `gpu-deepspeed`: Comes compiled off of the `nvidia/cuda` image and includes core parts like `bitsandbytes` as well as the latest `deepspeed` version. Runs off python 3.10.
+* `gpu-fp8-transformerengine`: Comes compiled off of `nvcr.io/nvidia/pytorch` and is specifically for running the `benchmarks/fp8` scripts on devices which support FP8 operations using the `TransformerEngine` library (RTX 4090, H100, etc)
 
 ## Nightlies vs Releases
 


### PR DESCRIPTION
# What does this PR do?

This PR adds FP8 benchmarking docker images. They are tagged as `huggingface/accelerate-gpu-fp8-transformerengine` + `-release`/`-nightly`. 

Also noticed that the deepspeed images weren't ever being built, so changes that/fixes it. 

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan 