### PR TITLE
Add FP8 runners + tweak building FP8 image

### DIFF
--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -102,8 +102,9 @@ jobs:
         id: date
         run: |
           echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-          echo "base_year=$(date '+%Y')" >> $GITHUB_ENV
-          echo "base_month=$(date '+%m')" >> $GITHUB_ENV
+          # Get the previous month
+          echo "base_year=$(date -d 'last month' '+%Y')" >> $GITHUB_ENV
+          echo "base_month=$(date -d 'last month' '+%m')" >> $GITHUB_ENV
       - name: Build and Push GPU
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
           # Get the previous month
-          echo "base_year=$(date -d 'last month' '+%Y')" >> $GITHUB_ENV
+          echo "base_year=$(date -d 'last month' '+%y')" >> $GITHUB_ENV
           echo "base_month=$(date -d 'last month' '+%m')" >> $GITHUB_ENV
       - name: Build and Push GPU
         uses: docker/build-push-action@v4

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -11,80 +11,80 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # latest-cpu:
-  #   name: "Latest Accelerate CPU [dev]"
-  #   runs-on:
-  #     group: aws-general-8-plus
-  #   steps:
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-  #     - name: Get current date
-  #       id: date
-  #       run: |
-  #         echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-  #     - name: Build and Push CPU
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         file: docker/accelerate-cpu/Dockerfile
-  #         push: true
-  #         tags: |
-  #           huggingface/accelerate:cpu-nightly
-  #           huggingface/accelerate:cpu-nightly-${{ env.date }}
+  latest-cpu:
+    name: "Latest Accelerate CPU [dev]"
+    runs-on:
+      group: aws-general-8-plus
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Build and Push CPU
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/accelerate-cpu/Dockerfile
+          push: true
+          tags: |
+            huggingface/accelerate:cpu-nightly
+            huggingface/accelerate:cpu-nightly-${{ env.date }}
 
-  # latest-cuda:
-  #   name: "Latest Accelerate GPU [dev]"
-  #   runs-on:
-  #     group: aws-g6-4xlarge-plus
-  #   steps:
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-  #     - name: Get current date
-  #       id: date
-  #       run: |
-  #         echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-  #     - name: Build and Push GPU
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         file: docker/accelerate-gpu/Dockerfile
-  #         push: true
-  #         tags: |
-  #           huggingface/accelerate:gpu-nightly
-  #           huggingface/accelerate:gpu-nightly-${{ env.date }}
+  latest-cuda:
+    name: "Latest Accelerate GPU [dev]"
+    runs-on:
+      group: aws-g6-4xlarge-plus
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/accelerate-gpu/Dockerfile
+          push: true
+          tags: |
+            huggingface/accelerate:gpu-nightly
+            huggingface/accelerate:gpu-nightly-${{ env.date }}
 
-  # latest-cuda-deepspeed:
-  #   name: "Latest Accelerate GPU DeepSpeed [dev]"
-  #   runs-on:
-  #     group: aws-g6-4xlarge-plus
-  #   steps:
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v2
-  #     - name: Login to DockerHub
-  #       uses: docker/login-action@v2
-  #       with:
-  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
-  #     - name: Get current date
-  #       id: date
-  #       run: |
-  #         echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-  #     - name: Build and Push GPU
-  #       uses: docker/build-push-action@v4
-  #       with:
-  #         file: docker/accelerate-gpu-deepspeed/Dockerfile
-  #         push: true
-  #         tags: |
-  #           huggingface/accelerate:gpu-deepspeed-nightly
-  #           huggingface/accelerate:gpu-deepspeed-nightly-${{ env.date }}
+  latest-cuda-deepspeed:
+    name: "Latest Accelerate GPU DeepSpeed [dev]"
+    runs-on:
+      group: aws-g6-4xlarge-plus
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Get current date
+        id: date
+        run: |
+          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Build and Push GPU
+        uses: docker/build-push-action@v4
+        with:
+          file: docker/accelerate-gpu-deepspeed/Dockerfile
+          push: true
+          tags: |
+            huggingface/accelerate:gpu-deepspeed-nightly
+            huggingface/accelerate:gpu-deepspeed-nightly-${{ env.date }}
 
   latest-cuda-fp8-transformerengine:
     name: "Latest Accelerate GPU FP8 TransformerEngine [dev]"

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -102,9 +102,14 @@ jobs:
         id: date
         run: |
           echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+          echo "base_year=$(date '+%Y')" >> $GITHUB_ENV
