### PR TITLE
MAINT: Upgrade ruff to v0.6.4

### DIFF
--- a/benchmarks/fp8/ddp.py
+++ b/benchmarks/fp8/ddp.py
@@ -17,6 +17,7 @@ This script tests to ensure that `accelerate` performs at the same level as raw 
 
 This particular script verifies this for DDP training.
 """
+
 import evaluate
 import torch
 import transformer_engine.common.recipe as te_recipe

--- a/benchmarks/fp8/distrib_deepspeed.py
+++ b/benchmarks/fp8/distrib_deepspeed.py
@@ -17,6 +17,7 @@ This script tests to ensure that `accelerate` performs at the same level as raw 
 
 This particular script verifies this for DDP training.
 """
+
 from unittest.mock import patch
 
 import deepspeed

--- a/benchmarks/fp8/fsdp.py
+++ b/benchmarks/fp8/fsdp.py
@@ -17,6 +17,7 @@ This script tests to ensure that `accelerate` performs at the same level as raw 
 
 This particular script verifies this for FSDP training.
 """
+
 from functools import partial
 
 import evaluate

--- a/benchmarks/fp8/non_distributed.py
+++ b/benchmarks/fp8/non_distributed.py
@@ -17,6 +17,7 @@ This script tests to ensure that `accelerate` performs at the same level as raw 
 
 This particular script verifies this for single GPU training.
 """
+
 import evaluate
 import torch
 import transformer_engine.common.recipe as te_recipe

--- a/examples/config_yaml_templates/run_me.py
+++ b/examples/config_yaml_templates/run_me.py
@@ -15,6 +15,7 @@
 """
 A base script which outputs the accelerate config for the given environment
 """
+
 from accelerate import Accelerator
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ target-version = "py38"
 
 [tool.ruff.lint]
 preview = true
-ignore-init-module-imports = true
 extend-select = [
     "B009", # static getattr
     "B010", # static setattr

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ extras = {}
 extras["quality"] = [
     "black ~= 23.1",  # hf-doc-builder has a hidden dependency on `black`
     "hf-doc-builder >= 0.3.0",
-    "ruff ~= 0.2.1",
+    "ruff ~= 0.6.4",
 ]
 extras["docs"] = []
 extras["test_prod"] = ["pytest>=7.2.0,<=8.0.0", "pytest-xdist", "pytest-subtests", "parameterized"]

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1281,14 +1281,14 @@ class FullyShardedDataParallelPlugin:
             "If passing in a `dict`, it should have the following keys: `param_dtype`, `reduce_dtype`, and `buffer_dtype`."
         },
     )
-    auto_wrap_policy: Optional[
-        Union[Callable, Literal["transformer_based_wrap", "size_based_wrap", "no_wrap"]]
-    ] = field(
-        default=None,
-        metadata={
-            "help": "A callable or string specifying a policy to recursively wrap layers with FSDP. If a string, it must be one of `transformer_based_wrap`, `size_based_wrap`, or `no_wrap`. "
-            "Defaults to `NO_WRAP`. See `torch.distributed.fsdp.wrap.size_based_wrap_policy` for a direction on what it should look like"
-        },
+    auto_wrap_policy: Optional[Union[Callable, Literal["transformer_based_wrap", "size_based_wrap", "no_wrap"]]] = (
+        field(
+            default=None,
+            metadata={
+                "help": "A callable or string specifying a policy to recursively wrap layers with FSDP. If a string, it must be one of `transformer_based_wrap`, `size_based_wrap`, or `no_wrap`. "
+                "Defaults to `NO_WRAP`. See `torch.distributed.fsdp.wrap.size_based_wrap_policy` for a direction on what it should look like"
+            },
+        )
     )
     cpu_offload: Union[bool, "torch.distributed.fsdp.CPUOffload"] = field(
         default=None,

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -106,7 +106,7 @@ def _nvidia_smi():
         # try from systemd drive with default installation path
         command = which("nvidia-smi")
         if command is None:
-            command = "%s\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe" % os.environ["systemdrive"]
+            command = f"{os.environ['systemdrive']}\\Program Files\\NVIDIA Corporation\\NVSMI\\nvidia-smi.exe"
     else:
         command = "nvidia-smi"
     return command

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -130,7 +130,7 @@ def load_fsdp_model(fsdp_plugin, accelerator, model, input_dir, model_index=0, a
         model, fsdp_plugin.state_dict_type, fsdp_plugin.state_dict_config, fsdp_plugin.optim_state_dict_config
     ):
         if fsdp_plugin.state_dict_type == StateDictType.FULL_STATE_DICT:
-            if type(model) is FSDP and accelerator.process_index != 0:
+            if type(model) is not FSDP and accelerator.process_index != 0:
                 if not fsdp_plugin.sync_module_states:
                     raise ValueError(
                         "Set the `sync_module_states` flag to `True` so that model states are synced across processes when "

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -130,7 +130,7 @@ def load_fsdp_model(fsdp_plugin, accelerator, model, input_dir, model_index=0, a
         model, fsdp_plugin.state_dict_type, fsdp_plugin.state_dict_config, fsdp_plugin.optim_state_dict_config
     ):
         if fsdp_plugin.state_dict_type == StateDictType.FULL_STATE_DICT:
-            if type(model) != FSDP and accelerator.process_index != 0:
+            if type(model) is FSDP and accelerator.process_index != 0:
                 if not fsdp_plugin.sync_module_states:
                     raise ValueError(
                         "Set the `sync_module_states` flag to `True` so that model states are synced across processes when "

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -16,6 +16,7 @@
 A collection of utilities for ensuring that training can always occur. Heavily influenced by the
 [toma](https://github.com/BlackHC/toma) library.
 """
+
 import functools
 import gc
 import importlib

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -783,9 +783,9 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 
     def test_ds_config_assertions(self):
         ambiguous_env = self.dist_env.copy()
-        ambiguous_env[
-            "ACCELERATE_CONFIG_DS_FIELDS"
-        ] = "gradient_accumulation_steps,gradient_clipping,zero_stage,offload_optimizer_device,offload_param_device,zero3_save_16bit_model,mixed_precision"
+        ambiguous_env["ACCELERATE_CONFIG_DS_FIELDS"] = (
+            "gradient_accumulation_steps,gradient_clipping,zero_stage,offload_optimizer_device,offload_param_device,zero3_save_16bit_model,mixed_precision"
+        )
 
         with mockenv_context(**ambiguous_env):
             with self.assertRaises(ValueError) as cm:


### PR DESCRIPTION
# What does this PR do?

Currently used version, 0.2.1, is quite old at this point.

Not a lot needed to be changed:

- Change ruff version in `setup.py`
- Remove deprecated `ignore-init-module-imports` option for ruff
- Type comparison should use `is not` and not `!=`
- Use f-string instead of `%` formatting
- Some line wrapping and empty lines

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?