### PR TITLE
[tests] make cuda-only test case device-agnostic

### DIFF
--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -176,7 +176,7 @@ class AcceleratorTester(AccelerateTestCase):
         with self.assertRaises(ValueError):
             _ = Accelerator(cpu=True)
 
-    # @require_cuda
+    @require_cuda
     def test_setting_cpu_affinity(self):
         with patch_environment(accelerate_cpu_affinity=1, accelerate_debug_mode=1):
             with self.assertLogs("accelerate.utils.environment", level="INFO") as cm:

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -176,7 +176,7 @@ class AcceleratorTester(AccelerateTestCase):
         with self.assertRaises(ValueError):
             _ = Accelerator(cpu=True)
 
-    @require_cuda
+    # @require_cuda
     def test_setting_cpu_affinity(self):
         with patch_environment(accelerate_cpu_affinity=1, accelerate_debug_mode=1):
             with self.assertLogs("accelerate.utils.environment", level="INFO") as cm:
@@ -788,7 +788,7 @@ class AcceleratorTester(AccelerateTestCase):
             assert torch.allclose(original_batchnorm, new_batchnorm)
             assert torch.allclose(original_linear2, new_linear2)
 
-    @require_cuda
+    @require_non_cpu
     @require_huggingface_suite
     def test_nested_hook(self):
         from transformers.modeling_utils import PretrainedConfig, PreTrainedModel


### PR DESCRIPTION
## What does this PR do?
This PR enables 1 cuda-only case on non-cuda hardware accelerators. Below is the test result on XPU: 
```bash
================================================= short test summary info ==================================================
PASSED tests/test_accelerator.py::AcceleratorTester::test_nested_hook
======================================= 1 passed, 417 deselected, 1 warning in 5.53s =======================================
```

cc @SunMarc and @muellerzr