### PR TITLE
fix version check bug in `get_xpu_available_memory`

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -24,6 +24,7 @@ import inspect
 import warnings
 
 import torch
+from packaging import version
 
 from .imports import (
     is_cuda_available,
@@ -167,7 +168,7 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
 
 def get_xpu_available_memory(device_index: int):
     if is_ipex_available():
-        ipex_version = importlib.metadata.version("intel_extension_for_pytorch")
+        ipex_version = version.parse(importlib.metadata.version("intel_extension_for_pytorch"))
         if compare_versions(ipex_version, ">=", "2.5"):
             from intel_extension_for_pytorch.xpu import mem_get_info
 


### PR DESCRIPTION
## What does this PR do?
This PR fixed the version check bug introduced in #3076. Below are the verified results with ipex "2.5.10+gitad5c117":

```bash
from accelerate.utils.memory import get_xpu_available_memory

mem = get_xpu_available_memory(1)
print(mem)
# 68719476736
```

@muellerzr