### PR TITLE
Use `numpy._core` instead of `numpy.core`

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -215,7 +215,7 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Fal
 
 # The following are considered "safe" globals to reconstruct various types of objects when using `weights_only=True`
 # These should be added and then removed after loading in the file
-np_core = np._core if Version(np.__version__) >= Version("2.0.0") else np.core
+np_core = np._core if is_numpy_available("2.0.0") else np.core
 TORCH_SAFE_GLOBALS = [
     # numpy arrays are just numbers, not objects, so we can reconstruct them safely
     np_core.multiarray._reconstruct,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -23,6 +23,7 @@ from typing import OrderedDict
 
 import numpy as np
 import torch
+from packaging import version
 from packaging.version import Version
 from safetensors.torch import save_file as safe_save_file
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -23,7 +23,6 @@ from typing import OrderedDict
 
 import numpy as np
 import torch
-from packaging import version
 from packaging.version import Version
 from safetensors.torch import save_file as safe_save_file
 
@@ -216,7 +215,7 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Fal
 
 # The following are considered "safe" globals to reconstruct various types of objects when using `weights_only=True`
 # These should be added and then removed after loading in the file
-np_core = np._core if version.parse(np.__version__) >= version.parse("2.0.0") else np.core
+np_core = np._core if Version(np.__version__) >= Version("2.0.0") else np.core
 TORCH_SAFE_GLOBALS = [
     # numpy arrays are just numbers, not objects, so we can reconstruct them safely
     np_core.multiarray._reconstruct,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -215,9 +215,10 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Fal
 
 # The following are considered "safe" globals to reconstruct various types of objects when using `weights_only=True`
 # These should be added and then removed after loading in the file
+np_core = np._core if version.parse(np.__version__) >= version.parse("2.0.0") else np.core
 TORCH_SAFE_GLOBALS = [
     # numpy arrays are just numbers, not objects, so we can reconstruct them safely
-    np._core.multiarray._reconstruct,
+    np_core.multiarray._reconstruct,
     np.ndarray,
     # The following are needed for the RNG states
     encode,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -217,7 +217,7 @@ def save(obj, f, save_on_each_node: bool = False, safe_serialization: bool = Fal
 # These should be added and then removed after loading in the file
 TORCH_SAFE_GLOBALS = [
     # numpy arrays are just numbers, not objects, so we can reconstruct them safely
-    np.core.multiarray._reconstruct,
+    np._core.multiarray._reconstruct,
     np.ndarray,
     # The following are needed for the RNG states
     encode,


### PR DESCRIPTION
# What does this PR do?

We've been getting this warning:

>   /fsx/qgallouedec/miniconda3/envs/trl/lib/python3.11/site-packages/accelerate/utils/other.py:220: DeprecationWarning: numpy.core is deprecated and has been renamed to numpy._core. The numpy._core namespace contains private NumPy internals and its use is discouraged, as NumPy internals can change without warning in any release. In practice, most real-world usage of numpy.core is to access functionality in the public NumPy API. If that is the case, use the public NumPy API. If not, you are using NumPy internals. If you would still like to access an internal attribute, use numpy._core.multiarray.
    np.core.multiarray._reconstruct,

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr @BenjaminBossan @SunMarc

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->