+          echo "base_month=$(date '+%m')" >> $GITHUB_ENV
       - name: Build and Push GPU
         uses: docker/build-push-action@v4
         with:
           file: benchmarks/fp8/transformer_engine/Dockerfile
           push: true
           tags: huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ env.date }}
+          build-args: |
+            BASE_YEAR=${{ env.base_year }}
+            BASE_MONTH=${{ env.base_month }}

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -11,80 +11,80 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  latest-cpu:
-    name: "Latest Accelerate CPU [dev]"
-    runs-on:
-      group: aws-general-8-plus
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Get current date
-        id: date
-        run: |
-          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Build and Push CPU
-        uses: docker/build-push-action@v4
-        with:
-          file: docker/accelerate-cpu/Dockerfile
-          push: true
-          tags: |
-            huggingface/accelerate:cpu-nightly
-            huggingface/accelerate:cpu-nightly-${{ env.date }}
+  # latest-cpu:
+  #   name: "Latest Accelerate CPU [dev]"
+  #   runs-on:
+  #     group: aws-general-8-plus
+  #   steps:
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  #     - name: Get current date
+  #       id: date
+  #       run: |
+  #         echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+  #     - name: Build and Push CPU
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         file: docker/accelerate-cpu/Dockerfile
+  #         push: true
+  #         tags: |
+  #           huggingface/accelerate:cpu-nightly
+  #           huggingface/accelerate:cpu-nightly-${{ env.date }}
 
-  latest-cuda:
-    name: "Latest Accelerate GPU [dev]"
-    runs-on:
-      group: aws-g6-4xlarge-plus
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Get current date
-        id: date
-        run: |
-          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Build and Push GPU
-        uses: docker/build-push-action@v4
-        with:
-          file: docker/accelerate-gpu/Dockerfile
-          push: true
-          tags: |
-            huggingface/accelerate:gpu-nightly
-            huggingface/accelerate:gpu-nightly-${{ env.date }}
+  # latest-cuda:
+  #   name: "Latest Accelerate GPU [dev]"
+  #   runs-on:
+  #     group: aws-g6-4xlarge-plus
+  #   steps:
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  #     - name: Get current date
+  #       id: date
+  #       run: |
+  #         echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+  #     - name: Build and Push GPU
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         file: docker/accelerate-gpu/Dockerfile
+  #         push: true
+  #         tags: |
+  #           huggingface/accelerate:gpu-nightly
+  #           huggingface/accelerate:gpu-nightly-${{ env.date }}
 
-  latest-cuda-deepspeed:
-    name: "Latest Accelerate GPU DeepSpeed [dev]"
-    runs-on:
-      group: aws-g6-4xlarge-plus
-    steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Get current date
-        id: date
-        run: |
-          echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Build and Push GPU
-        uses: docker/build-push-action@v4
-        with:
-          file: docker/accelerate-gpu-deepspeed/Dockerfile
-          push: true
-          tags: |
-            huggingface/accelerate:gpu-deepspeed-nightly
-            huggingface/accelerate:gpu-deepspeed-nightly-${{ env.date }}
+  # latest-cuda-deepspeed:
+  #   name: "Latest Accelerate GPU DeepSpeed [dev]"
+  #   runs-on:
+  #     group: aws-g6-4xlarge-plus
+  #   steps:
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v2
+  #     - name: Login to DockerHub
+  #       uses: docker/login-action@v2
+  #       with:
+  #         username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #         password: ${{ secrets.DOCKERHUB_PASSWORD }}
+  #     - name: Get current date
+  #       id: date
+  #       run: |
+  #         echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
+  #     - name: Build and Push GPU
+  #       uses: docker/build-push-action@v4
+  #       with:
+  #         file: docker/accelerate-gpu-deepspeed/Dockerfile
+  #         push: true
+  #         tags: |
+  #           huggingface/accelerate:gpu-deepspeed-nightly
+  #           huggingface/accelerate:gpu-deepspeed-nightly-${{ env.date }}
 
   latest-cuda-fp8-transformerengine:
     name: "Latest Accelerate GPU FP8 TransformerEngine [dev]"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run FP8 tests
         shell: bash
         run: |
