### PR TITLE
fix "clear_device_cache" in hooks.py causing a CUDA runtime error in multiple GPUs environment.

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -718,7 +718,6 @@ class CpuOffload(ModelHook):
     def pre_forward(self, module, *args, **kwargs):
         if self.prev_module_hook is not None:
             self.prev_module_hook.offload()
-            clear_device_cache()
         module.to(self.execution_device)
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -32,7 +32,6 @@ from .utils.imports import (
     is_npu_available,
     is_xpu_available,
 )
-from .utils.memory import clear_device_cache
 from .utils.modeling import get_non_persistent_buffers
 from .utils.other import recursive_getattr
 


### PR DESCRIPTION
```clear_device_cache``` in ```hooks.py``` can sometimes cause a CUDA runtime error in multiple GPUs environment.

This is a simple reproduction.

```pip install bitsandbytes diffusers```
```python
import os
os.environ["PYTORCH_CUDA_ALLOC_CONF"] = "expandable_segments:True"

from diffusers import FluxPipeline
import torch

pipeline = FluxPipeline.from_pretrained("eramth/flux-4bit",torch_dtype=torch.float16)
pipeline.to("cuda:1")
pipeline.enable_model_cpu_offload(1,"cuda")

pipeline(prompt="a cute cat",num_inference_steps=5)
```

```shell
/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py in decorate_context(*args, **kwargs)
    114     def decorate_context(*args, **kwargs):
    115         with ctx_factory():
--> 116             return func(*args, **kwargs)
    117 
    118     return decorate_context

/usr/local/lib/python3.10/dist-packages/diffusers/pipelines/flux/pipeline_flux.py in __call__(self, prompt, prompt_2, negative_prompt, negative_prompt_2, true_cfg_scale, height, width, num_inference_steps, sigmas, guidance_scale, num_images_per_prompt, generator, latents, prompt_embeds, pooled_prompt_embeds, ip_adapter_image, ip_adapter_image_embeds, negative_ip_adapter_image, negative_ip_adapter_image_embeds, negative_prompt_embeds, negative_pooled_prompt_embeds, output_type, return_dict, joint_attention_kwargs, callback_on_step_end, callback_on_step_end_tensor_inputs, max_sequence_length)
    918                 timestep = t.expand(latents.shape[0]).to(latents.dtype)
    919 
--> 920                 noise_pred = self.transformer(
    921                     hidden_states=latents,
    922                     timestep=timestep / 1000,

/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py in _wrapped_call_impl(self, *args, **kwargs)
   1734             return self._compiled_call_impl(*args, **kwargs)  # type: ignore[misc]
   1735         else:
-> 1736             return self._call_impl(*args, **kwargs)
   1737 
   1738     # torchrec tests the code consistency with the following code

/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py in _call_impl(self, *args, **kwargs)
   1745                 or _global_backward_pre_hooks or _global_backward_hooks
   1746                 or _global_forward_hooks or _global_forward_pre_hooks):
-> 1747             return forward_call(*args, **kwargs)
   1748 
   1749         result = None

/usr/local/lib/python3.10/dist-packages/accelerate/hooks.py in new_forward(module, *args, **kwargs)
    163 
    164     def new_forward(module, *args, **kwargs):
--> 165         args, kwargs = module._hf_hook.pre_forward(module, *args, **kwargs)
    166         if module._hf_hook.no_grad:
    167             with torch.no_grad():

/usr/local/lib/python3.10/dist-packages/accelerate/hooks.py in pre_forward(self, module, *args, **kwargs)
    705         if self.prev_module_hook is not None:
    706             self.prev_module_hook.offload()
--> 707             clear_device_cache()
    708         module.to(self.execution_device)
    709         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)

/usr/local/lib/python3.10/dist-packages/accelerate/utils/memory.py in clear_device_cache(garbage_collection)
     58         torch.mps.empty_cache()
     59     elif is_cuda_available():
---> 60         torch.cuda.empty_cache()
     61 
     62 

/usr/local/lib/python3.10/dist-packages/torch/cuda/memory.py in empty_cache()
    190     """
    191     if is_initialized():
--> 192         torch._C._cuda_emptyCache()
    193 
    194 

RuntimeError: CUDA error: an illegal memory access was encountered
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

BTW, IMO, the functions like ```torch.cuda.empty_cache``` should not be called or should be called very carefully in a relatively low-level library like ```accelerate```, beacuse the users maybe use it asynchronously, which can cause some errors like CUDA runtime error.

With this PR, the issue can be fixed.

@SunMarc 
I'll be very appreciated if you can check this PR.