### PR TITLE
Re-enable setting state dict type

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1498,7 +1498,7 @@ class FullyShardedDataParallelPlugin:
             # when using `sync_module_states`
             self.param_init_fn = lambda x: x.to_empty(device=device, recurse=False)
 
-    def set_state_dict_type(self):
+    def set_state_dict_type(self, state_dict_type=None):
         """
         Set the state dict config based on the `StateDictType`.
         """
@@ -1509,6 +1509,11 @@ class FullyShardedDataParallelPlugin:
             ShardedStateDictConfig,
             StateDictType,
         )
+
+        # Override the state_dict_type if provided, typical use case:
+        # user trains with sharded, but final save is with full
+        if state_dict_type is not None:
+            self.state_dict_type = state_dict_type
 
         if self.state_dict_type is None:
             self.state_dict_type = os.environ.get("FSDP_STATE_DICT_TYPE", "FULL_STATE_DICT")

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -136,6 +136,12 @@ class FSDPPluginIntegration(AccelerateTestCase):
                 assert fsdp_plugin.state_dict_config.offload_to_cpu
                 assert fsdp_plugin.state_dict_config.rank0_only
 
+        # We can also override the state_dict_type,
+        # typical case: user trains with sharded, but final save is with full
+        fsdp_plugin = FullyShardedDataParallelPlugin(state_dict_type="FULL_STATE_DICT")
+        fsdp_plugin.set_state_dict_type("SHARDED_STATE_DICT")
+        assert fsdp_plugin.state_dict_type == StateDictType.SHARDED_STATE_DICT
+
     def test_auto_wrap_policy(self):
         for model_name in [LLAMA_TESTING, BERT_BASE_CASED]:
             model = AutoModel.from_pretrained(model_name)


### PR DESCRIPTION
# What does this PR do?

0.34.0 removed the ability to set the state_dict_type on the fly, which I had assumed was fine, however I wasn't aware that users typically will:

* Use `SHARDED_STATE_DICT` for checkpoints
* Use `FULL_STATE_DICT` for the final model

As a result, brings it back and documents the desired behavior

Fixes https://github.com/huggingface/accelerate/issues/3072


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 