### PR TITLE
Fix device KeyError in tied_params_map

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -393,7 +393,8 @@ class AlignDevicesHook(ModelHook):
                         device = f"mlu:{device}"
                     elif is_musa_available():
                         device = f"musa:{device}"
-                del self.tied_params_map[value_pointer][device]
+                if device in self.tied_params_map[value_pointer]:
+                    del self.tied_params_map[value_pointer][device]
             self.tied_pointers_to_remove = set()
         if self.io_same_device and self.input_device is not None:
             output = send_to_device(output, self.input_device, skip_keys=self.skip_keys)


### PR DESCRIPTION
Fixes: #3402

The #3448 is a better way to fix the reported #3402, but the fix is XPU specific (as well as 3402 to be fair). I do worry that the issue might still exists for accelerators other than cuda and xpu which got aligned behavior after 3448. I don't have a way to verify that however. So, I am rebasing this PR and leave that to maintainers and users/developers of non-cuda/xpu devices to take it from here if needed. Better way however might be to aligned behavior of these accelerators on pytorch side and then make a fix similar to 3448.

CC: @SunMarc @faaany @zucchini-nlp