### PR TITLE
Update accelerator.py preventing FutureWarning when using GradScaler with cuda

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -498,7 +498,7 @@ class Accelerator:
             elif is_xpu_available():
                 self.scaler = torch.amp.GradScaler("xpu", **kwargs)
             else:
-                self.scaler = torch.cuda.amp.GradScaler(**kwargs)
+                self.scaler = torch.amp.GradScaler('cuda', **kwargs)
 
         elif self.state.mixed_precision == "bf16" and self.distributed_type not in (
             DistributedType.DEEPSPEED,


### PR DESCRIPTION
# What does this PR do?

This small edit prevents the FutureWarning: `torch.cuda.amp.GradScaler(args...)` is deprecated. Please use `torch.amp.GradScaler('cuda', args...)` instead.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?

## Who can review?

@muellerzr  @BenjaminBossan  @SunMarc, this should just be a simple edit, but let me know if anything else is needed.

