### PR TITLE
remove hook for bnb 4-bit 

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -355,7 +355,9 @@ def dispatch_model(
     # We need to force hook for quantized model that can't be moved with to()
     if getattr(model, "quantization_method", "bitsandbytes") == "bitsandbytes":
         # since bnb 0.43.2, we can move 4-bit model
-        if getattr(model, "is_loaded_in_8bit", False) or (getattr(model, "is_loaded_in_4bit", False) and not is_bnb_available(min_version="0.43.2")):
+        if getattr(model, "is_loaded_in_8bit", False) or (
+            getattr(model, "is_loaded_in_4bit", False) and not is_bnb_available(min_version="0.43.2")
+        ):
             force_hooks = True
 
     # We attach hooks if the device_map has at least 2 different devices or if

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -179,8 +179,13 @@ def is_8bit_bnb_available():
     return False
 
 
-def is_bnb_available():
-    return _is_package_available("bitsandbytes")
+def is_bnb_available(min_version=None):
+    package_exists = _is_package_available("bitsandbytes")
+    if package_exists and min_version is not None:
+        bnb_version = version.parse(importlib.metadata.version("bitsandbytes"))
+        return compare_versions(bnb_version, ">=", min_version)
+    else:
+        return package_exists
 
 
 def is_bitsandbytes_multi_backend_available():


### PR DESCRIPTION
# What does this PR do ?

This PR relax the condition that 4-bit bnb models needs to have a hook to work. It is not necessary as we can move the 4-bit model since bnb 0.43.2.

cc @sayakpaul 