### PR TITLE
Revert "Enable Unwrapping for Model State Dicts (FSDP)"

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3334,8 +3334,6 @@ class Accelerator:
             from torch.distributed.fsdp import FullStateDictConfig, StateDictType
             from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
-            if unwrap:
-                model = self.unwrap_model(model)
             full_state_dict_config = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
             with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, full_state_dict_config):
                 state_dict = model.state_dict()


### PR DESCRIPTION
Reverts huggingface/accelerate#2959
This PR breaks basic usage of FSDP with the torch 2.4 and 2.5 (regression ?). See https://github.com/huggingface/transformers/issues/33400 and https://github.com/huggingface/accelerate/issues/3061. 

Since there is no good solution yet, it's best to revert this PR. 
cc @evkogs @muellerzr @alex-jw-brooks