### PR TITLE
Fix `align_module_device`, ensure only cpu tensors for `get_state_dict_offloaded_model`

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1540,7 +1540,7 @@ def get_state_dict_offloaded_model(model: nn.Module):
                 placeholders.add(name + f".{key}")
                 continue
             params = module_state_dict[key]
-            state_dict[name + f".{key}"] = params
+            state_dict[name + f".{key}"] = params.to("cpu")  # move buffers to cpu
     for key in placeholders.copy():
         if key in state_dict:
             placeholders.remove(key)
@@ -1923,7 +1923,7 @@ def align_module_device(module: torch.nn.Module, execution_device: Optional[torc
                 module._hf_hook.execution_device = original_device
 
     elif execution_device is not None:
-        devices = {name: param.device for name, param in module.named_parameters()}
+        devices = {name: param.device for name, param in module.named_parameters(recurse=False)}
         try:
             for name in devices:
                 set_module_tensor_to_device(module, name, execution_device)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -809,7 +809,6 @@ class ModelingUtilsTester(unittest.TestCase):
 
             assert original_state_dict.keys() == state_dict.keys()
             for key in original_state_dict:
-                # note that get_state_dict_offloaded_model does not move buffers to cpu
                 assert torch.equal(original_state_dict[key], state_dict[key])
 
     def test_align_module_device_simple(self):


### PR DESCRIPTION
## Background ##
* Previous PR #3204 introduce an unintended behavior change where a module being aligned would also attempt to align parameters belonging to its submodules. This is a problem for functions like `get_state_dict_offloaded_model` which call `align_module_device` on non-leaf modules.

```
tests/test_modeling_utils.py:808
    state_dict = get_state_dict_offloaded_model(model)
src/accelerate/utils/modeling.py:1532: in get_state_dict_offloaded_model                                                                                                             
    with align_module_device(module, "cpu"): 
/usr/lib/python3.10/contextlib.py:135: in __enter__                                                                                                                                  
    return next(self.gen)  
src/accelerate/utils/modeling.py:1929: in align_module_device                                                                                                                        
    set_module_tensor_to_device(module, name, execution_device)
ValueError: weight is on the meta device, we need a `value` to put in on cpu.
```

## Purpose ##
* Fix `align_module_device` bug where the function attempts to align meta tensors belonging to submodule parameters
* Fix `get_state_dict_offloaded_model(model)` behavior to match `model.state_dict()`
* Introduce tests for `get_state_dict_offloaded_model`

## Changes ##
* `align_module_device` now only aligns parameters directly attached to the parent
* Move all tensors in module state dict to cpu before returning, including both parameters and buffers
* Add usage tests for `get_state_dict_offloaded_model`

## Testing ##
* Added tests fail without changes