### PR TITLE
Update transformers.deepspeed references from transformers 4.46.0 release

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1297,7 +1297,7 @@ class DeepSpeedPlugin:
         if ds_config.get("train_batch_size", None) == "auto":
             del ds_config["train_batch_size"]
 
-        if compare_versions("transformers", "<", "4.33"):
+        if compare_versions("transformers", "<", "4.46"):
             from transformers.deepspeed import HfDeepSpeedConfig, unset_hf_deepspeed_config
         else:
             from transformers.integrations import HfDeepSpeedConfig, unset_hf_deepspeed_config

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -271,7 +271,7 @@ class DeepSpeedConfigIntegration(AccelerateTestCase):
 
         with mockenv_context(**self.dist_env):
             accelerator = Accelerator(deepspeed_plugin=deepspeed_plugin)  # noqa: F841
-            from transformers.deepspeed import is_deepspeed_zero3_enabled
+            from transformers.integrations import is_deepspeed_zero3_enabled
 
             assert is_deepspeed_zero3_enabled()
 


### PR DESCRIPTION
# What does this PR do?

Fixes instances of `transformers.deepspeed` that were broken with the deprecation in transformers 4.46.0 released earlier today.  Updates those to use `transformers.integrations.deepspeed` since this is where those have been moved.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
- DeepSpeed: @muellerzr
