### PR TITLE
Support TP + FSDPv2 / HSDP or just FSDPv2 / HSDP

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1563,7 +1563,8 @@ class Accelerator:
                         "mp_policy": fsdp2_plugin.mp_policy,
                         "reshard_after_forward": fsdp2_plugin.reshard_after_forward,
                         "offload_policy": fsdp2_plugin.offload_policy,
-                        "ignored_params": fsdp2_plugin.ignored_params,
+                        # pretty recent feature so lets ignore it for now
+                        # "ignored_params": fsdp2_plugin.ignored_params,
                         "mesh": fsdp2_plugin.torch_device_mesh,
                     }
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1513,7 +1513,7 @@ class Accelerator:
         elif device_placement and not self.verify_device_map(model):
             model = model.to(self.device)
         if not evaluation_mode:
-            device_mesh = prepare_nd_device_mesh(self.state.torch_tp_plugin.tp_size if self.state.torch_tp_plugin is not None else 1, self.state.fsdp_plugin is not None)
+            device_mesh = prepare_nd_device_mesh(self.state.torch_tp_plugin.tp_size if self.state.torch_tp_plugin is not None else 1, self.state.fsdp2_plugin is not None)
             if self.distributed_type in (
                 DistributedType.MULTI_GPU,
                 DistributedType.MULTI_MLU,
@@ -1574,21 +1574,21 @@ class Accelerator:
                     #######
                     # does existing activation_checkpointing API work out of the box with FSDP2?
                     #######
-                    if fsdp_plugin.activation_checkpointing:
-                        from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-                            CheckpointImpl,
-                            apply_activation_checkpointing,
-                            checkpoint_wrapper,
-                        )
+                    # if fsdp_plugin.activation_checkpointing:
+                    #     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+                    #         CheckpointImpl,
+                    #         apply_activation_checkpointing,
+                    #         checkpoint_wrapper,
+                    #     )
 
-                        apply_activation_checkpointing(
-                            model,
-                            checkpoint_wrapper_fn=functools.partial(
-                                checkpoint_wrapper,
-                                checkpoint_impl=CheckpointImpl.NO_REENTRANT,
-                            ),
-                            auto_wrap_policy=fsdp_plugin.auto_wrap_policy,
-                        )
+                    #     apply_activation_checkpointing(
+                    #         model,
+                    #         checkpoint_wrapper_fn=functools.partial(
+                    #             checkpoint_wrapper,
+                    #             checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+                    #         ),
+                    #         auto_wrap_policy=fsdp_plugin.auto_wrap_policy,
+                    #     )
 
             elif self.distributed_type == DistributedType.FSDP:
                 # We need to fix the optimizer *before* sharding the model

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1558,14 +1558,13 @@ class Accelerator:
                 )
 
                 if not is_type_fsdp:
-                    fsdp2_plugin: FullyShardedDataParallelPlugin2 = self.state.fsdp2_plugin
                     fsdp2_kwargs  = {
-                        "mp_policy": fsdp2_plugin.mp_policy,
-                        "reshard_after_forward": fsdp2_plugin.reshard_after_forward,
-                        "offload_policy": fsdp2_plugin.offload_policy,
+                        "mp_policy": self.state.fsdp2_plugin.mp_policy,
+                        "reshard_after_forward": self.state.fsdp2_plugin.reshard_after_forward,
+                        "offload_policy": self.state.fsdp2_plugin.offload_policy,
                         # pretty recent feature so lets ignore it for now
                         # "ignored_params": fsdp2_plugin.ignored_params,
-                        "mesh": fsdp2_plugin.torch_device_mesh,
+                        "mesh": self.state.fsdp2_plugin.torch_device_mesh,
                     }
 
                     for layer in model.model.layers:

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2227,7 +2227,7 @@ class Accelerator:
         if device_placement is None:
             device_placement = self.device_placement if self.distributed_type != DistributedType.XLA else False
 
