### PR TITLE
[docs] add instruction to install bnb on non-cuda devices

### DIFF
--- a/docs/source/usage_guides/profiler.md
+++ b/docs/source/usage_guides/profiler.md
@@ -183,6 +183,8 @@ prof.export_chrome_trace("trace.json")
 
 </hfoption>
 <hfoption id="Accelerate">
+model = models.resnet18()
+inputs = torch.randn(5, 3, 224, 224).cuda()
 
 ```python
 profile_kwargs = ProfileKwargs(
@@ -198,6 +200,7 @@ with accelerator.profile() as prof:
 
 # The trace will be saved to the specified directory
 ```
+For other hardware accelerators, e.g. XPU, you can change `cuda` to `xpu` in the above example code.
 
 </hfoption>
 </hfoptions>
@@ -218,7 +221,7 @@ To illustrate how the API works, consider the following example:
 from torch.profiler import schedule
 
 my_schedule = schedule(
-    skip_first=10,
+    skip_first=1,
     wait=5,
     warmup=1,
     active=3,
@@ -251,7 +254,7 @@ def trace_handler(p):
 
 profile_kwargs = ProfileKwargs(
     activities=["cpu", "cuda"],
-    schedule_option={"wait": 5, "warmup": 1, "active": 3, "repeat": 2, "skip_first": 10},
+    schedule_option={"wait": 5, "warmup": 1, "active": 3, "repeat": 2, "skip_first": 1},
     on_trace_ready=trace_handler
 )
 

--- a/docs/source/usage_guides/profiler.md
+++ b/docs/source/usage_guides/profiler.md
@@ -183,10 +183,10 @@ prof.export_chrome_trace("trace.json")
 
 </hfoption>
 <hfoption id="Accelerate">
-model = models.resnet18()
-inputs = torch.randn(5, 3, 224, 224).cuda()
 
 ```python
+model = models.resnet18()
+inputs = torch.randn(5, 3, 224, 224).cuda()
 profile_kwargs = ProfileKwargs(
     activities=["cpu", "cuda"],
     output_trace_dir="trace"

--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -30,6 +30,8 @@ You will need to install the following requirements:
 ```bash
 pip install bitsandbytes
 ```
+For non-cuda devices, you can refer to the bitsandbytes installation guide [here](https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend)
+
 - Install latest `accelerate` from source
 ```bash
 pip install git+https://github.com/huggingface/accelerate.git

--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -30,7 +30,7 @@ You will need to install the following requirements:
 ```bash
 pip install bitsandbytes
 ```
-For non-cuda devices, you can refer to the bitsandbytes installation guide [here](https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend)
+For non-cuda devices, you can refer to the bitsandbytes installation guide [here](https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend).
 
 - Install latest `accelerate` from source
 ```bash


### PR DESCRIPTION
## What does this PR do?
`pip install bitsandbytes` doesn't work on non-cuda devices, e.g. CPU or XPU. So I add a comment for that. 

@muellerzr