-          conda activate; conda activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+          python -c "from accelerate import Accelerator; accelerator = Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on:
       group: aws-g6e-12xlarge
     container:
-      image: huggingface/accelerate:gpu-fp8-transformerengine-release-1.6.0
+      image: huggingface/accelerate:gpu-fp8-transformerengine-nightly-$(date -d "yesterday" '+%Y-%m-%d')
       options: --gpus all --shm-size "16gb"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   set-prev-day:
     runs-on: ubuntu-latest
+    outputs:
+      prev-day: ${{ steps.set-prev-day.outputs.prev-day }}
     steps:
       - name: Set PREV_DAY
         run: |
@@ -18,7 +20,7 @@ jobs:
     runs-on:
       group: aws-g6e-12xlarge
     container:
-      image: huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ env.PREV_DAY }}
+      image: huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ needs.set-prev-day.outputs.prev-day }}
       options: --gpus all --shm-size "16gb"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -1,0 +1,19 @@
+name: Test FP8 Runner
+
+on:
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  run-fp8-tests:
+    runs-on: [aws-g6e-12xlarge-use1-public-80]
+    container:
+      image: huggingface/accelerate:gpu-fp8-transformerengine-release-1.6.0
+      options: --gpus all --shm-size "16gb"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run FP8 tests
+        run: |
+          python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -2,6 +2,7 @@ name: Test FP8 Runner
 
 on:
   workflow_dispatch:
+  push:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install the library
         run: |
-            pip install -e .[test_prod]
+            pip install -e .[test_prod,test_fp8]
       - name: Show installed libraries
         run: |
           pip freeze

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set PREV_DAY
         run: |
           PREV_DAY=$(date -d "yesterday" '+%Y-%m-%d')
-          echo "PREV_DAY=$PREV_DAY" >> $GITHUB_ENV
+          echo "PREV_DAY=$PREV_DAY" >> $GITHUB_OUTPUT
   run-fp8-tests:
     needs: set-prev-day
     runs-on:

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -12,9 +12,10 @@ jobs:
       prev-day: ${{ steps.set-prev-day.outputs.prev-day }}
     steps:
       - name: Set PREV_DAY
+        id: set-prev-day
         run: |
           PREV_DAY=$(date -d "yesterday" '+%Y-%m-%d')
-          echo "PREV_DAY=$PREV_DAY" >> $GITHUB_OUTPUT
+          echo "prev-day=$PREV_DAY" >> $GITHUB_OUTPUT
   run-fp8-tests:
     needs: set-prev-day
     runs-on:

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -5,13 +5,20 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 jobs:
+  set-prev-day:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set PREV_DAY
+        run: |
+          PREV_DAY=$(date -d "yesterday" '+%Y-%m-%d')
+          echo "PREV_DAY=$PREV_DAY" >> $GITHUB_ENV
   run-fp8-tests:
+    needs: set-prev-day
     runs-on:
       group: aws-g6e-12xlarge
     container:
-      image: huggingface/accelerate:gpu-fp8-transformerengine-nightly-$(date -d "yesterday" '+%Y-%m-%d')
+      image: huggingface/accelerate:gpu-fp8-transformerengine-nightly-${{ env.PREV_DAY }}
       options: --gpus all --shm-size "16gb"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Run FP8 tests
         shell: bash
         run: |
-          source activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+          conda activate; conda activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run FP8 tests
         run: |
-          conda activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+          source activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   run-fp8-tests:
-    runs-on: [aws-g6e-12xlarge-use1-public-80]
+    runs-on: [self-hosted, aws-g6e-12xlarge]
     container:
       image: huggingface/accelerate:gpu-fp8-transformerengine-release-1.6.0
       options: --gpus all --shm-size "16gb"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Run FP8 tests
         shell: bash
         run: |
-          conda activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+          source activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Run FP8 tests
         run: |
-          python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+          conda activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -25,7 +25,13 @@ jobs:
       options: --gpus all --shm-size "16gb"
     steps:
       - uses: actions/checkout@v3
-      - name: Run FP8 tests
-        shell: bash
+      - name: Install the library
         run: |
