### PR TITLE
use the correct available memory API for XPU

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -427,12 +427,14 @@ def is_xpu_available(check_device=False):
 
 def get_xpu_available_memory(device_index: int):
     if is_ipex_available():
-
         try:
             from intel_extension_for_pytorch.xpu import mem_get_info
+
             return mem_get_info(device_index)[0]
         except Exception:
-            warnings.warn("The XPU `mem_get_info` API is available in IPEX version >=2.5. To get the correct available memory, pls consider upgrading your IPEX version")
+            warnings.warn(
+                "The XPU `mem_get_info` API is available in IPEX version >=2.5. The current returned availabel memory is incorrect. Pls consider upgrading your IPEX version."
+            )
             return torch.xpu.max_memory_allocated(device_index)
     else:
         # this branch is for stock PyTorch 2.4

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -425,22 +425,6 @@ def is_xpu_available(check_device=False):
     return hasattr(torch, "xpu") and torch.xpu.is_available()
 
 
-def get_xpu_available_memory(device_index: int):
-    if is_ipex_available():
-        try:
-            from intel_extension_for_pytorch.xpu import mem_get_info
-
-            return mem_get_info(device_index)[0]
-        except Exception:
-            warnings.warn(
-                "The XPU `mem_get_info` API is available in IPEX version >=2.5. The current returned availabel memory is incorrect. Pls consider upgrading your IPEX version."
-            )
-            return torch.xpu.max_memory_allocated(device_index)
-    else:
-        # this branch is for stock PyTorch 2.4
-        return torch.xpu.max_memory_allocated(device_index)
-
-
 def is_dvclive_available():
     return _is_package_available("dvclive")
 

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -425,14 +425,18 @@ def is_xpu_available(check_device=False):
     return hasattr(torch, "xpu") and torch.xpu.is_available()
 
 
-def get_xpu_available_memory(i: int):
+def get_xpu_available_memory(device_index: int):
     if is_ipex_available():
-        from intel_extension_for_pytorch.xpu import mem_get_info
 
-        return mem_get_info(i)[0]
+        try:
+            from intel_extension_for_pytorch.xpu import mem_get_info
+            return mem_get_info(device_index)[0]
+        except Exception:
+            warnings.warn("The XPU `mem_get_info` API is available in IPEX version >=2.5. To get the correct available memory, pls consider upgrading your IPEX version")
+            return torch.xpu.max_memory_allocated(device_index)
     else:
         # this branch is for stock PyTorch 2.4
-        return torch.xpu.max_memory_allocated(i)
+        return torch.xpu.max_memory_allocated(device_index)
 
 
 def is_dvclive_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -425,6 +425,16 @@ def is_xpu_available(check_device=False):
     return hasattr(torch, "xpu") and torch.xpu.is_available()
 
 
+def get_xpu_available_memory(i: int):
+    if is_ipex_available():
+        from intel_extension_for_pytorch.xpu import mem_get_info
+
+        return mem_get_info(i)[0]
+    else:
+        # this branch is for stock PyTorch 2.4
+        return torch.xpu.max_memory_allocated(i)
+
+
 def is_dvclive_available():
     return _is_package_available("dvclive")
 

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -172,6 +172,6 @@ def get_xpu_available_memory(device_index: int):
 
             return mem_get_info(device_index)[0]
     warnings.warn(
-            "The XPU `mem_get_info` API is available in IPEX version >=2.5. The current returned available memory is incorrect. Please consider upgrading your IPEX version."
-        )
+        "The XPU `mem_get_info` API is available in IPEX version >=2.5. The current returned available memory is incorrect. Please consider upgrading your IPEX version."
+    )
     return torch.xpu.max_memory_allocated(device_index)

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -171,7 +171,7 @@ def get_xpu_available_memory(device_index: int):
             from intel_extension_for_pytorch.xpu import mem_get_info
 
             return mem_get_info(device_index)[0]
