### PR TITLE
🐛 [HotFix] Handle Profiler Activities Based on PyTorch Version

### DIFF
--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from .constants import (
+    MITA_PROFILING_AVAILABLE_PYTORCH_VERSION,
     MODEL_NAME,
     OPTIMIZER_NAME,
     PROFILE_PATTERN_NAME,
@@ -28,6 +29,7 @@ from .constants import (
     WEIGHTS_INDEX_NAME,
     WEIGHTS_NAME,
     WEIGHTS_PATTERN_NAME,
+    XPU_PROFILING_AVAILABLE_PYTORCH_VERSION,
 )
 from .dataclasses import (
     AutocastKwargs,

--- a/src/accelerate/utils/constants.py
+++ b/src/accelerate/utils/constants.py
@@ -44,6 +44,8 @@ FSDP_MODEL_NAME = "pytorch_model_fsdp"
 DEEPSPEED_MULTINODE_LAUNCHERS = ["pdsh", "standard", "openmpi", "mvapich", "mpich"]
 TORCH_DYNAMO_MODES = ["default", "reduce-overhead", "max-autotune"]
 ELASTIC_LOG_LINE_PREFIX_TEMPLATE_PYTORCH_VERSION = "2.2.0"
+XPU_PROFILING_AVAILABLE_PYTORCH_VERSION = "2.4.0"
+MITA_PROFILING_AVAILABLE_PYTORCH_VERSION = "2.1.0"
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -29,7 +29,13 @@ from typing import Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple
 
 import torch
 
-from .constants import FSDP_AUTO_WRAP_POLICY, FSDP_BACKWARD_PREFETCH, FSDP_SHARDING_STRATEGY
+from .constants import (
+    FSDP_AUTO_WRAP_POLICY,
+    FSDP_BACKWARD_PREFETCH,
+    FSDP_SHARDING_STRATEGY,
+    MITA_PROFILING_AVAILABLE_PYTORCH_VERSION,
+    XPU_PROFILING_AVAILABLE_PYTORCH_VERSION,
+)
 from .environment import parse_flag_from_env, str_to_bool
 from .imports import (
     is_cuda_available,
@@ -39,7 +45,7 @@ from .imports import (
     is_transformer_engine_available,
     is_xpu_available,
 )
-from .versions import compare_versions
+from .versions import compare_versions, is_torch_version
 
 
 class KwargsHandler:
@@ -468,10 +474,14 @@ class ProfileKwargs(KwargsHandler):
 
         profiler_activity_map: dict[str, torch.profiler.ProfilerActivity] = {
             "cpu": torch.profiler.ProfilerActivity.CPU,
-            "xpu": torch.profiler.ProfilerActivity.XPU,
-            "mita": torch.profiler.ProfilerActivity.MTIA,
             "cuda": torch.profiler.ProfilerActivity.CUDA,
         }
+
+        if is_torch_version(">=", XPU_PROFILING_AVAILABLE_PYTORCH_VERSION):
+            profiler_activity_map["xpu"] = torch.profiler.ProfilerActivity.XPU
+
+        if is_torch_version(">=", MITA_PROFILING_AVAILABLE_PYTORCH_VERSION):
+            profiler_activity_map["mtia"] = torch.profiler.ProfilerActivity.MTIA
 
         if activity not in profiler_activity_map:
             raise ValueError(f"Invalid profiler activity: {activity}. Must be one of {list(profiler_activity_map)}.")


### PR DESCRIPTION
# What does this PR do?

This PR adds support for `XPU` and `MTIA` profiler activities in `accelerate.utils.dataclasses.ProfileKwargs` based on the installed PyTorch version. These activities are included conditionally depending on whether the current PyTorch version supports them (`XPU` in 2.4.0 and `MTIA` in 2.1.0).

Fixes #3128 

## Changes made:
- Added `XPU_PROFILING_AVAILABLE_PYTORCH_VERSION` and `MITA_PROFILING_AVAILABLE_PYTORCH_VERSION` constants to `constants.py`.
- Updated `ProfileKwargs._get_profiler_activity` to conditionally include `XPU` and `MTIA` activities based on PyTorch version.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?