-        nd_device_mesh = prepare_nd_device_mesh(self.state.torch_tp_plugin.tp_size if self.state.torch_tp_plugin is not None else 1, self.state.fsdp_plugin is not None)
+        nd_device_mesh = prepare_nd_device_mesh(self.state.torch_tp_plugin.tp_size if self.state.torch_tp_plugin is not None else 1, self.state.fsdp2_plugin is not None)
         prepared_data_loader = prepare_data_loader(
             data_loader,
             self.device,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -73,6 +73,7 @@ options_to_group = {
     "tpu": "TPU",
     "use_deepspeed": "DeepSpeed Arguments",
     "use_fsdp": "FSDP Arguments",
+    "use_fsdp2": "FSDP2 Arguments",
     "use_tp": "PyTorch TP Arguments",
     "use_megatron_lm": "Megatron-LM Arguments",
     "fp8_backend": "FP8 Arguments",
@@ -261,6 +262,12 @@ def launch_command_parser(subparsers=None):
         default=False,
         action="store_true",
         help="Whether to use fsdp.",
+    )
+    paradigm_args.add_argument(
+        "--use_fsdp2",
+        default=False,
+        action="store_true",
+        help="Whether to use fsdpv2.",
     )
     paradigm_args.add_argument(
         "--use_tp",
@@ -602,6 +609,54 @@ def launch_command_parser(subparsers=None):
         default=1,
         type=int,
         help="PyTorch Tensor Parallelism (TP) degree. Set a value greater than 1 to activate. (useful only when `use_tp` flag is passed)",
+    )
+
+    # fsdp2 args
+    fsdp2_args = parser.add_argument_group("FSDP2 Arguments", "Arguments related to Fully Shared Data Parallelism Version 2.")
+    fsdp2_args.add_argument(
+        "--fsdp2_reshard_after_forward",
+        default="true",
+        type=str,
+        help="Decides Whether (true|false) to reshard parameters after forward pass.",
+    )
+    fsdp2_args.add_argument(
+        "--fsdp2_cpu_offload",
+        default="false",
+        type=str,
+        help="Decides Whether (true|false) to offload to CPU.",
+    )
+    fsdp2_args.add_argument(
+        "--fsdp2_cpu_offload_pin_memory",
+        default="false",
+        type=str,
+        help="Decides Whether (true|false) to pin memory during CPU offload.",
+    )
+    fsdp2_args.add_argument(
+        "--fsdp2_mp_param_dtype",
+        default="no",
+        type=str,
+        choices=["no", "fp16", "bf16", "fp8"],
+        help="Parameter datatype to be used in mixed precision training.",
+    )
+    fsdp2_args.add_argument(
+        "--fsdp2_mp_reduce_dtype",
+        default="no",
+        type=str,
+        choices=["no", "fp16", "bf16", "fp8"],
+        help="Dtype for gradient reduction to be used in mixed precision training.",
+    )
+    fsdp2_args.add_argument(
+        "--fsdp2_mp_output_dtype",
+        default="no",
+        type=str,
+        choices=["no", "fp16", "bf16", "fp8"],
+        help="Dtype for forward outputs to be used in mixed precision training.",
+    )
+    fsdp2_args.add_argument(
+        "--FSDP2_CAST_FORWARD_INPUTS",
+        default="false",
+        type=str,
+        help="Decides Whether (true|false) to cast forward inputs in mixed precision training.",
     )
 
     # megatron_lm args

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -653,7 +653,7 @@ def launch_command_parser(subparsers=None):
         help="Dtype for forward outputs to be used in mixed precision training.",
     )
     fsdp2_args.add_argument(
-        "--FSDP2_CAST_FORWARD_INPUTS",
+        "--fsdp2_cast_forward_inputs",
         default="false",
         type=str,
         help="Decides Whether (true|false) to cast forward inputs in mixed precision training.",

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -612,7 +612,9 @@ def launch_command_parser(subparsers=None):
     )
 
     # fsdp2 args
