### PR TITLE
fix bnb

### DIFF
--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -334,26 +334,25 @@ def _replace_with_bnb_layers(
                     break
             if proceed:
                 # Load bnb module with empty weight and replace ``nn.Linear` module
-                with torch.device(module.weight.device): # in case of meta device
-                    if bnb_quantization_config.load_in_8bit:
-                        bnb_module = bnb.nn.Linear8bitLt(
-                            module.in_features,
-                            module.out_features,
-                            module.bias is not None,
-                            has_fp16_weights=False,
-                            threshold=bnb_quantization_config.llm_int8_threshold,
-                        )
-                    elif bnb_quantization_config.load_in_4bit:
-                        bnb_module = bnb.nn.Linear4bit(
-                            module.in_features,
-                            module.out_features,
-                            module.bias is not None,
-                            bnb_quantization_config.bnb_4bit_compute_dtype,
-                            compress_statistics=bnb_quantization_config.bnb_4bit_use_double_quant,
-                            quant_type=bnb_quantization_config.bnb_4bit_quant_type,
-                        )
-                    else:
-                        raise ValueError("load_in_8bit and load_in_4bit can't be both False")
+                if bnb_quantization_config.load_in_8bit:
+                    bnb_module = bnb.nn.Linear8bitLt(
+                        module.in_features,
+                        module.out_features,
+                        module.bias is not None,
+                        has_fp16_weights=False,
+                        threshold=bnb_quantization_config.llm_int8_threshold,
+                    )
+                elif bnb_quantization_config.load_in_4bit:
+                    bnb_module = bnb.nn.Linear4bit(
+                        module.in_features,
+                        module.out_features,
+                        module.bias is not None,
+                        bnb_quantization_config.bnb_4bit_compute_dtype,
+                        compress_statistics=bnb_quantization_config.bnb_4bit_use_double_quant,
+                        quant_type=bnb_quantization_config.bnb_4bit_quant_type,
+                    )
+                else:
+                    raise ValueError("load_in_8bit and load_in_4bit can't be both False")
                 bnb_module.weight.data = module.weight.data
                 if module.bias is not None:
                     bnb_module.bias.data = module.bias.data

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -334,25 +334,26 @@ def _replace_with_bnb_layers(
                     break
             if proceed:
                 # Load bnb module with empty weight and replace ``nn.Linear` module
-                if bnb_quantization_config.load_in_8bit:
-                    bnb_module = bnb.nn.Linear8bitLt(
-                        module.in_features,
-                        module.out_features,
-                        module.bias is not None,
-                        has_fp16_weights=False,
-                        threshold=bnb_quantization_config.llm_int8_threshold,
-                    )
-                elif bnb_quantization_config.load_in_4bit:
-                    bnb_module = bnb.nn.Linear4bit(
-                        module.in_features,
-                        module.out_features,
-                        module.bias is not None,
-                        bnb_quantization_config.bnb_4bit_compute_dtype,
-                        compress_statistics=bnb_quantization_config.bnb_4bit_use_double_quant,
-                        quant_type=bnb_quantization_config.bnb_4bit_quant_type,
-                    )
-                else:
-                    raise ValueError("load_in_8bit and load_in_4bit can't be both False")
+                with torch.device(module.weight.device): # in case of meta device
+                    if bnb_quantization_config.load_in_8bit:
+                        bnb_module = bnb.nn.Linear8bitLt(
+                            module.in_features,
+                            module.out_features,
+                            module.bias is not None,
+                            has_fp16_weights=False,
+                            threshold=bnb_quantization_config.llm_int8_threshold,
+                        )
+                    elif bnb_quantization_config.load_in_4bit:
+                        bnb_module = bnb.nn.Linear4bit(
+                            module.in_features,
+                            module.out_features,
+                            module.bias is not None,
+                            bnb_quantization_config.bnb_4bit_compute_dtype,
+                            compress_statistics=bnb_quantization_config.bnb_4bit_use_double_quant,
+                            quant_type=bnb_quantization_config.bnb_4bit_quant_type,
+                        )
+                    else:
+                        raise ValueError("load_in_8bit and load_in_4bit can't be both False")
                 bnb_module.weight.data = module.weight.data
                 if module.bias is not None:
                     bnb_module.bias.data = module.bias.data

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -2451,10 +2451,10 @@ class BnbQuantizationConfig:
             raise ValueError("load_in_4bit must be a boolean")
 
         if self.load_in_4bit and self.load_in_8bit:
-            raise ValueError("load_in_4bit and load_in_8 can't be both True")
+            raise ValueError("load_in_4bit and load_in_8bit can't be both True")
 
         if not self.load_in_4bit and not self.load_in_8bit:
-            raise ValueError("load_in_4bit and load_in_8 can't be both False")
+            raise ValueError("load_in_4bit and load_in_8bit can't be both False")
 
         if not isinstance(self.llm_int8_threshold, (int, float)):
             raise ValueError("llm_int8_threshold must be a float or an int")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -2401,7 +2401,7 @@ class BnbQuantizationConfig:
     bnb_4bit_quant_type: str = field(
         default="fp4",
         metadata={
-            "help": "set the quantization data type in the `bnb.nn.Linear4Bit` layers. Options are {'fp4','np4'}."
+            "help": "set the quantization data type in the `bnb.nn.Linear4Bit` layers. Options are {'fp4','nf4'}."
         },
     )
 
@@ -2412,7 +2412,7 @@ class BnbQuantizationConfig:
         },
     )
 
-    bnb_4bit_compute_dtype: bool = field(
+    bnb_4bit_compute_dtype: str = field(
         default="fp16",
         metadata={
             "help": "This sets the computational type which might be different than the input time. For example, inputs might be "


### PR DESCRIPTION
# What does this PR do?
Fixed the type of `bnb_4bit_compute_dtype`, which was incorrectly set as bool. Changed it to str to ensure that `transformers.HfArgumentParser` can parse it from the CLI, as Union is not valid in this context.
## Who can review?

- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
