### PR TITLE
only move model to device when model is in cpu and target device is xpu

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2005,7 +2005,7 @@ class Accelerator:
                 optimizer = obj
         if optimizer is not None and model is not None:
             dtype = torch.bfloat16 if self.state.mixed_precision == "bf16" else None
-            if self.device.type == "xpu":
+            if self.device.type == "xpu" and model.device.type == "cpu":
                 model = model.to(self.device)
             # ipex.optimize() is available only for IPEX, both IPEX-CPU and IPEX-XPU
             if is_ipex_available():

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -703,7 +703,7 @@ class PartialState:
         elif torch.cuda.is_available():
             return torch.device("cuda")
         elif is_xpu_available():
-            return torch.device("xpu:0")
+            return torch.device("xpu")
         else:
             return torch.device("cpu")
 


### PR DESCRIPTION
## What does this PR do?
When model is loaded across multiple devices, fine-tuning on XPU crashes with the message:
```bash
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, xpu:0 and xpu:3! (when checking argument for argument mat2 in method wrapper_XPU__bmm)
```
The reason is that the whole model is moved back to `xpu:0` in the `_prepare_ipex_or_xpu` method. After the fix, fine-tuning works. 

## Who can review?
 @SunMarc and @muellerzr