### PR TITLE
[Utils] `has_offloaded_params`

### DIFF
--- a/docs/source/package_reference/big_modeling.md
+++ b/docs/source/package_reference/big_modeling.md
@@ -90,3 +90,9 @@ rendered properly in your Markdown viewer.
 ### remove_hook_from_submodules
 
 [[autodoc]] hooks.remove_hook_from_submodules
+
+## Utilities
+
+### has_offloaded_params
+
+[[autodoc]] utils.has_offloaded_params

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -79,6 +79,7 @@ from .utils import (
     get_grad_scaler,
     get_mixed_precision_context_manager,
     get_pretty_name,
+    has_offloaded_params,
     is_bf16_available,
     is_bitsandbytes_multi_backend_available,
     is_deepspeed_available,
@@ -106,7 +107,7 @@ from .utils import (
     wait_for_everyone,
 )
 from .utils.constants import FSDP_PYTORCH_VERSION, PROFILE_PATTERN_NAME
-from .utils.modeling import get_state_dict_offloaded_model, has_offloaded_params
+from .utils.modeling import get_state_dict_offloaded_model
 from .utils.other import is_compiled_module
 
 

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -135,6 +135,7 @@ from .modeling import (
     get_max_layer_size,
     get_max_memory,
     get_mixed_precision_context_manager,
+    has_offloaded_params,
     id_tensor_storage,
     infer_auto_device_map,
     is_peft_model,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1907,7 +1907,8 @@ def get_grad_scaler(distributed_type: DistributedType = None, **kwargs):
 
 def has_offloaded_params(module: torch.nn.Module) -> bool:
     """
-    Checks if a module has offloaded parameters by checking if the given module has a AlignDevicesHook attached with offloading enabled
+    Checks if a module has offloaded parameters by checking if the given module has a AlignDevicesHook attached with
+    offloading enabled
 
     Args:
         module (`torch.nn.Module`): The module to check for an offload hook.
@@ -1916,4 +1917,5 @@ def has_offloaded_params(module: torch.nn.Module) -> bool:
         bool: `True` if the module has an offload hook and offloading is enabled, `False` otherwise.
     """
     from ..hooks import AlignDevicesHook  # avoid circular import
+
     return hasattr(module, "_hf_hook") and isinstance(module._hf_hook, AlignDevicesHook) and module._hf_hook.offload

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1907,7 +1907,7 @@ def get_grad_scaler(distributed_type: DistributedType = None, **kwargs):
 
 def has_offloaded_params(module: torch.nn.Module) -> bool:
     """
-    Checks if the given module has an offload hook attached.
+    Checks if a module has offloaded parameters by checking if the given module has a AlignDevicesHook attached with offloading enabled
 
     Args:
         module (`torch.nn.Module`): The module to check for an offload hook.


### PR DESCRIPTION
## Purpose ##
* Add a `has_offloaded_params` utility function which returns `True` iff there is an `AlignDevicesHook` with offloading enabled
* Prepare for other utility functions to be implemented in future PRs

## Changes ##
* Implement utility function in `accelerate.utils.modeling`, exposed through `accelerate.utils`
* Replace repeat code use in `accelerate.utils.modeling` and `accelerate.accelerator` with newly added function

## Testing ##

<details><summary>test_has_offloaded_params.py</summary>

```python3
import torch

from accelerate.utils import has_offloaded_params
from accelerate.hooks import attach_align_device_hook
from accelerate.big_modeling import cpu_offload_with_hook

class ModelForTest(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.linear1 = torch.nn.Linear(3, 4)
        self.batchnorm = torch.nn.BatchNorm1d(4)
        self.linear2 = torch.nn.Linear(4, 5)

    def forward(self, x):
        return self.linear2(self.batchnorm(self.linear1(x)))
    
model = ModelForTest()
assert not has_offloaded_params(model.linear1)
assert not has_offloaded_params(model.batchnorm)
assert not has_offloaded_params(model.batchnorm)

model = ModelForTest()
model, hook = cpu_offload_with_hook(model, execution_device="cuda:0")
assert not has_offloaded_params(model.linear1)
assert not has_offloaded_params(model.batchnorm)
assert not has_offloaded_params(model.batchnorm)

model = ModelForTest()
attach_align_device_hook(model, offload=False)
assert not has_offloaded_params(model.linear1)
assert not has_offloaded_params(model.batchnorm)
assert not has_offloaded_params(model.batchnorm)

model = ModelForTest()
attach_align_device_hook(model, offload=True)
assert has_offloaded_params(model.linear1)
assert has_offloaded_params(model.batchnorm)
assert has_offloaded_params(model.batchnorm)
```

</details>

## Who can review?
@SunMarc
@LysandreJik 
@mgoin