### PR TITLE
Solve link error in internal_mechanism documentation (#3506)

### DIFF
--- a/docs/source/concept_guides/internal_mechanism.md
+++ b/docs/source/concept_guides/internal_mechanism.md
@@ -71,4 +71,4 @@ setting the same seed in the main random number generator in all processes.
 
 If you have [`torchdata>=0.8.0`](https://github.com/pytorch/data/tree/main) installed, and you have passed `use_stateful_dataloader=True` into your [`~utils.DataLoaderConfiguration`], these classes will directly inherit from `StatefulDataLoader` instead, and maintain a `state_dict`.
 
-For more details about the internals, see the [Internals page](package_reference/torch_wrappers).
+For more details about the internals, see the [Internals page](../package_reference/torch_wrappers.md).

--- a/docs/source/concept_guides/internal_mechanism.md
+++ b/docs/source/concept_guides/internal_mechanism.md
@@ -71,4 +71,4 @@ setting the same seed in the main random number generator in all processes.
 
 If you have [`torchdata>=0.8.0`](https://github.com/pytorch/data/tree/main) installed, and you have passed `use_stateful_dataloader=True` into your [`~utils.DataLoaderConfiguration`], these classes will directly inherit from `StatefulDataLoader` instead, and maintain a `state_dict`.
 
-For more details about the internals, see the [Internals page](../package_reference/torch_wrappers.md).
+For more details about the internals, see the [Internals page](../package_reference/torch_wrappers).


### PR DESCRIPTION
# What does this PR do?
This PR changes a documentation link that was not correct. Now, you should be able to access `docs/source/package_reference/torch_wrappers.md` from `docs/source/concept_guides/internal_mechanism.md`, solving the link error in [this page](https://huggingface.co/docs/accelerate/concept_guides/internal_mechanism).

Now, at least in GitHub, the link works.

Fixes #3506

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc, as he commented on the issue.

## How to test?

1. Go to the file that contained the error in my fork and my branch: https://github.com/alvaro-mazcu/accelerate/blob/patch-1/docs/source/concept_guides/internal_mechanism.md
2. Click on the last link. You should get redirected to `docs/source/package_reference/torch_wrappers.md` smoothly.