### PR TITLE
Fix deepspeed tests

### DIFF
--- a/src/accelerate/test_utils/scripts/external_deps/test_performance.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_performance.py
@@ -97,10 +97,16 @@ def training_function(config, args):
 
     set_seed(seed)
     train_dataloader, eval_dataloader = get_dataloaders(accelerator, batch_size, model_name)
+
+    # Add TP related kwargs if provided
+    model_kwargs = {}
+    if args.tp_plan is not None:
+        model_kwargs["tp_plan"] = args.tp_plan
+    if args.tp_size is not None:
+        model_kwargs["tp_size"] = args.tp_size
+
     # Instantiate the model (we build the model here so that the seed also control new weights initialization)
-    model = AutoModelForSequenceClassification.from_pretrained(
-        model_name, return_dict=True, tp_plan=args.tp_plan, tp_size=args.tp_size
-    )
+    model = AutoModelForSequenceClassification.from_pretrained(model_name, return_dict=True, **model_kwargs)
 
     if args.add_pad_token:
         if model.config.pad_token_id is None:

--- a/src/accelerate/test_utils/scripts/external_deps/test_performance.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_performance.py
@@ -80,8 +80,13 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: 
 
 
 def training_function(config, args):
+    accelerator_kwargs = {}
+    # need this for DeepSpeed tests as `args.tp_size` would be None and `torch.distributed.init_device_mesh` would fail
+    if args.tp_size is not None:
+        accelerator_kwargs["torch_tp_plugin"] = TorchTensorParallelPlugin(tp_size=args.tp_size)
+
     # Initialize accelerator
-    accelerator = Accelerator(torch_tp_plugin=TorchTensorParallelPlugin(tp_size=args.tp_size))
+    accelerator = Accelerator(**accelerator_kwargs)
 
     # Sample hyper-parameters for learning rate, batch size, seed and a few other HPs
     lr = config["lr"]

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -2034,8 +2034,11 @@ class TorchTensorParallelPlugin:
     torch_device_mesh: Optional["torch.distributed.DeviceMesh"] = field(default=None)
 
     def __post_init__(self):
-        if self.tp_size == 1:
-            raise ValueError("Provide TP degree > 1.")
+        if not isinstance(self.tp_size, int):
+            raise ValueError(f"`tp_size` set to {self.tp_size}, please set to an `int`.")
+
+        if self.tp_size <= 1:
+            raise ValueError("`tp_size` must be greater than 1.")
 
         if is_torch_version("<", BETA_TP_AVAILABLE_PYTORCH_VERSION):
             raise ValueError(


### PR DESCRIPTION
This test fails on main: `tests/deepspeed/test_deepspeested.yy::DeepSpeedConfigIntegration::test_basic_run` because of #3457 where test `test_performance` script was changed to include `TorchTensorParallelPlugin`. 

This PR changes this to include this plugin only if `args.tp_size` is specified. Also included a sticter check in the `TorchTensorParallelPlugin` as the previous error was slightly cryptic (we passed in None)

cc @kmehant 