### PR TITLE
Adds a `multiply_grads` akin to fairseq

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -197,7 +197,7 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
             self._optimizer_original_step_method = self.optimizer.step
             self._optimizer_patched_step_method = patch_optimizer_step(self, self.optimizer.step)
 
-    def multiply_grads(self, constant: float | torch.Tensor) -> None:
+    def multiply_grads(self, constant) -> None:
         """
         Multiplies the gradients of the parameters by a constant. Needed during gradient accumulation.
 

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -197,7 +197,7 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
             self._optimizer_original_step_method = self.optimizer.step
             self._optimizer_patched_step_method = patch_optimizer_step(self, self.optimizer.step)
 
-    def multiply_grads(self, constant) -> None:
+    def multiply_grads(self, constant):
         """
         Multiplies the gradients of the parameters by a constant. Needed during gradient accumulation.
 

--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 import inspect
+from collections import defaultdict
 
 import torch
-from collections import defaultdict
+
 from .state import AcceleratorState, GradientState
 from .utils import DistributedType, honor_type, is_lomo_available, is_torch_xla_available
 
@@ -198,10 +199,10 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
 
     def multiply_grads(self, constant: float | torch.Tensor) -> None:
         """
-        Multiplies the gradients of the parameters by a constant.
-        Needed during gradient accumulation.
+        Multiplies the gradients of the parameters by a constant. Needed during gradient accumulation.
 
-        Based on the implementation out of `fairseq`: https://github.com/facebookresearch/fairseq/blob/main/fairseq/optim/fairseq_optimizer.py
+        Based on the implementation out of `fairseq`:
+        https://github.com/facebookresearch/fairseq/blob/main/fairseq/optim/fairseq_optimizer.py
         """
         per_device_and_dtype_grads = defaultdict(lambda: defaultdict(list))
         for param_group in self.param_groups:


### PR DESCRIPTION
# What does this PR do?

Helps w/ DDP wrt https://github.com/huggingface/transformers/pull/34283

`fairseq` came up with a technique to help also with countering gradient accumulation by countering grad update by multiplying the gradients by `num_gpus / num_items_in_batch`. This PR adds an interface for the `Trainer` to hook into. 

Without it:

![W B Chart 10_22_2024, 12_30_21 PM](https://github.com/user-attachments/assets/0bfca4c1-36a0-4756-8c4d-b66667f1f338)

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 