### PR TITLE
Ensure explicit output `dtype` for `pad_across_processes`

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -669,7 +669,7 @@ def pad_across_processes(tensor, dim=0, pad_index=0, pad_first=False):
         old_size = tensor.shape
         new_size = list(old_size)
         new_size[dim] = max_size
-        new_tensor = tensor.new_zeros(tuple(new_size)) + pad_index
+        new_tensor = (tensor.new_zeros(tuple(new_size)) + pad_index).to(tensor.dtype)
         if pad_first:
             indices = tuple(
                 slice(max_size - old_size[dim], max_size) if i == dim else slice(None) for i in range(len(new_size))


### PR DESCRIPTION
# What does this PR do?



Fixes #3218.

Current implementation casts `torch.bool` to `torch.int64` because of `+ pad_index`, where `pad_index` is `0` by default: https://github.com/huggingface/accelerate/blob/d0e80e51b68a2d39741ee948a9800d8298c8c95d/src/accelerate/utils/operations.py#L672

Adds a test case for checking that `torch.bool` is output with the same type.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

@muellerzr @BenjaminBossan @SunMarc

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->