### PR TITLE
use duck-typing to ensure underlying optimizer supports schedulefree hooks

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -125,13 +125,15 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         """
         Sets the optimizer to "train" mode. Useful for optimizers like `schedule_free`
         """
-        return self.optimizer.train()
+        if hasattr(self.optimizer, "train") and callable(getattr(self.optimizer, "train")):
+            self.optimizer.train()
 
     def eval(self):
         """
         Sets the optimizer to "eval" mode. Useful for optimizers like `schedule_free`
         """
-        return self.optimizer.eval()
+        if hasattr(self.optimizer, "eval") and callable(getattr(self.optimizer, "eval")):
+            self.optimizer.eval()
 
     def step(self, closure=None):
         if is_lomo_available():

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -125,14 +125,14 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         """
         Sets the optimizer to "train" mode. Useful for optimizers like `schedule_free`
         """
-        if hasattr(self.optimizer, "train") and callable(getattr(self.optimizer, "train")):
+        if hasattr(self.optimizer, "train") and callable(self.optimizer.train):
             self.optimizer.train()
 
     def eval(self):
         """
         Sets the optimizer to "eval" mode. Useful for optimizers like `schedule_free`
         """
-        if hasattr(self.optimizer, "eval") and callable(getattr(self.optimizer, "eval")):
+        if hasattr(self.optimizer, "eval") and callable(self.optimizer.eval):
             self.optimizer.eval()
 
     def step(self, closure=None):


### PR DESCRIPTION
the new duck-typing approach in https://github.com/huggingface/transformers/pull/30079 is causing build failures over there, because of the path through accelerate

```
/usr/local/lib/python3.10/site-packages/transformers/trainer.py:3448: in training_step
    self.optimizer.train()
/usr/local/lib/python3.10/site-packages/accelerate/optimizer.py:128: in train
    return self.optimizer.train()
E   AttributeError: 'AdamW' object has no attribute 'train'
```

we need to replicate that logic here, ensuring this code path is safe to call for all optimizers

cc @amyeroberts @muellerzr @winglian https://github.com/huggingface/accelerate/pull/2631