### PR TITLE
Fix : get_balanced_memory when using multi gpus with small models or quantized models with a large vocabulary

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1066,11 +1066,11 @@ def get_balanced_memory(
     )
     # The last device is left with max_memory just in case the buffer is not enough.
     for idx in gpus_idx_list[:-1]:
-        if idx == 0 and not low_zero and module_sizes['model.embed_tokens'] > per_gpu * 0.9: 
-            max_memory[idx] = min(module_sizes['model.embed_tokens'] * 1.3, max_memory[idx])
-        elif idx == 1 and low_zero and module_sizes['model.embed_tokens'] > per_gpu * 0.9 :
-            max_memory[idx] = min(module_sizes['model.embed_tokens'] * 1.3, max_memory[idx])
-        else :
+        if idx == 0 and not low_zero and module_sizes["model.embed_tokens"] > per_gpu * 0.9:
+            max_memory[idx] = min(module_sizes["model.embed_tokens"] * 1.3, max_memory[idx])
+        elif idx == 1 and low_zero and module_sizes["model.embed_tokens"] > per_gpu * 0.9:
+            max_memory[idx] = min(module_sizes["model.embed_tokens"] * 1.3, max_memory[idx])
+        else:
             max_memory[idx] = min(max_memory[0] if low_zero and idx == 0 else per_gpu, max_memory[idx])
 
     if low_zero:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1066,7 +1066,12 @@ def get_balanced_memory(
     )
     # The last device is left with max_memory just in case the buffer is not enough.
     for idx in gpus_idx_list[:-1]:
-        max_memory[idx] = min(max_memory[0] if low_zero and idx == 0 else per_gpu, max_memory[idx])
+        if idx == 0 and not low_zero and module_sizes['model.embed_tokens'] > per_gpu * 0.9: 
+            max_memory[idx] = min(module_sizes['model.embed_tokens'] * 1.3, max_memory[idx])
+        elif idx == 1 and low_zero and module_sizes['model.embed_tokens'] > per_gpu * 0.9 :
+            max_memory[idx] = min(module_sizes['model.embed_tokens'] * 1.3, max_memory[idx])
+        else :
+            max_memory[idx] = min(max_memory[0] if low_zero and idx == 0 else per_gpu, max_memory[idx])
 
     if low_zero:
         min_zero = max(0, module_sizes[""] - sum([max_memory[i] for i in range(1, num_devices)]))

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1065,11 +1065,12 @@ def get_balanced_memory(
         )
     )
     # The last device is left with max_memory just in case the buffer is not enough.
+    max_leave_size = max([module_sizes[leave] for leave in leaves])
     for idx in gpus_idx_list[:-1]:
-        if idx == 0 and not low_zero and module_sizes["model.embed_tokens"] > per_gpu * 0.9:
-            max_memory[idx] = min(module_sizes["model.embed_tokens"] * 1.3, max_memory[idx])
-        elif idx == 1 and low_zero and module_sizes["model.embed_tokens"] > per_gpu * 0.9:
-            max_memory[idx] = min(module_sizes["model.embed_tokens"] * 1.3, max_memory[idx])
+        if idx == 0 and not low_zero and max_leave_size > per_gpu * 0.9:
+            max_memory[idx] = min(max_leave_size * 1.3, max_memory[idx])
+        elif idx == 1 and low_zero and max_leave_size > per_gpu * 0.9:
+            max_memory[idx] = min(max_leave_size * 1.3, max_memory[idx])
         else:
             max_memory[idx] = min(max_memory[0] if low_zero and idx == 0 else per_gpu, max_memory[idx])
 


### PR DESCRIPTION
# What does this PR do?
Fixes https://github.com/huggingface/transformers/issues/34751, and part of https://github.com/huggingface/transformers/issues/34706. 
### Explanation of `get_balanced_memory` Behavior and Handling of Large `embed_tokens` Layers  

When a small model or a relatively large quantized model is loaded using `device_map=auto`, the function `get_balanced_memory` calculates the maximum memory usage for each visible device. Its goal is to distribute the model evenly across all devices while reserving all available memory on the last device.  

#### Issue with Large `embed_tokens` Layers  

For models with a small number of parameters but a large vocabulary size (e.g., *Gemma2 2B*), the `embed_tokens` layer can consume a significant amount of memory. This layer might exceed the `max_memory` limit on the initial devices. As a result, the `infer_auto_device_map` function bypasses all earlier devices, placing the `embed_tokens` layer—and all subsequent layers—on the last device.  

A similar issue arises with quantized models. Since embedding layers are often **not quantized**, the `max_memory` per device might be insufficient to accommodate the `embed_tokens` layer, leading to the same behavior.  

#### Improvement in This PR  

This pull request addresses the issue by comparing the size of the `embed_tokens` layer to the memory available per GPU (`per_gpu`). It adjusts the memory allocation strategy to ensure that `embed_tokens` can be distributed appropriately across devices, improving the handling of models with large embeddings.  
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc
