### PR TITLE
[tests] remove `require_non_xpu` test markers

### DIFF
--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -27,7 +27,6 @@ from accelerate.test_utils import (
     path_in_accelerate_package,
     require_multi_device,
     require_non_cpu,
-    require_non_xpu,
 )
 from accelerate.test_utils.testing import slow
 from accelerate.utils import AutocastKwargs, KwargsHandler, ProfileKwargs, TorchDynamoPlugin, clear_environment

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -50,7 +50,6 @@ class KwargsHandlerTester(unittest.TestCase):
         assert MockClass(a=2, c=2.25).to_kwargs() == {"a": 2, "c": 2.25}
 
     @require_non_cpu
-    @require_non_xpu
     def test_grad_scaler_kwargs(self):
         # If no defaults are changed, `to_kwargs` returns an empty dict.
         scaler_handler = GradScalerKwargs(init_scale=1024, growth_factor=2)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -19,7 +19,7 @@ import torch
 
 from accelerate import Accelerator
 from accelerate.state import AcceleratorState
-from accelerate.test_utils import require_cpu, require_non_cpu, require_non_xpu
+from accelerate.test_utils import require_cpu, require_non_cpu
 
 
 @require_cpu

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -37,7 +37,6 @@ class CPUOptimizerTester(unittest.TestCase):
 
 
 @require_non_cpu
-@require_non_xpu
 class OptimizerTester(unittest.TestCase):
     def test_accelerated_optimizer_step_was_skipped(self):
         model = torch.nn.Linear(5, 5)


### PR DESCRIPTION
## What does this PR do?
Both test cases work on XPU now. Below are the rest results:

```bash
===================================================================== PASSES ======================================================================
============================================================= short test summary info =============================================================
PASSED tests/test_optimizer.py::OptimizerTester::test_accelerated_optimizer_step_was_skipped
========================================================== PASSES ===========================================================
================================================== short test summary info ==================================================
PASSED tests/test_kwargs_handlers.py::KwargsHandlerTester::test_grad_scaler_kwargs
======================================== 1 passed, 6 deselected, 1 warning in 3.79s =========================================
```