### PR TITLE
Allow for full dynamo config passed to Accelerator

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -224,6 +224,8 @@ class Accelerator:
             or mixed precision are created. See [kwargs](kwargs) for more information.
         dynamo_backend (`str` or [`~utils.DynamoBackend`], *optional*, defaults to `"no"`):
             Set to one of the possible dynamo backends to optimize your training with torch dynamo.
+        dynamo_plugin ([`~utils.TorchDynamoPlugin`], *optional*):
+            A configuration for how torch dynamo should be handled, if more tweaking than just the `backend` or `mode` is needed.
         gradient_accumulation_plugin ([`~utils.GradientAccumulationPlugin`], *optional*):
             A configuration for how gradient accumulation should be handled, if more tweaking than just the
             `gradient_accumulation_steps` is needed.
@@ -263,6 +265,7 @@ class Accelerator:
         step_scheduler_with_optimizer: bool = True,
         kwargs_handlers: list[KwargsHandler] | None = None,
         dynamo_backend: DynamoBackend | str | None = None,
+        dynamo_plugin: TorchDynamoPlugin | None = None,
         deepspeed_plugins: DeepSpeedPlugin | dict[str, DeepSpeedPlugin] | None = None,
     ):
         self.trackers = []
@@ -279,7 +282,12 @@ class Accelerator:
                     f"Unknown mixed_precision mode: {mixed_precision}. Choose between {PrecisionType.list()}"
                 )
 
-        dynamo_plugin = TorchDynamoPlugin() if dynamo_backend is None else TorchDynamoPlugin(backend=dynamo_backend)
+        if dynamo_plugin is not None and dynamo_backend is not None:
+            raise ValueError("You cannot pass in both `dynamo_plugin` and `dynamo_backend`, please only pass in one.")
+        if dynamo_backend is not None:
+            dynamo_plugin = TorchDynamoPlugin(backend=dynamo_backend)
+        elif dynamo_plugin is None:
+            dynamo_plugin = TorchDynamoPlugin()
 
         if deepspeed_plugins is not None and deepspeed_plugin is not None:
             raise ValueError("You cannot pass in both `deepspeed_plugins` and `deepspeed_plugin`.")

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -225,7 +225,8 @@ class Accelerator:
         dynamo_backend (`str` or [`~utils.DynamoBackend`], *optional*, defaults to `"no"`):
             Set to one of the possible dynamo backends to optimize your training with torch dynamo.
         dynamo_plugin ([`~utils.TorchDynamoPlugin`], *optional*):
-            A configuration for how torch dynamo should be handled, if more tweaking than just the `backend` or `mode` is needed.
+            A configuration for how torch dynamo should be handled, if more tweaking than just the `backend` or `mode`
+            is needed.
         gradient_accumulation_plugin ([`~utils.GradientAccumulationPlugin`], *optional*):
             A configuration for how gradient accumulation should be handled, if more tweaking than just the
             `gradient_accumulation_steps` is needed.


### PR DESCRIPTION
# What does this PR do?

`Accelerator` doesn't allow for explicitly passing in `TorchDynamoPlugin`. This is needed since the `TrainingArguments` can pass in a `mode` (and I want to try and remove all env vars from the `Trainer`)

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @BenjaminBossan 