### PR TITLE
Add torchao to FP8 error message

### DIFF
--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -168,7 +168,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> tuple[list[str]
     if args.mixed_precision.lower() == "fp8":
         if not is_fp8_available():
             raise RuntimeError(
-                "FP8 is not available on this machine. Please ensure that either Transformer Engine or MSAMP is installed."
+                "FP8 is not available on this machine. Please ensure that either Transformer Engine, MSAMP or torchao is installed."
             )
         current_env = setup_fp8_env(args, current_env)
 
@@ -262,7 +262,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
     if args.mixed_precision.lower() == "fp8":
         if not is_fp8_available():
             raise RuntimeError(
-                "FP8 is not available on this machine. Please ensure that either Transformer Engine or MSAMP is installed."
+                "FP8 is not available on this machine. Please ensure that either Transformer Engine, MSAMP or torchao is installed."
             )
         current_env = setup_fp8_env(args, current_env)
 
@@ -442,7 +442,7 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> tuple[list[str], dict
     if args.mixed_precision.lower() == "fp8":
         if not is_fp8_available():
             raise RuntimeError(
-                "FP8 is not available on this machine. Please ensure that either Transformer Engine or MSAMP is installed."
+                "FP8 is not available on this machine. Please ensure that either Transformer Engine, MSAMP or torchao is installed."
             )
         current_env = setup_fp8_env(args, current_env)
     current_env["ACCELERATE_CONFIG_DS_FIELDS"] = str(args.deepspeed_fields_from_accelerate_config).lower()
@@ -586,7 +586,7 @@ def prepare_sagemager_args_inputs(
     if args.mixed_precision.lower() == "fp8":
         if not is_fp8_available():
             raise RuntimeError(
-                "FP8 is not available on this machine. Please ensure that either Transformer Engine or MSAMP is installed."
+                "FP8 is not available on this machine. Please ensure that either Transformer Engine, MSAMP or torchao is installed."
             )
         environment = setup_fp8_env(args, environment)
     # configure distribution set up


### PR DESCRIPTION
# What does this PR do?

When trying to get FP8 training to work, i was confused by the error message (as the docs say that FP8 via torchao is supported as well). 
`is_fp8_available` tests for all 3 FP8 methods, so the error message should also state all FP8 options :). 



## Before submitting
- [X ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@muellerzr @zach-huggingface 