### PR TITLE
Update ruff target-version to py39 and apply more fixes

### DIFF
--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-from typing import List
 
 import evaluate
 import numpy as np
@@ -61,7 +60,7 @@ EVAL_BATCH_SIZE = 32
 
 
 def get_fold_dataloaders(
-    accelerator: Accelerator, dataset: DatasetDict, train_idxs: List[int], valid_idxs: List[int], batch_size: int = 16
+    accelerator: Accelerator, dataset: DatasetDict, train_idxs: list[int], valid_idxs: list[int], batch_size: int = 16
 ):
     """
     Gets a set of train, valid, and test dataloaders for a particular fold

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.ruff]
 line-length = 119
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 preview = true

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -16,7 +16,7 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import wraps
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -171,8 +171,8 @@ def cpu_offload(
     model: nn.Module,
     execution_device: Optional[torch.device] = None,
     offload_buffers: bool = False,
-    state_dict: Optional[Dict[str, torch.Tensor]] = None,
-    preload_module_classes: Optional[List[str]] = None,
+    state_dict: Optional[dict[str, torch.Tensor]] = None,
+    preload_module_classes: Optional[list[str]] = None,
 ):
     """
     Activates full CPU offload for a model. As a result, all parameters of the model will be offloaded and only one
@@ -262,7 +262,7 @@ def disk_offload(
     offload_dir: Union[str, os.PathLike],
     execution_device: Optional[torch.device] = None,
     offload_buffers: bool = False,
-    preload_module_classes: Optional[List[str]] = None,
+    preload_module_classes: Optional[list[str]] = None,
 ):
     """
     Activates full disk offload for a model. As a result, all parameters of the model will be offloaded as
@@ -305,14 +305,14 @@ def disk_offload(
 
 def dispatch_model(
     model: nn.Module,
-    device_map: Dict[str, Union[str, int, torch.device]],
+    device_map: dict[str, Union[str, int, torch.device]],
     main_device: Optional[torch.device] = None,
-    state_dict: Optional[Dict[str, torch.Tensor]] = None,
+    state_dict: Optional[dict[str, torch.Tensor]] = None,
     offload_dir: Optional[Union[str, os.PathLike]] = None,
-    offload_index: Optional[Dict[str, str]] = None,
+    offload_index: Optional[dict[str, str]] = None,
     offload_buffers: bool = False,
-    skip_keys: Optional[Union[str, List[str]]] = None,
-    preload_module_classes: Optional[List[str]] = None,
+    skip_keys: Optional[Union[str, list[str]]] = None,
+    preload_module_classes: Optional[list[str]] = None,
     force_hooks: bool = False,
 ):
     """
