### PR TITLE
Fix: Resolve #3060, `preload_module_classes` is lost for nested modules

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -436,7 +436,8 @@ def attach_execution_device_hook(
         return
 
     for child in module.children():
-        attach_execution_device_hook(child, execution_device, skip_keys=skip_keys, tied_params_map=tied_params_map)
+        attach_execution_device_hook(child, execution_device, skip_keys=skip_keys, 
+            preload_module_classes=preload_module_classes, tied_params_map=tied_params_map)
 
 
 def attach_align_device_hook(

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -436,8 +436,13 @@ def attach_execution_device_hook(
         return
 
     for child in module.children():
-        attach_execution_device_hook(child, execution_device, skip_keys=skip_keys, 
-            preload_module_classes=preload_module_classes, tied_params_map=tied_params_map)
+        attach_execution_device_hook(
+            child,
+            execution_device,
+            skip_keys=skip_keys,
+            preload_module_classes=preload_module_classes,
+            tied_params_map=tied_params_map,
+        )
 
 
 def attach_align_device_hook(

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -762,3 +762,65 @@ class AcceleratorTester(AccelerateTestCase):
             assert torch.allclose(original_linear1, new_linear1)
             assert torch.allclose(original_batchnorm, new_batchnorm)
             assert torch.allclose(original_linear2, new_linear2)
+
+    @require_cuda
+    def test_nested_hook(self, use_safetensors):
+        from transformers.modeling_utils import PretrainedConfig, PreTrainedModel
+
+        class MyLinear(torch.nn.Module):
+            def __init__(self, device=None, dtype=None):
+                factory_kwargs = {"device": device, "dtype": dtype}
+                super().__init__()
+                self.centroid = torch.nn.Embedding(1, 2)
+                self.indices = torch.nn.parameter(torch.empty((1, 2, 2), **factory_kwargs))
+
+            def forward(self, x):
+                orig_shape = x.shape
+                x = torch.abs(x + self.indices).long()
+                x = x % 2
+                x = x.sum(-1)
+                x = (self.centroid.weight + x).reshape(orig_shape)
+                return x
+
+        class MySubModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layer = MyLinear()
+
+            def forward(self, x):
+                return self.layer(x)
+
+        class MyModel(PreTrainedModel):
+            def __init__(self, config):
+                super().__init__(config)
+                self.layer = torch.nn.ModuleList([MySubModel() for i in range(4)])
+
+            def forward(self, x):
+                for layer in self.layer:
+                    x = layer(x)
+                return x
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            check_point = tmpdirname
+            offload_folder = check_point + "/offload"
+            os.makedirs(offload_folder, exist_ok=True)
+            config = PretrainedConfig()
+            m = MyModel(config)
+            m.save_pretrained(check_point)
+
+            with init_empty_weights():
+                my_model = MyModel(config)
+            my_model = load_checkpoint_and_dispatch(
+                my_model,
+                checkpoint=check_point,
+                max_memory={"cpu": 60, 0: 60},
+                device_map="auto",
+                no_split_module_classes=["MySubModel"],
+                offload_folder=offload_folder,
+                preload_module_classes=["VQuantLinear"],
+            )
+            x = torch.randn(1, 2)
+            print(my_model(x))
+        # before fix, this would raise an error
+        #       weight is on the meta device, we need a `value` to put in on 0
+        my_model(x)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -30,9 +30,9 @@ from accelerate.data_loader import DataLoaderDispatcher, DataLoaderShard, skip_f
 from accelerate.state import GradientState, PartialState
 from accelerate.test_utils import (
     require_bnb,
+    require_huggingface_suite,
     require_multi_gpu,
     require_non_cpu,
-    require_huggingface_suite,
     require_transformer_engine,
     slow,
     torch_device,

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -819,8 +819,7 @@ class AcceleratorTester(AccelerateTestCase):
                 offload_folder=offload_folder,
                 preload_module_classes=["VQuantLinear"],
             )
-            x = torch.randn(1, 2)
-            print(my_model(x))
         # before fix, this would raise an error
         #       weight is on the meta device, we need a `value` to put in on 0
+        x = torch.randn(1, 2)
         my_model(x)

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -32,6 +32,7 @@ from accelerate.test_utils import (
     require_bnb,
     require_multi_gpu,
     require_non_cpu,
+    require_huggingface_suite,
     require_transformer_engine,
     slow,
     torch_device,
@@ -764,6 +765,7 @@ class AcceleratorTester(AccelerateTestCase):
             assert torch.allclose(original_linear2, new_linear2)
 
     @require_cuda
+    @require_huggingface_suite
     def test_nested_hook(self, use_safetensors):
         from transformers.modeling_utils import PretrainedConfig, PreTrainedModel
 
@@ -817,7 +819,7 @@ class AcceleratorTester(AccelerateTestCase):
                 device_map="auto",
                 no_split_module_classes=["MySubModel"],
                 offload_folder=offload_folder,
-                preload_module_classes=["VQuantLinear"],
+                preload_module_classes=["MyLinear"],
             )
         # before fix, this would raise an error
         #       weight is on the meta device, we need a `value` to put in on 0


### PR DESCRIPTION
# What does this PR do?
We ran into this issue when try to load [VPTQ](https://github.com/microsoft/VPTQ/tree/main)  models by multiple devices, the `VQLinear` layer has embending as its sub-module. This function should move all constant buffers/parameters to the corresponding devices from Meta device.
So `add_hook_to_module` should pass `preload_module_classes` to the next recursive calling for the nested modules.

https://github.com/microsoft/VPTQ/blob/ac7258f461e214ca705f5895513f314576750528/vptq/layers/vqlinear.py#L160C18-L160C18

This PR is to fix https://github.com/huggingface/accelerate/issues/3060

- Big modeling: @SunMarc

