### PR TITLE
Models With Tied Weights Need Re-Tieing After FSDP Param Init

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1472,6 +1472,14 @@ class Accelerator:
                 if not is_type_fsdp:
                     self.state.fsdp_plugin.set_auto_wrap_policy(model)
                     fsdp_plugin = self.state.fsdp_plugin
+
+                    # need to do this here to access the model
+                    # - there is a default param_init_fn inside but we ignore it
+                    # - qlora low_mem_mode requires trl > 0.11.2
+                    # - we should make this a passthrough if there are no meta devices
+                    from .utils.fsdp_utils import build_param_init_fn
+                    fsdp_plugin.param_init_fn = build_param_init_fn(model, self.device)
+
                     kwargs = {
                         "sharding_strategy": fsdp_plugin.sharding_strategy,
                         "cpu_offload": fsdp_plugin.cpu_offload,

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -74,8 +74,8 @@ from .utils import (
     compare_versions,
     convert_model,
     convert_outputs_to_fp32,
-    extract_model_from_parallel,
     ensure_weights_retied,
+    extract_model_from_parallel,
     gather,
     gather_object,
     get_grad_scaler,
@@ -1477,7 +1477,9 @@ class Accelerator:
                     # need to ensure that params are re-tied after running
                     # param_init_fn
                     fsdp_plugin.param_init_fn = ensure_weights_retied(
-                        fsdp_plugin.param_init_fn, model, self.device, 
+                        fsdp_plugin.param_init_fn,
+                        model,
+                        self.device,
                     )
 
                     kwargs = {

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -200,12 +200,12 @@ from .bnb import has_4bit_bnb_layers, load_and_quantize_model
 from .fsdp_utils import (
     disable_fsdp_ram_efficient_loading,
     enable_fsdp_ram_efficient_loading,
+    ensure_weights_retied,
     load_fsdp_model,
     load_fsdp_optimizer,
     merge_fsdp_weights,
     save_fsdp_model,
     save_fsdp_optimizer,
-    ensure_weights_retied,
 )
 from .launch import (
     PrepareForLaunch,

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -205,6 +205,7 @@ from .fsdp_utils import (
     merge_fsdp_weights,
     save_fsdp_model,
     save_fsdp_optimizer,
+    ensure_weights_retied,
 )
 from .launch import (
     PrepareForLaunch,

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -13,11 +13,10 @@
 # limitations under the License.
 import os
 import shutil
-from pathlib import Path
 from collections import defaultdict
+from pathlib import Path
 
 import torch
-
 
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, OPTIMIZER_NAME, SAFE_WEIGHTS_NAME, WEIGHTS_NAME
@@ -327,37 +326,34 @@ def merge_fsdp_weights(
             shutil.rmtree(checkpoint_dir)
     state.wait_for_everyone()
 
-def ensure_weights_retied(
-    param_init_fn, model: torch.nn.Module, device: torch.cuda.device
-):
 
+def ensure_weights_retied(param_init_fn, model: torch.nn.Module, device: torch.cuda.device):
     _tied_names = model._tied_weights_keys
     if not _tied_names:
         # if no tied names just passthrough
         return param_init_fn
 
-    # get map of parameter instances to params. 
+    # get map of parameter instances to params.
     # - needed for replacement later
     _tied_params = {}
     for name in _tied_names:
-        name = name.split('.')
-        name, param_name = '.'.join(name[:-1]), name[-1]
+        name = name.split(".")
+        name, param_name = ".".join(name[:-1]), name[-1]
         mod = model.get_submodule(name)
         param = getattr(mod, param_name)
 
-        _tied_params[id(param)] = None # placeholder for the param first
-    
+        _tied_params[id(param)] = None  # placeholder for the param first
+
     # build param_init_fn for the case with tied params
     def param_init_fn_tied_param(module: torch.nn.Module):
-
-        # track which params to tie 
+        # track which params to tie
         # - usually only 1, but for completeness consider > 1
         params_to_tie = defaultdict(list)
         for n, param in module.named_parameters(recurse=False):
             if id(param) in _tied_params:
                 params_to_tie[id(param)].append(n)
 
-        # call the param init fn, which potentially re-allocates the 
+        # call the param init fn, which potentially re-allocates the
         # parameters
         module = param_init_fn(module)
 
@@ -370,8 +366,8 @@ def ensure_weights_retied(
                     # param is observed
                     _tied_params[id_key] = getattr(module, param_name)
                 else:
-                    setattr(module, param_name, param) # tie
-                    
+                    setattr(module, param_name, param)  # tie
+
         return module
 
     return param_init_fn_tied_param

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -327,15 +327,14 @@ def merge_fsdp_weights(
             shutil.rmtree(checkpoint_dir)
     state.wait_for_everyone()
 
-def build_param_init_fn(model: torch.nn.Module, device: torch.cuda.device):
-
-    # this can be used if there are no tied weights
-    init_empty_module = lambda x: x.to_empty(device=device, recurse=False)
+def ensure_weights_retied(
+    param_init_fn, model: torch.nn.Module, device: torch.cuda.device
+):
 
     _tied_names = model._tied_weights_keys
     if not _tied_names:
-        # if no tied names
-        return init_empty_module
+        # if no tied names just passthrough
+        return param_init_fn
 
     # get map of parameter instances to params. 
     # - needed for replacement later
@@ -348,19 +347,19 @@ def build_param_init_fn(model: torch.nn.Module, device: torch.cuda.device):
 
         _tied_params[id(param)] = None # placeholder for the param first
     
-    # build init_empty_module for the case with tied params
-    def init_empty_module_tied_params(module: torch.nn.Module):
+    # build param_init_fn for the case with tied params
+    def param_init_fn_tied_param(module: torch.nn.Module):
 
         # track which params to tie 
         # - usually only 1, but for completeness consider > 1
         params_to_tie = defaultdict(list)
         for n, param in module.named_parameters(recurse=False):
-            if id(param) in _tied_params and param.device == torch.device('meta'):
+            if id(param) in _tied_params:
                 params_to_tie[id(param)].append(n)
 
-        # this initializes the parameters on meta device, and so
-        # thier ids will change.
-        module = init_empty_module(module)
+        # call the param init fn, which potentially re-allocates the 
+        # parameters
+        module = param_init_fn(module)
 
         # search the parameters again and tie them up again
         for id_key, _param_names in params_to_tie.items():
@@ -375,4 +374,4 @@ def build_param_init_fn(model: torch.nn.Module, device: torch.cuda.device):
                     
         return module
 
-    return init_empty_module_tied_params
+    return param_init_fn_tied_param


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Currently in `FullyShardedDataParallelPlugin`, the `param_init_fn` [is set when sync_module_states=True](https://github.com/huggingface/accelerate/blob/6f79b63b865a33b92a3f1c9e2562b88ee7a4d89d/src/accelerate/utils/dataclasses.py#L1699). This is required by `FSDP` to initialize the shards (i.e. rank > 0) params in a [variety of situations](https://github.com/pytorch/pytorch/blob/8321eec009c8c79145ebccd51fdfc336e5f8b848/torch/distributed/fsdp/_init_utils.py#L588-L603), including the important one where the parameter was on `torch.device("meta")` because `low_cpu_mem_mode` was used. 

However `FullyShardedDataParallelPlugin.param_init_fn` is now set to 
```python
self.param_init_fn = lambda x: x.to_empty(device=device, recurse=False)
```
which causes problems when there are tied weights. Consider the following scenario
1. there are two modules `A` and `B` that share a tied weight `A.weight = B.weight`
2. `A.to_empty()` is called, then `A.weight` will be reassigned to a new tensor.
3. Similarly `B.empty()` is called, and then now `A.weight != B.weight`.

This is observed to cause problems in the `low_cpu_mem_mode=True` case, because now when getting the `managed_params` in FSDP, see [here](https://github.com/pytorch/pytorch/blob/8321eec009c8c79145ebccd51fdfc336e5f8b848/torch/distributed/fsdp/_init_utils.py#L626), 
- in rank = 0, `param_init_fn` is not called, because `low_cpu_mem_mode` will load weights in this shard. So `managed_params` will not have duplicates if weights are tied.
- In other ranks > 0, `param_init_fn` is called and `managed_params` may have duplicates. 

Then when FSDP calls `_sync_module_params_and_buffers`, the `torch.distributed._broadcast_coalesced` will be trying to communicate different number of tensors. This is not as intended and causes unexpected behaviors.

Fixes inconsistency in current logic in general, in particular is required to fix https://github.com/huggingface/trl/pull/2089 to completion.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->