### PR TITLE
remove device index workaround on xpu since xpu supports integer device index as cuda now

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -495,8 +495,6 @@ def dispatch_model(
             device = f"sdaa:{device}"
         elif is_musa_available() and isinstance(device, int):
             device = f"musa:{device}"
-        elif is_xpu_available() and isinstance(device, int):
-            device = f"xpu:{device}"
         if device != "disk":
             model.to(device)
         else:

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -30,7 +30,6 @@ from .utils.imports import (
     is_mlu_available,
     is_musa_available,
     is_npu_available,
-    is_xpu_available,
 )
 from .utils.memory import clear_device_cache
 from .utils.modeling import get_non_persistent_buffers

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -356,6 +356,7 @@ class AlignDevicesHook(ModelHook):
                     and value.data_ptr() in self.tied_params_map
                     and self.execution_device not in self.tied_params_map[value.data_ptr()]
                 ):
+                    print(f"value.data_ptr(): {value.data_ptr()}, execution_device: {self.execution_device}")
                     self.tied_pointers_to_remove.add((value.data_ptr(), self.execution_device))
 
                 set_module_tensor_to_device(
@@ -386,6 +387,7 @@ class AlignDevicesHook(ModelHook):
 
             # We may have loaded tied weights into self.tied_params_map (avoiding to load them several times in e.g. submodules): remove them from
             # this dictionary to allow the garbage collector to do its job.
+            print(f"self.tied_params_map: {self.tied_params_map}")
             for value_pointer, device in self.tied_pointers_to_remove:
                 if isinstance(device, int):
                     if is_npu_available():
@@ -394,8 +396,6 @@ class AlignDevicesHook(ModelHook):
                         device = f"mlu:{device}"
                     elif is_musa_available():
                         device = f"musa:{device}"
-                    elif is_xpu_available():
-                        device = f"xpu:{device}"
                 del self.tied_params_map[value_pointer][device]
             self.tied_pointers_to_remove = set()
         if self.io_same_device and self.input_device is not None:

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -356,7 +356,6 @@ class AlignDevicesHook(ModelHook):
                     and value.data_ptr() in self.tied_params_map
                     and self.execution_device not in self.tied_params_map[value.data_ptr()]
                 ):
-                    print(f"value.data_ptr(): {value.data_ptr()}, execution_device: {self.execution_device}")
                     self.tied_pointers_to_remove.add((value.data_ptr(), self.execution_device))
 
                 set_module_tensor_to_device(
@@ -387,7 +386,6 @@ class AlignDevicesHook(ModelHook):
 
             # We may have loaded tied weights into self.tied_params_map (avoiding to load them several times in e.g. submodules): remove them from
             # this dictionary to allow the garbage collector to do its job.
-            print(f"self.tied_params_map: {self.tied_params_map}")
             for value_pointer, device in self.tied_pointers_to_remove:
                 if isinstance(device, int):
                     if is_npu_available():

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -321,8 +321,6 @@ def set_module_tensor_to_device(
                 device = f"sdaa:{device}"
             elif is_musa_available():
                 device = f"musa:{device}"
-            elif is_xpu_available():
-                device = f"xpu:{device}"
             elif is_hpu_available():
                 device = "hpu"
         if "xpu" in str(device) and not is_xpu_available():
@@ -792,6 +790,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                 try:
                     _ = torch.tensor(0, device=torch.device("xpu", i))
                     max_memory[i] = get_xpu_available_memory(i)
+                    print(f"i: {i}, memory: {max_memory[i]}")
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
@@ -1158,6 +1157,8 @@ def get_module_size_with_ties(
     tied_module_names = []
     tied_modules = []
 
+    print(f"tied_params: {tied_params}")
+    print(f"modules_to_treat: {modules_to_treat}")
     for tied_param in tied_params:
         tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if tied_param.startswith(n + ".")][0]
         tied_module_names.append(modules_to_treat[tied_module_index][0])
@@ -1650,9 +1651,7 @@ def load_state_dict(checkpoint_file, device_map=None):
                 device = list(device_map.values())[0]
                 target_device = device
                 if isinstance(device, int):
-                    if is_xpu_available():
-                        target_device = f"xpu:{device}"
-                    elif is_npu_available():
+                    if is_npu_available():
                         target_device = f"npu:{device}"
                     elif is_hpu_available():
                         target_device = "hpu"
@@ -1688,9 +1687,7 @@ def load_state_dict(checkpoint_file, device_map=None):
             for device in devices:
                 target_device = device
                 if isinstance(device, int):
-                    if is_xpu_available():
-                        target_device = f"xpu:{device}"
-                    elif is_npu_available():
+                    if is_npu_available():
                         target_device = f"npu:{device}"
                     elif is_hpu_available():
                         target_device = "hpu"

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -790,7 +790,6 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
                 try:
                     _ = torch.tensor(0, device=torch.device("xpu", i))
                     max_memory[i] = get_xpu_available_memory(i)
-                    print(f"i: {i}, memory: {max_memory[i]}")
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
@@ -1157,8 +1156,6 @@ def get_module_size_with_ties(
     tied_module_names = []
     tied_modules = []
 
-    print(f"tied_params: {tied_params}")
-    print(f"modules_to_treat: {modules_to_treat}")
     for tied_param in tied_params:
         tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if tied_param.startswith(n + ".")][0]
         tied_module_names.append(modules_to_treat[tied_module_index][0])

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -30,7 +30,6 @@ from .imports import (
     is_npu_available,
     is_torch_distributed_available,
     is_torch_xla_available,
-    is_xpu_available,
 )
 
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -149,8 +149,6 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
         # `torch.Tensor.to("npu")` could not find context when called for the first time (see this [issue](https://gitee.com/ascend/pytorch/issues/I8KECW?from=project-issue)).
         if device == "npu":
             device = "npu:0"
-        if device == "xpu":
-            device = "xpu:0"
         try:
             return tensor.to(device, non_blocking=non_blocking)
         except TypeError:  # .to() doesn't accept non_blocking as kwarg
@@ -161,9 +159,6 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             if is_npu_available():
                 if isinstance(device, int):
                     device = f"npu:{device}"
-            elif is_xpu_available():
-                if isinstance(device, int):
-                    device = f"xpu:{device}"
             else:
                 raise error
         try:


### PR DESCRIPTION
remove device index workaround on xpu since it supports integer device index as cuda now

this can fix https://github.com/huggingface/accelerate/issues/3402, this issue is brought by inconsistent device key(integer(x) vs string("xpu:x")).

- blip, dab_detr and vilt can pass
- roberta fail, but CUDA fail w/ same log, so it's another issue, may open another PR to fix