### PR TITLE
Fix 'AdamW' object has no attribute 'optim_bits' error when deepspeed zero2 is enabled

### DIFF
--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -67,16 +67,18 @@ def map_pytorch_optim_to_deepspeed(optimizer):
             is_ada = isinstance(optimizer, (bnb_opt.Adagrad, bnb_opt.Adagrad32bit)) and optimizer.optim_bits == 32
         if is_ada:
             from deepspeed.ops.adagrad import DeepSpeedCPUAdagrad
-
+            
+            defaults.pop("adamw_mode")
             optimizer_class = DeepSpeedCPUAdagrad
 
     # For DeepSpeedCPULion
     if is_bnb_available(min_version="0.38.0") and compare_versions("deepspeed", ">=", "0.11.0"):
         from bitsandbytes.optim import Lion, Lion32bit
 
-        if isinstance(optimizer, (Lion, Lion32bit)) and optimizer.optim_bits == 32:
+        if isinstance(optimizer, (Lion, Lion32bit)) and optimizer.args.optim_bits == 32:
             from deepspeed.ops.lion import DeepSpeedCPULion
 
+            defaults.pop("adamw_mode")
             optimizer_class = DeepSpeedCPULion
 
     return optimizer_class(optimizer.param_groups, **defaults)

--- a/src/accelerate/utils/deepspeed.py
+++ b/src/accelerate/utils/deepspeed.py
@@ -50,7 +50,7 @@ def map_pytorch_optim_to_deepspeed(optimizer):
         if is_bnb_available() and not is_adaw:
             import bitsandbytes.optim as bnb_opt
 
-            is_adaw = isinstance(optimizer, (bnb_opt.AdamW, bnb_opt.AdamW32bit)) and optimizer.optim_bits == 32
+            is_adaw = isinstance(optimizer, (bnb_opt.AdamW, bnb_opt.AdamW32bit)) and optimizer.args.optim_bits == 32
 
         if is_adaw:
             defaults["adamw_mode"] = True


### PR DESCRIPTION
# What does this PR do?
This PR fixes the `has no attribute 'optim_bits' error` when using AdamW or lion_32bit optimizers with deepspeed zero2 enabled. 

Also popping `"adamw_mode"` from `defaults` dict if using lion or adagrad so that `DeepSpeedCPUAdagrad` and `DeepSpeedCPULion` can be respectively initialized without unexpected argument in `"adamw_mode"`.

Fixes # (issue)
https://github.com/axolotl-ai-cloud/axolotl/issues/2191
