### PR TITLE
POC: Allow for a `data_seed`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2100,6 +2100,7 @@ class Accelerator:
             use_seedable_sampler=self.use_seedable_sampler,
             non_blocking=self.non_blocking,
             use_stateful_dataloader=self.use_stateful_dataloader,
+            data_seed=self.dataloader_config.data_seed,
         )
         self._dataloaders.append(prepared_data_loader)
         return prepared_data_loader

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2098,9 +2098,9 @@ class Accelerator:
             even_batches=self.even_batches,
             slice_fn_for_dispatch=slice_fn_for_dispatch,
             use_seedable_sampler=self.use_seedable_sampler,
+            data_seed=self.dataloader_config.data_seed,
             non_blocking=self.non_blocking,
             use_stateful_dataloader=self.use_stateful_dataloader,
-            data_seed=self.dataloader_config.data_seed,
         )
         self._dataloaders.append(prepared_data_loader)
         return prepared_data_loader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -77,11 +77,10 @@ class SeedableRandomSampler(RandomSampler):
     """
 
     def __init__(self, *args, **kwargs):
-        self.initial_seed = kwargs.pop("initial_seed", None)
-        if self.initial_seed is None:
-            self.initial_seed = torch.random.initial_seed()
-
+        data_seed = kwargs.pop("data_seed", None)
         super().__init__(*args, **kwargs)
+
+        self.initial_seed = data_seed if data_seed is not None else torch.random.initial_seed()
         self.epoch = 0
 
     def __iter__(self):
@@ -1073,7 +1072,7 @@ def prepare_data_loader(
             replacement=sampler.replacement,
             num_samples=sampler._num_samples,
             generator=getattr(sampler, "generator", torch.Generator()),
-            initial_seed=data_seed,
+            data_seed=data_seed,
         )
 
     if isinstance(dataloader.sampler, RandomSampler) and state.distributed_type == DistributedType.XLA:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -77,9 +77,12 @@ class SeedableRandomSampler(RandomSampler):
     """
 
     def __init__(self, *args, **kwargs):
+        self.initial_seed = kwargs.pop("initial_seed", None)
+        if self.initial_seed is None:
+            self.initial_seed = torch.random.initial_seed()
+
         super().__init__(*args, **kwargs)
         self.epoch = 0
-        self.initial_seed = torch.random.initial_seed()
 
     def __iter__(self):
         if self.generator is None:
@@ -939,6 +942,7 @@ def prepare_data_loader(
     use_seedable_sampler: bool = False,
     non_blocking: bool = False,
     use_stateful_dataloader: bool = False,
+    data_seed: Optional[int] = None,
 ) -> DataLoader:
     """
     Wraps a PyTorch `DataLoader` to generate batches for one of the processes only.
@@ -1069,6 +1073,7 @@ def prepare_data_loader(
             replacement=sampler.replacement,
             num_samples=sampler._num_samples,
             generator=getattr(sampler, "generator", torch.Generator()),
+            initial_seed=data_seed,
         )
 
     if isinstance(dataloader.sampler, RandomSampler) and state.distributed_type == DistributedType.XLA:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -939,9 +939,9 @@ def prepare_data_loader(
     even_batches: bool = True,
     slice_fn_for_dispatch: Optional[Callable] = None,
     use_seedable_sampler: bool = False,
+    data_seed: Optional[int] = None,
     non_blocking: bool = False,
     use_stateful_dataloader: bool = False,
-    data_seed: Optional[int] = None,
 ) -> DataLoader:
     """
     Wraps a PyTorch `DataLoader` to generate batches for one of the processes only.
