### PR TITLE
take `torch.nn.Module` model into account when moving to device  

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1995,7 +1995,7 @@ class Accelerator:
                 optimizer = obj
         if optimizer is not None and model is not None:
             dtype = torch.bfloat16 if self.state.mixed_precision == "bf16" else None
-            if self.device.type == "xpu" and model.device.type == "cpu":
+            if self.device.type == "xpu" and hasattr(model, "device") and model.device.type == "cpu":
                 model = model.to(self.device)
             # ipex.optimize() is available only for IPEX, both IPEX-CPU and IPEX-XPU
             if is_ipex_available():

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1995,7 +1995,7 @@ class Accelerator:
                 optimizer = obj
         if optimizer is not None and model is not None:
             dtype = torch.bfloat16 if self.state.mixed_precision == "bf16" else None
-            if self.device.type == "xpu" and hasattr(model, "device") and model.device.type == "cpu":
+            if self.device.type == "xpu" and next(model.parameters()).device.type == "cpu":
                 model = model.to(self.device)
             # ipex.optimize() is available only for IPEX, both IPEX-CPU and IPEX-XPU
             if is_ipex_available():


### PR DESCRIPTION
## What does this PR do?
Last time in #3133, I introduced the check to only move the model when the model is on "cpu". But this doesn't take the `torch.nn.module` Model into account, e.g. 

```python
from accelerate import Accelerator, DDPCommunicationHookType, DistributedDataParallelKwargs
from torch.utils.data import DataLoader, TensorDataset
import torch

class MyModel(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.layer = torch.nn.Linear(10, 10)

    def forward(self, x):
        return self.layer(x)


# Create a dummy dataset
data = torch.randn(100, 10)
targets = torch.randint(0, 10, (100,))
dataset = TensorDataset(data, targets)

# Define the loss function
criterion = torch.nn.CrossEntropyLoss()

# DDP Communication Hook setup
ddp_kwargs = DistributedDataParallelKwargs(comm_hook=DDPCommunicationHookType.FP16)
accelerator = Accelerator(kwargs_handlers=[ddp_kwargs])

model = MyModel()
optimizer = torch.optim.Adam(model.parameters())
data_loader = DataLoader(dataset, batch_size=16)

model, optimizer, data_loader = accelerator.prepare(model, optimizer, data_loader)
# Training loop
for data, targets in data_loader:
    outputs = model(data)
    loss = criterion(outputs, targets)
    accelerator.backward(loss)
    optimizer.step()
    optimizer.zero_grad()\
```

In this case, model doesn't have device as an attribute. So this PR fixes this issue. 

@muellerzr
