### PR TITLE
Fix immediate StopIteration in DataLoaderShard

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -562,7 +562,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         try:
             current_batch = next(dataloader_iter)
         except StopIteration:
-            yield
+            return
 
         batch_index = 0
         while True:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -578,6 +578,8 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
                 next_batch = next(dataloader_iter)
             except StopIteration:
                 self.end_of_dataloader = True
+                # Need to call update again to set "_iterator_finished"
+                self._update_state_dict()
 
             if batch_index >= self.skip_batches:
                 yield current_batch

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -570,7 +570,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
             current_batch = next_batch
             # But we still move it to the device so it is done before `StopIteration` is reached
             if self.device is not None:
-                    current_batch = send_to_device(current_batch, self.device, non_blocking=self._non_blocking)
+                current_batch = send_to_device(current_batch, self.device, non_blocking=self._non_blocking)
 
             try:
                 next_batch = next(dataloader_iter)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -558,29 +558,20 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
 
         self.set_epoch(self.iteration)
         dataloader_iter = self.base_dataloader.__iter__()
-        # We iterate one batch ahead to check when we are at the end
-        try:
-            current_batch = next(dataloader_iter)
-        except StopIteration:
-            return
 
         batch_index = 0
         while True:
             try:
-                # But we still move it to the device so it is done before `StopIteration` is reached
+                current_batch = next(dataloader_iter)
                 if self.device is not None:
                     current_batch = send_to_device(current_batch, self.device, non_blocking=self._non_blocking)
                 self._update_state_dict()
-                next_batch = next(dataloader_iter)
                 if batch_index >= self.skip_batches:
                     yield current_batch
                 batch_index += 1
-                current_batch = next_batch
             except StopIteration:
                 self.end_of_dataloader = True
                 self._update_state_dict()
-                if batch_index >= self.skip_batches:
-                    yield current_batch
                 break
 
         self.iteration += 1

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -564,6 +564,8 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
             next_batch = next(dataloader_iter)
         except StopIteration:
             self.end_of_dataloader = True
+            # Need to call update to set "_iterator_finished"
+            self._update_state_dict()
 
         batch_index = 0
         while not self.end_of_dataloader:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -572,12 +572,13 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
             if self.device is not None:
                 current_batch = send_to_device(current_batch, self.device, non_blocking=self._non_blocking)
 
+            # We need to update the state dict before iterating again
+            self._update_state_dict()
             try:
                 next_batch = next(dataloader_iter)
             except StopIteration:
                 self.end_of_dataloader = True
 
-            self._update_state_dict()
             if batch_index >= self.skip_batches:
                 yield current_batch
             batch_index += 1


### PR DESCRIPTION
Fixes DataLoaderShard to also immediately return StopIteration when its dataloader immediately returns StopIteration.

Fixes  #3367 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@muellerzr

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.