### PR TITLE
fix notebook_launcher for Colab TPU compatibility.

### DIFF
--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -132,8 +132,9 @@ def notebook_launcher(
             f"Unknown mixed_precision mode: {args.mixed_precision.lower()}. Choose between {PrecisionType.list()}."
         )
 
-    if (in_colab or in_kaggle) and \
-        ((os.environ.get("TPU_NAME", None) is not None) or (os.environ.get("PJRT_DEVICE", "") == "TPU")):
+    if (in_colab or in_kaggle) and (
+        (os.environ.get("TPU_NAME", None) is not None) or (os.environ.get("PJRT_DEVICE", "") == "TPU")
+    ):
         # TPU launch
         import torch_xla.distributed.xla_multiprocessing as xmp
 
@@ -145,7 +146,7 @@ def notebook_launcher(
             )
 
         launcher = PrepareForLaunch(function, distributed_type="XLA")
-        print(f"Launching a training on TPU cores.")
+        print("Launching a training on TPU cores.")
         xmp.spawn(launcher, args=args, start_method="fork")
     elif in_colab and get_gpu_info()[1] < 2:
         # No need for a distributed launch otherwise as it's either CPU or one GPU.

--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -132,10 +132,10 @@ def notebook_launcher(
             f"Unknown mixed_precision mode: {args.mixed_precision.lower()}. Choose between {PrecisionType.list()}."
         )
 
-    if (in_colab or in_kaggle) and (os.environ.get("TPU_NAME", None) is not None):
+    if (in_colab or in_kaggle) and \
+        ((os.environ.get("TPU_NAME", None) is not None) or (os.environ.get("PJRT_DEVICE", "") == "TPU")):
         # TPU launch
         import torch_xla.distributed.xla_multiprocessing as xmp
-        from torch_xla import device_count
 
         if len(AcceleratorState._shared_state) > 0:
             raise ValueError(
@@ -145,7 +145,7 @@ def notebook_launcher(
             )
 
         launcher = PrepareForLaunch(function, distributed_type="XLA")
-        print(f"Launching a training on {device_count()} TPU cores.")
+        print(f"Launching a training on TPU cores.")
         xmp.spawn(launcher, args=args, start_method="fork")
     elif in_colab and get_gpu_info()[1] < 2:
         # No need for a distributed launch otherwise as it's either CPU or one GPU.


### PR DESCRIPTION
This change enhances the TPU autodetection logic in notebook_launcher and remove call of device_count() before xmp.spawn for avoiding earlier devices initialising for passing check on torch_xla._XLAC._xla_runtime_is_initialized().

- Added a check for PJRT_DEVICE == "TPU" when TPU_NAME is undefined.
- Removed calls to torch_xla.device_count() before xmp.spawn because it initialised devices.

Fixes [#3358](https://github.com/huggingface/accelerate/issues/3358)

@BenjaminBossan @SunMarc @zach-huggingface 
