### PR TITLE
Fix: require transformers version for tp tests

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -35,6 +35,7 @@ import accelerate
 from ..state import AcceleratorState
 from ..utils import (
     check_cuda_fp8_capability,
+    compare_versions,
     gather,
     is_bnb_available,
     is_clearml_available,
@@ -421,7 +422,10 @@ def require_tp(test_case):
     """
     Decorator marking a test that requires TP installed. These tests are skipped when TP isn't installed
     """
-    return unittest.skipUnless(is_torch_version(">=", "2.3.0"), "test requires torch version >= 2.3.0")(test_case)
+    return unittest.skipUnless(
+        is_torch_version(">=", "2.3.0") and compare_versions("transformers", ">=", "4.52.0"),
+        "test requires torch version >= 2.3.0 and transformers version >= 4.52.0",
+    )(test_case)
 
 
 def require_torch_min_version(test_case=None, version=None):


### PR DESCRIPTION
With #3457 this introduces another bug in our CI, where it fails on nightly runners for `TPIntegrationPlugin` on `ValueError("... requires transformers version 4.52.0...")` due to the version of `transformers` on that runner being old (viz [here](https://github.com/huggingface/accelerate/actions/runs/14459958612)). I believe this fail also introduces further unrelated fail, so this should be handled.