### PR TITLE
[tests] skip pippy tests for XPU 

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,6 +30,7 @@ from accelerate.test_utils.testing import (
     require_huggingface_suite,
     require_multi_device,
     require_multi_gpu,
+    require_non_xpu,
     require_pippy,
     require_schedulefree,
     require_trackers,
@@ -274,12 +275,14 @@ class FeatureExamplesTests(TempDirTestCase):
         testargs = ["examples/inference/distributed/phi2.py"]
         run_command(self.launch_args + testargs)
 
+    @require_non_xpu
     @require_pippy
     @require_multi_gpu
     def test_pippy_examples_bert(self):
         testargs = ["examples/inference/pippy/bert.py"]
         run_command(self.launch_args + testargs)
 
+    @require_non_xpu
     @require_pippy
     @require_multi_gpu
     def test_pippy_examples_gpt2(self):

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -30,6 +30,7 @@ from accelerate.test_utils import (
     require_multi_device,
     require_multi_gpu,
     require_non_torch_xla,
+    require_non_xpu,
     require_pippy,
     require_torchvision,
     torch_device,
@@ -93,6 +94,7 @@ class MultiDeviceTester(unittest.TestCase):
         with patch_environment(**env_kwargs):
             execute_subprocess_async(cmd)
 
+    @require_non_xpu
     @require_multi_gpu
     @require_pippy
     @require_torchvision


### PR DESCRIPTION
## What does this PR do?
XPU doesn't support pippy yet. So we should skip the pippy-related tests for now.   

@muellerzr @SunMarc 