### PR TITLE
fix triton version check

### DIFF
--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -228,8 +228,16 @@ def is_timm_available():
     return _is_package_available("timm")
 
 
+@lru_cache
 def is_triton_available():
-    return _is_package_available("triton")
+    try:
+        from triton.compiler.compiler import triton_key
+
+        return triton_key is not None
+    except ImportError:
+        return False
+    except RuntimeError:
+        return False
 
 
 def is_aim_available():


### PR DESCRIPTION
## What does this PR do?
Simply checking whether "triton" package is available is not enough for XPU, because "triton" only supports NV GPU, AMD GPU and CPU currently. XPU has an additional package called pytorch-triton-xpu ([link](https://github.com/intel/intel-xpu-backend-for-triton)).

The better way to check whether triton is available is to align with the way in pytorch as can be seen from [here](https://github.com/pytorch/pytorch/blob/main/torch/utils/_triton.py#L7). 


cc @muellerzr @sywangyi @yao-matrix 
