### PR TITLE
Fix lomo conflict with scaler

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2381,10 +2381,10 @@ class Accelerator:
             self.deepspeed_engine_wrapped.backward(loss, **kwargs)
         elif self.distributed_type == DistributedType.MEGATRON_LM:
             return
-        elif self.scaler is not None:
-            self.scaler.scale(loss).backward(**kwargs)
         elif learning_rate is not None and self.has_lomo_optimizer:
             self.lomo_backward(loss, learning_rate)
+        elif self.scaler is not None:
+            self.scaler.scale(loss).backward(**kwargs)
         else:
             loss.backward(**kwargs)
 


### PR DESCRIPTION
# Reorder Lomo backward to prevent conflicts

Moved the check for `self.scaler` after the Lomo `learning_rate` check to ensure the backward pass is used based on the presence of `scaler`.
For Lomo optimizer integration, this quick fix will avoid the error if a scaler was created, in which case the code went to `self.scaler.scale(loss).backward(**kwargs)`, raising TypeError: backward() got an unexpected keyword argument 'learning_rate'

This pull request includes a small change to the `src/accelerate/accelerator.py` file. The change reorders the check for the `scaler` in the `backward` method to ensure the correct execution flow. 

