### PR TITLE
Fix logging logic when in_order is set to True

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 import functools
 import logging

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -53,6 +53,7 @@ def test_log_stack(caplog):
     )
 
     message = "Test"
+    expected_message, _ = logger.process(message, {})
     lineno = current_lineno() + 1  # the next line is the actual callsite
     logger.warning(message)
 
@@ -63,7 +64,7 @@ def test_log_stack(caplog):
     assert rec.name == __name__
     assert rec.lineno == lineno
     assert rec.funcName == test_log_stack.__name__
-    assert rec.message == message
+    assert rec.message == expected_message
 
 
 @pytest.mark.usefixtures("accelerator")
@@ -76,6 +77,7 @@ def test_custom_stacklevel(caplog):
     logger = CustomLogger(wrapped_logger, {})
 
     message = "Test"
+    expected_message, _ = wrapped_logger.process(message, {})
     lineno = current_lineno() + 1  # the next line is the actual callsite
     logger.warning(message)
 
@@ -88,4 +90,4 @@ def test_custom_stacklevel(caplog):
     assert rec.name == __name__
     assert rec.lineno == lineno
     assert rec.funcName == test_custom_stacklevel.__name__
-    assert rec.message == message
+    assert rec.message == expected_message


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR fix the logging logic when `in_order` is set to `True`. Right now, the `in_order` flag either hangs the program when `main_process_only` is also set to `True`, or does nothing when `main_process_only` is set to `False`.

A simple code snippet to test (run with `accelerate launch  --num_processes=2 test.py`):
```python
from accelerate import PartialState
from accelerate.logging import get_logger


s = PartialState()

logger = get_logger("accelerate")
in_order = True
main_process_only = False  # True

logger.info(f"[{s.process_index}] Hello, world!", in_order=in_order, main_process_only=main_process_only)
logger.warning(f"[{s.process_index}] Hello, world!", in_order=in_order, main_process_only=main_process_only)
logger.error(f"[{s.process_index}] Hello, world!", in_order=in_order, main_process_only=main_process_only)

```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->