### PR TITLE
Fix CI due to missing package 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         if [[ ${{ matrix.test-kind }} != test_prod ]]; then pip install -e .[testing,test_trackers]; fi
         if [[ ${{ matrix.test-kind }} = test_rest ]]; then pip uninstall comet_ml -y; fi
         if [[ ${{ matrix.pytorch-version }} = minimum ]]; then pip install torchvision==0.18.1 torch==2.3.1; fi
-        pip install pytest-reportlog tabulate setuptools
+        pip install pytest-reportlog tabulate setuptools importlib_metadata
 
     - name: Show installed libraries
       run: |

--- a/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
+++ b/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
@@ -54,6 +54,7 @@ def manage_process_group(func: Callable[..., Any]) -> Callable[..., Any]:
 @manage_process_group
 def load_checkpoint_and_dispatch_fsdp2():
     from torch.distributed._tensor import DTensor
+
     torch.cuda.set_device(device := torch.device(dist.get_rank()))
 
     pretrained_model_name_or_path = "bigscience/bloom-560m"

--- a/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
+++ b/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
@@ -23,6 +23,7 @@ from huggingface_hub import hf_hub_download
 from torch import distributed as dist
 from torch import nn
 from torch.distributed._composable.fsdp import fully_shard
+from torch.distributed._tensor import DTensor
 from torch.distributed.device_mesh import init_device_mesh
 from torch.distributed.fsdp.wrap import _recursive_wrap, transformer_auto_wrap_policy
 from torch.nn.parallel import DistributedDataParallel
@@ -53,8 +54,6 @@ def manage_process_group(func: Callable[..., Any]) -> Callable[..., Any]:
 
 @manage_process_group
 def load_checkpoint_and_dispatch_fsdp2():
-    from torch.distributed._tensor import DTensor
-
     torch.cuda.set_device(device := torch.device(dist.get_rank()))
 
     pretrained_model_name_or_path = "bigscience/bloom-560m"

--- a/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
+++ b/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
@@ -33,7 +33,7 @@ from accelerate.utils.imports import is_torch_version, is_transformers_available
 # Cache this result has it's a C FFI call which can be pretty time-consuming
 _torch_distributed_available = torch.distributed.is_available()
 
-if is_torch_version("2.5",">=") and _torch_distributed_available:
+if is_torch_version(">=","2.5") and _torch_distributed_available:
     from torch.distributed._composable.fsdp import fully_shard
     from torch.distributed._tensor import DTensor
     from torch.distributed.device_mesh import init_device_mesh

--- a/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
+++ b/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
@@ -22,16 +22,22 @@ import torch
 from huggingface_hub import hf_hub_download
 from torch import distributed as dist
 from torch import nn
-from torch.distributed._composable.fsdp import fully_shard
-from torch.distributed._tensor import DTensor
-from torch.distributed.device_mesh import init_device_mesh
-from torch.distributed.fsdp.wrap import _recursive_wrap, transformer_auto_wrap_policy
 from torch.nn.parallel import DistributedDataParallel
 
 from accelerate import init_empty_weights, load_checkpoint_and_dispatch
 from accelerate.test_utils import execute_subprocess_async, get_torch_dist_unique_port, require_multi_gpu
 from accelerate.test_utils.testing import require_torch_min_version, require_transformers
-from accelerate.utils.imports import is_transformers_available
+from accelerate.utils.imports import is_torch_version, is_transformers_available
+
+
+# Cache this result has it's a C FFI call which can be pretty time-consuming
+_torch_distributed_available = torch.distributed.is_available()
+
+if is_torch_version("2.5") and _torch_distributed_available:
+    from torch.distributed._composable.fsdp import fully_shard
+    from torch.distributed._tensor import DTensor
+    from torch.distributed.device_mesh import init_device_mesh
+    from torch.distributed.fsdp.wrap import _recursive_wrap, transformer_auto_wrap_policy
 
 
 if is_transformers_available():

--- a/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
+++ b/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
@@ -33,7 +33,7 @@ from accelerate.utils.imports import is_torch_version, is_transformers_available
 # Cache this result has it's a C FFI call which can be pretty time-consuming
 _torch_distributed_available = torch.distributed.is_available()
 
-if is_torch_version("2.5") and _torch_distributed_available:
+if is_torch_version("2.5",">=") and _torch_distributed_available:
     from torch.distributed._composable.fsdp import fully_shard
     from torch.distributed._tensor import DTensor
     from torch.distributed.device_mesh import init_device_mesh


### PR DESCRIPTION
# What does this PR do?
Fixes CI. Pytorch 3.7 with python < 3.10 requires `importlib_metadata` to be installed. This can be removed when switching to 3.10. 