### PR TITLE
Fix seeding of new generator for multi GPU

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1203,6 +1203,8 @@ def prepare_data_loader(
                     sampler.generator = torch.Generator(
                         device=torch.get_default_device() if hasattr(torch, "get_default_device") else "cpu"
                     )
+                    seed = int(torch.empty((), dtype=torch.int64).random_().item())
+                    sampler.generator.manual_seed(seed)
                 synchronized_generator = sampler.generator
             batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler
             new_batch_sampler = BatchSamplerShard(

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1181,7 +1181,9 @@ def prepare_data_loader(
         # isinstance(dataloader.sampler, RandomSampler) indicates the original dataloader has `shuffle` enabled.
         generator = torch.Generator(
             device=torch.get_default_device() if hasattr(torch, "get_default_device") else "cpu"
-        ).manual_seed(42)
+        )
+        seed = int(torch.empty((), dtype=torch.int64).random_().item())
+        generator.manual_seed(seed)
         dataloader.generator = generator
         dataloader.sampler.generator = generator
     # No change if no multiprocess


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #3398 

The initial state of the new generator was always the same, whatever the seed passed to `accelerate.utils.set_seed`. This PR makes sure that we get reproducible results but different numbers for different seeds passed to `set_seed`. This is already the case when multi GPU is disabled because generator is None (see https://github.com/pytorch/pytorch/blob/main/torch/utils/data/sampler.py#L170).
Before adding a test, I will wait for a first reviewer to confirm this is OK, I am not yet very familiar with accelerate.

Maybe the same should be done for https://github.com/huggingface/accelerate/blob/main/src/accelerate/data_loader.py#L1184 where the seed is set to 42 and thus will always produce the same number whatever the first global initial seed passed to `set_seed`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Based on git blame I would say @muellerzr :)

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @muellerzr
- DeepSpeed: @muellerzr
- Command Line Interface: @muellerzr
- Documentation: @muellerzr
- Core parts of the library: @muellerzr @BenjaminBossan @SunMarc
- Maintained examples: @muellerzr or @SunMarc

 -->