### PR TITLE
[WIP] FEAT Decorator to purge accelerate env vars

### DIFF
--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -174,6 +174,8 @@ When setting up 🤗 Accelerate for the first time, rather than running `acceler
 
 [[autodoc]] utils.environment.override_numa_affinity
 
+[[autodoc]] utils.purge_accelerate_environment
+
 ## Memory
 
 [[autodoc]] utils.find_executable_batch_size

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -71,6 +71,7 @@ from .environment import (
     parse_choice_from_env,
     parse_flag_from_env,
     patch_environment,
+    purge_accelerate_environment,
     set_numa_affinity,
     str_to_bool,
 )

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -383,6 +383,7 @@ def purge_accelerate_environment(func_or_cls):
                             os.environ[key] = existing_vars[key]
                         else:
                             os.environ.pop(key, None)
+
         wrapper._is_purged_accelerate_environment_wrapped = True
         return wrapper
 
@@ -391,16 +392,16 @@ def purge_accelerate_environment(func_or_cls):
         return wrap_function(func_or_cls)
 
     # Deal with classes. Special care has to be taken that we correctly deal with subclasses too.
-    original_init_subclass = getattr(func_or_cls, '__init_subclass__', None)
+    original_init_subclass = getattr(func_or_cls, "__init_subclass__", None)
 
     @classmethod
     def init_subclass(cls, **kwargs):
         if original_init_subclass:
             original_init_subclass(**kwargs)
         for attr_name in dir(cls):
-            if attr_name.startswith('test_'):
+            if attr_name.startswith("test_"):
                 attr = getattr(cls, attr_name)
-                if callable(attr) and not hasattr(attr, '_is_purged_accelerate_environment_wrapped'):
+                if callable(attr) and not hasattr(attr, "_is_purged_accelerate_environment_wrapped"):
                     wrapped_method = wrap_function(attr)
                     setattr(cls, attr_name, wrapped_method)
 
@@ -408,9 +409,9 @@ def purge_accelerate_environment(func_or_cls):
 
     # Wrap existing methods in the class
     for attr_name in dir(func_or_cls):
-        if attr_name.startswith('test'):
+        if attr_name.startswith("test"):
             attr = getattr(func_or_cls, attr_name)
-            if callable(attr) and not hasattr(attr, '_is_purged_accelerate_environment_wrapped'):
+            if callable(attr) and not hasattr(attr, "_is_purged_accelerate_environment_wrapped"):
                 wrapped_method = wrap_function(attr)
                 setattr(func_or_cls, attr_name, wrapped_method)
     return func_or_cls


### PR DESCRIPTION
# What does this PR do?

In some circumstances, calling certain classes or functions can result in accelerate env vars being set and not being cleaned up afterwards. As an example, when calling:

`TrainingArguments(fp16=True, ...)`

The following env var will be set:

`ACCELERATE_MIXED_PRECISION=fp16`

This can affect subsequent code, since the env var takes precedence over `TrainingArguments(fp16=False)`. This is especially relevant for unit testing, where we want to avoid the individual tests to have side effects on one another. Decorate the unit test function or whole class with this decorator to ensure that after each test, the env vars are cleaned up. This works for both `unittest.TestCase` and normal classes (pytest) and standalone functions; it also works when decorating the parent class and in conjunction with other decorators.

## Notes

In its current state, this PR adds the new decorator and tests it, but the decorator is not yet applied to potentially problematic functions or classes.

Personally, I'm not super happy with the implementation, as it turned out to be more complicated than I initially thought (mainly because of the subclassing). I tested this decorator on the initial test failure in PEFT and it solved it. However, it requires to decorate each and every class/function that could potentially have side effects. It is thus easy to miss something.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] ~~Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.~~ Internal discussion on Slack
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

