### PR TITLE
enable cpu bnb distributed lora finetune

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1421,7 +1421,10 @@ class Accelerator:
                     current_device.index if isinstance(current_device, torch.device) else current_device
                 )
 
-                if torch.device(current_device_index) != self.device and self.device.type != "cpu":
+                if self.device.type == "cpu" and is_bitsandbytes_multi_backend_available():
+                    # bnb with multi-backend supports CPU which don't need to check index.
+                    pass
+                elif torch.device(current_device_index) != self.device:
                     # if on the first device (GPU 0) we don't care
                     if (self.device.index is not None) or (current_device_index != 0):
                         raise ValueError(

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1421,7 +1421,7 @@ class Accelerator:
                     current_device.index if isinstance(current_device, torch.device) else current_device
                 )
 
-                if torch.device(current_device_index) != self.device:
+                if torch.device(current_device_index) != self.device and self.device.type != "cpu":
                     # if on the first device (GPU 0) we don't care
                     if (self.device.index is not None) or (current_device_index != 0):
                         raise ValueError(


### PR DESCRIPTION
Hi @SunMarc , this PR enables cpu bnb model distributed finetune by removing check index because we don't need index in cpu device. Please review it. Thanks!