-    fsdp2_args = parser.add_argument_group("FSDP2 Arguments", "Arguments related to Fully Shared Data Parallelism Version 2.")
+    fsdp2_args = parser.add_argument_group(
+        "FSDP2 Arguments", "Arguments related to Fully Shared Data Parallelism Version 2."
+    )
     fsdp2_args.add_argument(
         "--fsdp2_reshard_after_forward",
         default="true",
@@ -1059,6 +1061,7 @@ def _validate_launch_command(args):
             and not args.tpu_use_cluster
             and not args.use_deepspeed
             and not args.use_fsdp
+            and not args.use_fsdp2
             and not args.use_tp
             and not args.use_megatron_lm
         ):
@@ -1078,6 +1081,7 @@ def _validate_launch_command(args):
             args.tpu = defaults.distributed_type == DistributedType.XLA
             args.use_fsdp = defaults.distributed_type == DistributedType.FSDP
             args.use_tp = defaults.distributed_type == DistributedType.TP
+            args.use_fsdp2 = defaults.distributed_type == DistributedType.FSDP2
             args.use_megatron_lm = defaults.distributed_type == DistributedType.MEGATRON_LM
             args.tpu_use_cluster = defaults.tpu_use_cluster if args.tpu else False
         if args.gpu_ids is None:
@@ -1236,6 +1240,8 @@ def launch_command(args):
         args.deepspeed_fields_from_accelerate_config = ",".join(args.deepspeed_fields_from_accelerate_config)
         deepspeed_launcher(args)
     elif args.use_fsdp and not args.cpu:
+        multi_gpu_launcher(args)
+    elif args.use_fsdp2 and not args.cpu:
         multi_gpu_launcher(args)
     elif args.use_tp and not args.cpu:
         multi_gpu_launcher(args)

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -851,6 +851,7 @@ class AcceleratorState:
         dynamo_plugin=None,
         deepspeed_plugin=None,
         fsdp_plugin=None,
+        fsdp2_plugin=None,
         torch_tp_plugin=None,
         megatron_lm_plugin=None,
         _from_accelerator: bool = False,
@@ -867,6 +868,7 @@ class AcceleratorState:
             self.deepspeed_plugins = None
             self.use_ipex = None
             self.torch_tp_plugin = torch_tp_plugin
