### PR TITLE
Add `log_artifact`, `log_artifacts` and `log_figure` capabilities to the MLflowTracker.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["deepspeed"] = ["deepspeed"]
 extras["rich"] = ["rich"]
 
-extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard", "dvclive"]
+extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard", "dvclive", "mlflow", "matplotlib"]
 extras["dev"] = extras["quality"] + extras["testing"] + extras["rich"]
 
 extras["sagemaker"] = [

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -42,6 +42,7 @@ from ..utils import (
     is_deepspeed_available,
     is_dvclive_available,
     is_import_timer_available,
+    is_matplotlib_available,
     is_mlflow_available,
     is_mlu_available,
     is_mps_available,
@@ -439,6 +440,13 @@ def require_torchao(test_case):
     Decorator marking a test that requires torchao installed. These tests are skipped when torchao isn't installed
     """
     return unittest.skipUnless(is_torchao_available(), "test requires torchao")(test_case)
+
+
+def require_matplotlib(test_case):
+    """
+    Decorator marking a test that requires matplotlib installed. These tests are skipped when matplotlib isn't installed
+    """
+    return unittest.skipUnless(is_matplotlib_available(), "test requires matplotlib")(test_case)
 
 
 _atleast_one_tracker_available = (

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -42,6 +42,7 @@ from ..utils import (
     is_deepspeed_available,
     is_dvclive_available,
     is_import_timer_available,
+    is_mlflow_available,
     is_mlu_available,
     is_mps_available,
     is_musa_available,
@@ -401,6 +402,13 @@ def require_pandas(test_case):
     Decorator marking a test that requires pandas installed. These tests are skipped when pandas isn't installed
     """
     return unittest.skipUnless(is_pandas_available(), "test requires pandas")(test_case)
+
+
+def require_mlflow(test_case):
+    """
+    Decorator marking a test that requires mlflow installed. These tests are skipped when mlflow isn't installed
+    """
+    return unittest.skipUnless(is_mlflow_available(), "test requires mlflow")(test_case)
 
 
 def require_pippy(test_case):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -444,7 +444,8 @@ def require_torchao(test_case):
 
 def require_matplotlib(test_case):
     """
-    Decorator marking a test that requires matplotlib installed. These tests are skipped when matplotlib isn't installed
+    Decorator marking a test that requires matplotlib installed. These tests are skipped when matplotlib isn't
+    installed
     """
     return unittest.skipUnless(is_matplotlib_available(), "test requires matplotlib")(test_case)
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -712,6 +712,48 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Successfully logged to mlflow")
 
     @on_main_process
+    def log_figure(self,
+                  figure: Any,
+                  artifact_file: str,
+                  **save_kwargs):
+        """
+        Logs an image to the current run.
+
+        Args:
+            figure (Any):
+            The figure to be logged.
+            artifact_file (`str`, *optional*):
+            The run-relative artifact file path in posixpath format to which the image is saved.
+            If not provided, the image is saved to a default location.
+            **kwargs:
+            Additional keyword arguments passed to the underlying mlflow.log_image function.
+        """
+        import mlflow
+
+        mlflow.log_figure(figure=figure, artifact_file=artifact_file, **save_kwargs)
+        logger.debug("Successfully logged image to mlflow")
+
+    @on_main_process
+    def log_artifacts(self,
+                      local_dir: str,
+                      artifact_path: Optional[str] = None):
+        """
+        Logs an artifact (file) to the current run.
+
+            local_dir (`str`):
+                Path to the directory to be logged as an artifact.
+            artifact_path (`str`, *optional*):
+                Directory within the run's artifact directory where the artifact will be logged.
+                If omitted, the artifact will be logged to the root of the run's artifact directory.
+                The run step. If included, the artifact will be affiliated with this step.
+        """
+        import mlflow
+
+        mlflow.log_artifacts(local_dir=local_dir, artifact_path=artifact_path)
+        logger.debug("Successfully logged artofact to mlflow")
+
+
+    @on_main_process
     def finish(self):
         """
         End the active MLflow run.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -717,7 +717,7 @@ class MLflowTracker(GeneralTracker):
                   artifact_file: str,
                   **save_kwargs):
         """
-        Logs an image to the current run.
+        Logs an figure to the current run.
 
         Args:
             figure (Any):
@@ -738,7 +738,7 @@ class MLflowTracker(GeneralTracker):
                       local_dir: str,
                       artifact_path: Optional[str] = None):
         """
-        Logs an artifact (file) to the current run.
+        Logs an artifacts (all content of a dir) to the current run.
 
             local_dir (`str`):
                 Path to the directory to be logged as an artifact.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -738,9 +738,9 @@ class MLflowTracker(GeneralTracker):
             local_dir (`str`):
                 Path to the directory to be logged as an artifact.
             artifact_path (`str`, *optional*):
-                Directory within the run's artifact directory where the artifact will be logged.
-                If omitted, the artifact will be logged to the root of the run's artifact directory.
-                The run step. If included, the artifact will be affiliated with this step.
+                Directory within the run's artifact directory where the artifact will be logged. If omitted, the
+                artifact will be logged to the root of the run's artifact directory. The run step. If included, the
+                artifact will be affiliated with this step.
         """
         import mlflow
 
@@ -755,9 +755,9 @@ class MLflowTracker(GeneralTracker):
             local_path (`str`):
                 Path to the file to be logged as an artifact.
             artifact_path (`str`, *optional*):
-                Directory within the run's artifact directory where the artifact will be logged.
-                If omitted, the artifact will be logged to the root of the run's artifact directory.
-                The run step. If included, the artifact will be affiliated with this step.
+                Directory within the run's artifact directory where the artifact will be logged. If omitted, the
+                artifact will be logged to the root of the run's artifact directory. The run step. If included, the
+                artifact will be affiliated with this step.
         """
         import mlflow
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -752,6 +752,24 @@ class MLflowTracker(GeneralTracker):
         mlflow.log_artifacts(local_dir=local_dir, artifact_path=artifact_path)
         logger.debug("Successfully logged artofact to mlflow")
 
+    @on_main_process
+    def log_artifact(self,
+                      local_path: str,
+                      artifact_path: Optional[str] = None):
+        """
+        Logs an artifact (file) to the current run.
+
+            local_path (`str`):
+                Path to the file to be logged as an artifact.
+            artifact_path (`str`, *optional*):
+                Directory within the run's artifact directory where the artifact will be logged.
+                If omitted, the artifact will be logged to the root of the run's artifact directory.
+                The run step. If included, the artifact will be affiliated with this step.
+        """
+        import mlflow
+
+        mlflow.log_artifact(local_path=local_path, artifact_path=artifact_path)
+        logger.debug("Successfully logged artofact to mlflow")
 
     @on_main_process
     def finish(self):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -712,66 +712,6 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Successfully logged to mlflow")
 
     @on_main_process
-    def log_figure(self,
-                  figure: Any,
-                  artifact_file: str,
-                  **save_kwargs):
-        """
-        Logs an image to the current run.
-
-        Args:
-            figure (Any):
-            The figure to be logged.
-            artifact_file (`str`, *optional*):
-            The run-relative artifact file path in posixpath format to which the image is saved.
-            If not provided, the image is saved to a default location.
-            **kwargs:
-            Additional keyword arguments passed to the underlying mlflow.log_image function.
-        """
-        import mlflow
-
-        mlflow.log_figure(figure=figure, artifact_file=artifact_file, **save_kwargs)
-        logger.debug("Successfully logged image to mlflow")
-
-    @on_main_process
-    def log_artifacts(self,
-                      local_dir: str,
-                      artifact_path: Optional[str] = None):
-        """
-        Logs an artifact (file) to the current run.
-
-            local_dir (`str`):
-                Path to the directory to be logged as an artifact.
-            artifact_path (`str`, *optional*):
-                Directory within the run's artifact directory where the artifact will be logged.
-                If omitted, the artifact will be logged to the root of the run's artifact directory.
-                The run step. If included, the artifact will be affiliated with this step.
-        """
-        import mlflow
-
-        mlflow.log_artifacts(local_dir=local_dir, artifact_path=artifact_path)
-        logger.debug("Successfully logged artofact to mlflow")
-
-    @on_main_process
-    def log_artifact(self,
-                      local_path: str,
-                      artifact_path: Optional[str] = None):
-        """
-        Logs an artifact (file) to the current run.
-
-            local_path (`str`):
-                Path to the file to be logged as an artifact.
-            artifact_path (`str`, *optional*):
-                Directory within the run's artifact directory where the artifact will be logged.
-                If omitted, the artifact will be logged to the root of the run's artifact directory.
-                The run step. If included, the artifact will be affiliated with this step.
-        """
-        import mlflow
-
-        mlflow.log_artifact(local_path=local_path, artifact_path=artifact_path)
-        logger.debug("Successfully logged artofact to mlflow")
-
-    @on_main_process
     def finish(self):
         """
         End the active MLflow run.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -712,10 +712,7 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Successfully logged to mlflow")
 
     @on_main_process
-    def log_figure(self,
-                  figure: Any,
-                  artifact_file: str,
-                  **save_kwargs):
+    def log_figure(self, figure: Any, artifact_file: str, **save_kwargs):
         """
         Logs an figure to the current run.
 
@@ -734,9 +731,7 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Successfully logged image to mlflow")
 
     @on_main_process
-    def log_artifacts(self,
-                      local_dir: str,
-                      artifact_path: Optional[str] = None):
+    def log_artifacts(self, local_dir: str, artifact_path: Optional[str] = None):
         """
         Logs an artifacts (all content of a dir) to the current run.
 
@@ -753,9 +748,7 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Successfully logged artofact to mlflow")
 
     @on_main_process
-    def log_artifact(self,
-                      local_path: str,
-                      artifact_path: Optional[str] = None):
+    def log_artifact(self, local_path: str, artifact_path: Optional[str] = None):
         """
         Logs an artifact (file) to the current run.
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -712,6 +712,66 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Successfully logged to mlflow")
 
     @on_main_process
+    def log_figure(self,
+                  figure: Any,
+                  artifact_file: str,
+                  **save_kwargs):
+        """
+        Logs an image to the current run.
+
+        Args:
+            figure (Any):
+            The figure to be logged.
+            artifact_file (`str`, *optional*):
+            The run-relative artifact file path in posixpath format to which the image is saved.
+            If not provided, the image is saved to a default location.
+            **kwargs:
+            Additional keyword arguments passed to the underlying mlflow.log_image function.
+        """
+        import mlflow
+
+        mlflow.log_figure(figure=figure, artifact_file=artifact_file, **save_kwargs)
+        logger.debug("Successfully logged image to mlflow")
+
+    @on_main_process
+    def log_artifacts(self,
+                      local_dir: str,
+                      artifact_path: Optional[str] = None):
+        """
+        Logs an artifact (file) to the current run.
+
+            local_dir (`str`):
+                Path to the directory to be logged as an artifact.
+            artifact_path (`str`, *optional*):
+                Directory within the run's artifact directory where the artifact will be logged.
+                If omitted, the artifact will be logged to the root of the run's artifact directory.
+                The run step. If included, the artifact will be affiliated with this step.
+        """
+        import mlflow
+
+        mlflow.log_artifacts(local_dir=local_dir, artifact_path=artifact_path)
+        logger.debug("Successfully logged artofact to mlflow")
+
+    @on_main_process
+    def log_artifact(self,
+                      local_path: str,
+                      artifact_path: Optional[str] = None):
+        """
+        Logs an artifact (file) to the current run.
+
+            local_path (`str`):
+                Path to the file to be logged as an artifact.
+            artifact_path (`str`, *optional*):
+                Directory within the run's artifact directory where the artifact will be logged.
+                If omitted, the artifact will be logged to the root of the run's artifact directory.
+                The run step. If included, the artifact will be affiliated with this step.
+        """
+        import mlflow
+
+        mlflow.log_artifact(local_path=local_path, artifact_path=artifact_path)
+        logger.debug("Successfully logged artofact to mlflow")
+
+    @on_main_process
     def finish(self):
         """
         End the active MLflow run.

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -101,6 +101,7 @@ from .imports import (
     is_import_timer_available,
     is_ipex_available,
     is_lomo_available,
+    is_matplotlib_available,
     is_megatron_lm_available,
     is_mlflow_available,
     is_mlu_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -288,6 +288,10 @@ def is_pandas_available():
     return _is_package_available("pandas")
 
 
+def is_matplotlib_available():
+    return _is_package_available("matplotlib")
+
+
 def is_mlflow_available():
     if _is_package_available("mlflow"):
         return True

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -37,12 +37,13 @@ from accelerate.test_utils.testing import (
     require_clearml,
     require_comet_ml,
     require_dvclive,
+    require_mlflow,
     require_pandas,
     require_tensorboard,
     require_wandb,
     skip,
 )
-from accelerate.tracking import CometMLTracker, GeneralTracker
+from accelerate.tracking import CometMLTracker, GeneralTracker, MLflowTracker
 from accelerate.utils import (
     ProjectConfiguration,
     is_comet_ml_available,
@@ -199,6 +200,89 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
         assert logged_items["iteration"] == "1"
         assert logged_items["my_text"] == "some_value"
         assert logged_items["_step"] == "0"
+
+
+@require_mlflow
+class MLflowTrackingTest(unittest.TestCase):
+    def _get_tracker(self, tmpdir: str) -> MLflowTracker:
+        """
+        Helper to instantiate a MLflowTracker.
+        We patch out the MLflow initialization functions so that the tracker can be created without side effects.
+        """
+        patch_search = mock.patch("mlflow.search_experiments", return_value=[])
+        patch_create = mock.patch("mlflow.create_experiment", return_value="exp_id")
+        patch_start = mock.patch("mlflow.start_run")
+        patch_end = mock.patch("mlflow.end_run")
+        self.addCleanup(patch_search.stop)
+        self.addCleanup(patch_create.stop)
+        self.addCleanup(patch_start.stop)
+        self.addCleanup(patch_end.stop)
+        mock_search = patch_search.start()
+        patch_create.start()
+        mock_start = patch_start.start()
+        patch_end.start()
+        # Return a dummy run from mlflow.start_run so that self.active_run is set.
+        dummy_run = mock.Mock()
+        mock_start.return_value = dummy_run
+        tracker = MLflowTracker(experiment_name="test_exp", logging_dir=tmpdir)
+        return tracker
+
+    def test_log(self):
+        """Test that log calls mlflow.log_metrics with only numeric values and the correct step."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            values = {
+                "accuracy": 0.95,
+                "loss": 0.1,
+                "non_numeric": "text",  # This should be filtered out
+            }
+            with mock.patch("mlflow.log_metrics") as mock_log_metrics:
+                tracker = self._get_tracker(tmpdir)
+                tracker.log(values, step=5)
+                # Expect only numeric values to be logged
+                mock_log_metrics.assert_called_once_with({"accuracy": 0.95, "loss": 0.1}, step=5)
+
+    def test_log_figure(self):
+        """Test that log_figure calls mlflow.log_figure with the correct arguments."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dummy_figure = object()  # This could be any figure-like object (or a mock)
+            with mock.patch("mlflow.log_figure") as mock_log_figure:
+                tracker = self._get_tracker(tmpdir)
+                tracker.log_figure(dummy_figure, artifact_file="dummy_figure.png", dpi=300)
+                mock_log_figure.assert_called_once_with(
+                    figure=dummy_figure,
+                    artifact_file="dummy_figure.png",
+                    dpi=300,
+                )
+
+    def test_log_artifact(self):
+        """Test that log_artifact calls mlflow.log_artifact with the correct file path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dummy_file_path = os.path.join(tmpdir, "dummy.txt")
+            with open(dummy_file_path, "w") as f:
+                f.write("dummy content")
+            with mock.patch("mlflow.log_artifact") as mock_log_artifact:
+                tracker = self._get_tracker(tmpdir)
+                tracker.log_artifact(dummy_file_path, artifact_path="artifact_dir")
+                mock_log_artifact.assert_called_once_with(
+                    local_path=dummy_file_path,
+                    artifact_path="artifact_dir",
+                )
+
+    def test_log_artifacts(self):
+        """Test that log_artifacts calls mlflow.log_artifacts with the correct directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dummy_dir = os.path.join(tmpdir, "dummy_dir")
+            os.mkdir(dummy_dir)
+            dummy_file_path = os.path.join(dummy_dir, "dummy.txt")
+            with open(dummy_file_path, "w") as f:
+                f.write("dummy content")
+            with mock.patch("mlflow.log_artifacts") as mock_log_artifacts:
+                tracker = self._get_tracker(tmpdir)
+                tracker.log_artifacts(dummy_dir, artifact_path="artifact_dir")
+                mock_log_artifacts.assert_called_once_with(
+                    local_dir=dummy_dir,
+                    artifact_path="artifact_dir",
+                )
 
 
 # Comet has a special `OfflineExperiment` we need to use for testing

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Optional
 from unittest import mock
 
-import matplotlib.pyplot as plt
 import mlflow
 import numpy as np
 import torch
@@ -39,6 +38,7 @@ from accelerate.test_utils.testing import (
     require_clearml,
     require_comet_ml,
     require_dvclive,
+    require_matplotlib,
     require_mlflow,
     require_pandas,
     require_tensorboard,
@@ -210,7 +210,11 @@ class MLflowTrackingTest(unittest.TestCase):
         self.tmpdir = tempfile.TemporaryDirectory()
         mlflow.set_tracking_uri("file://" + self.tmpdir.name)
 
+    @require_matplotlib
     def create_mock_figure(self):
+        """Create a mock figure for testing."""
+        import matplotlib.pyplot as plt
+
         fig = plt.figure(figsize=(6, 4))
         return fig
 
@@ -232,6 +236,7 @@ class MLflowTrackingTest(unittest.TestCase):
         self.assertEqual(metrics.get("loss"), 0.1)
         self.assertNotIn("non_numeric", metrics)
 
+    @require_matplotlib
     def test_log_figure(self):
         """Test that log_figure calls mlflow.log_figure with the correct arguments."""
         dummy_figure = self.create_mock_figure()

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -239,6 +239,7 @@ class MLflowTrackingTest(unittest.TestCase):
         self.assertEqual(metrics.get("loss"), 0.1)
         self.assertNotIn("non_numeric", metrics)
 
+    @require_matplotlib
     def test_log_figure(self):
         import mlflow
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -216,12 +216,10 @@ class MLflowTrackingTest(unittest.TestCase):
 
     def create_mock_figure(self):
         fig = plt.figure(figsize=(6, 4))
-
         return fig
 
     def test_log(self):
         """Test that log calls mlflow.log_metrics with only numeric values and the correct step."""
-        # tracker = self._get_tracker()
         values = {"accuracy": 0.95, "loss": 0.1, "non_numeric": "ignored"}
         tracker = self.init_tracker()
         tracker.log(values, step=10)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -27,11 +27,9 @@ from unittest import mock
 
 import matplotlib.pyplot as plt
 import mlflow
-import mlflow.artifacts
 import numpy as np
 import torch
 from packaging import version
-from sqlalchemy import create_mock_engine
 
 # We use TF to parse the logs
 from accelerate import Accelerator
@@ -227,6 +225,7 @@ class MLflowTrackingTest(unittest.TestCase):
         values = {"accuracy": 0.95, "loss": 0.1, "non_numeric": "ignored"}
         tracker = self.init_tracker()
         tracker.log(values, step=10)
+
         run_id = tracker.active_run.info.run_id
         tracker.finish()
 
@@ -242,8 +241,10 @@ class MLflowTrackingTest(unittest.TestCase):
         dummy_figure = self.create_mock_figure()
         tracker = self.init_tracker()
         tracker.log_figure(dummy_figure, artifact_file="dummy_figure.png")
+
         run_id = tracker.active_run.info.run_id
         tracker.finish()
+
         self.assertIn(
             "dummy_figure.png",
             [artifact.path for artifact in mlflow.artifacts.list_artifacts(run_id=run_id)],
@@ -280,6 +281,7 @@ class MLflowTrackingTest(unittest.TestCase):
 
         run_id = tracker.active_run.info.run_id
         tracker.finish()
+
         self.assertIn(
             "artifact_dir/dummy.txt",
             [

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from typing import Optional
 from unittest import mock
 
-import mlflow
 import numpy as np
 import torch
 from packaging import version
@@ -207,6 +206,8 @@ class WandBTrackingTest(TempDirTestCase, MockingTestCase):
 @require_mlflow
 class MLflowTrackingTest(unittest.TestCase):
     def setUp(self):
+        import mlflow
+
         self.tmpdir = tempfile.TemporaryDirectory()
         mlflow.set_tracking_uri("file://" + self.tmpdir.name)
 
@@ -219,6 +220,8 @@ class MLflowTrackingTest(unittest.TestCase):
         return fig
 
     def test_log(self):
+        import mlflow
+
         """Test that log calls mlflow.log_metrics with only numeric values and the correct step."""
         values = {"accuracy": 0.95, "loss": 0.1, "non_numeric": "ignored"}
         tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
@@ -236,8 +239,9 @@ class MLflowTrackingTest(unittest.TestCase):
         self.assertEqual(metrics.get("loss"), 0.1)
         self.assertNotIn("non_numeric", metrics)
 
-    @require_matplotlib
     def test_log_figure(self):
+        import mlflow
+
         """Test that log_figure calls mlflow.log_figure with the correct arguments."""
         dummy_figure = self.create_mock_figure()
         tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
@@ -254,6 +258,8 @@ class MLflowTrackingTest(unittest.TestCase):
         )
 
     def test_log_artifact(self):
+        import mlflow
+
         """Test that log_artifact calls mlflow.log_artifact with the correct file path."""
         dummy_file_path = os.path.join(self.tmpdir.name, "dummy.txt")
         with open(dummy_file_path, "w") as f:
@@ -275,6 +281,8 @@ class MLflowTrackingTest(unittest.TestCase):
         )
 
     def test_log_artifacts(self):
+        import mlflow
+
         """Test that log_artifacts calls mlflow.log_artifacts with the correct directory."""
         dummy_dir = os.path.join(self.tmpdir.name, "dummy_dir")
         os.mkdir(dummy_dir)


### PR DESCRIPTION
# What does this PR do?
Add `log_artifact`, `log_artifacts` and `log_figure` capabilities to the MLflowTracker.

When using `Accelerator` for training, the MLFlowTracker did not offer logs to artifact(s) and figures, which are fully implemented at MLFlow. With this PR, those functionalities are now available at MLFlowTracker as well.

Fixes #2070 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [X] Did you write any new necessary tests?


@muellerzr @BenjaminBossan @SunMarc 