### PR TITLE
Fix seed random sampler to use initial seed from generator

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -84,6 +84,7 @@ class SeedableRandomSampler(RandomSampler):
         if self.generator is None:
             self.generator = torch.Generator()
             self.initial_seed = torch.random.initial_seed()
+            self.generator.manual_seed(self.initial_seed)
         else:
             self.initial_seed = self.generator.initial_seed()
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -81,11 +81,13 @@ class SeedableRandomSampler(RandomSampler):
         self.epoch = 0
         self.initial_seed = torch.random.initial_seed()
 
-    def __iter__(self):
         if self.generator is None:
             self.generator = torch.Generator()
-            self.generator.manual_seed(self.initial_seed)
+            self.initial_seed = torch.random.initial_seed()
+        else:
+            self.initial_seed = self.generator.initial_seed()
 
+    def __iter__(self):
         # Allow `self.epoch` to modify the seed of the generator
         seed = self.epoch + self.initial_seed
         # print("Setting seed at epoch", self.epoch, seed)


### PR DESCRIPTION
# What does this PR do?

This PR fixes the behavior of SeedableRandomSampler, when self.generator is not None, we use the initial_seed of the generator instead of initializing a random seed. We need it for transformers PR https://github.com/huggingface/transformers/pull/33731 to enable data_seed.
See the issue : https://github.com/huggingface/transformers/issues/31818

For example in this code : 
```
from datasets import load_dataset
from transformers import AutoTokenizer, TrainingArguments, AutoModelForSequenceClassification, Trainer, set_seed
import torch

set_seed(125)

tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
model = AutoModelForSequenceClassification.from_pretrained("bert-base-uncased", num_labels=2)

dataset = load_dataset("glue", "mrpc", split="train")

def tokenize_function(example):
    return tokenizer(example["sentence1"], example["sentence2"], truncation=True)

dataset = dataset.map(tokenize_function, batched=True)
SEED = 126
DATA_SEED = 762
training_args = TrainingArguments(f"test-trainer_dataseed_{DATA_SEED}_seed_{SEED}", max_steps=400, logging_steps=40, seed=SEED, data_seed=DATA_SEED)
trainer = Trainer(
    model,
    training_args,
    train_dataset=dataset,
    tokenizer=tokenizer,
)

trainer.train()
```
When we set the seed using `set_seed`, if the data sampler's seed is chosen using `torch.random.initial_seed()`, it will remain deterministic even when the `data_seed` value changes. To address this, the PR checks whether a generator using the `data_seed` is already available. If it exists, we use the initial `data_seed` provided by the user. If not, we randomly select one. This ensures that even when `set_seed` is used, the randomness of the data sampler remains unaffected when different `data_seed` values are used.
