### PR TITLE
use XPU instead of GPU in the `accelerate config` prompt text

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -603,6 +603,8 @@ def get_cluster_input():
             machine_type = "MLU(s)"
         elif is_musa_available():
             machine_type = "MUSA(s)"
+        elif is_xpu_available():
+            machine_type = "XPU(s)"
         else:
             machine_type = "GPU(s)"
         gpu_ids = _ask_field(


### PR DESCRIPTION
## What does this PR do?
When using `accelerate config` to configure params on XPU, it shows "What GPU(s) (by id)..." rather than "What XPU(s) (by id)..." as shown below:

```bash
In which compute environment are you running?
This machine                                                                                                                                
--------------------------------------------------------------------------------------------------------------------------------------------Which type of machine are you using?                                                                                                        
multi-XPU                                                                                                                                   
How many different machines will you use (use more than 1 for multi-node training)? [1]: 1                                                  
Should distributed operations be checked while running for errors? This can avoid timeout issues but will be slower. [yes/NO]: no           
Do you want to use XPU plugin to speed up training on XPU? [yes/NO]:yes                                                                     
Do you wish to optimize your script with torch dynamo?[yes/NO]:no                                                                           
Do you want to use DeepSpeed? [yes/NO]: no                                                                                                  
Do you want to use FullyShardedDataParallel? [yes/NO]: no                                                                                   
How many XPU(s) should be used for distributed training? [1]:2                                                                              
What GPU(s) (by id) should be used for training on this machine as a comma-seperated list? [all]:1,2    
```

This PR fixes this issue.

@muellerzr @BenjaminBossan 