+            self.fsdp2_plugin = fsdp2_plugin
             mixed_precision = (
                 parse_choice_from_env("ACCELERATE_MIXED_PRECISION", "no")
                 if mixed_precision is None
@@ -926,6 +928,10 @@ class AcceleratorState:
                     self.megatron_lm_plugin = megatron_lm_plugin
                 if os.environ.get("ACCELERATE_USE_TP", "false") == "true" or self.torch_tp_plugin is not None:
                     self.distributed_type = DistributedType.TP
+                if os.environ.get("ACCELERATE_USE_FSDP2", "false") == "true" or self.fsdp2_plugin is not None:
+                    self.distributed_type = DistributedType.FSDP2
+                    if os.environ.get("ACCELERATE_USE_TP", "false") == "true" or self.torch_tp_plugin is not None:
+                        self.distributed_type = DistributedType.FSDP2_TP
             elif self.distributed_type in [DistributedType.MULTI_CPU, DistributedType.MULTI_XPU, DistributedType.NO]:
                 if is_ipex_available():
                     # check if user disables it explicitly

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -44,6 +44,7 @@ from .dataclasses import (
     DynamoBackend,
     FP8RecipeKwargs,
     FullyShardedDataParallelPlugin,
+    FullyShardedDataParallelPlugin2,
     GradientAccumulationPlugin,
     GradScalerKwargs,
     InitProcessGroupKwargs,
@@ -272,3 +273,4 @@ from .transformer_engine import (
     convert_model,
     has_transformer_engine_layers,
 )
+from .pytorch_utils import prepare_nd_device_mesh

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1886,11 +1886,8 @@ class FullyShardedDataParallelPlugin2:
         if self.reshard_after_forward is None:
             self.reshard_after_forward = str_to_bool(os.environ.get(env_prefix + "RESHARD_AFTER_FORWARD", "True")) == 1
         
-        if isinstance(self.offload_policy, dict):
-            self.set_offload_policy()
-        
-        if isinstance(self.mp_policy, dict):
-            self.set_mp_policy()
+        self.set_offload_policy()
+        self.set_mp_policy()
 
         from torch.distributed.device_mesh import init_device_mesh
         dp_mesh_dim_name = "dp"

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -542,6 +542,8 @@ class DistributedType(str, enum.Enum):
     MULTI_XPU = "MULTI_XPU"
     DEEPSPEED = "DEEPSPEED"
     FSDP = "FSDP"
+    FSDP2 = "FSDP2"
+    FSDP2_TP = "FSDP2_TP"
     TP = "TP"
     XLA = "XLA"
     MEGATRON_LM = "MEGATRON_LM"
@@ -1816,6 +1818,135 @@ class FullyShardedDataParallelPlugin:
 
 
 @dataclass
+class FullyShardedDataParallelPlugin2:
+    """
+    This plugin is used to enable fully sharded data parallelism version 2
+
+    Args:
+        torch_device_mesh (`Optional[torch.distributed.DeviceMesh]`, defaults to `'None'`):
+            Device mesh for FSDP is automatically inferred based on reshard_after_forward and world size.
+        reshard_after_forward (`Optional[bool]`, defaults to `None`):
+            If reshard_after_forward is True, the parameters are sharded on every forward pass and all-gathered during backward pass.
+            reshard_after_forward in conjunction with device mesh dimension would mean different strategies like the following:
+            reshard_after_forward=True and 1D device mesh mean full shard
+            reshard_after_forward=True and 2D device mesh mean hybrid shard
+            reshard_after_forward=False and 1D device mesh mean shard grad and optimizer states only
+            reshard_after_forward=False and 2D device mesh mean hybrid shard with grad and optim sharding only
+        offload_policy (`Optional[Union[dict, torch.distributed._composable.OffloadPolicy]]`, defaults to `None`)::
+            A config to enable CPU offload. If passing in a `dict`, it should have the following key: `pin_memory`.
+        mp_policy (`Optional[Union[dict, torch.distributed._composable.MixedPrecisionPolicy]]`, defaults to `None`):
+            A config to enable mixed precision training with FullyShardedDataParallelv2. If passing in a `dict`, it
+            should have the following keys: `param_dtype`, `reduce_dtype`, `output_dtype`, and cast_forward_inputs.
+        ignored_params: Optional(set[torch.nn.Parameter]): The set of parameters that we
+            don't want to shard with FSDP.
+    """
+
+    torch_device_mesh: Optional["torch.distributed.DeviceMesh"] = field(
+        default=None,
+        metadata={
+            "help": "Device mesh for FSDP is automatically inferred based on reshard_after_forward and world size."
+        },
+    )
+    reshard_after_forward: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": 
+                "If reshard_after_forward is True, the parameters are sharded on every forward pass and all-gathered during backward pass."
+                "reshard_after_forward in conjunction with device mesh dimension would mean different strategies like the following:"
+                "reshard_after_forward=True and 1D device mesh mean full shard"
+                "reshard_after_forward=True and 2D device mesh mean hybrid shard"
+                "reshard_after_forward=False and 1D device mesh mean shard grad and optimizer states only"
+                "reshard_after_forward=False and 2D device mesh mean hybrid shard with grad and optim sharding only"
+        },
+    )
+    offload_policy: Optional[Union[dict, "torch.distributed._composable.OffloadPolicy"]] = field(
+        default=None,
+        metadata={
+            "help": "A config to enable CPU offload. If passing in a `dict`, it should have the following key: `pin_memory`."
+        },
+    )
+    mp_policy: Optional[Union[dict, "torch.distributed._composable.MixedPrecisionPolicy"]] = (
+        field(
+            default=None,
+            metadata={
+                "help": "A config to enable mixed precision training with FullyShardedDataParallelv2. If passing in a `dict`, it"
+            "should have the following keys: `param_dtype`, `reduce_dtype`, `output_dtype`, and `cast_forward_inputs`. "
+            },
+        )
+    )
+    ignored_params: Optional[set["torch.nn.Parameter"]] = field(
+        default=None,
+        metadata={
+            "help": "The set of parameters that we don't want to shard with FSDP."
+        },
+    )
+
+    def __post_init__(self):
+        env_prefix = "FSDP2_"
+        if self.reshard_after_forward is None:
+            self.reshard_after_forward = str_to_bool(os.environ.get(env_prefix + "RESHARD_AFTER_FORWARD", "True")) == 1
+        
+        if isinstance(self.offload_policy, dict):
+            self.set_offload_policy()
+        
+        if isinstance(self.mp_policy, dict):
+            self.set_mp_policy()
+
+        from torch.distributed.device_mesh import init_device_mesh
+        dp_mesh_dim_name = "dp"
+        fsdp_mesh_dim_name = "fsdp"
+        device = "cuda"  # support for other devices has to be investigated
+        num_nodes = torch.distributed.get_world_size() // torch.cuda.device_count()
+        nproc_per_node = torch.cuda.device_count()
+        self.torch_device_mesh = init_device_mesh(device, (num_nodes,nproc_per_node), mesh_dim_names=(dp_mesh_dim_name, fsdp_mesh_dim_name))
+
+    def set_offload_policy(self, pin_memory=None):
+        """
+        Set the offload policy
+        """
+        from torch.distributed._composable.fsdp import CPUOffloadPolicy
+        env_prefix = "FSDP2_"
+        
+        if self.offload_policy is None:
+            fsdp2_cpu_offload = str_to_bool(os.environ.get(env_prefix + "CPU_OFFLOAD", "False")) == 1
+            if fsdp2_cpu_offload:
+                pin_memory = str_to_bool(os.environ.get(env_prefix + "CPU_OFFLOAD_PIN_MEMORY", "False")) == 1
+            if pin_memory is not None:
+                self.offload_policy = CPUOffloadPolicy(pin_memory=pin_memory)
+        if isinstance(self.offload_policy, dict):
+            self.offload_policy = CPUOffloadPolicy(**self.offload_policy)
+
+    def set_mp_policy(self, param_dtype=None, reduce_dtype=None, output_dtype=None, cast_forward_inputs=None):
+        """
+        Set mixed precision policy
+        """
+        from torch.distributed._composable.fsdp import MixedPrecisionPolicy
+        env_prefix = "FSDP2_"
+        mixed_precision_mapping = {
+            "fp8": torch.bfloat16,
+            "fp16": torch.float16,
+            "bf16": torch.bfloat16,
+            "fp32": torch.float32,
+        }
+
+        # current_env["FSDP2_MP_PARAM_DTYPE"] = str(args.fsdp2_mp_param_dtype).lower()
+        # current_env["FSDP2_MP_REDUCE_DTYPE"] = str(args.fsdp2_mp_reduce_dtype).lower()
+        # current_env["FSDP2_MP_OUTPUT_DTYPE"] = str(args.fsdp2_mp_output_dtype).lower()
+        # current_env["FSDP2_CAST_FORWARD_INPUTS"] = str(args.fsdp2_cast_forward_inputs).lower()
+        
+        if self.mp_policy is None:
+            param_dtype = mixed_precision_mapping.get(os.environ.get(env_prefix + "MP_PARAM_DTYPE", param_dtype), None)
+            reduce_dtype = mixed_precision_mapping.get(os.environ.get(env_prefix + "MP_REDUCE_DTYPE", reduce_dtype), None)
+            output_dtype = mixed_precision_mapping.get(os.environ.get(env_prefix + "MP_OUTPUT_DTYPE", output_dtype), None)
+            if not cast_forward_inputs:
+                cast_forward_inputs = str_to_bool(os.environ.get(env_prefix + "CAST_FORWARD_INPUTS", "False")) == 1
+            self.mp_policy = MixedPrecisionPolicy(param_dtype=param_dtype, reduce_dtype=reduce_dtype, output_dtype=output_dtype, cast_forward_inputs=cast_forward_inputs)
+
+        if isinstance(self.mp_policy, dict):
+            self.mp_policy = MixedPrecisionPolicy(**self.mp_policy)
+
+
+@dataclass
 class TorchTensorParallelPlugin:
     """
     This plugin is used to enable tensor parallelism using PyTorch >= 2.0.
@@ -1826,7 +1957,7 @@ class TorchTensorParallelPlugin:
         metadata={"help": "tensor parallel size will be used in the device mesh preparation"},
     )
 
-    # torch_device_mesh is fo type "torch.distributed.DeviceMesh"
+    # torch_device_mesh is of type "torch.distributed.DeviceMesh"
     torch_device_mesh: Optional["torch.distributed.DeviceMesh"] = field(default=None)
 
     def __post_init__(self):
@@ -1844,6 +1975,47 @@ class TorchTensorParallelPlugin:
         device = "cuda"  # support for other devices has to be investigated
         self.torch_device_mesh = init_device_mesh(device, (self.tp_size,), mesh_dim_names=(mesh_dim_name,))
 
+
+@dataclass
+class DeviceMeshHandler:
+    """
+    This handler is used to create and hold device mesh state throughout the training 
+    and dynamically support any combination of parallelisms.
+    """
+
+    tp_size: int = field(
+        default=1,
+        metadata={"help": "tensor parallel size will be used in the device mesh preparation with other parallelisms."},
+    )
+    
+    use_fsdp: bool = field(
+        default=False,
+        metadata={"help": "fsdp v2 will be used with other parallelisms for device mesh preparation."},
+    )
+
+    torch_device_mesh: Optional["torch.distributed.DeviceMesh"] = field(default=None)
+
+    def __post_init__(self):
+        self.tp_size = self.tp_size if os.environ.get("TP_SIZE", "1") == "1" else int(os.environ.get("TP_SIZE", "1"))
+        self.use_fsdp = self.use_fsdp or str_to_bool(os.environ.get("ACCELERATE_USE_FSDP2", "False")) == 1
+        if self.tp_size == 1:
+            raise ValueError("Provide TP degree > 1.")
+
+        if is_torch_version("<", BETA_TP_AVAILABLE_PYTORCH_VERSION):
+            raise ValueError(
+                f"Minimum PyTorch version {BETA_TP_AVAILABLE_PYTORCH_VERSION} needed to use tensor parallel."
+            )
+        from torch.distributed.device_mesh import init_device_mesh
+
+        mesh_dim_names = ("tp",)
+        mesh_dims = (self.tp_size,)
+        if self.use_fsdp:
+            num_nodes = torch.distributed.get_world_size() // torch.cuda.device_count()
+            nproc_per_node = torch.cuda.device_count()
+            mesh_dim_names = ("dp", "fsdp",) + mesh_dim_names
+            mesh_dims = (num_nodes, nproc_per_node, ) + mesh_dims
+        device = "cuda"  # support for other devices has to be investigated
+        self.torch_device_mesh = init_device_mesh(device, mesh_dims, mesh_dim_names=mesh_dim_names)
 
 @dataclass
 class MegatronLMPlugin:

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -290,6 +290,16 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
         current_env["FSDP_SYNC_MODULE_STATES"] = str(args.fsdp_sync_module_states).lower()
         current_env["FSDP_ACTIVATION_CHECKPOINTING"] = str(args.fsdp_activation_checkpointing).lower()
 
+    if args.use_fsdp2:
+        current_env["ACCELERATE_USE_FSDP2"] = "true"
+        current_env["FSDP2_RESHARD_AFTER_FORWARD"] = str(args.fsdp2_reshard_after_forward).lower()
+        current_env["FSDP2_CPU_OFFLOAD"] = str(args.fsdp2_cpu_offload).lower()
+        current_env["FSDP2_CPU_OFFLOAD_PIN_MEMORY"] = str(args.fsdp2_cpu_offload_pin_memory).lower()
+        current_env["FSDP2_MP_PARAM_DTYPE"] = str(args.fsdp2_mp_param_dtype).lower()
+        current_env["FSDP2_MP_REDUCE_DTYPE"] = str(args.fsdp2_mp_reduce_dtype).lower()
+        current_env["FSDP2_MP_OUTPUT_DTYPE"] = str(args.fsdp2_mp_output_dtype).lower()
+        current_env["FSDP2_CAST_FORWARD_INPUTS"] = str(args.fsdp2_cast_forward_inputs).lower()
+
     if args.use_tp:
         current_env["ACCELERATE_USE_TP"] = "true"
         current_env["TP_SIZE"] = str(args.tp_size)

--- a/src/accelerate/utils/pytorch_utils.py
+++ b/src/accelerate/utils/pytorch_utils.py
@@ -1,0 +1,21 @@
+import torch
+
+def prepare_nd_device_mesh(tp_size=1, use_fsdp=False):
+    """Returns a multi dimensional device mesh.
+    Extend this function to support various combinations of parallelisms.
+    """
+    from torch.distributed.device_mesh import init_device_mesh
+    mesh_dim_names = ()
+    mesh_dims = ()
+    if tp_size <= 1 and not use_fsdp:
+        return None
+    if tp_size > 1:
+        mesh_dim_names = ("tp",)
+        mesh_dims = (tp_size,)
+    if use_fsdp:
+        num_nodes = torch.distributed.get_world_size() // torch.cuda.device_count()
+        nproc_per_node = torch.cuda.device_count()
+        mesh_dim_names = ("dp", "fsdp",) + mesh_dim_names
+        mesh_dims = (num_nodes, nproc_per_node, ) + mesh_dims
+    device = "cuda"
+    return init_device_mesh(device, mesh_dims, mesh_dim_names=mesh_dim_names)

--- a/src/accelerate/utils/pytorch_utils.py
+++ b/src/accelerate/utils/pytorch_utils.py
@@ -1,10 +1,12 @@
 import torch
 
+
 def prepare_nd_device_mesh(tp_size=1, use_fsdp=False):
     """Returns a multi dimensional device mesh.
     Extend this function to support various combinations of parallelisms.
     """
     from torch.distributed.device_mesh import init_device_mesh
+
     mesh_dim_names = ()
     mesh_dims = ()
     if tp_size <= 1 and not use_fsdp:
@@ -15,7 +17,13 @@ def prepare_nd_device_mesh(tp_size=1, use_fsdp=False):
     if use_fsdp:
         num_nodes = torch.distributed.get_world_size() // torch.cuda.device_count()
         nproc_per_node = torch.cuda.device_count()
-        mesh_dim_names = ("dp", "fsdp",) + mesh_dim_names
-        mesh_dims = (num_nodes, nproc_per_node, ) + mesh_dims
+        mesh_dim_names = (
+            "dp",
+            "fsdp",
+        ) + mesh_dim_names
+        mesh_dims = (
+            num_nodes,
+            nproc_per_node // tp_size,
+        ) + mesh_dims
     device = "cuda"
     return init_device_mesh(device, mesh_dims, mesh_dim_names=mesh_dim_names)


### PR DESCRIPTION
# What does this PR do?

1. This PR proposes having FSDP2 as a separate distributed type for accelerate residing along with the FSDPv1 implementation. 
2. Furthermore, the PR also proposes use of `prepare_nd_device_mesh` util function to extend creation of device meshes for any combination of parallelisms. Currently it supports any combination of TP and FSDP/HSDP
3. This PR should potentially supersede https://github.com/huggingface/accelerate/pull/3231



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc @muellerzr
@kwen2501 from PyTorch