### PR TITLE
(fix) remove sampler_is_batch_sampler code in prepare_data_loader(..)

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -19,7 +19,7 @@ from typing import Callable, Optional, Union
 
 import torch
 from packaging import version
-from torch.utils.data import BatchSampler, DataLoader, IterableDataset, RandomSampler
+from torch.utils.data import BatchSampler, DataLoader, IterableDataset, RandomSampler, Sampler
 
 from .logging import get_logger
 from .state import DistributedType, GradientState, PartialState, is_torch_xla_available
@@ -631,13 +631,10 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         return get_sampler(self)
 
     def set_sampler(self, sampler):
-        sampler_is_batch_sampler = isinstance(self.sampler, BatchSampler)
-        if sampler_is_batch_sampler:
+        if isinstance(sampler, BatchSampler):
+            self.sampler.batch_sampler = sampler
+        elif isinstance(sampler, Sampler):
             self.sampler.sampler = sampler
-        else:
-            self.batch_sampler.sampler = sampler
-            if hasattr(self.batch_sampler, "batch_sampler"):
-                self.batch_sampler.batch_sampler.sampler = sampler
 
 
 if is_torch_xla_available():
@@ -958,13 +955,12 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
         return get_sampler(self)
 
     def set_sampler(self, sampler):
-        sampler_is_batch_sampler = isinstance(self.sampler, BatchSampler)
-        if sampler_is_batch_sampler:
+        if isinstance(sampler, BatchSampler):
+            self.sampler.batch_sampler = sampler
+        elif isinstance(sampler, Sampler):
             self.sampler.sampler = sampler
         else:
-            self.batch_sampler.sampler = sampler
-            if hasattr(self.batch_sampler, "batch_sampler"):
-                self.batch_sampler.batch_sampler.sampler = sampler
+            raise ValueError(f"{sampler} must be of type torch.utills.data.Sampler or torch.utils.data.BatchSampler")
 
 
 def get_sampler(dataloader):
