### PR TITLE
docs: fix a wrong word in comment in src/accelerate/accelerate.py:1255

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1252,7 +1252,7 @@ class Accelerator:
         >>> accelerator = Accelerator()
         >>> # Assume a model, optimizer, data_loader and scheduler are defined
         >>> device_placement = [True, True, False, False]
-        >>> # Will place the first to items passed in automatically to the right device but not the last two.
+        >>> # Will place the first two items passed in automatically to the right device but not the last two.
         >>> model, optimizer, data_loader, scheduler = accelerator.prepare(
         ...     model, optimizer, data_loader, scheduler, device_placement=device_placement
         ... )


### PR DESCRIPTION
What does this PR do?
---
Hi, I am a beginner to `huggingface/accelerate` and have learned a lot from the repo. However, I find a possible spelling mistake in `src/accelerate/accelerate.py:1255`.

Could you please examine this comment again to confirm whether this is an error?

---
P.S. I am also a beginner to contributing to open source project (maybe also to English communication). Could you please let me know if this PR violate some conventions in this community? I will appreciate it!