### PR TITLE
Fix check_tied_parameters_in_config for multimodal models

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -136,11 +136,10 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
 
 
     >>> @find_executable_batch_size(starting_batch_size=128)
-    ... def train(batch_size, model, optimizer):
-    ...     ...
+    ... def train(batch_size, model, optimizer): ...
 
 
-    >>> train(model, optimizer)
+    ... train(model, optimizer)
     ```
     """
     if function is None:

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -136,10 +136,11 @@ def find_executable_batch_size(function: callable = None, starting_batch_size: i
 
 
     >>> @find_executable_batch_size(starting_batch_size=128)
-    ... def train(batch_size, model, optimizer): ...
+    ... def train(batch_size, model, optimizer):
+    ...     ...
 
 
-    ... train(model, optimizer)
+    >>> train(model, optimizer)
     ```
     """
     if function is None:


### PR DESCRIPTION
# What does this PR do?

This PR fixes the tied weights check as `tie_word_embeddings` is only for the decoder part of a model. So for multimodal model, we need to get the decoder config and not the global config. The issue with the global config is that `tie_word_embeddings` is set to `True` by default. 