### PR TITLE
Fixup Zero3 + `save_model`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2838,8 +2838,6 @@ class Accelerator:
             logger.error(f"Provided path ({save_directory}) should be a directory, not a file")
             return
 
-        os.makedirs(save_directory, exist_ok=True)
-
         # get the state_dict of the model
         if any(
             [
@@ -2857,6 +2855,7 @@ class Accelerator:
         # Case: DeepSpeed zero3 gets gathered and `state_dict` is empty
         if state_dict is None:
             return
+        os.makedirs(save_directory, exist_ok=True)
 
         if safe_serialization:
             state_dict = clean_state_dict_for_safetensors(state_dict)

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2854,6 +2854,10 @@ class Accelerator:
                 raise RuntimeError("You can't save the model since some parameters are on the meta device.")
             state_dict = self.get_state_dict(model)
 
+        # Case: DeepSpeed zero3 gets gathered and `state_dict` is empty
+        if state_dict is None:
+            return
+
         if safe_serialization:
             state_dict = clean_state_dict_for_safetensors(state_dict)
         weights_name = SAFE_WEIGHTS_NAME if safe_serialization else WEIGHTS_NAME

--- a/src/accelerate/test_utils/scripts/external_deps/test_performance.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_performance.py
@@ -14,6 +14,7 @@
 import argparse
 import json
 import os
+from pathlib import Path
 
 import evaluate
 import torch
@@ -205,6 +206,13 @@ def training_function(config, args):
     if accelerator.is_main_process:
         with open(os.path.join(args.output_dir, "all_results.json"), "w") as f:
             json.dump(performance_metric, f)
+
+    # Finally try saving the model
+    accelerator.save_model(model, args.output_dir)
+    accelerator.wait_for_everyone()
+    assert Path(
+        args.output_dir, "model.safetensors"
+    ).exists(), "Model was not saved when calling `Accelerator.save_model`"
     accelerator.end_training()
 
 

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -62,6 +62,7 @@ QWEN_MOE = "peft-internal-testing/tiny-random-qwen-1.5-MoE"
 
 ZERO2 = "zero2"
 ZERO3 = "zero3"
+
 FP16 = "fp16"
 BF16 = "bf16"
 

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -62,7 +62,6 @@ QWEN_MOE = "peft-internal-testing/tiny-random-qwen-1.5-MoE"
 
 ZERO2 = "zero2"
 ZERO3 = "zero3"
-
 FP16 = "fp16"
 BF16 = "bf16"
 


### PR DESCRIPTION
# What does this PR do?

When `save_model` is called under Zero3 only a single rank has all of the parameters. As a result `Accelerator.save_model` will throw an error under zero3 saying `'NoneType' object has no attribute 'items'` because in this case the `state_dict` of the model on non-0-ranks won't exist. 

Fixes https://github.com/huggingface/accelerate/issues/2985


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @BenjaminBossan 