### PR TITLE
[bug] fix device index bug for model training loaded with bitsandbytes

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1478,9 +1478,12 @@ class Accelerator:
                 )
             elif len(model_devices) == 1:
                 current_device = list(model_devices)[0]
-                current_device_index = (
-                    current_device.index if isinstance(current_device, torch.device) else current_device
-                )
+                if isinstance(current_device, torch.device):
+                    current_device_index = current_device.index
+                elif isinstance(current_device, str):
+                    current_device_index = torch.device(current_device).index
+                else:
+                    current_device_index = current_device
 
                 if self.device.type == "cpu" and is_bitsandbytes_multi_backend_available():
                     # bnb with multi-backend supports CPU which don't need to check index.


### PR DESCRIPTION
## What does this PR do?
I am running following TRL test on a single device:
```bash
pytest -rA tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_23_trl_internal_testing_tiny_MistralForCausalLM_0_2
```
But it fails on XPU, but works on CUDA. Then I found that the root cause is that in [this ](https://github.com/huggingface/accelerate/blob/8039158d71418e4520113e43bfe3567ffeedd7db/src/accelerate/big_modeling.py#L485) line of code, `device` on CUDA is an integer value 0, but on XPU it is "xpu:0". 

This PR fixes this error. After the fix, all tests passed:
```bash
==================================================== short test summary info =====================================================
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_0_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_1_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_2_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_3_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_4_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_5_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_6_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_bare_model_7_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_00_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_01_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_02_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_03_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_04_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_05_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_06_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_07_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_08_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_09_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_10_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_11_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_12_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_13_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_14_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_15_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_16_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_17_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_18_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_19_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_20_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_21_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_22_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_23_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_00_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_01_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_02_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_03_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_04_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_05_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_06_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_07_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_08_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_09_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_10_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_11_trl_internal_testing_tiny_LlamaForCausalLM_3_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_12_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_13_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_14_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_15_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_16_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_17_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_18_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_19_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_20_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_21_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_22_trl_internal_testing_tiny_MistralForCausalLM_0_2
PASSED tests/slow/test_dpo_slow.py::DPOTrainerSlowTester::test_dpo_peft_model_qlora_23_trl_internal_testing_tiny_MistralForCausalLM_0_2
================================== 56 passed, 729 deselected, 70 warnings in 289.52s (0:04:49) ===================================
```


cc @SunMarc and @muellerzr 
