### PR TITLE
add xpu check in `get_quantized_model_device_map`

### DIFF
--- a/docs/source/usage_guides/quantization.md
+++ b/docs/source/usage_guides/quantization.md
@@ -86,7 +86,7 @@ To quantize your empty model with the selected configuration, you need to use [`
 
 ```py
 from accelerate.utils import load_and_quantize_model
-quantized_model = load_and_quantize_model(empty_model, weights_location=weights_location, bnb_quantization_config=bnb_quantization_config, device_map = "auto")
+quantized_model = load_and_quantize_model(empty_model, weights_location=weights_location, bnb_quantization_config=bnb_quantization_config)
 ```
 
 ### Saving and loading 8-bit model

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -169,7 +169,6 @@ def load_and_quantize_model(
             model = replace_with_bnb_layers(
                 model, bnb_quantization_config, modules_to_not_convert=modules_to_not_convert
             )
-
         device_map = get_quantized_model_device_map(
             model,
             bnb_quantization_config,
@@ -201,6 +200,8 @@ def get_quantized_model_device_map(
     if device_map is None:
         if torch.cuda.is_available():
             device_map = {"": torch.cuda.current_device()}
+        elif torch.xpu.is_available():
+            device_map = {"": torch.xpu.current_device()}
         else:
             raise RuntimeError("No GPU found. A GPU is needed for quantization.")
         logger.info("The device_map was not initialized." "Setting device_map to `{'':torch.cuda.current_device()}`.")


### PR DESCRIPTION
## What does this PR do?
When going through the following code example in `Model quantization` doc, the below code returns error that no GPU is found. This PR can fixes this error. 
```bash
from accelerate import init_empty_weights
from mingpt.model import GPT
import torch

model_config = GPT.get_default_config()
model_config.model_type = 'gpt2-xl'
model_config.vocab_size = 50257
model_config.block_size = 1024

with init_empty_weights():
    empty_model = GPT(model_config)
    
from huggingface_hub import snapshot_download
weights_location = snapshot_download(repo_id="marcsun13/gpt2-xl-linear-sharded")

from accelerate.utils import BnbQuantizationConfig
bnb_quantization_config = BnbQuantizationConfig(load_in_4bit=True, bnb_4bit_compute_dtype=torch.bfloat16, bnb_4bit_use_double_quant=True, bnb_4bit_quant_type="nf4")

# Generate the device map
from accelerate.utils import load_and_quantize_model
quantized_model = load_and_quantize_model(empty_model, weights_location=weights_location, bnb_quantization_config=bnb_quantization_config)
```
Another issue I found is that with "device_map="auto" the following error returns:
I got the following error: 
```bash
Traceback (most recent call last):
  File "/home/sdp/fanli/doc_to_fix.py", line 21, in <module>
    quantized_model = load_and_quantize_model(empty_model, no_split_module_classes=["GPT"], weights_location=weights_location, bnb_quantization_config=bnb_quantization_config, device_map="auto")
  File "/home/sdp/fanli/accelerate/src/accelerate/utils/bnb.py", line 184, in load_and_quantize_model
    load_checkpoint_in_model(
  File "/home/sdp/fanli/accelerate/src/accelerate/utils/modeling.py", line 1903, in load_checkpoint_in_model
    raise ValueError(f"{param_name} doesn't have any device set.")
ValueError: transformer.h.5.attn.bias doesn't have any device set.
```
It seems that GPT should be a no_split_module (see https://github.com/huggingface/transformers/issues/23294). So I removed the `device_map="auto"`, but I am not 100% sure. If you have any ideas or suggestion, pls let me know and I can further investigate it. 


cc @SunMarc and @muellerzr 