### PR TITLE
MNT Permission for PRs for GH token in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      pull-requests: write
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
Continuation of #3102.

The equivalent PR in PEFT (https://github.com/huggingface/peft/pull/2064) was successful to restore stale bot function to PRs as well. Hence also making the same change for accelerate.