### PR TITLE
add support for DeepSpeed's boolean zero_optimization configuration

### DIFF
--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -135,6 +135,12 @@ class HfDeepSpeedConfig:
                     f"Expected a string path to an existing deepspeed config, or a dictionary, or a base64 encoded string. Received: {config_file_or_dict}"
                 )
 
+        if "zero_optimization" in config and isinstance(config["zero_optimization"], bool):
+            from deepspeed.runtime.zero.config import read_zero_config_deprecated
+
+            zero_config_dict = read_zero_config_deprecated(config)
+            config["zero_optimization"] = zero_config_dict
+
         self.config = config
 
         self.set_stage_and_offload()


### PR DESCRIPTION
# What does this PR do?

DeepSpeed‘s [Getting Started](https://github.com/microsoft/DeepSpeed/blob/v0.16.0/docs/_tutorials/getting-started.md) guide indicates that `zero_optimization` can be a boolean value.
```json
{
  "train_batch_size": 8,
  "gradient_accumulation_steps": 1,
  "optimizer": {
    "type": "Adam",
    "params": {
      "lr": 0.00015
    }
  },
  "fp16": {
    "enabled": true
  },
  "zero_optimization": true
}
```
Add boolean `zero_optimization` support by referring to  https://github.com/microsoft/DeepSpeed/blob/0c6c98110947300636937d45d6b3392c84996130/deepspeed/runtime/zero/config.py#L54-L72



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->