### PR TITLE
[FSDP][Example] Fix FSDP example for `use_orig_params=False` 

### DIFF
--- a/docs/source/usage_guides/fsdp.md
+++ b/docs/source/usage_guides/fsdp.md
@@ -184,7 +184,6 @@ accelerate merge-weights pytorch_model_fsdp_0/ output_path
 * `NO_SHARD` maps to `ZeRO Stage-0`. No sharding wherein each GPU has full copy of model, optimizer states and gradients.
 * `HYBRID_SHARD` maps to `ZeRO++ Stage-3` wherein `zero_hpz_partition_size=<num_gpus_per_node>`. Here, this will shard optimizer states, gradients and parameters within each node while each node has full copy.
 
-
 ## A few caveats to be aware of
 
 - PyTorch FSDP auto wraps sub-modules. With `use_orig_params=False`, it flattens the parameters in each sub-module and shards them in place.

--- a/docs/source/usage_guides/fsdp.md
+++ b/docs/source/usage_guides/fsdp.md
@@ -180,9 +180,10 @@ accelerate merge-weights pytorch_model_fsdp_0/ output_path
 
 ## Mapping between FSDP sharding strategies and DeepSpeed ZeRO Stages
 * `FULL_SHARD` maps to the DeepSpeed `ZeRO Stage-3`. Shards optimizer states, gradients and parameters.
-* `SHARD_GRAD_OP` maps to the DeepSpeed `ZeRO Stage-2`. Shards optimizer states and gradients.
+* `SHARD_GRAD_OP` maps to DeepSpeed `ZeRO Stage-2`. Shards optimizer states and gradients. A key difference from `ZeRO Stage-2` is that `SHARD_GRAD_OP` also shards the model parameters outside of computation (forward/backward passes).
 * `NO_SHARD` maps to `ZeRO Stage-0`. No sharding wherein each GPU has full copy of model, optimizer states and gradients.
 * `HYBRID_SHARD` maps to `ZeRO++ Stage-3` wherein `zero_hpz_partition_size=<num_gpus_per_node>`. Here, this will shard optimizer states, gradients and parameters within each node while each node has full copy.
+
 
 ## A few caveats to be aware of
 

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -245,7 +245,7 @@ def training_function(config, args):
     model = AutoModelForSequenceClassification.from_pretrained(
         args.model_name_or_path, return_dict=True, low_cpu_mem_usage=True
     )
-    # In FSDP, ith `use_orig_params` as False, we need to `.prepare` the model before instantiating the optimizer. 
+    # In FSDP, with `use_orig_params` as False, we need to `.prepare` the model before instantiating the optimizer. 
     # We prepare the model beforehand in all cases for simplicity.
     model = accelerator.prepare(model)
 

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -245,9 +245,6 @@ def training_function(config, args):
     model = AutoModelForSequenceClassification.from_pretrained(
         args.model_name_or_path, return_dict=True, low_cpu_mem_usage=True
     )
-    # In FSDP, with `use_orig_params` as False, we need to `.prepare` the model before instantiating the optimizer.
-    # We prepare the model beforehand in all cases for simplicity.
-    model = accelerator.prepare(model)
 
     no_decay = ["bias", "LayerNorm.weight"]
     optimizer_grouped_parameters = [
@@ -270,8 +267,8 @@ def training_function(config, args):
         num_training_steps=(len(train_dataloader) * num_epochs) // gradient_accumulation_steps,
     )
 
-    optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
-        optimizer, train_dataloader, eval_dataloader, lr_scheduler
+    model, optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
+        model, optimizer, train_dataloader, eval_dataloader, lr_scheduler
     )
 
     overall_step = 0

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -245,7 +245,7 @@ def training_function(config, args):
     model = AutoModelForSequenceClassification.from_pretrained(
         args.model_name_or_path, return_dict=True, low_cpu_mem_usage=True
     )
-    # In FSDP, with `use_orig_params` as False, we need to `.prepare` the model before instantiating the optimizer. 
+    # In FSDP, with `use_orig_params` as False, we need to `.prepare` the model before instantiating the optimizer.
     # We prepare the model beforehand in all cases for simplicity.
     model = accelerator.prepare(model)
 
@@ -269,7 +269,6 @@ def training_function(config, args):
         num_warmup_steps=10,
         num_training_steps=(len(train_dataloader) * num_epochs) // gradient_accumulation_steps,
     )
-
 
     optimizer, train_dataloader, eval_dataloader, lr_scheduler = accelerator.prepare(
         optimizer, train_dataloader, eval_dataloader, lr_scheduler


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Fixes the FSDP example for `use_orig_params=False`. I recently started using FSDP via Accelerate and hit some roadblocks due to rough edges in documentation and examples. Some improvements in this PR: 

- `use_orig_params=False` should be the recommended route all the time (full param/ lora), since it's typically more efficient.  
- `use_orig_params=False` requires model preparation before optimizer instantiation. This is a silent failure - I noticed that loss didn't decrease in this case. I believe it is best if `.prepare` has extra validation for this and raise an Error to the user. (Might do this in a separate PR if I get time). The example prepares everything together because it assumes `use_orig_params` is True from this PR: https://github.com/huggingface/accelerate/pull/2177
- Documentation has removed this caveat with `use_orig_params`. I found a note from an older version so I brought it back. 
- `SHARD_GRAD_OP` is a bit different from Zero Stage 2, this PR adds a tiny note. 


<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->
 
 cc @muellerzr 