-          python -c "from accelerate import Accelerator; accelerator = Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+            pip install -e .[test_prod]
+      - name: Show installed libraries
+        run: |
+          pip freeze
+      - name: Run TE FP8 tests
+        run: |
+          python -m pytest -s -v ./tests/test_fp8.py
+

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -8,7 +8,8 @@ env:
 
 jobs:
   run-fp8-tests:
-    runs-on: [self-hosted, aws-g6e-12xlarge]
+    runs-on:
+      group: aws-g6e-12xlarge
     container:
       image: huggingface/accelerate:gpu-fp8-transformerengine-release-1.6.0
       options: --gpus all --shm-size "16gb"

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -2,7 +2,6 @@ name: Test FP8 Runner
 
 on:
   workflow_dispatch:
-  push:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fp8_runner.yml
+++ b/.github/workflows/fp8_runner.yml
@@ -16,5 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Run FP8 tests
+        shell: bash
         run: |
-          source activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"
+          conda activate accelerate; python -c "from accelerate import Accelerator; Accelerator(mixed_precision='fp8'); print(accelerator.state)"

--- a/benchmarks/fp8/transformer_engine/Dockerfile
+++ b/benchmarks/fp8/transformer_engine/Dockerfile
@@ -1,4 +1,7 @@
-FROM nvcr.io/nvidia/pytorch:24.07-py3
+ARG BASE_YEAR=25
+ARG BASE_MONTH=03
+
+FROM nvcr.io/nvidia/pytorch:${BASE_YEAR}.${BASE_MONTH}-py3
 
 RUN pip install transformers evaluate datasets
 RUN git clone https://github.com/huggingface/accelerate.git

--- a/benchmarks/fp8/transformer_engine/Dockerfile
+++ b/benchmarks/fp8/transformer_engine/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_YEAR=25
 ARG BASE_MONTH=03
 
-FROM nvcr.io/nvidia/pytorch:${BASE_YEAR}.${BASE_MONTH}-py3
+FROM nvcr.io/nvidia/pytorch:${BASE_YEAR}.${BASE_MONTH}-py3-igpu
 
 RUN pip install transformers evaluate datasets
 RUN git clone https://github.com/huggingface/accelerate.git

--- a/benchmarks/fp8/transformer_engine/Dockerfile
+++ b/benchmarks/fp8/transformer_engine/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_YEAR=25
 ARG BASE_MONTH=03
 
-FROM nvcr.io/nvidia/pytorch:${BASE_YEAR}.${BASE_MONTH}-py3-igpu
+FROM nvcr.io/nvidia/pytorch:${BASE_YEAR}.${BASE_MONTH}-py3
 
 RUN pip install transformers evaluate datasets
 RUN git clone https://github.com/huggingface/accelerate.git

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["deepspeed"] = ["deepspeed"]
 extras["rich"] = ["rich"]
 
-extras["test_fp8"] = ["torchao"]
+extras["test_fp8"] = ["torchao"] # note: TE for now needs to be done via pulling down the docker image directly
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard", "dvclive", "mlflow", "matplotlib"]
 extras["dev"] = extras["quality"] + extras["testing"] + extras["rich"]
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["deepspeed"] = ["deepspeed"]
 extras["rich"] = ["rich"]
 
+extras["test_fp8"] = ["torchao"]
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard", "dvclive", "mlflow", "matplotlib"]
 extras["dev"] = extras["quality"] + extras["testing"] + extras["rich"]
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extras["testing"] = extras["test_prod"] + extras["test_dev"]
 extras["deepspeed"] = ["deepspeed"]
 extras["rich"] = ["rich"]
 
-extras["test_fp8"] = ["torchao"] # note: TE for now needs to be done via pulling down the docker image directly
+extras["test_fp8"] = ["torchao"]  # note: TE for now needs to be done via pulling down the docker image directly
 extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard", "dvclive", "mlflow", "matplotlib"]
 extras["dev"] = extras["quality"] + extras["testing"] + extras["rich"]
 


### PR DESCRIPTION
# What does this PR do?

This PR adds in running TE/FP8 tests through our dedicated CI runner for said tests. 

Also tweaks the docker image to allow for us to request which CUDA NVIDIA image we use (so we can get the latest TE version of the month). By default it builds with the prior month's image (so we always build off of the "latest-ish" release.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @S1ro1 