### PR TITLE
Fix max_memory init/passing

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1111,7 +1111,6 @@ def _init_infer_auto_device_map(
     """
     Initialize variables required for computing the device map for model allocation.
     """
-    max_memory = get_max_memory(max_memory)
     if no_split_module_classes is None:
         no_split_module_classes = []
     elif not isinstance(no_split_module_classes, (list, tuple)):
@@ -1354,6 +1353,8 @@ def infer_auto_device_map(
     """
 
     # Initialize the variables
+    max_memory = get_max_memory(max_memory)
+
     (
         devices,
         main_devices,


### PR DESCRIPTION


# What does this PR do?

There is a regression between 1.1.1 and 1.2.0 where `max_memory` is not correctly passed to those all the sub-methods that needs it, causing code such below to fail since `max_memory` is used before init. 

(https://github.com/CSY-ModelCloud/accelerate/blob/8bdde005e8cc09db4a3c1d34a6eb1baf59d34335/src/accelerate/utils/modeling.py#L1416)

```py
        device = devices[current_device]
       # max_memory dict used before init <----------
        current_max_size = max_memory[device] if device != "disk" else None 
```
<!-- Remove if not applicable -->

Partial-Fixes https://github.com/huggingface/accelerate/issues/3292


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr @BenjaminBossan @SunMarc