### PR TITLE
fix torch_dtype in estimate memory

### DIFF
--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import torch
 from huggingface_hub import model_info
 from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
 
@@ -24,7 +25,7 @@ from accelerate.utils import (
     is_timm_available,
     is_transformers_available,
 )
-import torch
+
 
 if is_transformers_available():
     import transformers

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -63,7 +63,7 @@ def check_has_model(error):
 
 def create_empty_model(model_name: str, library_name: str, trust_remote_code: bool = False, access_token: str = None):
     """
-    Creates an empty model from its parent library on the `Hub` to calculate the overall memory consumption.
+    Creates an empty model in full precision from its parent library on the `Hub` to calculate the overall memory consumption.
 
     Args:
         model_name (`str`):
@@ -121,6 +121,7 @@ def create_empty_model(model_name: str, library_name: str, trust_remote_code: bo
                         break
                 if value is not None:
                     constructor = getattr(transformers, value)
+            # we need to pass the dtype, otherwise it is going to use the torch_dtype that is saved in the config
             model = constructor.from_config(config, torch_dtype=torch.float32, trust_remote_code=trust_remote_code)
     elif library_name == "timm":
         if not is_timm_available():

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -63,7 +63,8 @@ def check_has_model(error):
 
 def create_empty_model(model_name: str, library_name: str, trust_remote_code: bool = False, access_token: str = None):
     """
-    Creates an empty model in full precision from its parent library on the `Hub` to calculate the overall memory consumption.
+    Creates an empty model in full precision from its parent library on the `Hub` to calculate the overall memory
+    consumption.
 
     Args:
         model_name (`str`):

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -24,7 +24,7 @@ from accelerate.utils import (
     is_timm_available,
     is_transformers_available,
 )
-
+import torch
 
 if is_transformers_available():
     import transformers
@@ -120,7 +120,7 @@ def create_empty_model(model_name: str, library_name: str, trust_remote_code: bo
                         break
                 if value is not None:
                     constructor = getattr(transformers, value)
-            model = constructor.from_config(config, trust_remote_code=trust_remote_code)
+            model = constructor.from_config(config, torch_dtype=torch.float32, trust_remote_code=trust_remote_code)
     elif library_name == "timm":
         if not is_timm_available():
             raise ImportError(


### PR DESCRIPTION
# What does this PR do ?

Fixes https://github.com/huggingface/accelerate/issues/3379
This PR fixes the estimate memory command as it gave wrong results when `torch_dtype` is specified in the config we are loading. 