-        warnings.warn(
+    warnings.warn(
             "The XPU `mem_get_info` API is available in IPEX version >=2.5. The current returned available memory is incorrect. Please consider upgrading your IPEX version."
         )
     return torch.xpu.max_memory_allocated(device_index)

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -16,21 +16,24 @@
 A collection of utilities for ensuring that training can always occur. Heavily influenced by the
 [toma](https://github.com/BlackHC/toma) library.
 """
-
 import functools
 import gc
+import importlib
 import inspect
+import warnings
 
 import torch
 
 from .imports import (
     is_cuda_available,
+    is_ipex_available,
     is_mlu_available,
     is_mps_available,
     is_musa_available,
     is_npu_available,
     is_xpu_available,
 )
+from .versions import compare_versions
 
 
 def clear_device_cache(garbage_collection=False):
@@ -159,3 +162,16 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
                     raise
 
     return decorator
+
+
+def get_xpu_available_memory(device_index: int):
+    if is_ipex_available():
+        ipex_version = importlib.metadata.version("intel_extension_for_pytorch")
+        if compare_versions(ipex_version, ">=", "2.5"):
+            from intel_extension_for_pytorch.xpu import mem_get_info
+
+            return mem_get_info(device_index)[0]
+        warnings.warn(
+            "The XPU `mem_get_info` API is available in IPEX version >=2.5. The current returned available memory is incorrect. Please consider upgrading your IPEX version."
+        )
+    return torch.xpu.max_memory_allocated(device_index)

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -908,7 +908,6 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
-
         else:
             for i in range(torch.cuda.device_count()):
                 try:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -32,7 +32,6 @@ from ..state import AcceleratorState
 from .constants import SAFE_WEIGHTS_NAME, WEIGHTS_NAME
 from .dataclasses import AutocastKwargs, CustomDtype, DistributedType
 from .imports import (
-    get_xpu_available_memory,
     is_mlu_available,
     is_mps_available,
     is_musa_available,
@@ -41,7 +40,7 @@ from .imports import (
     is_torch_xla_available,
     is_xpu_available,
 )
-from .memory import clear_device_cache
+from .memory import clear_device_cache, get_xpu_available_memory
 from .offload import load_offloaded_weight, offload_weight, save_offload_index
 from .tqdm import is_tqdm_available, tqdm
 from .versions import compare_versions, is_torch_version

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -32,6 +32,7 @@ from ..state import AcceleratorState
 from .constants import SAFE_WEIGHTS_NAME, WEIGHTS_NAME
 from .dataclasses import AutocastKwargs, CustomDtype, DistributedType
 from .imports import (
+    get_xpu_available_memory,
     is_mlu_available,
     is_mps_available,
     is_musa_available,
@@ -900,15 +901,14 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
         elif is_xpu_available():
-            from intel_extension_for_pytorch.xpu import mem_get_info
-
             for i in range(torch.xpu.device_count()):
                 try:
                     _ = torch.tensor(0, device=torch.device("xpu", i))
-                    max_memory[i] = mem_get_info(i)[0]
+                    max_memory[i] = get_xpu_available_memory(i)
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
+
         else:
             for i in range(torch.cuda.device_count()):
                 try:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -900,10 +900,12 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
         elif is_xpu_available():
+            from intel_extension_for_pytorch.xpu import mem_get_info
+
             for i in range(torch.xpu.device_count()):
                 try:
                     _ = torch.tensor(0, device=torch.device("xpu", i))
-                    max_memory[i] = torch.xpu.max_memory_allocated(i)
+                    max_memory[i] = mem_get_info(i)[0]
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue


### PR DESCRIPTION
## What does this PR do?
This PR introduces the new API for get xpu available memory. Below is an example of before and after:

```python
from transformers import AutoModelForSeq2SeqLM

model = AutoModelForSeq2SeqLM.from_pretrained("bigscience/T0pp", device_map="auto")
print(model.hf_device_map)
```

Before
```python
{'': 'cpu'}
```

After
```python
{'shared': 0, 'decoder.embed_tokens': 0, 'encoder.embed_tokens': 0, 'encoder.block.0': 0, 'encoder.block.1': 0, 'encoder.block.2': 0, 'encoder.block.3': 0, 'encoder.block.4': 0, 'encoder.block.5': 0, 'encoder.block.6': 1, 'encoder.block.7': 1, 'encoder.block.8': 1, 'encoder.block.9': 1, 'encoder.block.10': 1, 'encoder.block.11': 1, 'encoder.block.12': 1, 'encoder.block.13': 1, 'encoder.block.14': 2, 'encoder.block.15': 2, 'encoder.block.16': 2, 'encoder.block.17': 2, 'encoder.block.18': 2, 'encoder.block.19': 2, 'encoder.block.20': 2, 'encoder.block.21': 2, 'encoder.block.22': 3, 'encoder.block.23': 3, 'encoder.final_layer_norm': 3, 'encoder.dropout': 3, 'decoder.block.0': 3, 'decoder.block.1': 3, 'decoder.block.2': 3, 'decoder.block.3': 3, 'decoder.block.4': 4, 'decoder.block.5': 4, 'decoder.block.6': 4, 'decoder.block.7': 4, 'decoder.block.8': 4, 'decoder.block.9': 4, 'decoder.block.10': 5, 'decoder.block.11': 5, 'decoder.block.12': 5, 'decoder.block.13': 5, 'decoder.block.14': 5, 'decoder.block.15': 5, 'decoder.block.16': 6, 'decoder.block.17': 6, 'decoder.block.18': 6, 'decoder.block.19': 6, 'decoder.block.20': 6, 'decoder.block.21': 6, 'decoder.block.22': 7, 'decoder.block.23': 7, 'decoder.final_layer_norm': 7, 'decoder.dropout': 7, 'lm_head': 7}
```