### PR TITLE
xpu: enable xccl distributed backend

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -48,6 +48,7 @@ from .utils import (
     is_npu_available,
     is_sdaa_available,
     is_torch_xla_available,
+    is_xccl_available,
     is_xpu_available,
     parse_choice_from_env,
     parse_flag_from_env,
@@ -768,6 +769,10 @@ class PartialState:
                 if backend is None:
                     backend = "nccl"
                 distributed_type = DistributedType.MULTI_GPU
+            elif is_xpu_available() and is_xccl_available():
+                if backend is None:
+                    backend = "xccl"
+                distributed_type = DistributedType.MULTI_XPU
 
         if distributed_type is None and (
             int(os.environ.get("LOCAL_RANK", -1)) != -1

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -133,6 +133,7 @@ from .imports import (
     is_triton_available,
     is_wandb_available,
     is_weights_only_available,
+    is_xccl_available,
     is_xpu_available,
     torchao_required,
 )

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -62,6 +62,17 @@ def is_torch_distributed_available() -> bool:
     return _torch_distributed_available
 
 
+def is_xccl_available():
+    # Currently IPEX uses custom "ccl" distributed backend. Return False for "xccl"
+    # here to avoid collisions.
+    if is_ipex_available():
+        return False
+    # TODO: switch to is_torch_version() once torch 2.7 will be released
+    if version.parse(torch.__version__).release >= version.parse("2.7").release:
+        return torch.distributed.distributed_c10d.is_xccl_available()
+    return False
+
+
 def is_ccl_available():
     try:
         pass


### PR DESCRIPTION
xccl distributed backend is available for XPU device backend starting from torch 2.7 (requires torch built with `USE_XCCL=1 USE_C10D_XCCL=1`).

This change is verified with the following Transformers tests:
* `tests/extended/test_trainer_ext.py`
* `tests/trainer/test_trainer_distributed.py`

This commit does not impact IPEX which currently remains using custom distributed backend.

CC: @muellerzr