### PR TITLE
[`data_loader`] Optionally also propagate set_epoch to batch sampler

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -586,6 +586,8 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         # In case it is manually passed in, the user can set it to what they like
         if self.iteration != epoch:
             self.iteration = epoch
+        if hasattr(self.batch_sampler, "set_epoch"):
+            self.batch_sampler.set_epoch(epoch)
         if hasattr(self.batch_sampler, "sampler") and hasattr(self.batch_sampler.sampler, "set_epoch"):
             self.batch_sampler.sampler.set_epoch(epoch)
         # We support if a custom `Dataset` implementation has `set_epoch`


### PR DESCRIPTION
# What does this PR do?

When training with the `transformers` Trainer or related (Sentence Transformers, SpanMarker, SetFit, etc.), `set_epoch` is called on the dataloader. This is propagated down to the `dataloader.batch_sampler.sampler` if that has a `set_epoch` , but not to `dataloader.batch_sampler`.

This prevents epoch-specific generator seeding in custom batch samplers, such as the ones that are common in Sentence Transformers: https://sbert.net/docs/package_reference/sentence_transformer/sampler.html

See also https://github.com/UKPLab/sentence-transformers/issues/3069 by @antigregory which showed that `set_epoch` in my Batch Samplers is not called like I expected them to be.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr (p.s. get better soon!)

- Tom Aarsen