### PR TITLE
Add `keep_torch_compile` param to `unwrap_model` and `extract_model_from_parallel` for distributed compiled model.

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2601,7 +2601,7 @@ class Accelerator:
         """
         return pad_across_processes(tensor, dim=dim, pad_index=pad_index, pad_first=pad_first)
 
-    def unwrap_model(self, model, keep_fp32_wrapper: bool = True):
+    def unwrap_model(self, model, keep_fp32_wrapper: bool = True, keep_torch_compile: bool = True):
         """
         Unwraps the `model` from the additional layer possible added by [`~Accelerator.prepare`]. Useful before saving
         the model.
@@ -2611,7 +2611,8 @@ class Accelerator:
                 The model to unwrap.
             keep_fp32_wrapper (`bool`, *optional*, defaults to `True`):
                 Whether to not remove the mixed precision hook if it was added.
-
+            keep_torch_compile (`bool`, *optional*, defaults to `True`):
+                Whether to not unwrap compiled model if compiled.
         Returns:
             `torch.nn.Module`: The unwrapped model.
 
@@ -2632,7 +2633,7 @@ class Accelerator:
         MyModel
         ```
         """
-        return extract_model_from_parallel(model, keep_fp32_wrapper)
+        return extract_model_from_parallel(model, keep_fp32_wrapper, keep_torch_compile)
 
     def wait_for_everyone(self):
         """

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -59,7 +59,9 @@ def is_compiled_module(module):
     return isinstance(module, torch._dynamo.eval_frame.OptimizedModule)
 
 
-def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive: bool = False):
+def extract_model_from_parallel(
+    model, keep_fp32_wrapper: bool = True, keep_torch_compile: bool = True, recursive: bool = False
+):
     """
     Extract a model from its distributed containers.
 
@@ -68,6 +70,8 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive
             The model to extract.
         keep_fp32_wrapper (`bool`, *optional*):
             Whether to remove mixed precision hooks from the model.
+        keep_torch_compile (`bool`, *optional*):
+            Whether to unwrap compiled model.
         recursive (`bool`, *optional*, defaults to `False`):
             Whether to recursively extract all cases of `module.module` from `model` as well as unwrap child sublayers
             recursively, not just the top-level distributed containers.
@@ -124,7 +128,7 @@ def extract_model_from_parallel(model, keep_fp32_wrapper: bool = True, recursive
         if getattr(model, "_converted_to_transformer_engine", False):
             convert_model(model, to_transformer_engine=False)
 
-    if is_compiled:
+    if keep_torch_compile and is_compiled:
         compiled_model._orig_mod = model
         model = compiled_model
 

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -611,6 +611,30 @@ class AcceleratorTester(AccelerateTestCase):
         model_loaded = pickle.loads(pickle.dumps(model))
         model_loaded(inputs)
 
+    def test_can_unwrap_distributed_compiled_model_keep_torch_compile(self):
+        model = create_components()[0]
+        accelerator = Accelerator()
+
+        compiled_model = torch.compile(model)
+
+        distributed_model = torch.nn.DataParallel(model)
+        distributed_compiled_model = torch.compile(distributed_model)
+        unwrapped_model = accelerator.unwrap_model(distributed_compiled_model, keep_torch_compile=True)
+
+        assert compiled_model._orig_mod == unwrapped_model._orig_mod
+
+    def test_can_unwrap_distributed_compiled_model_remove_torch_compile(self):
+        model = create_components()[0]
+        accelerator = Accelerator()
+
+        compiled_model = torch.compile(model)
+
+        distributed_model = torch.nn.DataParallel(model)
+        distributed_compiled_model = torch.compile(distributed_model)
+        unwrapped_model = accelerator.unwrap_model(distributed_compiled_model, keep_torch_compile=False)
+
+        assert compiled_model._orig_mod == unwrapped_model
+
     @parameterized.expand([True, False])
     def test_can_pickle_dataloader(self, dispatch_batches):
         """


### PR DESCRIPTION
# What does this PR do?
This PR fixes the unexpected behavior of `Accelerator.unwrap_model` (Issue https://github.com/huggingface/accelerate/issues/3281). Right now, if the model is wrapped in both distributed wrapper (e.g. `DistributedDataParallel` or `DeepSpeedEngine`) and compiled module (`OptimizedModule`) it only unwraps the distributed module. This behavior arises from the following code in L80 of `utils/others.py`: https://github.com/huggingface/accelerate/blob/cb8b7c637a8588668c52bd306f9b2828f69d9585/src/accelerate/utils/other.py#L80

Instead of checking for compiled model both **before and after** unwrapping distributed wrapper, the current code only checks for compilation before unwrapping the distributed wrapper. If the model is wrapped in both, `is_compiled` will be set to `False` and won't unwrap the model fully, resulting in unexpected behavior (users expect fully unwrapped model before saving, but gets `OptimizedModule` instead, which may result in an error when loading the state dict due to key mismatch).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Related Issue
- https://github.com/huggingface/accelerate/issues/3281

## Who can review?
@muellerzr @SunMarc
