### PR TITLE
Fix cache issue by upgrading github actions version 

### DIFF
--- a/.github/workflows/build-docker-images-release.yml
+++ b/.github/workflows/build-docker-images-release.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       version: ${{ steps.step1.outputs.version }}
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@4
       - id: step1
         run: echo "version=$(python setup.py --version)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       changed: ${{ steps.was_changed.outputs.changed }}
     steps:
-      - uses: actions/checkout@v3.1.0
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: "2"
       

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -26,9 +26,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
     - name: Set up python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         cache: 'pip'

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,9 +6,9 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         cache: 'pip'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,10 +16,10 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
     
     - name: Setup Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
           test_rest
         ]
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
     - name: Set up python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         cache: 'pip'

--- a/.github/workflows/test_imports.yml
+++ b/.github/workflows/test_imports.yml
@@ -26,9 +26,9 @@ jobs:
           minimum,
         ]
     steps:
-    - uses: actions/checkout@v3.1.0
+    - uses: actions/checkout@v4
     - name: Set up python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: 3.9
         cache: 'pip'


### PR DESCRIPTION
# What does this PR do?

Fix cache service that is making our CI fail by upgrading the related github action to the latest version
Related https://github.com/actions/setup-python/issues/1085