### PR TITLE
Allow DataLoaderAdapter subclasses to be pickled by implementing `__reduce__`

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -572,7 +572,20 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.end()
 
     def __reduce__(self):
-        return super().__reduce__()
+        return (
+            DataLoaderShard,
+            (
+                self.base_dataloader.dataset,
+                self.device,
+                self.rng_types,
+                self.synchronized_generator,
+                self.skip_batches,
+                self.use_stateful_dataloader,
+                self._drop_last,
+                self._non_blocking,
+            ),
+            self.__dict__,
+        )
 
     def set_epoch(self, epoch: int):
         # In case it is manually passed in, the user can set it to what they like

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -572,20 +572,9 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.end()
 
     def __reduce__(self):
-        return (
-            DataLoaderShard,
-            (
-                self.base_dataloader.dataset,
-                self.device,
-                self.rng_types,
-                self.synchronized_generator,
-                self.skip_batches,
-                self.use_stateful_dataloader,
-                self._drop_last,
-                self._non_blocking,
-            ),
-            self.__dict__,
-        )
+        args = super().__reduce__()
+        return (DataLoaderShard, *args[1:])
+
 
     def set_epoch(self, epoch: int):
         # In case it is manually passed in, the user can set it to what they like
@@ -881,19 +870,8 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
             return math.ceil(whole_length / self.state.num_processes)
 
     def __reduce__(self):
-        return (
-            DataLoaderDispatcher,
-            (
-                self.base_dataloader.dataset,
-                self.split_batches,
-                self.skip_batches,
-                self.use_stateful_dataloader,
-                self._drop_last,
-                self._non_blocking,
-                self.slice_fn,
-            ),
-            self.__dict__,
-        )
+        args = super().__reduce__()
+        return (DataLoaderDispatcher, *args[1:])
 
     @property
     def total_batch_size(self):
@@ -1238,11 +1216,9 @@ class SkipDataLoader(DataLoaderAdapter, DataLoaderStateMixin):
         return len(self.base_dataloader) - self.skip_batches
 
     def __reduce__(self):
-        return (
-            SkipDataLoader,
-            (self.base_dataloader.dataset, self.skip_batches, self.use_stateful_dataloader),
-            self.__dict__,
-        )
+        args = super().__reduce__()
+        return (SkipDataLoader, *args[1:])
+
 
 
 def skip_first_batches(dataloader, num_batches=0):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1212,7 +1212,6 @@ class SkipDataLoader(DataLoaderAdapter, DataLoaderStateMixin):
         self.end()
 
     def __len__(self):
