### PR TITLE
Fix fp8 deepspeed config

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -810,6 +810,8 @@ def get_cluster_input():
                             default=False,
                         )
                         fp8_config["override_linear_precision"] = (fprop, dgrad, wgrad)
+                    else:
+                        fp8_config["override_linear_precision"] = (False, False, False)
 
                 elif fp8_config["backend"] == "MSAMP":
                     if not is_msamp_available():


### PR DESCRIPTION
# What does this PR do?
Fixes https://github.com/huggingface/accelerate/issues/3489 
`override_linear_precision` is incorrectly set when using `accelerate config`