@@ -999,6 +999,9 @@ def prepare_data_loader(
             reproducability. Comes at a cost of potentially different performances due to different shuffling
             algorithms but ensures results will be the *exact* same. Should be paired with `set_seed()` at every
             `self.set_epoch`
+        data_seed (`int`, *optional*, defaults to `None`):
+            The seed to use for the underlying generator when using `use_seedable_sampler`. If `None`, the generator
+            will use the current default seed from torch.
         non_blocking (`bool`, *optional*, defaults to `False`):
             If set to `True`, dataloader will utilize non-blocking host-to-device transfers. If the dataloader has
             `pin_memory` set to `True`, this will help to increase overlap between data transfer and computations.

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -34,10 +34,12 @@ from accelerate.utils import (
     DistributedType,
     gather,
     is_bf16_available,
+    is_datasets_available,
     is_ipex_available,
     is_mlu_available,
     is_musa_available,
     is_npu_available,
+    is_pytest_available,
     is_xpu_available,
     set_seed,
     synchronize_rng_states,
@@ -774,79 +776,79 @@ def test_reinstantiated_state():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
-    # state.wait_for_everyone()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
+    state.wait_for_everyone()
 
-    # if state.distributed_type == DistributedType.MULTI_GPU:
-    #     num_processes_per_node = torch.cuda.device_count()
-    # else:
-    #     num_processes_per_node = state.num_processes
+    if state.distributed_type == DistributedType.MULTI_GPU:
+        num_processes_per_node = torch.cuda.device_count()
+    else:
+        num_processes_per_node = state.num_processes
 
-    # # We only run this test on non-multinode
-    # if num_processes_per_node == state.num_processes:
-    #     if state.process_index == 0:
-    #         print("\n**Test process execution**")
-    #     process_execution_check()
+    # We only run this test on non-multinode
+    if num_processes_per_node == state.num_processes:
+        if state.process_index == 0:
+            print("\n**Test process execution**")
+        process_execution_check()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a list**")
-    #     test_split_between_processes_list()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a list**")
+        test_split_between_processes_list()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a dict**")
-    #     test_split_between_processes_nested_dict()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a dict**")
+        test_split_between_processes_nested_dict()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a tensor**")
-    #     test_split_between_processes_tensor()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a tensor**")
+        test_split_between_processes_tensor()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes evenly**")
-    #     test_split_between_processes_evenly()
+        if state.process_index == 0:
+            print("\n**Test split between processes evenly**")
+        test_split_between_processes_evenly()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a datasets.Dataset**")
-    #     if is_datasets_available():
-    #         from datasets import Dataset as datasets_Dataset
+        if state.process_index == 0:
+            print("\n**Test split between processes as a datasets.Dataset**")
+        if is_datasets_available():
+            from datasets import Dataset as datasets_Dataset
 
-    #         test_split_between_processes_dataset(datasets_Dataset)
-    #     else:
-    #         print("Skipped because Hugging Face datasets is not available")
+            test_split_between_processes_dataset(datasets_Dataset)
+        else:
+            print("Skipped because Hugging Face datasets is not available")
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    if state.local_process_index == 0:
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.XLA:
-    #     central_dl_preparation_check()
-    #     custom_sampler_check()
-    #     check_seedable_sampler()
+    if state.local_process_index == 0:
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.XLA:
+        central_dl_preparation_check()
+        custom_sampler_check()
+        check_seedable_sampler()
 
-    # if state.num_processes > 1:
-    #     check_seedable_sampler_in_batch_sampler_shard()
+    if state.num_processes > 1:
+        check_seedable_sampler_in_batch_sampler_shard()
 
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check(use_seedable_sampler=False)
-    # training_check(use_seedable_sampler=True)
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check(use_seedable_sampler=False)
+    training_check(use_seedable_sampler=True)
 
-    # if state.local_process_index == 0:
-    #     print("\n**Breakpoint trigger test**")
-    # test_trigger()
+    if state.local_process_index == 0:
+        print("\n**Breakpoint trigger test**")
+    test_trigger()
 
-    # if is_pytest_available():
-    #     if state.local_process_index == 0:
-    #         print("\n**Test reinstantiated state**")
-    #     test_reinstantiated_state()
+    if is_pytest_available():
+        if state.local_process_index == 0:
+            print("\n**Test reinstantiated state**")
+        test_reinstantiated_state()
 
     check_seedable_sampler_with_data_seed()
 

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -828,6 +828,7 @@ def main():
         central_dl_preparation_check()
         custom_sampler_check()
         check_seedable_sampler()
+        check_seedable_sampler_with_data_seed()
 
     if state.num_processes > 1:
         check_seedable_sampler_in_batch_sampler_shard()
@@ -849,8 +850,6 @@ def main():
         if state.local_process_index == 0:
             print("\n**Test reinstantiated state**")
         test_reinstantiated_state()
-
-    check_seedable_sampler_with_data_seed()
 
     state.destroy_process_group()
 

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -34,12 +34,10 @@ from accelerate.utils import (
     DistributedType,
     gather,
     is_bf16_available,
-    is_datasets_available,
     is_ipex_available,
     is_mlu_available,
     is_musa_available,
     is_npu_available,
-    is_pytest_available,
     is_xpu_available,
     set_seed,
     synchronize_rng_states,
@@ -400,6 +398,33 @@ def check_seedable_sampler_in_batch_sampler_shard():
     ), "Sampler in BatchSamplerShard is not SeedableRandomSampler."
 
 
+def check_seedable_sampler_with_data_seed():
+    # Set seed
+    set_seed(42)
+    data_seed = 43
+    train_set = RegressionDataset(length=10, seed=data_seed)
+    train_dl = DataLoader(train_set, batch_size=2, shuffle=True)
+
+    config = DataLoaderConfiguration(use_seedable_sampler=True, data_seed=data_seed)
+    accelerator = Accelerator(dataloader_config=config)
+    train_dl = accelerator.prepare(train_dl)
+    original_items = []
+    for _ in range(3):
+        for batch in train_dl:
+            original_items.append(batch["x"])
+    original_items = torch.cat(original_items)
+
+    # Set seed again and the epoch
+    set_seed(42)
+    train_dl.set_epoch(0)
+    new_items = []
+    for _ in range(3):
+        for batch in train_dl:
+            new_items.append(batch["x"])
+    new_items = torch.cat(new_items)
+    assert torch.allclose(original_items, new_items), "Did not obtain the same items with the same seed and epoch."
+
+
 def mock_training(length, batch_size, generator, use_seedable_sampler=False):
     set_seed(42)
     generator.manual_seed(42)
@@ -450,7 +475,9 @@ def training_check(use_seedable_sampler=False):
 
     accelerator.print("Training yielded the same results on one CPU or distributed setup with no batch split.")
 
-    dataloader_config = DataLoaderConfiguration(split_batches=True, use_seedable_sampler=use_seedable_sampler)
+    dataloader_config = DataLoaderConfiguration(
+        split_batches=True, use_seedable_sampler=use_seedable_sampler, data_seed=generator.initial_seed()
+    )
     accelerator = Accelerator(dataloader_config=dataloader_config)
     train_dl = generate_baseline_dataloader(
         train_set, generator, batch_size * state.num_processes, use_seedable_sampler
@@ -748,79 +775,81 @@ def test_reinstantiated_state():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
-    state.wait_for_everyone()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
+    # state.wait_for_everyone()
 
-    if state.distributed_type == DistributedType.MULTI_GPU:
-        num_processes_per_node = torch.cuda.device_count()
-    else:
-        num_processes_per_node = state.num_processes
+    # if state.distributed_type == DistributedType.MULTI_GPU:
+    #     num_processes_per_node = torch.cuda.device_count()
+    # else:
+    #     num_processes_per_node = state.num_processes
 
-    # We only run this test on non-multinode
-    if num_processes_per_node == state.num_processes:
-        if state.process_index == 0:
-            print("\n**Test process execution**")
-        process_execution_check()
+    # # We only run this test on non-multinode
+    # if num_processes_per_node == state.num_processes:
+    #     if state.process_index == 0:
+    #         print("\n**Test process execution**")
+    #     process_execution_check()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a list**")
-        test_split_between_processes_list()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a list**")
+    #     test_split_between_processes_list()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a dict**")
-        test_split_between_processes_nested_dict()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a dict**")
+    #     test_split_between_processes_nested_dict()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a tensor**")
-        test_split_between_processes_tensor()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a tensor**")
+    #     test_split_between_processes_tensor()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes evenly**")
-        test_split_between_processes_evenly()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes evenly**")
+    #     test_split_between_processes_evenly()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a datasets.Dataset**")
-        if is_datasets_available():
-            from datasets import Dataset as datasets_Dataset
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a datasets.Dataset**")
+    #     if is_datasets_available():
+    #         from datasets import Dataset as datasets_Dataset
 
-            test_split_between_processes_dataset(datasets_Dataset)
-        else:
-            print("Skipped because Hugging Face datasets is not available")
+    #         test_split_between_processes_dataset(datasets_Dataset)
+    #     else:
+    #         print("Skipped because Hugging Face datasets is not available")
 
-    if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.XLA:
-        central_dl_preparation_check()
-        custom_sampler_check()
-        check_seedable_sampler()
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.XLA:
+    #     central_dl_preparation_check()
+    #     custom_sampler_check()
+    #     check_seedable_sampler()
 
-    if state.num_processes > 1:
-        check_seedable_sampler_in_batch_sampler_shard()
+    # if state.num_processes > 1:
+    #     check_seedable_sampler_in_batch_sampler_shard()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check(use_seedable_sampler=False)
-    training_check(use_seedable_sampler=True)
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check(use_seedable_sampler=False)
+    # training_check(use_seedable_sampler=True)
 
-    if state.local_process_index == 0:
-        print("\n**Breakpoint trigger test**")
-    test_trigger()
+    # if state.local_process_index == 0:
+    #     print("\n**Breakpoint trigger test**")
+    # test_trigger()
 
-    if is_pytest_available():
-        if state.local_process_index == 0:
-            print("\n**Test reinstantiated state**")
-        test_reinstantiated_state()
+    # if is_pytest_available():
+    #     if state.local_process_index == 0:
+    #         print("\n**Test reinstantiated state**")
+    #     test_reinstantiated_state()
+
+    check_seedable_sampler_with_data_seed()
 
     state.destroy_process_group()
 

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -419,7 +419,7 @@ def check_seedable_sampler_with_data_seed():
     # Set new data seed
     config.data_seed = 43
     accelerator = Accelerator(dataloader_config=config)
-    train_dl = accelerator.prepare(train_dl)
+    prepared_dl = accelerator.prepare(train_dl)
     new_items = []
     for _ in range(3):
         for batch in prepared_dl:

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -34,12 +34,10 @@ from accelerate.utils import (
     DistributedType,
     gather,
     is_bf16_available,
-    is_datasets_available,
     is_ipex_available,
     is_mlu_available,
     is_musa_available,
     is_npu_available,
-    is_pytest_available,
     is_xpu_available,
     set_seed,
     synchronize_rng_states,
@@ -403,28 +401,29 @@ def check_seedable_sampler_in_batch_sampler_shard():
 def check_seedable_sampler_with_data_seed():
     # Set seed
     set_seed(42)
-    data_seed = 43
-    train_set = RegressionDataset(length=10, seed=data_seed)
+    data_seed = 42
+    train_set = RegressionDataset(length=10, seed=42)
     train_dl = DataLoader(train_set, batch_size=2, shuffle=True)
 
     config = DataLoaderConfiguration(use_seedable_sampler=True, data_seed=data_seed)
     accelerator = Accelerator(dataloader_config=config)
-    train_dl = accelerator.prepare(train_dl)
+    prepared_dl = accelerator.prepare(train_dl)
     original_items = []
     for _ in range(3):
-        for batch in train_dl:
+        for batch in prepared_dl:
             original_items.append(batch["x"])
     original_items = torch.cat(original_items)
 
-    # Set seed again and the epoch
-    set_seed(42)
-    train_dl.set_epoch(0)
+    # Set new data seed
+    config.data_seed = 43
+    accelerator = Accelerator(dataloader_config=config)
+    train_dl = accelerator.prepare(train_dl)
     new_items = []
     for _ in range(3):
-        for batch in train_dl:
+        for batch in prepared_dl:
             new_items.append(batch["x"])
     new_items = torch.cat(new_items)
-    assert torch.allclose(original_items, new_items), "Did not obtain the same items with the same seed and epoch."
+    assert not torch.allclose(original_items, new_items), "Obtained the same items with different data seed."
 
 
 def mock_training(length, batch_size, generator, use_seedable_sampler=False):
@@ -775,79 +774,79 @@ def test_reinstantiated_state():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    if state.local_process_index == 0:
-        print("**Initialization**")
-    init_state_check()
-    state.wait_for_everyone()
+    # if state.local_process_index == 0:
+    #     print("**Initialization**")
+    # init_state_check()
+    # state.wait_for_everyone()
 
-    if state.distributed_type == DistributedType.MULTI_GPU:
-        num_processes_per_node = torch.cuda.device_count()
-    else:
-        num_processes_per_node = state.num_processes
+    # if state.distributed_type == DistributedType.MULTI_GPU:
+    #     num_processes_per_node = torch.cuda.device_count()
+    # else:
+    #     num_processes_per_node = state.num_processes
 
-    # We only run this test on non-multinode
-    if num_processes_per_node == state.num_processes:
-        if state.process_index == 0:
-            print("\n**Test process execution**")
-        process_execution_check()
+    # # We only run this test on non-multinode
+    # if num_processes_per_node == state.num_processes:
+    #     if state.process_index == 0:
+    #         print("\n**Test process execution**")
+    #     process_execution_check()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a list**")
-        test_split_between_processes_list()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a list**")
+    #     test_split_between_processes_list()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a dict**")
-        test_split_between_processes_nested_dict()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a dict**")
+    #     test_split_between_processes_nested_dict()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a tensor**")
-        test_split_between_processes_tensor()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a tensor**")
+    #     test_split_between_processes_tensor()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes evenly**")
-        test_split_between_processes_evenly()
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes evenly**")
+    #     test_split_between_processes_evenly()
 
-        if state.process_index == 0:
-            print("\n**Test split between processes as a datasets.Dataset**")
-        if is_datasets_available():
-            from datasets import Dataset as datasets_Dataset
+    #     if state.process_index == 0:
+    #         print("\n**Test split between processes as a datasets.Dataset**")
+    #     if is_datasets_available():
+    #         from datasets import Dataset as datasets_Dataset
 
-            test_split_between_processes_dataset(datasets_Dataset)
-        else:
-            print("Skipped because Hugging Face datasets is not available")
+    #         test_split_between_processes_dataset(datasets_Dataset)
+    #     else:
+    #         print("Skipped because Hugging Face datasets is not available")
 
-    if state.local_process_index == 0:
-        print("\n**Test random number generator synchronization**")
-    rng_sync_check()
+    # if state.local_process_index == 0:
+    #     print("\n**Test random number generator synchronization**")
+    # rng_sync_check()
 
-    if state.local_process_index == 0:
-        print("\n**DataLoader integration test**")
-    dl_preparation_check()
-    if state.distributed_type != DistributedType.XLA:
-        central_dl_preparation_check()
-        custom_sampler_check()
-        check_seedable_sampler()
+    # if state.local_process_index == 0:
+    #     print("\n**DataLoader integration test**")
+    # dl_preparation_check()
+    # if state.distributed_type != DistributedType.XLA:
+    #     central_dl_preparation_check()
+    #     custom_sampler_check()
+    #     check_seedable_sampler()
 
-    if state.num_processes > 1:
-        check_seedable_sampler_in_batch_sampler_shard()
+    # if state.num_processes > 1:
+    #     check_seedable_sampler_in_batch_sampler_shard()
 
-    # Trainings are not exactly the same in DeepSpeed and CPU mode
-    if state.distributed_type == DistributedType.DEEPSPEED:
-        return
+    # # Trainings are not exactly the same in DeepSpeed and CPU mode
+    # if state.distributed_type == DistributedType.DEEPSPEED:
+    #     return
 
-    if state.local_process_index == 0:
-        print("\n**Training integration test**")
-    training_check(use_seedable_sampler=False)
-    training_check(use_seedable_sampler=True)
+    # if state.local_process_index == 0:
+    #     print("\n**Training integration test**")
+    # training_check(use_seedable_sampler=False)
+    # training_check(use_seedable_sampler=True)
 
-    if state.local_process_index == 0:
-        print("\n**Breakpoint trigger test**")
-    test_trigger()
+    # if state.local_process_index == 0:
+    #     print("\n**Breakpoint trigger test**")
+    # test_trigger()
 
-    if is_pytest_available():
-        if state.local_process_index == 0:
-            print("\n**Test reinstantiated state**")
-        test_reinstantiated_state()
+    # if is_pytest_available():
+    #     if state.local_process_index == 0:
+    #         print("\n**Test reinstantiated state**")
+    #     test_reinstantiated_state()
 
     check_seedable_sampler_with_data_seed()
 

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -477,9 +477,7 @@ def training_check(use_seedable_sampler=False):
 
     accelerator.print("Training yielded the same results on one CPU or distributed setup with no batch split.")
 
-    dataloader_config = DataLoaderConfiguration(
-        split_batches=True, use_seedable_sampler=use_seedable_sampler, data_seed=generator.initial_seed()
-    )
+    dataloader_config = DataLoaderConfiguration(split_batches=True, use_seedable_sampler=use_seedable_sampler)
     accelerator = Accelerator(dataloader_config=dataloader_config)
     train_dl = generate_baseline_dataloader(
         train_set, generator, batch_size * state.num_processes, use_seedable_sampler

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -34,10 +34,12 @@ from accelerate.utils import (
     DistributedType,
     gather,
     is_bf16_available,
+    is_datasets_available,
     is_ipex_available,
     is_mlu_available,
     is_musa_available,
     is_npu_available,
+    is_pytest_available,
     is_xpu_available,
     set_seed,
     synchronize_rng_states,
@@ -775,79 +777,79 @@ def test_reinstantiated_state():
 def main():
     accelerator = Accelerator()
     state = accelerator.state
-    # if state.local_process_index == 0:
-    #     print("**Initialization**")
-    # init_state_check()
-    # state.wait_for_everyone()
+    if state.local_process_index == 0:
+        print("**Initialization**")
+    init_state_check()
+    state.wait_for_everyone()
 
-    # if state.distributed_type == DistributedType.MULTI_GPU:
-    #     num_processes_per_node = torch.cuda.device_count()
-    # else:
-    #     num_processes_per_node = state.num_processes
+    if state.distributed_type == DistributedType.MULTI_GPU:
+        num_processes_per_node = torch.cuda.device_count()
+    else:
+        num_processes_per_node = state.num_processes
 
-    # # We only run this test on non-multinode
-    # if num_processes_per_node == state.num_processes:
-    #     if state.process_index == 0:
-    #         print("\n**Test process execution**")
-    #     process_execution_check()
+    # We only run this test on non-multinode
+    if num_processes_per_node == state.num_processes:
+        if state.process_index == 0:
+            print("\n**Test process execution**")
+        process_execution_check()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a list**")
-    #     test_split_between_processes_list()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a list**")
+        test_split_between_processes_list()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a dict**")
-    #     test_split_between_processes_nested_dict()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a dict**")
+        test_split_between_processes_nested_dict()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a tensor**")
-    #     test_split_between_processes_tensor()
+        if state.process_index == 0:
+            print("\n**Test split between processes as a tensor**")
+        test_split_between_processes_tensor()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes evenly**")
-    #     test_split_between_processes_evenly()
+        if state.process_index == 0:
+            print("\n**Test split between processes evenly**")
+        test_split_between_processes_evenly()
 
-    #     if state.process_index == 0:
-    #         print("\n**Test split between processes as a datasets.Dataset**")
-    #     if is_datasets_available():
-    #         from datasets import Dataset as datasets_Dataset
+        if state.process_index == 0:
+            print("\n**Test split between processes as a datasets.Dataset**")
+        if is_datasets_available():
+            from datasets import Dataset as datasets_Dataset
 
-    #         test_split_between_processes_dataset(datasets_Dataset)
-    #     else:
-    #         print("Skipped because Hugging Face datasets is not available")
+            test_split_between_processes_dataset(datasets_Dataset)
+        else:
+            print("Skipped because Hugging Face datasets is not available")
 
-    # if state.local_process_index == 0:
-    #     print("\n**Test random number generator synchronization**")
-    # rng_sync_check()
+    if state.local_process_index == 0:
+        print("\n**Test random number generator synchronization**")
+    rng_sync_check()
 
-    # if state.local_process_index == 0:
-    #     print("\n**DataLoader integration test**")
-    # dl_preparation_check()
-    # if state.distributed_type != DistributedType.XLA:
-    #     central_dl_preparation_check()
-    #     custom_sampler_check()
-    #     check_seedable_sampler()
+    if state.local_process_index == 0:
+        print("\n**DataLoader integration test**")
+    dl_preparation_check()
+    if state.distributed_type != DistributedType.XLA:
+        central_dl_preparation_check()
+        custom_sampler_check()
+        check_seedable_sampler()
 
-    # if state.num_processes > 1:
-    #     check_seedable_sampler_in_batch_sampler_shard()
+    if state.num_processes > 1:
+        check_seedable_sampler_in_batch_sampler_shard()
 
-    # # Trainings are not exactly the same in DeepSpeed and CPU mode
-    # if state.distributed_type == DistributedType.DEEPSPEED:
-    #     return
+    # Trainings are not exactly the same in DeepSpeed and CPU mode
+    if state.distributed_type == DistributedType.DEEPSPEED:
+        return
 
-    # if state.local_process_index == 0:
-    #     print("\n**Training integration test**")
-    # training_check(use_seedable_sampler=False)
-    # training_check(use_seedable_sampler=True)
+    if state.local_process_index == 0:
+        print("\n**Training integration test**")
+    training_check(use_seedable_sampler=False)
+    training_check(use_seedable_sampler=True)
 
-    # if state.local_process_index == 0:
-    #     print("\n**Breakpoint trigger test**")
-    # test_trigger()
+    if state.local_process_index == 0:
+        print("\n**Breakpoint trigger test**")
+    test_trigger()
 
-    # if is_pytest_available():
-    #     if state.local_process_index == 0:
-    #         print("\n**Test reinstantiated state**")
-    #     test_reinstantiated_state()
+    if is_pytest_available():
+        if state.local_process_index == 0:
+            print("\n**Test reinstantiated state**")
+        test_reinstantiated_state()
 
     check_seedable_sampler_with_data_seed()
 

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -737,6 +737,9 @@ class DataLoaderConfiguration:
             training results are fully reproducable using a different sampling technique. While seed-to-seed results
             may differ, on average the differences are neglible when using multiple different seeds to compare. Should
             also be ran with [`~utils.set_seed`] for the best results.
+        data_seed (`int`, defaults to `None`):
+            The seed to use for the underlying generator when using `use_seedable_sampler`. If `None`, the generator
+            will use the current default seed from torch.
         non_blocking (`bool`, defaults to `False`):
             If set to `True`, the dataloader prepared by the Accelerator will utilize non-blocking host-to-device
             transfers, allowing for better overlap between dataloader communication and computation. Recommended that

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -796,6 +796,10 @@ class DataLoaderConfiguration:
             "[torchdata.StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader). This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed."
         },
     )
+    data_seed: int = field(
+        default=None,
+        metadata={"help": "The seed to use for the dataloader. If not set, will use the seed of the main process."},
+    )
 
 
 @dataclass

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -781,6 +781,13 @@ class DataLoaderConfiguration:
             "multiple different seeds to compare. Should also be ran with [`~utils.set_seed`] for the best results."
         },
     )
+    data_seed: int = field(
+        default=None,
+        metadata={
+            "help": "The seed to use for the underlying generator when using `use_seedable_sampler`. If `None`, the generator"
+            " will use the current default seed from torch."
+        },
+    )
     non_blocking: bool = field(
         default=False,
         metadata={
@@ -795,10 +802,6 @@ class DataLoaderConfiguration:
             "help": "If set to `True`, the dataloader prepared by the Accelerator will be backed by "
             "[torchdata.StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader). This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed."
         },
-    )
-    data_seed: int = field(
-        default=None,
-        metadata={"help": "The seed to use for the dataloader. If not set, will use the seed of the main process."},
     )
 
 


### PR DESCRIPTION
# What does this PR do?

Adds in the ability to pass in a `data_seed` when using the `seedable_random_sampler`. Alternative to https://github.com/huggingface/accelerate/pull/3130

Essentially all we *really* want to do is make sure that the `initial_seed` in the `SeedableRandomSampler` can be changed to not be the same as the one used by torch. so as a result, adds it to the `DataLoaderConfiguration` class

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@BenjaminBossan @SunMarc @MekkCyber