-        print("len called")
         return len(self.base_dataloader) - self.skip_batches
 
     def __reduce__(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -435,9 +435,8 @@ class DataLoaderAdapter:
     @property
     def __class__(self):
         """
-        In order to maintain backwards compatability with other code, we need to ensure `isinstance(obj, DataLoader)`
-        returs true. This is because some downstream code assumes that the `DataLoader` is the base class of the
-        object.
+        In order to maintain backwards compatability with other code, we need to ensure `isinstance(obj, DataLoader)` returs true.
+        This is because some downstream code assumes that the `DataLoader` is the base class of the object.
         """
         return self.base_dataloader.__class__
 
@@ -479,18 +478,6 @@ class DataLoaderAdapter:
             self.adjust_state_dict_for_prefetch()
             # Then tag if we are at the end of the dataloader
             self.dl_state_dict["_iterator_finished"] = self.end_of_dataloader
-
-
-class DataLoaderAdapterImpl(DataLoaderAdapter, DataLoader):
-    pass
-
-
-if is_torchdata_stateful_dataloader_available():
-    from torchdata.stateful_dataloader import StatefulDataLoader
-
-    class StatefulDataLoaderAdapterImpl(DataLoaderAdapter, StatefulDataLoader):
-        pass
-
 
 class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
     """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1234,6 +1234,7 @@ class SkipDataLoader(DataLoaderAdapter, DataLoaderStateMixin):
         self.end()
 
     def __len__(self):
+        print("len called")
         return len(self.base_dataloader) - self.skip_batches
 
     def __reduce__(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -572,20 +572,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.end()
 
     def __reduce__(self):
-        return (
-            DataLoaderShard,
-            (
-                self.base_dataloader.dataset,
-                self.device,
-                self.rng_types,
-                self.synchronized_generator,
-                self.skip_batches,
-                self.use_stateful_dataloader,
-                self._drop_last,
-                self._non_blocking,
-            ),
-            self.__dict__,
-        )
+        return super().__reduce__()
 
     def set_epoch(self, epoch: int):
         # In case it is manually passed in, the user can set it to what they like
@@ -872,7 +859,7 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
             self.dataset.set_epoch(epoch)
 
     def __len__(self):
-        whole_length = self.base_dataloader.__len__()
+        whole_length = len(self.base_dataloader)
         if self.split_batches:
             return whole_length
         elif self._drop_last:
@@ -881,19 +868,7 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
             return math.ceil(whole_length / self.state.num_processes)
 
     def __reduce__(self):
-        return (
-            DataLoaderDispatcher,
-            (
-                self.base_dataloader.dataset,
-                self.split_batches,
-                self.skip_batches,
-                self.use_stateful_dataloader,
-                self._drop_last,
-                self._non_blocking,
-                self.slice_fn,
-            ),
-            self.__dict__,
-        )
+        return super().__reduce__()
 
     @property
     def total_batch_size(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -881,7 +881,19 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
             return math.ceil(whole_length / self.state.num_processes)
 
     def __reduce__(self):
-        return super().__reduce__()
+        return (
+            DataLoaderDispatcher,
+            (
+                self.base_dataloader.dataset,
+                self.split_batches,
+                self.skip_batches,
+                self.use_stateful_dataloader,
+                self._drop_last,
+                self._non_blocking,
+                self.slice_fn,
+            ),
+            self.__dict__,
+        )
 
     @property
     def total_batch_size(self):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -435,8 +435,9 @@ class DataLoaderAdapter:
     @property
     def __class__(self):
         """
-        In order to maintain backwards compatability with other code, we need to ensure `isinstance(obj, DataLoader)` returs true.
-        This is because some downstream code assumes that the `DataLoader` is the base class of the object.
+        In order to maintain backwards compatability with other code, we need to ensure `isinstance(obj, DataLoader)`
+        returs true. This is because some downstream code assumes that the `DataLoader` is the base class of the
+        object.
         """
         return self.base_dataloader.__class__
 
@@ -478,6 +479,7 @@ class DataLoaderAdapter:
             self.adjust_state_dict_for_prefetch()
             # Then tag if we are at the end of the dataloader
             self.dl_state_dict["_iterator_finished"] = self.end_of_dataloader
+
 
 class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
     """
@@ -572,9 +574,13 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.end()
 
     def __reduce__(self):
+        """
+        Define the `__reduce__` method to ensure a `DataLoaderShard` can be pickled and unpickled. This needs to be
+        explicitly defined since default pickling behavior is broken by `DataLoaderAdapter` messing with its
+        `__class__` member.
+        """
         args = super().__reduce__()
         return (DataLoaderShard, *args[1:])
-
 
     def set_epoch(self, epoch: int):
         # In case it is manually passed in, the user can set it to what they like
@@ -870,6 +876,11 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
             return math.ceil(whole_length / self.state.num_processes)
 
     def __reduce__(self):
+        """
+        Define the `__reduce__` method to ensure a `DataLoaderDispatcher` can be pickled and unpickled. This needs to
+        be explicitly defined since default pickling behavior is broken by `DataLoaderAdapter` messing with its
+        `__class__` member.
+        """
         args = super().__reduce__()
         return (DataLoaderDispatcher, *args[1:])
 
@@ -1215,9 +1226,13 @@ class SkipDataLoader(DataLoaderAdapter, DataLoaderStateMixin):
         return len(self.base_dataloader) - self.skip_batches
 
     def __reduce__(self):
+        """
+        Define the `__reduce__` method to ensure a `SkipDataLoader` can be pickled and unpickled. This needs to be
+        explicitly defined since default pickling behavior is broken by `DataLoaderAdapter` messing with its
+        `__class__` member.
+        """
         args = super().__reduce__()
         return (SkipDataLoader, *args[1:])
-
 
 
 def skip_first_batches(dataloader, num_batches=0):

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -253,7 +253,8 @@ def test_pickle_accelerator():
     _ = accelerator.prepare(data_loader)
     pickled_accelerator = pickle.dumps(accelerator)
     unpickled_accelerator = pickle.loads(pickled_accelerator)
-    assert accelerator.state == unpickled_accelerator.state
+    # TODO: Maybe this should be implemented as __eq__ for AcceleratorState?
+    assert accelerator.state.__dict__ == unpickled_accelerator.state.__dict__
 
 
 def test_data_loader(data_loader, accelerator):

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -340,7 +340,7 @@ def test_stateful_dataloader_save_state(accelerator):
     finally:
         accelerator.dataloader_config = old_dataloader_config
 
-def test_pickled_dataloader(accelerator):
+def test_pickled_dataloader(data_loader, accelerator):
     # Prepare the DataLoader
     data_loader = accelerator.prepare(data_loader)
     # Pickle then reload the dataloader
@@ -412,7 +412,8 @@ def main():
 
     # Dataloader after pickling
     loader = DataLoader(dataset, shuffle=False, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
-    test_pickled_dataloader(accelerator)
+    test_pickled_dataloader(loader, accelerator)
+
     accelerator.end_training()
 
 

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -411,7 +411,7 @@ def main():
     test_stateful_dataloader_save_state(accelerator)
 
     # Dataloader after pickling
-    loader = DataLoader(dataset, shuffle=False, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
+    loader = DataLoader(DummyIterableDataset(), shuffle=False, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
     test_pickled_dataloader(loader, accelerator)
 
     accelerator.end_training()

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -74,7 +74,7 @@ class DummyIterableDataset(IterableDataset):
 def create_accelerator(even_batches=True):
     dataloader_config = DataLoaderConfiguration(even_batches=even_batches)
     accelerator = Accelerator(dataloader_config=dataloader_config)
-    # assert accelerator.num_processes == 2, "this script expects that two GPUs are available"
+    assert accelerator.num_processes == 2, "this script expects that two GPUs are available"
     return accelerator
 
 
@@ -341,8 +341,6 @@ def test_stateful_dataloader_save_state(accelerator):
         accelerator.dataloader_config = old_dataloader_config
 
 def test_pickled_dataloader(data_loader, accelerator):
-    # Prepare the DataLoader
-    data_loader = accelerator.prepare(data_loader)
     # Pickle then reload the dataloader
     prepared_model_dumps = pickle.dumps(accelerator)
     loaded_accelerator = pickle.loads(prepared_model_dumps)

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -411,8 +411,10 @@ def main():
     test_stateful_dataloader_save_state(accelerator)
 
     # Dataloader after pickling
-    iterable_loader = create_dataloader(accelerator, dataset_size=NUM_ELEMENTS, batch_size=BATCH_SIZE, iterable=True)
-    test_pickled_dataloader(iterable_loader, accelerator)
+    # This test case currently fails.
+
+    # iterable_loader = create_dataloader(accelerator, dataset_size=NUM_ELEMENTS, batch_size=BATCH_SIZE, iterable=True)
+    # test_pickled_dataloader(iterable_loader, accelerator)
 
     accelerator.end_training()
 

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -412,8 +412,7 @@ def main():
 
     # Dataloader after pickling
     iterable_loader = create_dataloader(accelerator, dataset_size=NUM_ELEMENTS, batch_size=BATCH_SIZE, iterable=True)
-    loader = DataLoader(DummyIterableDataset(iterable_loader), shuffle=False, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
-    test_pickled_dataloader(loader, accelerator)
+    test_pickled_dataloader(iterable_loader, accelerator)
 
     accelerator.end_training()
 

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -247,6 +247,7 @@ def test_join_raises_warning_for_iterable_when_overriding_even_batches():
         assert issubclass(w[-1].category, UserWarning)
         assert "only supported for map-style datasets" in str(w[-1].message)
 
+
 def test_pickle_accelerator():
     accelerator = create_accelerator()
     data_loader = create_dataloader(accelerator, dataset_size=32, batch_size=4)
@@ -348,6 +349,7 @@ def test_stateful_dataloader_save_state(accelerator):
                     assert torch.equal(v1, v2), f"Batch {b1} and {b2} are not equal"
     finally:
         accelerator.dataloader_config = old_dataloader_config
+
 
 def main():
     accelerator = create_accelerator()

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -411,7 +411,8 @@ def main():
     test_stateful_dataloader_save_state(accelerator)
 
     # Dataloader after pickling
-    loader = DataLoader(DummyIterableDataset(), shuffle=False, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
+    iterable_loader = create_dataloader(accelerator, dataset_size=NUM_ELEMENTS, batch_size=BATCH_SIZE, iterable=True)
+    loader = DataLoader(DummyIterableDataset(iterable_loader), shuffle=False, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
     test_pickled_dataloader(loader, accelerator)
 
     accelerator.end_training()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -27,7 +27,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import DistributedType, infer_auto_device_map, init_empty_weights, load_checkpoint_and_dispatch
 from accelerate.accelerator import Accelerator
-from accelerate.data_loader import DataLoaderDispatcher, DataLoaderShard, skip_first_batches
+from accelerate.data_loader import DataLoaderDispatcher, DataLoaderShard, SkipDataLoader, skip_first_batches
 from accelerate.state import GradientState, PartialState
 from accelerate.test_utils import (
     require_bnb,
@@ -656,30 +656,38 @@ class AcceleratorTester(AccelerateTestCase):
         data = torch.arange(10).to(torch_device)
         ds = torch.utils.data.TensorDataset(data)
         dl = torch.utils.data.DataLoader(ds)
+        skip_dl = skip_first_batches(dl, 2)
+
         # Currently, StatefulDataLoader doesn't seem to support pickling, so we aren't testing that functionality
         # TODO: Add support for pickling StatefulDataLoader
         dataloader_config = DataLoaderConfiguration(dispatch_batches=dispatch_batches, use_stateful_dataloader=False)
         accelerator = Accelerator(dataloader_config=dataloader_config)
-        original_dl = accelerator.prepare(dl)
+        original_dl, prepared_skip_dl = accelerator.prepare(dl, skip_dl)
         prepared_model_dumps = pickle.dumps(accelerator)
 
         model_loaded = pickle.loads(prepared_model_dumps)
+        assert len(model_loaded._dataloaders) == 2
+
         # Assert equality of recovered and original dataloader
-        assert isinstance(model_loaded._dataloaders[0], DataLoader)
+        loaded_dl = model_loaded._dataloaders[0]
+        assert isinstance(loaded_dl, DataLoader)
         if dispatch_batches:
-            assert isinstance(model_loaded._dataloaders[0], DataLoaderDispatcher)
+            assert isinstance(loaded_dl, DataLoaderDispatcher)
         else:
-            assert isinstance(model_loaded._dataloaders[0], DataLoaderShard)
-        assert len(model_loaded._dataloaders[0]) == len(original_dl)
-        assert [i for i in model_loaded._dataloaders[0]] == [i for i in original_dl]
+            assert isinstance(loaded_dl, DataLoaderShard)
+        assert len(loaded_dl) == len(original_dl)
+        assert [i for i in loaded_dl] == [i for i in original_dl]
 
         # Test skip dataloader works as expected as well
-        skip_dl = skip_first_batches(dl, 2)
-        assert isinstance(skip_dl, DataLoader)
-        assert len(skip_dl) == len(original_dl) - 2
-        orig_items = [i for i in original_dl]
-        skip_dl_items = [i for i in skip_dl]
-        assert orig_items[2:] == skip_dl_items
+        loaded_skip_dl = model_loaded._dataloaders[1]
+        print(model_loaded._dataloaders)
+        assert isinstance(loaded_skip_dl, DataLoader)
+        if dispatch_batches:
+            assert isinstance(loaded_dl, DataLoaderDispatcher)
+        else:
+            assert isinstance(loaded_dl, DataLoaderShard)
+        assert len(loaded_skip_dl) == len(original_dl) - 2
+        assert [i for i in loaded_skip_dl] == [i for i in original_dl][2:]
 
     # Ideally would be a parameterized test which works with either stateful or non-stateful dataloaders, but dependencies are a bit awkward.
     @require_torchdata_stateful_dataloader

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -662,6 +662,7 @@ class AcceleratorTester(AccelerateTestCase):
         # TODO: Add support for pickling StatefulDataLoader
         dataloader_config = DataLoaderConfiguration(dispatch_batches=dispatch_batches, use_stateful_dataloader=False)
         accelerator = Accelerator(dataloader_config=dataloader_config)
+        torch.manual_seed(accelerator.process_index)
         original_dl, prepared_skip_dl = accelerator.prepare(dl, skip_dl)
         prepared_model_dumps = pickle.dumps(accelerator)
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -664,6 +664,11 @@ class AcceleratorTester(AccelerateTestCase):
         accelerator = Accelerator(dataloader_config=dataloader_config)
 
         original_dl, prepared_skip_dl = accelerator.prepare(dl, skip_dl)
+        if dispatch_batches:
+            assert isinstance(original_dl, DataLoaderDispatcher)
+        else:
+            assert isinstance(original_dl, DataLoaderShard)
+
         prepared_model_dumps = pickle.dumps(accelerator)
 
         model_loaded = pickle.loads(prepared_model_dumps)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -686,7 +686,6 @@ class AcceleratorTester(AccelerateTestCase):
 
         # Test skip dataloader works as expected as well
         loaded_skip_dl = model_loaded._dataloaders[1]
-        print(model_loaded._dataloaders)
         assert isinstance(loaded_skip_dl, DataLoader)
         if dispatch_batches:
             assert isinstance(loaded_dl, DataLoaderDispatcher)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -662,7 +662,7 @@ class AcceleratorTester(AccelerateTestCase):
         # TODO: Add support for pickling StatefulDataLoader
         dataloader_config = DataLoaderConfiguration(dispatch_batches=dispatch_batches, use_stateful_dataloader=False)
         accelerator = Accelerator(dataloader_config=dataloader_config)
-        torch.manual_seed(accelerator.process_index)
+
         original_dl, prepared_skip_dl = accelerator.prepare(dl, skip_dl)
         prepared_model_dumps = pickle.dumps(accelerator)
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -653,7 +653,7 @@ class AcceleratorTester(AccelerateTestCase):
         """
         Test that pickling a prepared dataloader works.
         """
-        data = torch.arange(10)
+        data = torch.arange(10).to(torch_device)
         ds = torch.utils.data.TensorDataset(data)
         dl = torch.utils.data.DataLoader(ds)
         # Currently, StatefulDataLoader doesn't seem to support pickling, so we aren't testing that functionality
@@ -674,8 +674,8 @@ class AcceleratorTester(AccelerateTestCase):
         assert [i for i in model_loaded._dataloaders[0]] == [i for i in original_dl]
 
         # Test skip dataloader works as expected as well
-        skip_dl = skip_first_batches(original_dl, 2)
-        assert isinstance(skip_dl, torch.utils.data.DataLoader)
+        skip_dl = skip_first_batches(dl, 2)
+        assert isinstance(skip_dl, DataLoader)
         assert len(skip_dl) == len(original_dl) - 2
         orig_items = [i for i in original_dl]
         skip_dl_items = [i for i in skip_dl]

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -27,7 +27,7 @@ from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import DistributedType, infer_auto_device_map, init_empty_weights, load_checkpoint_and_dispatch
 from accelerate.accelerator import Accelerator
-from accelerate.data_loader import DataLoaderDispatcher, DataLoaderShard, SkipDataLoader, skip_first_batches
+from accelerate.data_loader import DataLoaderDispatcher, DataLoaderShard, skip_first_batches
 from accelerate.state import GradientState, PartialState
 from accelerate.test_utils import (
     require_bnb,
@@ -663,7 +663,7 @@ class AcceleratorTester(AccelerateTestCase):
         dataloader_config = DataLoaderConfiguration(dispatch_batches=dispatch_batches, use_stateful_dataloader=False)
         accelerator = Accelerator(dataloader_config=dataloader_config)
 
-        original_dl, prepared_skip_dl = accelerator.prepare(dl, skip_dl)
+        original_dl, _ = accelerator.prepare(dl, skip_dl)
         if dispatch_batches:
             assert isinstance(original_dl, DataLoaderDispatcher)
         else:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -420,6 +420,14 @@ class DataLoaderTester(unittest.TestCase):
         skip_dl = SkipDataLoader(range(16), batch_size=4, skip_batches=2)
         dl_shard = DataLoaderShard(range(16), batch_size=4)
         dl_dispatcher = DataLoaderDispatcher(range(16), batch_size=4)
+
+        # Test dataloaders are instances of instantiated classes
+        # These asserts look redundant, but it's worth checking since we are doing magic tricks such as dynamically overriding __class__
+        assert isinstance(skip_dl, SkipDataLoader)
+        assert isinstance(dl_shard, DataLoaderShard)
+        assert isinstance(dl_dispatcher, DataLoaderDispatcher)
+
+        # Test dataloaders are instances of base classes
         assert isinstance(skip_dl, DataLoader)
         assert isinstance(dl_shard, DataLoader)
         assert isinstance(dl_dispatcher, DataLoader)
@@ -556,6 +564,13 @@ class StatefulDataLoaderTester(unittest.TestCase):
         skip_dl = SkipDataLoader(range(16), batch_size=4, skip_batches=2, use_stateful_dataloader=True)
         dl_shard = DataLoaderShard(range(16), batch_size=4, use_stateful_dataloader=True)
         dl_dispatcher = DataLoaderDispatcher(range(16), batch_size=4, use_stateful_dataloader=True)
+
+        # Test dataloaders are instances of instantiated classes
+        # These asserts look redundant, but it's worth checking since we are doing magic tricks such as dynamically overriding __class__
+        assert isinstance(skip_dl, SkipDataLoader)
+        assert isinstance(dl_shard, DataLoaderShard)
+        assert isinstance(dl_dispatcher, DataLoaderDispatcher)
+
         assert isinstance(skip_dl, StatefulDataLoader)
         assert isinstance(dl_shard, StatefulDataLoader)
         assert isinstance(dl_dispatcher, StatefulDataLoader)


### PR DESCRIPTION
# What does this PR do?

Fixes #3070

This PR contains the following:

1. Cleanup the dynamic class resolution of DataLoaderAdapter a bit. Instead of performing dynamic class overriding in `__init__`, we instead override the property to pass through the base dataloader's class.

    *Note:* This means `isinstance(obj, DataLoaderAdapter)` breaks. However, since `DataLoaderAdapter` was introduced very recently, it's very unlikely this will break anything, since there [shouldn't](https://www.hyrumslaw.com/) be any reason why existing downstream code would be checking this.
2. Implement `__reduce__` in DataLoaderAdapter subclasses to allow pickling of these classes, despite the `__class__` override. This implementation just repasses the object's init arguments and `__dict__` back into the constructor.
3. Some cleanup in DataLoaderDispatcher (use base_dataloader instead of `super()`), and some cleanup in SkipDataLoader (implement `__len__`)

Some caveats:

1. StatefulDataLoader's state_dict [might not be pickleable](https://github.com/pytorch/pytorch/blob/main/torch/utils/data/dataloader.py#L724-L730).
2. Pickling in general seems dubious and fragile.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?
@muellerzr
@BenjaminBossan 