### PR TITLE
add support for port 0 auto-selection in multi-GPU environments

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -307,6 +307,19 @@ def is_port_in_use(port: int = None) -> bool:
         return s.connect_ex(("localhost", port)) == 0
 
 
+def get_free_port() -> int:
+    """
+    Gets a free port on `localhost`. Useful for automatic port selection when port 0 is specified in distributed
+    training scenarios.
+
+    Returns:
+        int: An available port number
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))  # bind to port 0 for OS to assign a free port
+        return s.getsockname()[1]
+
+
 def convert_bytes(size):
     "Converts `size` from bytes to the largest possible unit"
     for x in ["bytes", "KB", "MB", "GB", "TB"]:

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,0 +1,71 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import unittest
+
+from accelerate.utils.launch import prepare_multi_gpu_env
+
+
+class TestPrepareMultiGpuEnv(unittest.TestCase):
+    def test_auto_port_selection(self):
+        args = argparse.Namespace(
+            num_processes=1,
+            num_machines=1,
+            main_process_ip="127.0.0.1",
+            main_process_port=0,
+            machine_rank=0,
+            module=False,
+            no_python=False,
+            debug=False,
+            gpu_ids="all",
+            mixed_precision="no",
+            dynamo_backend="NO",
+            dynamo_mode="default",
+            dynamo_use_fullgraph=False,
+            dynamo_use_dynamic=False,
+            use_fsdp=False,
+            fsdp_cpu_ram_efficient_loading=False,
+            fsdp_sync_module_states=False,
+            fsdp_version=None,
+            fsdp_sharding_strategy=None,
+            fsdp_reshard_after_forward=False,
+            fsdp_offload_params=False,
+            fsdp_min_num_params=0,
+            fsdp_auto_wrap_policy=None,
+            fsdp_transformer_layer_cls_to_wrap=None,
+            fsdp_backward_prefetch=None,
+            fsdp_state_dict_type=None,
+            fsdp_forward_prefetch=False,
+            fsdp_use_orig_params=False,
+            fsdp_activation_checkpointing=False,
+            use_tp=False,
+            tp_size=1,
+            use_megatron_lm=False,
+            megatron_lm_tp_degree=1,
+            megatron_lm_pp_degree=1,
+            megatron_lm_gradient_clipping=1.0,
+            megatron_lm_num_micro_batches=None,
+            megatron_lm_sequence_parallelism=None,
+            megatron_lm_recompute_activations=None,
+            megatron_lm_use_distributed_optimizer=None,
+            num_cpu_threads_per_process=1,
+            enable_cpu_affinity=False,
+            same_network=False,
+        )
+
+        prepare_multi_gpu_env(args)
+        self.assertIn("master_port", args.__dict__)
+        self.assertNotEqual(args.master_port, "0")
+        self.assertTrue(args.master_port.isdigit())


### PR DESCRIPTION
# What does this PR do?

This PR implements support for port 0 auto-selection in multi-GPU environments (`prepare_multi_gpu_env()`). The documentation already mentions that setting port to 0 will automatically select the next available port, but this functionality wasn't actually implemented in the code.

When `main_process_port` is set to `0`, the code now:
- Automatically finds an available port through socket binding
- Updates relevant arguments (`master_port`, `rdzv_endpoint`) with the selected port
- Provides a more seamless experience for users working in environments where specific ports might be occupied

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [[contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr)](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [[forum](https://discuss.huggingface.co/)](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [[documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs)](https://github.com/huggingface/accelerate/tree/main/docs), and [[here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification)](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests? `tests/test_launch.py`

## Who can review?

@SunMarc @zach-huggingface - This relates to the Command Line Interface and distributed training functionality.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- DeepSpeed: @SunMarc @zach-huggingface
- Command Line Interface: @SunMarc @zach-huggingface
- Documentation: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface

 -->