### PR TITLE
Fix unwanted cuda init due to torchao

### DIFF
--- a/src/accelerate/utils/ao.py
+++ b/src/accelerate/utils/ao.py
@@ -17,15 +17,16 @@ Needed utilities for torchao FP8 training.
 """
 
 from functools import partial
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 
 from .imports import is_torchao_available, torchao_required
 
 
-if is_torchao_available():
-    from torchao.float8.float8_linear import Float8LinearConfig
+if TYPE_CHECKING:
+    if is_torchao_available():
+        from torchao.float8.float8_linear import Float8LinearConfig
 
 
 def find_first_last_linear_layers(model: torch.nn.Module):


### PR DESCRIPTION
# What does this PR do?

This PR protects better the import as it initializes cuda somehow, breaking the notebook launcher. This was not pick-up by the CI as it requires to install torchao

Fixes https://github.com/huggingface/accelerate/issues/3524
Thanks for the report @jmurph1

To reproduce with the following script or one of our tests:

`CUDA_VISIBLE_DEVICES=0,1 pytest tests/test_cli.py::AccelerateLauncherTester::test_notebook_launcher -s -vvvv`

```python 
from accelerate import notebook_launcher, Accelerator

# A completely dummy function doing nothing with CUDA/ML
def dummy_fn():
    import os
    accelerator = Accelerator()
    print(f"Dummy function started in process {os.environ.get('LOCAL_RANK', 0)}.")
    import time
    time.sleep(5)
    print(f"Dummy function finished in process {os.environ.get('LOCAL_RANK', 0)}.")

print("Calling notebook_launcher...")
try:
    notebook_launcher(dummy_fn, num_processes=2)
    print("notebook_launcher call finished successfully.")
except Exception as e:
    print(f"notebook_launcher failed: {e}")
    import traceback
    traceback.print_exc() # Print full traceback if it fails
```