### PR TITLE
Fix for offloading when using TorchAO >= 0.7.0

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -366,6 +366,7 @@ def set_module_tensor_to_device(
                             new_value.quant_max,
                             new_value.zero_point_domain,
                         )
+                        requires_grad=old_value.requires_grad,
                     ).to(device)
                 else:
                     new_value = torch.nn.Parameter(

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -365,7 +365,7 @@ def set_module_tensor_to_device(
                             new_value.quant_min,
                             new_value.quant_max,
                             new_value.zero_point_domain,
-                        )
+                        ),
                         requires_grad=old_value.requires_grad,
                     ).to(device)
                 else:

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -351,15 +351,18 @@ def set_module_tensor_to_device(
             elif param_cls.__name__ in ["QTensor", "QBitsTensor"]:
                 new_value = torch.nn.Parameter(new_value, requires_grad=old_value.requires_grad).to(device)
             elif param_cls.__name__ in ["AffineQuantizedTensor"]:
-                if (
-                    importlib.util.find_spec("torchao") is not None
-                    and compare_versions("torchao", ">=", "0.7.0")
-                ):
+                if importlib.util.find_spec("torchao") is not None and compare_versions("torchao", ">=", "0.7.0"):
                     # TorchAO v0.7.0 made layout_tensor an internal private variable and exposed tensor_impl
                     args = (new_value.tensor_impl,)
                 else:
                     args = (new_value.layout_tensor,)
-                args += (new_value.block_size, new_value.shape, new_value.quant_min, new_value.quant_max, new_value.zero_point_domain)
+                args += (
+                    new_value.block_size,
+                    new_value.shape,
+                    new_value.quant_min,
+                    new_value.quant_max,
+                    new_value.zero_point_domain,
+                )
                 new_value = torch.nn.Parameter(param_cls(*args), requires_grad=old_value.requires_grad).to(device)
             else:
                 new_value = param_cls(new_value, requires_grad=old_value.requires_grad).to(device)


### PR DESCRIPTION
# What does this PR do?

There was a breaking change made in TorchAO v0.7.0, where `layout_tensor` was made an internal private attribute and `tensor_impl` was added as another parameter.

This causes sequential offloading implementation to break in Diffusers: https://github.com/huggingface/diffusers/issues/10470

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 