@@ -509,15 +509,15 @@ def dispatch_model(
 def load_checkpoint_and_dispatch(
     model: nn.Module,
     checkpoint: Union[str, os.PathLike],
-    device_map: Optional[Union[str, Dict[str, Union[int, str, torch.device]]]] = None,
-    max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,
-    no_split_module_classes: Optional[List[str]] = None,
+    device_map: Optional[Union[str, dict[str, Union[int, str, torch.device]]]] = None,
+    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
+    no_split_module_classes: Optional[list[str]] = None,
     offload_folder: Optional[Union[str, os.PathLike]] = None,
     offload_buffers: bool = False,
     dtype: Optional[Union[str, torch.dtype]] = None,
     offload_state_dict: Optional[bool] = None,
-    skip_keys: Optional[Union[str, List[str]]] = None,
-    preload_module_classes: Optional[List[str]] = None,
+    skip_keys: Optional[Union[str, list[str]]] = None,
+    preload_module_classes: Optional[list[str]] = None,
     force_hooks: bool = False,
     strict: bool = False,
 ):
@@ -594,8 +594,7 @@ def load_checkpoint_and_dispatch(
     """
     if isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
         raise ValueError(
-            "If passing a string for `device_map`, please choose 'auto', 'balanced', 'balanced_low_0' or "
-            "'sequential'."
+            "If passing a string for `device_map`, please choose 'auto', 'balanced', 'balanced_low_0' or 'sequential'."
         )
     if isinstance(device_map, str):
         if device_map != "sequential":

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -14,7 +14,6 @@
 
 import random
 from pathlib import Path
-from typing import List
 
 import numpy as np
 import torch
@@ -56,7 +55,7 @@ logger = get_logger(__name__)
 
 def save_accelerator_state(
     output_dir: str,
-    model_states: List[dict],
+    model_states: list[dict],
     optimizers: list,
     schedulers: list,
     dataloaders: list,

--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -18,7 +18,7 @@ import json
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import yaml
 
@@ -211,9 +211,9 @@ class ClusterConfig(BaseConfig):
     tpu_use_cluster: bool = False
     tpu_use_sudo: bool = False
     command_file: str = None
-    commands: List[str] = None
-    tpu_vm: List[str] = None
-    tpu_env: List[str] = None
+    commands: list[str] = None
+    tpu_vm: list[str] = None
+    tpu_env: list[str] = None
 
     # args for dynamo
     dynamo_config: dict = None

--- a/src/accelerate/commands/env.py
+++ b/src/accelerate/commands/env.py
@@ -79,7 +79,7 @@ def env_command(args):
         "PyTorch MLU available": str(pt_mlu_available),
         "PyTorch SDAA available": str(pt_sdaa_available),
         "PyTorch MUSA available": str(pt_musa_available),
-        "System RAM": f"{psutil.virtual_memory().total / 1024 ** 3:.2f} GB",
+        "System RAM": f"{psutil.virtual_memory().total / 1024**3:.2f} GB",
     }
     if pt_cuda_available:
         info["GPU type"] = torch.cuda.get_device_name()

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -175,7 +175,7 @@ def create_ascii_table(headers: list, rows: list, title: str):
     for i, line in enumerate(rows):
         centered_line = [t.center(column_widths[i]) for i, t in enumerate(line)]
         table += f"{pattern % tuple(centered_line)}\n"
-    table += f'└{"┴".join([in_between * n for n in column_widths])}┘'
+    table += f"└{'┴'.join([in_between * n for n in column_widths])}┘"
 
     return table
 

--- a/src/accelerate/commands/menu/input.py
+++ b/src/accelerate/commands/menu/input.py
@@ -17,8 +17,6 @@ This file contains utilities for handling input from the user and registering sp
 based on https://github.com/bchao1/bullet
 """
 
-from typing import List
-
 from .keymap import KEYMAP, get_character
 
 
@@ -36,7 +34,7 @@ def mark(key: str):
     return decorator
 
 
-def mark_multiple(*keys: List[str]):
+def mark_multiple(*keys: list[str]):
     """
     Mark the function with the key codes so it can be handled in the register
     """

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -15,7 +15,7 @@
 import importlib
 import math
 from contextlib import suppress
-from typing import Callable, List, Optional, Union
+from typing import Callable, Optional, Union
 
 import torch
 from packaging import version
@@ -992,7 +992,7 @@ def prepare_data_loader(
     process_index: Optional[int] = None,
     split_batches: bool = False,
     put_on_device: bool = False,
-    rng_types: Optional[List[Union[str, RNGType]]] = None,
+    rng_types: Optional[list[Union[str, RNGType]]] = None,
     dispatch_batches: Optional[bool] = None,
     even_batches: bool = True,
     slice_fn_for_dispatch: Optional[Callable] = None,

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import functools
-from typing import Dict, List, Mapping, Optional, Union
+from collections.abc import Mapping
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -250,8 +251,8 @@ class AlignDevicesHook(ModelHook):
         weights_map: Optional[Mapping] = None,
         offload_buffers: bool = False,
         place_submodules: bool = False,
-        skip_keys: Optional[Union[str, List[str]]] = None,
-        tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
+        skip_keys: Optional[Union[str, list[str]]] = None,
+        tied_params_map: Optional[dict[int, dict[torch.device, torch.Tensor]]] = None,
     ):
         self.execution_device = execution_device
         self.offload = offload
@@ -412,9 +413,9 @@ class AlignDevicesHook(ModelHook):
 def attach_execution_device_hook(
     module: torch.nn.Module,
     execution_device: Union[int, str, torch.device],
-    skip_keys: Optional[Union[str, List[str]]] = None,
-    preload_module_classes: Optional[List[str]] = None,
-    tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
+    skip_keys: Optional[Union[str, list[str]]] = None,
+    preload_module_classes: Optional[list[str]] = None,
+    tied_params_map: Optional[dict[int, dict[torch.device, torch.Tensor]]] = None,
 ):
     """
     Recursively attaches `AlignDevicesHook` to all submodules of a given model to make sure they have the right
@@ -464,9 +465,9 @@ def attach_align_device_hook(
     weights_map: Optional[Mapping] = None,
     offload_buffers: bool = False,
     module_name: str = "",
-    skip_keys: Optional[Union[str, List[str]]] = None,
-    preload_module_classes: Optional[List[str]] = None,
-    tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
+    skip_keys: Optional[Union[str, list[str]]] = None,
+    preload_module_classes: Optional[list[str]] = None,
+    tied_params_map: Optional[dict[int, dict[torch.device, torch.Tensor]]] = None,
 ):
     """
     Recursively attaches `AlignDevicesHook` to all submodules of a given model that have direct parameters and/or
@@ -554,14 +555,14 @@ def remove_hook_from_submodules(module: nn.Module):
 
 def attach_align_device_hook_on_blocks(
     module: nn.Module,
-    execution_device: Optional[Union[torch.device, Dict[str, torch.device]]] = None,
-    offload: Union[bool, Dict[str, bool]] = False,
+    execution_device: Optional[Union[torch.device, dict[str, torch.device]]] = None,
+    offload: Union[bool, dict[str, bool]] = False,
     weights_map: Mapping = None,
     offload_buffers: bool = False,
     module_name: str = "",
-    skip_keys: Optional[Union[str, List[str]]] = None,
-    preload_module_classes: Optional[List[str]] = None,
-    tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
+    skip_keys: Optional[Union[str, list[str]]] = None,
+    preload_module_classes: Optional[list[str]] = None,
+    tied_params_map: Optional[dict[int, dict[torch.device, torch.Tensor]]] = None,
 ):
     """
     Attaches `AlignDevicesHook` to all blocks of a given model as needed.

--- a/src/accelerate/inference.py
+++ b/src/accelerate/inference.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import math
 from types import MethodType
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from .state import PartialState
 from .utils import (
@@ -123,10 +123,10 @@ def pippy_forward(forward, num_chunks, gather_output, *args, **kwargs):
 
 def prepare_pippy(
     model,
-    split_points: Optional[Union[str, List[str]]] = "auto",
-    no_split_module_classes: Optional[List[str]] = None,
-    example_args: Optional[Tuple[Any]] = (),
-    example_kwargs: Optional[Dict[str, Any]] = None,
+    split_points: Optional[Union[str, list[str]]] = "auto",
+    no_split_module_classes: Optional[list[str]] = None,
+    example_args: Optional[tuple[Any]] = (),
+    example_kwargs: Optional[dict[str, Any]] = None,
     num_chunks: Optional[int] = None,
     gather_output: Optional[bool] = False,
 ):

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -21,7 +21,7 @@ import warnings
 import weakref
 from contextlib import contextmanager
 from functools import partial
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import torch
 
@@ -1207,7 +1207,7 @@ class GradientState:
 
     _shared_state = SharedDict()
 
-    def __init__(self, gradient_accumulation_plugin: Optional[GradientAccumulationPlugin] = None):
+    def __init__(self, gradient_accumulation_plugin: GradientAccumulationPlugin | None = None):
         self.__dict__ = self._shared_state
         if not self.initialized:
             self.sync_gradients = True

--- a/src/accelerate/test_utils/examples.py
+++ b/src/accelerate/test_utils/examples.py
@@ -20,10 +20,9 @@ others are used to either get the code that matters, or to preprocess them (such
 """
 
 import os
-from typing import List
 
 
-def get_function_contents_by_name(lines: List[str], name: str):
+def get_function_contents_by_name(lines: list[str], name: str):
     """
     Extracts a function from `lines` of segmented source code with the name `name`.
 
@@ -49,7 +48,7 @@ def get_function_contents_by_name(lines: List[str], name: str):
             good_lines.append(line)
 
 
-def clean_lines(lines: List[str]):
+def clean_lines(lines: list[str]):
     """
     Filters `lines` and removes any entries that start with a comment ('#') or is just a newline ('\n')
 

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -17,7 +17,6 @@
 import pickle
 import tempfile
 import warnings
-from typing import List
 from unittest.mock import Mock
 
 import torch
@@ -102,8 +101,8 @@ def verify_dataloader_batch_sizes(
     accelerator: Accelerator,
     dataset_size: int,
     batch_size: int,
-    process_0_expected_batch_sizes: List[int],
-    process_1_expected_batch_sizes: List[int],
+    process_0_expected_batch_sizes: list[int],
+    process_1_expected_batch_sizes: list[int],
 ):
     """
     A helper function for verifying the batch sizes coming from a prepared dataloader in each process

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -24,7 +24,7 @@ import unittest
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
-from typing import List, Union
+from typing import Union
 from unittest import mock
 
 import torch
@@ -633,7 +633,7 @@ class MockingTestCase(unittest.TestCase):
     ```
     """
 
-    def add_mocks(self, mocks: Union[mock.Mock, List[mock.Mock]]):
+    def add_mocks(self, mocks: Union[mock.Mock, list[mock.Mock]]):
         """
         Add custom mocks for tests that should be repeated on each test. Should be called during
         `MockingTestCase.setUp`, after `super().setUp()`.
@@ -741,7 +741,7 @@ class SubprocessCallException(Exception):
     pass
 
 
-def run_command(command: List[str], return_stdout=False, env=None):
+def run_command(command: list[str], return_stdout=False, env=None):
     """
     Runs `command` with `subprocess.check_output` and will potentially return the `stdout`. Will also properly capture
     if an error occured while running `command`

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -19,7 +19,7 @@ import json
 import os
 import time
 from functools import wraps
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 import yaml
 
@@ -360,8 +360,8 @@ class WandBTracker(GeneralTracker):
     def log_table(
         self,
         table_name: str,
-        columns: List[str] = None,
-        data: List[List[Any]] = None,
+        columns: list[str] = None,
+        data: list[list[Any]] = None,
         dataframe: Any = None,
         step: Optional[int] = None,
         **kwargs,
@@ -537,7 +537,7 @@ class AimTracker(GeneralTracker):
             self.writer.track(value, name=key, step=step, **kwargs)
 
     @on_main_process
-    def log_images(self, values: dict, step: Optional[int] = None, kwargs: Optional[Dict[str, dict]] = None):
+    def log_images(self, values: dict, step: Optional[int] = None, kwargs: Optional[dict[str, dict]] = None):
         """
         Logs `images` to the current run.
 
@@ -613,7 +613,7 @@ class MLflowTracker(GeneralTracker):
         experiment_name: str = None,
         logging_dir: Optional[Union[str, os.PathLike]] = None,
         run_id: Optional[str] = None,
-        tags: Optional[Union[Dict[str, Any], str]] = None,
+        tags: Optional[Union[dict[str, Any], str]] = None,
         nested_run: Optional[bool] = False,
         run_name: Optional[str] = None,
         description: Optional[str] = None,
@@ -820,7 +820,7 @@ class ClearMLTracker(GeneralTracker):
         return self.task.connect_configuration(values)
 
     @on_main_process
-    def log(self, values: Dict[str, Union[int, float]], step: Optional[int] = None, **kwargs):
+    def log(self, values: dict[str, Union[int, float]], step: Optional[int] = None, **kwargs):
         """
         Logs `values` dictionary to the current run. The dictionary keys must be strings. The dictionary values must be
         ints or floats
@@ -875,8 +875,8 @@ class ClearMLTracker(GeneralTracker):
     def log_table(
         self,
         table_name: str,
-        columns: List[str] = None,
-        data: List[List[Any]] = None,
+        columns: list[str] = None,
+        data: list[list[Any]] = None,
         dataframe: Any = None,
         step: Optional[int] = None,
         **kwargs,
@@ -1022,7 +1022,7 @@ LOGGER_TYPE_TO_CLASS = {
 
 
 def filter_trackers(
-    log_with: List[Union[str, LoggerType, GeneralTracker]],
+    log_with: list[Union[str, LoggerType, GeneralTracker]],
     logging_dir: Union[str, os.PathLike] = None,
 ):
     """

--- a/src/accelerate/utils/ao.py
+++ b/src/accelerate/utils/ao.py
@@ -17,7 +17,7 @@ Needed utilities for torchao FP8 training.
 """
 
 from functools import partial
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 import torch
 
@@ -45,7 +45,7 @@ def find_first_last_linear_layers(model: torch.nn.Module):
     return first_linear, last_linear
 
 
-def filter_linear_layers(module, fqn: str, layers_to_filter: List[str]) -> bool:
+def filter_linear_layers(module, fqn: str, layers_to_filter: list[str]) -> bool:
     """
     A function which will check if `module` is:
     - a `torch.nn.Linear` layer

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -16,7 +16,7 @@
 import logging
 import os
 from copy import deepcopy
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -45,9 +45,9 @@ def load_and_quantize_model(
     model: torch.nn.Module,
     bnb_quantization_config: BnbQuantizationConfig,
     weights_location: Union[str, os.PathLike] = None,
-    device_map: Optional[Dict[str, Union[int, str, torch.device]]] = None,
-    no_split_module_classes: Optional[List[str]] = None,
-    max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,
+    device_map: Optional[dict[str, Union[int, str, torch.device]]] = None,
+    no_split_module_classes: Optional[list[str]] = None,
+    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
     offload_folder: Optional[Union[str, os.PathLike]] = None,
     offload_state_dict: bool = False,
 ):
@@ -204,7 +204,7 @@ def get_quantized_model_device_map(
             device_map = {"": torch.xpu.current_device()}
         else:
             raise RuntimeError("No GPU found. A GPU is needed for quantization.")
-        logger.info("The device_map was not initialized." "Setting device_map to `{'':torch.cuda.current_device()}`.")
+        logger.info("The device_map was not initialized.Setting device_map to `{'':torch.cuda.current_device()}`.")
 
     if isinstance(device_map, str):
         if device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -23,10 +23,11 @@ import functools
 import logging
 import os
 import warnings
+from collections.abc import Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Literal, Optional, Tuple, Union, get_args
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union, get_args
 
 import torch
 
@@ -192,14 +193,14 @@ class DistributedDataParallelKwargs(KwargsHandler):
     def register_comm_hook(self, model):
         from torch.distributed.algorithms.ddp_comm_hooks import default_hooks, powerSGD_hook
 
-        hook_map: Dict[DDPCommunicationHookType, Callable] = {
+        hook_map: dict[DDPCommunicationHookType, Callable] = {
             DDPCommunicationHookType.FP16: default_hooks.fp16_compress_hook,
             DDPCommunicationHookType.BF16: default_hooks.bf16_compress_hook,
             DDPCommunicationHookType.POWER_SGD: powerSGD_hook.powerSGD_hook,
             DDPCommunicationHookType.BATCHED_POWER_SGD: powerSGD_hook.batched_powerSGD_hook,
         }
 
-        wrapper_map: Dict[DDPCommunicationHookType, Callable] = {
+        wrapper_map: dict[DDPCommunicationHookType, Callable] = {
             DDPCommunicationHookType.FP16: default_hooks.fp16_compress_wrapper,
             DDPCommunicationHookType.BF16: default_hooks.bf16_compress_wrapper,
         }
@@ -355,7 +356,7 @@ class TERecipeKwargs(KwargsHandler):
     fp8_format: FP8Format = None
     amax_history_len: int = None
     amax_compute_algo: AmaxComputeAlgorithm = None
-    override_linear_precision: Tuple[bool, bool, bool] = None
+    override_linear_precision: tuple[bool, bool, bool] = None
 
     def __post_init__(self):
         env_prefix = "ACCELERATE_FP8_"
@@ -483,8 +484,8 @@ class ProfileKwargs(KwargsHandler):
             to None, which means profiling does not store json files.
     """
 
-    activities: Optional[List[ProfilerActivity]] = None
-    schedule_option: Optional[Dict[str, int]] = None
+    activities: Optional[list[ProfilerActivity]] = None
+    schedule_option: Optional[dict[str, int]] = None
     on_trace_ready: Optional[Callable] = None
     record_shapes: bool = False
     profile_memory: bool = False
@@ -530,7 +531,7 @@ class ProfileKwargs(KwargsHandler):
         Returns:
             torch.profiler.profile: The profiler object.
         """
-        activities: Optional[List[ProfilerActivity]] = None
+        activities: Optional[list[ProfilerActivity]] = None
         if self.activities is not None:
             activities = [self._get_profiler_activity(activity) for activity in self.activities]
         schedule: Optional[torch.profiler.schedule] = None
@@ -1647,7 +1648,7 @@ class FullyShardedDataParallelPlugin:
             "Only applicable for 🤗 Transformers. When using this, `sync_module_states` needs to be `True`. Defaults to `False`."
         },
     )
-    transformer_cls_names_to_wrap: Optional[List[str]] = field(
+    transformer_cls_names_to_wrap: Optional[list[str]] = field(
         default=None,
         metadata={
             "help": "A list of transformer layer class names to wrap. Only applicable when `auto_wrap_policy` is `transformer_based_wrap`."
@@ -1835,7 +1836,7 @@ class FullyShardedDataParallelPlugin:
 
         #  Single warning for all deprecation warnings due to FSDP2 conversion
         if _fsdp2_warnings:
-            logger.warning("Multiple deprecation warnings due to FSDP2 conversion:" "\n".join(_fsdp2_warnings))
+            logger.warning("Multiple deprecation warnings due to FSDP2 conversion:\n".join(_fsdp2_warnings))
 
     def set_state_dict_type(self, state_dict_type=None):
         """
@@ -2228,7 +2229,7 @@ class MegatronLMPlugin:
         default=0,
         metadata={"help": "Minumum value for learning rate. The scheduler clip values below this threshold."},
     )
-    consumed_samples: List[int] = field(
+    consumed_samples: list[int] = field(
         default=None,
         metadata={
             "help": "Number of samples consumed in the same order as the dataloaders to `accelerator.prepare` call."
@@ -2277,7 +2278,7 @@ class MegatronLMPlugin:
         default=None,
         metadata={"help": "Custom train step class."},
     )
-    custom_train_step_kwargs: Optional[Dict[str, Any]] = field(
+    custom_train_step_kwargs: Optional[dict[str, Any]] = field(
         default=None,
         metadata={"help": "Custom train step kwargs."},
     )
@@ -2306,7 +2307,7 @@ class MegatronLMPlugin:
 
     # remaining args such as enabling Alibi/ROPE positional embeddings,
     # wandb logging, Multi-Query Attention, etc.
-    other_megatron_args: Optional[Dict[str, Any]] = field(
+    other_megatron_args: Optional[dict[str, Any]] = field(
         default=None,
         metadata={"help": "Other Megatron-LM arguments. Please refer Megatron-LM"},
     )
@@ -2667,14 +2668,14 @@ class BnbQuantizationConfig:
         },
     )
 
-    skip_modules: List[str] = field(
+    skip_modules: list[str] = field(
         default=None,
         metadata={
             "help": "an explicit list of the modules that we don't quantize. The dtype of these modules will be `torch_dtype`."
         },
     )
 
-    keep_in_fp32_modules: List[str] = field(
+    keep_in_fp32_modules: list[str] = field(
         default=None,
         metadata={"help": "an explicit list of the modules that we don't quantize. We keep them in `torch.float32`."},
     )

--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -22,7 +22,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import lru_cache, wraps
 from shutil import which
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import torch
 from packaging.version import parse
@@ -91,7 +91,7 @@ def parse_choice_from_env(key, default="no"):
     return value
 
 
-def are_libraries_initialized(*library_names: str) -> List[str]:
+def are_libraries_initialized(*library_names: str) -> list[str]:
     """
     Checks if any of `library_names` are imported in the environment. Will return any names that are.
     """

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 from ast import literal_eval
 from shutil import which
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import torch
 
@@ -77,7 +77,7 @@ def _get_mpirun_args():
         return mpi_app, "-f", "-n", "-ppn", ""
 
 
-def setup_fp8_env(args: argparse.Namespace, current_env: Dict[str, str]):
+def setup_fp8_env(args: argparse.Namespace, current_env: dict[str, str]):
     """
     Setup the FP8 environment variables.
     """
@@ -95,7 +95,7 @@ def setup_fp8_env(args: argparse.Namespace, current_env: Dict[str, str]):
     return current_env
 
 
-def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict[str, str]]:
+def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> tuple[list[str], dict[str, str]]:
     """
     Prepares and returns the command list and an environment with the correct simple launcher environment variables.
     """
@@ -192,7 +192,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> Tuple[List[str]
     return cmd, current_env
 
 
-def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
+def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
     """
     Prepares and returns an environment with the correct multi-GPU environment variables.
     """
@@ -331,7 +331,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> Dict[str, str]:
     return current_env
 
 
-def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict[str, str]]:
+def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> tuple[list[str], dict[str, str]]:
     """
     Prepares and returns the command list and an environment with the correct DeepSpeed environment variables.
     """
@@ -476,8 +476,8 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> Tuple[List[str], Dict
 
 
 def prepare_tpu(
-    args: argparse.Namespace, current_env: Dict[str, str], pod: bool = False
-) -> Tuple[argparse.Namespace, Dict[str, str]]:
+    args: argparse.Namespace, current_env: dict[str, str], pod: bool = False
+) -> tuple[argparse.Namespace, dict[str, str]]:
     """
     Prepares and returns an environment with the correct TPU environment variables.
     """
@@ -495,7 +495,7 @@ def prepare_tpu(
     return args, current_env
 
 
-def _convert_nargs_to_dict(nargs: List[str]) -> Dict[str, str]:
+def _convert_nargs_to_dict(nargs: list[str]) -> dict[str, str]:
     if len(nargs) < 0:
         return {}
     # helper function to infer type for argsparser
@@ -539,7 +539,7 @@ def _convert_nargs_to_dict(nargs: List[str]) -> Dict[str, str]:
 
 def prepare_sagemager_args_inputs(
     sagemaker_config: SageMakerConfig, args: argparse.Namespace
-) -> Tuple[argparse.Namespace, Dict[str, Any]]:
+) -> tuple[argparse.Namespace, dict[str, Any]]:
     # configure environment
     print("Configuring Amazon SageMaker environment")
     os.environ["AWS_DEFAULT_REGION"] = sagemaker_config.region

--- a/src/accelerate/utils/megatron_lm.py
+++ b/src/accelerate/utils/megatron_lm.py
@@ -195,8 +195,7 @@ class MegatronLMDummyDataLoader:
             old_value = getattr(args, key, "")
             if old_value != value:
                 print(
-                    f"WARNING: MegatronLMDummyDataLoader overriding arguments for "
-                    f"{key}:{old_value} with {key}:{value}"
+                    f"WARNING: MegatronLMDummyDataLoader overriding arguments for {key}:{old_value} with {key}:{value}"
                 )
             setattr(args, key, value)
 
@@ -887,7 +886,7 @@ def initialize(accelerator, extra_args_provider=None, args_defaults={}):
         if getattr(args, key, None) is not None:
             if args.rank == 0:
                 print(
-                    f"WARNING: overriding default arguments for " f"{key}:{getattr(args, key)} with {key}:{value}",
+                    f"WARNING: overriding default arguments for {key}:{getattr(args, key)} with {key}:{value}",
                     flush=True,
                 )
         setattr(args, key, value)

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -24,7 +24,7 @@ import shutil
 import tempfile
 import warnings
 from collections import OrderedDict, defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union
 
 import torch
 import torch.nn as nn
@@ -178,7 +178,7 @@ def dtype_byte_size(dtype: torch.dtype):
     return bit_size // 8
 
 
-def id_tensor_storage(tensor: torch.Tensor) -> Tuple[torch.device, int, int]:
+def id_tensor_storage(tensor: torch.Tensor) -> tuple[torch.device, int, int]:
     """
     Unique identifier to a tensor storage. Multiple different tensors can share the same underlying storage. For
     example, "meta" tensors all share the same storage, and thus their identifier will all be equal. This identifier is
@@ -221,7 +221,7 @@ def set_module_tensor_to_device(
     value: Optional[torch.Tensor] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     fp16_statistics: Optional[torch.HalfTensor] = None,
-    tied_params_map: Optional[Dict[int, Dict[torch.device, torch.Tensor]]] = None,
+    tied_params_map: Optional[dict[int, dict[torch.device, torch.Tensor]]] = None,
 ):
     """
     A helper function to set a given tensor (parameter of buffer) of a module on a specific device (note that doing
@@ -654,7 +654,7 @@ def _get_proper_dtype(dtype: Union[str, torch.device]) -> torch.dtype:
 def compute_module_sizes(
     model: nn.Module,
     dtype: Optional[Union[str, torch.device]] = None,
-    special_dtypes: Optional[Dict[str, Union[str, torch.device]]] = None,
+    special_dtypes: Optional[dict[str, Union[str, torch.device]]] = None,
     buffers_only: bool = False,
 ):
     """
@@ -696,7 +696,7 @@ def compute_module_sizes(
 def compute_module_total_buffer_size(
     model: nn.Module,
     dtype: Optional[Union[str, torch.device]] = None,
-    special_dtypes: Optional[Dict[str, Union[str, torch.device]]] = None,
+    special_dtypes: Optional[dict[str, Union[str, torch.device]]] = None,
 ):
     """
     Compute the total size of buffers in each submodule of a given model.
@@ -706,7 +706,7 @@ def compute_module_total_buffer_size(
 
 
 def get_max_layer_size(
-    modules: List[Tuple[str, torch.nn.Module]], module_sizes: Dict[str, int], no_split_module_classes: List[str]
+    modules: list[tuple[str, torch.nn.Module]], module_sizes: dict[str, int], no_split_module_classes: list[str]
 ):
     """
     Utility function that will scan a list of named modules and return the maximum size used by one full layer. The
@@ -744,7 +744,7 @@ def get_max_layer_size(
     return max_size, layer_names
 
 
-def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None):
+def get_max_memory(max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None):
     """
     Get the maximum memory available if nothing is passed, converts string to int otherwise.
     """
@@ -855,7 +855,7 @@ def get_max_memory(max_memory: Optional[Dict[Union[int, str], Union[int, str]]] 
     return max_memory
 
 
-def clean_device_map(device_map: Dict[str, Union[int, str, torch.device]], module_name: str = ""):
+def clean_device_map(device_map: dict[str, Union[int, str, torch.device]], module_name: str = ""):
     """
     Cleans a device_map by grouping all submodules that go on the same device together.
     """
@@ -920,10 +920,10 @@ def get_module_leaves(module_sizes):
 
 def get_balanced_memory(
     model: nn.Module,
-    max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,
-    no_split_module_classes: Optional[List[str]] = None,
+    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
+    no_split_module_classes: Optional[list[str]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
-    special_dtypes: Optional[Dict[str, Union[str, torch.device]]] = None,
+    special_dtypes: Optional[dict[str, Union[str, torch.device]]] = None,
     low_zero: bool = False,
 ):
     """
@@ -1071,19 +1071,19 @@ def calculate_maximum_sizes(model: torch.nn.Module):
 
 def _init_infer_auto_device_map(
     model: nn.Module,
-    max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,
-    no_split_module_classes: Optional[List[str]] = None,
+    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
+    no_split_module_classes: Optional[list[str]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
-    special_dtypes: Optional[Dict[str, Union[str, torch.device]]] = None,
-) -> Tuple[
-    List[Union[int, str]],
-    Dict[Union[int, str], Union[int, str]],
-    List[Union[int, str]],
-    List[int],
-    Dict[str, int],
-    List[List[str]],
-    List[str],
-    List[Tuple[str, nn.Module]],
+    special_dtypes: Optional[dict[str, Union[str, torch.device]]] = None,
+) -> tuple[
+    list[Union[int, str]],
+    dict[Union[int, str], Union[int, str]],
+    list[Union[int, str]],
+    list[int],
+    dict[str, int],
+    list[list[str]],
+    list[str],
+    list[tuple[str, nn.Module]],
 ]:
     """
     Initialize variables required for computing the device map for model allocation.
@@ -1139,7 +1139,7 @@ def get_module_size_with_ties(
     module_size,
     module_sizes,
     modules_to_treat,
-) -> Tuple[int, List[str], List[nn.Module]]:
+) -> tuple[int, list[str], list[nn.Module]]:
     """
     Calculate the total size of a module, including its tied parameters.
 
@@ -1171,12 +1171,12 @@ def get_module_size_with_ties(
 
 
 def fallback_allocate(
-    modules: List[Tuple[str, nn.Module]],
-    module_sizes: Dict[str, int],
+    modules: list[tuple[str, nn.Module]],
+    module_sizes: dict[str, int],
     size_limit: Union[int, str],
-    no_split_module_classes: Optional[List[str]] = None,
-    tied_parameters: Optional[List[List[str]]] = None,
-) -> Tuple[Optional[str], Optional[nn.Module], List[Tuple[str, nn.Module]]]:
+    no_split_module_classes: Optional[list[str]] = None,
+    tied_parameters: Optional[list[list[str]]] = None,
+) -> tuple[Optional[str], Optional[nn.Module], list[tuple[str, nn.Module]]]:
     """
     Find a module that fits in the size limit using BFS and return it with its name and the remaining modules.
 
@@ -1280,10 +1280,10 @@ def fallback_allocate(
 
 def infer_auto_device_map(
     model: nn.Module,
-    max_memory: Optional[Dict[Union[int, str], Union[int, str]]] = None,
-    no_split_module_classes: Optional[List[str]] = None,
+    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
+    no_split_module_classes: Optional[list[str]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
-    special_dtypes: Optional[Dict[str, Union[str, torch.dtype]]] = None,
+    special_dtypes: Optional[dict[str, Union[str, torch.dtype]]] = None,
     verbose: bool = False,
     clean_result: bool = True,
     offload_buffers: bool = False,
@@ -1586,7 +1586,7 @@ def infer_auto_device_map(
     return device_map
 
 
-def check_device_map(model: nn.Module, device_map: Dict[str, Union[int, str, torch.device]]):
+def check_device_map(model: nn.Module, device_map: dict[str, Union[int, str, torch.device]]):
     """
     Checks a device map covers everything in a given model.
 
@@ -1747,7 +1747,7 @@ def get_state_dict_offloaded_model(model: nn.Module):
 def get_state_dict_from_offload(
     module: nn.Module,
     module_name: str,
-    state_dict: Dict[str, Union[str, torch.tensor]],
+    state_dict: dict[str, Union[str, torch.tensor]],
     device_to_put_offload: Union[int, str, torch.device] = "cpu",
 ):
     """
@@ -1783,12 +1783,12 @@ def get_state_dict_from_offload(
 def load_checkpoint_in_model(
     model: nn.Module,
     checkpoint: Union[str, os.PathLike],
-    device_map: Optional[Dict[str, Union[int, str, torch.device]]] = None,
+    device_map: Optional[dict[str, Union[int, str, torch.device]]] = None,
     offload_folder: Optional[Union[str, os.PathLike]] = None,
     dtype: Optional[Union[str, torch.dtype]] = None,
     offload_state_dict: bool = False,
     offload_buffers: bool = False,
-    keep_in_fp32_modules: List[str] = None,
+    keep_in_fp32_modules: list[str] = None,
     offload_8bit_bnb: bool = False,
     strict: bool = False,
 ):

--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -15,7 +15,7 @@
 import json
 import os
 from collections.abc import Mapping
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -82,7 +82,7 @@ def save_offload_index(index, offload_folder):
         json.dump(current_index, f, indent=2)
 
 
-def offload_state_dict(save_dir: Union[str, os.PathLike], state_dict: Dict[str, torch.Tensor]):
+def offload_state_dict(save_dir: Union[str, os.PathLike], state_dict: dict[str, torch.Tensor]):
     """
     Offload a state dict in a given folder.
 
@@ -140,7 +140,7 @@ class OffloadedWeightsLoader(Mapping):
 
     def __init__(
         self,
-        state_dict: Dict[str, torch.Tensor] = None,
+        state_dict: dict[str, torch.Tensor] = None,
         save_folder: Optional[Union[str, os.PathLike]] = None,
         index: Mapping = None,
         device=None,
@@ -191,7 +191,7 @@ class OffloadedWeightsLoader(Mapping):
         return len(self.all_keys)
 
 
-def extract_submodules_state_dict(state_dict: Dict[str, torch.Tensor], submodule_names: List[str]):
+def extract_submodules_state_dict(state_dict: dict[str, torch.Tensor], submodule_names: list[str]):
     """
     Extract the sub state-dict corresponding to a list of given submodules.
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -17,9 +17,10 @@ A set of basic tensor ops compatible with tpu, gpu, and multigpu
 
 import pickle
 import warnings
+from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from functools import update_wrapper, wraps
-from typing import Any, Mapping
+from typing import Any
 
 import torch
 

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -17,9 +17,9 @@ import platform
 import re
 import socket
 from codecs import encode
+from collections import OrderedDict
 from functools import partial, reduce
 from types import MethodType
-from typing import OrderedDict
 
 import numpy as np
 import torch

--- a/src/accelerate/utils/random.py
+++ b/src/accelerate/utils/random.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import random
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import numpy as np
 import torch
@@ -151,6 +151,6 @@ def synchronize_rng_state(rng_type: Optional[RNGType] = None, generator: Optiona
         generator.set_state(rng_state)
 
 
-def synchronize_rng_states(rng_types: List[Union[str, RNGType]], generator: Optional[torch.Generator] = None):
+def synchronize_rng_states(rng_types: list[Union[str, RNGType]], generator: Optional[torch.Generator] = None):
     for rng_type in rng_types:
         synchronize_rng_state(RNGType(rng_type), generator=generator)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -18,7 +18,7 @@ import tempfile
 import unittest
 import warnings
 from collections import OrderedDict
-from typing import Dict, Optional
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -499,7 +499,7 @@ class ModelingUtilsTester(unittest.TestCase):
             assert new_model.float_param.dtype == torch.float16
 
     @parameterized.expand([(None,), ({"": "cpu"},)])
-    def test_load_checkpoint_in_model_unexpected_keys(self, device_map: Optional[Dict]):
+    def test_load_checkpoint_in_model_unexpected_keys(self, device_map: Optional[dict]):
         model = ModelForTest()
 
         state_dict = model.state_dict()


### PR DESCRIPTION
# What does this PR do?

Use Python 3.9 as base version for ruff.