### PR TITLE
[tests] make cuda-only test work on other hardware accelerators

### DIFF
--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -852,7 +852,7 @@ class ModelingUtilsTester(unittest.TestCase):
         expected_device_map = {"batchnorm": 0, "linear1": "disk", "linear2": "disk"}
         assert device_map == expected_device_map
 
-    @require_cuda
+    @require_non_cpu
     def test_get_balanced_memory(self):
         model = ModelForTest()
         # model has size 236: linear1 64, batchnorm 72, linear2 100

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -28,7 +28,6 @@ from safetensors.torch import save_file
 from accelerate import init_empty_weights
 from accelerate.big_modeling import cpu_offload
 from accelerate.test_utils import (
-    require_cuda,
     require_huggingface_suite,
     require_multi_device,
     require_non_cpu,


### PR DESCRIPTION
## What does this PR do?
The below test works on XPU, and it should also work on other hardware accelerators:

```bash
===================================================================== PASSES ======================================================================
============================================================= short test summary info =============================================================
PASSED tests/test_modeling_utils.py::ModelingUtilsTester::test_get_balanced_memory
```