### PR TITLE
add set_epoch for MpDeviceLoaderWrapper

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -653,8 +653,8 @@ if is_torch_xla_available():
             return super().__iter__()
 
         def set_epoch(self, epoch: int):
-             if hasattr(self.dataloader, "set_epoch"):
-                 self.dataloader.set_epoch(epoch)
+            if hasattr(self.dataloader, "set_epoch"):
+                self.dataloader.set_epoch(epoch)
 
         @property
         def total_batch_size(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -652,6 +652,10 @@ if is_torch_xla_available():
 
             return super().__iter__()
 
+        def set_epoch(self, epoch: int):
+             if hasattr(self.dataloader, "set_epoch"):
+                 self.dataloader.set_epoch(epoch)
+
         @property
         def total_batch_size(self):
             return self._loader.total_batch_size


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

in transformers' trainer.py, when using xla resume, the data_iterator used during resumption is different from the original data_iterator. It is necessary to use set_epoch with the current epoch value: https://github.com/huggingface/transformers/blob/3bf6dd8aa141ff6bebd579649e9d0ba8bf5d03db/src/transformers/trainer.py#L2264. However accelerator adds an additional wrapper for xla: MpDeviceLoaderWrapper, which does not have a set_epoch method, this leads to incorrect epoch value and data being used in subsequent training (the random seed in the data loader's sampler is related to the epoch value). To resolve this issue, we add a set_epoch method to MpDeviceLoaderWrapper.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->