### PR TITLE
tensor parallel dataloder for deepspeed accelerator

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1705,6 +1705,7 @@ class Accelerator:
         tp_size = self.deepspeed_plugin.deepspeed_config["tensor_parallel"].get("autotp_size", 0)
         if tp_size > 1:
             from torch.distributed.device_mesh import init_device_mesh
+
             mesh_dim_name = "tp"
             self.state.ds_device_mesh = init_device_mesh(self.device.type, (tp_size,), mesh_dim_names=(mesh_dim_name,))
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1096,13 +1096,12 @@ def prepare_data_loader(
     if process_index is None:
         process_index = state.process_index
 
-
     if torch_device_mesh:
         if state.distributed_type == DistributedType.DEEPSPEED:
-            # In DeepSpeed, the optimizer sharing level in DP is determined by the config file.  
-            # Only considers "dp" and "tp".  
-            # Given a device mesh (dp, tp) = (2, 3):  
-            # - From the data parallel perspective, ranks should be structured as: 0 0 0 1 1 1  
+            # In DeepSpeed, the optimizer sharing level in DP is determined by the config file.
+            # Only considers "dp" and "tp".
+            # Given a device mesh (dp, tp) = (2, 3):
+            # - From the data parallel perspective, ranks should be structured as: 0 0 0 1 1 1
             # - Processes with the same DP rank will receive the same batch.
             if "tp" in torch_device_mesh.mesh_dim_names:
                 submesh_tp_size = torch_device_mesh["tp"].size()


### PR DESCRIPTION
This PR adds support for TP data loader in the DeepSpeed accelerator.  
The related DeepSpeed APIs are already supported.  
Currently, TP+DP training and validation (ZeRO-0 and ZeRO-1) for Llama have been successfully completed.  
(https://github.com/deepspeedai/DeepSpeed/pull/6922)   @muellerzr 

cc @sywangyi  @delock
cc DeepSpeed Member: @tjruwase  
