### PR TITLE
fix warning error

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import sys
+import warnings
 from pathlib import Path
 
 import psutil
@@ -1169,7 +1170,7 @@ def _validate_launch_command(args):
                 )
 
     if args.use_xpu is not None:
-        logger.warning(
+        warnings.warn(
             "use_xpu is deprecated and ignored, will be removed in Accelerate v1.20. "
             "XPU is a PyTorch native citizen now, we don't need extra argument to enable it any more.",
             FutureWarning,

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -20,7 +20,6 @@ import logging
 import os
 import subprocess
 import sys
-import warnings
 from pathlib import Path
 
 import psutil
@@ -1170,10 +1169,9 @@ def _validate_launch_command(args):
                 )
 
     if args.use_xpu is not None:
-        warnings.warn(
+        logger.warning(
             "use_xpu is deprecated and ignored, will be removed in Accelerate v1.20. "
-            "XPU is a PyTorch native citizen now, we don't need extra argument to enable it any more.",
-            FutureWarning,
+            "XPU is a PyTorch native citizen now, we don't need extra argument to enable it any more."
         )
 
     if any(warned):


### PR DESCRIPTION
## What does this PR do?
I got the following error when running a deepspeed test case:

```bash
_________________________________ DeepSpeedConfigIntegration.test_train_multiple_models _________________________________

self = <test_deepspeed_multiple_model.DeepSpeedConfigIntegration testMethod=test_train_multiple_models>

    @run_first
    @require_huggingface_suite
    @require_multi_device
    @slow
    def test_train_multiple_models(self):
        self.test_file_path = self.test_scripts_folder / "test_ds_multiple_model.py"
        args = ["--num_processes=2", "--num_machines=1", str(self.test_file_path)]
        args = self.parser.parse_args(args)
>       launch_command(args)

tests/deepspeed/test_deepspeed_multiple_model.py:183: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/accelerate/commands/launch.py:1189: in launch_command
    args, defaults, mp_from_config_flag = _validate_launch_command(args)
src/accelerate/commands/launch.py:1172: in _validate_launch_command
    logger.warning(
/usr/lib/python3.11/logging/__init__.py:1501: in warning
    self._log(WARNING, msg, args, **kwargs)
/usr/lib/python3.11/logging/__init__.py:1634: in _log
    self.handle(record)
/usr/lib/python3.11/logging/__init__.py:1644: in handle
    self.callHandlers(record)
/usr/lib/python3.11/logging/__init__.py:1706: in callHandlers
    hdlr.handle(record)
/usr/lib/python3.11/logging/__init__.py:978: in handle
    self.emit(record)
/usr/local/lib/python3.11/dist-packages/_pytest/logging.py:372: in emit
    super().emit(record)
/usr/lib/python3.11/logging/__init__.py:1118: in emit
    self.handleError(record)
/usr/lib/python3.11/logging/__init__.py:1110: in emit
    msg = self.format(record)
/usr/lib/python3.11/logging/__init__.py:953: in format
    return fmt.format(record)
/usr/local/lib/python3.11/dist-packages/_pytest/logging.py:136: in format
    return super().format(record)
/usr/lib/python3.11/logging/__init__.py:687: in format
    record.message = record.getMessage()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <LogRecord: accelerate.commands.launch, 30, /.tests/accelerate/src/accelerate/commands/launch.py, 1172, "use_xpu is de...removed in Accelerate v1.20. XPU is a PyTorch native citizen now, we don't need extra argument to enable it any more.">

    def getMessage(self):
        """
        Return the message for this LogRecord.
    
        Return the message for this LogRecord after merging any user-supplied
        arguments with the message.
        """
        msg = str(self.msg)
        if self.args:
>           msg = msg % self.args
E           TypeError: not all arguments converted during string formatting

/usr/lib/python3.11/logging/__init__.py:377: TypeError
```

The reason is that line 1172 uses the wrong warning method. `logger.warning` doesn't accept a second argument like this.  It expects the log message to be a single string. 

Fix:
use the `warnings.warn` function instead of `logger.warning` to issue a deprecation warning. 