@@ -977,10 +973,8 @@ def get_sampler(dataloader):
     Returns:
         `torch.utils.data.Sampler`: The sampler associated to the dataloader
     """
-    sampler_is_batch_sampler = isinstance(dataloader.sampler, BatchSampler)
-    if sampler_is_batch_sampler:
-        sampler = getattr(dataloader.sampler, "sampler", None)
-    else:
+    sampler = getattr(dataloader.sampler, "sampler", None)
+    if not sampler:
         sampler = getattr(dataloader.batch_sampler, "sampler", None)
     return sampler
 
@@ -1155,11 +1149,16 @@ def prepare_data_loader(
 
     new_dataset = dataloader.dataset
     # Iterable dataset doesn't like batch_sampler, but data_loader creates a default one for it
-    new_batch_sampler = dataloader.batch_sampler if not isinstance(new_dataset, IterableDataset) else None
-    sampler_is_batch_sampler = isinstance(dataloader.sampler, BatchSampler)
-    synchronized_generator = None
+    if isinstance(dataloader.sampler, BatchSampler):
+        raise ValueError(
+            "Should not pass a BatchSampler do dataloader sampler argument. As per pytorch>2.1.0 documentation, please pass this to sampler instead"
+        )
 
-    sampler = get_sampler(dataloader)
+    new_batch_sampler = dataloader.batch_sampler if not isinstance(new_dataset, IterableDataset) else None
+
+    synchronized_generator = None
+    sampler = dataloader.sampler
+
     if isinstance(sampler, RandomSampler) and use_seedable_sampler:
         # When iterating through the dataloader during distributed processes
         # we want to ensure that on each process we are iterating through the same
@@ -1208,9 +1207,8 @@ def prepare_data_loader(
                     seed = int(torch.empty((), dtype=torch.int64).random_().item())
                     sampler.generator.manual_seed(seed)
                 synchronized_generator = sampler.generator
-            batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler
             new_batch_sampler = BatchSamplerShard(
-                batch_sampler,
+                dataloader.batch_sampler,
                 num_processes=num_processes,
                 process_index=process_index,
                 split_batches=split_batches,
@@ -1252,19 +1250,6 @@ def prepare_data_loader(
             slice_fn=slice_fn_for_dispatch,
             use_stateful_dataloader=use_stateful_dataloader,
             torch_device_mesh=torch_device_mesh,
-            **kwargs,
-        )
-    elif sampler_is_batch_sampler:
-        dataloader = DataLoaderShard(
-            new_dataset,
-            device=device if put_on_device and state.distributed_type != DistributedType.XLA else None,
-            sampler=new_batch_sampler,
-            batch_size=dataloader.batch_size,
-            rng_types=rng_types,
-            _drop_last=dataloader.drop_last,
-            _non_blocking=non_blocking,
-            synchronized_generator=synchronized_generator,
-            use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
         )
     else:
@@ -1361,13 +1346,15 @@ def skip_first_batches(dataloader, num_batches=0):
         dataloader = dataloader.dataloader
 
     dataset = dataloader.dataset
-    sampler_is_batch_sampler = False
+    if isinstance(dataloader.sampler, BatchSampler):
+        raise ValueError(
+            "Should not pass a BatchSampler do dataloader sampler argument. As per the latest pytorch documentation, please pass this to sampler instead"
+        )
+
     if isinstance(dataset, IterableDataset):
         new_batch_sampler = None
     else:
-        sampler_is_batch_sampler = isinstance(dataloader.sampler, BatchSampler)
-        batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler
-        new_batch_sampler = SkipBatchSampler(batch_sampler, skip_batches=num_batches)
+        new_batch_sampler = SkipBatchSampler(dataloader.batch_sampler, skip_batches=num_batches)
 
     # We ignore all of those since they are all dealt with by our new_batch_sampler
     ignore_kwargs = [
@@ -1404,9 +1391,6 @@ def skip_first_batches(dataloader, num_batches=0):
         if new_batch_sampler is None:
             # Need to manually skip batches in the dataloader
             kwargs["skip_batches"] = num_batches
-        elif sampler_is_batch_sampler:
-            kwargs["sampler"] = new_batch_sampler
-            kwargs["batch_size"] = dataloader.batch_size
         else:
             kwargs["batch_sampler"] = new_batch_sampler
         dataloader = DataLoaderShard(

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -960,7 +960,7 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
         elif isinstance(sampler, Sampler):
             self.sampler.sampler = sampler
         else:
-            raise ValueError(f"{sampler} must be of type torch.utills.data.Sampler or torch.utils.data.BatchSampler")
+            raise ValueError(f"{sampler} must be of type torch.utils.data.Sampler or torch.utils.data.BatchSampler")
 
 
 def get_sampler(dataloader):
@@ -1150,8 +1150,10 @@ def prepare_data_loader(
     new_dataset = dataloader.dataset
     # Iterable dataset doesn't like batch_sampler, but data_loader creates a default one for it
     if isinstance(dataloader.sampler, BatchSampler):
-        raise ValueError(
-            "Should not pass a BatchSampler do dataloader sampler argument. As per pytorch>2.1.0 documentation, please pass this to sampler instead"
+        logger.warning(
+            "BatchSampler was passed to sampler argument."
+            "If you have a custom Sampler that yields a list of batch indices at a time, please pass it as the batch_sampler argument instead."
+            "For more information, see https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"
         )
 
     new_batch_sampler = dataloader.batch_sampler if not isinstance(new_dataset, IterableDataset) else None
@@ -1347,8 +1349,10 @@ def skip_first_batches(dataloader, num_batches=0):
 
     dataset = dataloader.dataset
     if isinstance(dataloader.sampler, BatchSampler):
-        raise ValueError(
-            "Should not pass a BatchSampler do dataloader sampler argument. As per the latest pytorch documentation, please pass this to sampler instead"
+        logger.warning(
+            "BatchSampler was passed to sampler argument."
+            "If you have a custom Sampler that yields a list of batch indices at a time, please pass it as the batch_sampler argument instead."
+            "For more information, see https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader"
         )
 
     if isinstance(dataset, IterableDataset):


### PR DESCRIPTION
### What does this PR do?

This PR fixes various confusions wrt to `torch.utils.data.DataLoader`, `torch.utils.data.BatchSampler`, and `accelerate/data_loader.py:: prepare_data_loader(..)`.

~~https://github.com/huggingface/accelerate/issues/3322~~ *Edit, not quite this*
https://github.com/huggingface/accelerate/issues/3014
https://github.com/huggingface/accelerate/issues/2091

### Motivation

1. `accelerate/data_loader.py` has various patches allowing for a `BatchSampler` object to be passed as an argument to `sampler`. 

2. In the code, it allows this behavior using `sampler_is_batch_sampler = isinstance(dataloader.sampler, BatchSampler)`.

3. Allowing this is unintuitive for developers as it directly conflicts with `torch.utils.data.DataLoader` documentation, when accelerate should only wrap the pytorch dataloader and not change/allow different logic or arguments. 

4. It also permits various unintended behavior from other libraries relying on accelerate. For instance, when passing a custom BatchSampler to the dataloader argument in HuggingFace Trainer, the `sampler` kwargs is currently used, regardless of whether the sampler is BatchSampler or just RandomSampler. https://github.com/huggingface/transformers/blob/3b07ca78bb696825feee3e976795fab58f2b6d0c/src/transformers/trainer.py#L1026 (I'll be making a separate PR in HuggingFace on this) 

5. I believe this is due to a misunderstanding stemming from this Issue #https://github.com/huggingface/accelerate/issues/679. As @sgugger  initially suspected, this is probably a typo or misunderstanding from HuggingFace. 

This should not be allowed behavior, based on the following basic test case which will throw the datasets/formatting/formatting.py: `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'list'`

```
from torch.utils.data import BatchSampler, RandomSampler
from datasets import load_dataset

ds = load_dataset("wikitext", "wikitext-103-raw-v1", split='validation')

train_dataloader = DataLoader(
    ds,
    sampler=BatchSampler(RandomSampler(dev_ds), batch_size=32, drop_last=False),
    num_workers=0,  # Adjust based on your setup
    pin_memory=True,
)

for batch in train_dataloader:
  print(batch)
```



[Official Pytorch Documentation](https://pytorch.org/docs/stable/data.html) for reference:
```
DataLoader(dataset, batch_size=1, shuffle=False, sampler=None, 
           batch_sampler=None, num_workers=0, collate_fn=None,
           pin_memory=False, drop_last=False, timeout=0,
           worker_init_fn=None, *, prefetch_factor=2,
           persistent_workers=False)
```


### This PR

1. Reverses this historical PR: https://github.com/huggingface/accelerate/pull/687 which supports the wrong logic.
2. Removes all traces of `sampler_is_batch_sampler`, simplifying the code
3. ~~Immediately throws an error~~  *Edit: Throws a warning* if a `BatchSampler` had been passed as an argument to `sampler`

### Tests

Passes all tests in tests/test_data_loader.py, but does not introduce any new tests. Open to suggestions.

### Considerations

1. The PR Immediately throws an error if a BatchSampler had been passed as an argument to Sampler. Technically this error should be thrown earlier or in `torch.utils.data.Sampler` but we can make it explicit that the problem is not coming from the Accelerate Library, since it had previously been allowed.   

2. Upon reading the [torch.utils.data source code](https://github.com/pytorch/pytorch/blob/v2.6.0/torch/utils/data/dataloader.py) v2.6.0, I figured that `torch.utils.data.DataLoader` will attempt to construct a BatchSampler from a Sampler if `batch_sampler=None`, and will also construct a default sampler if `sampler=None`. 

This means, we should always be able to recover a `dataloader.batch_sampler` when wrapping accelerate around an already constructed pytorch `dataloader`, and there is no need to check whether `sampler_is_batch_sampler` again, if the intent is just to get "`new_batch_sampler`". 



### Before submitting
- [ Yes ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ No ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [NA; no docs mention batch_sampler ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [No, open to suggestion ] Did you write any new necessary tests?


### Who can review?
@SunMarc @BenjaminBossan  @zach-huggingface @muellerzr 