### PR TITLE
canonicalize optimized names before fixing optimizer in fdsp2

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -82,6 +82,7 @@ from .utils import (
     convert_outputs_to_fp32,
     ensure_weights_retied,
     extract_model_from_parallel,
+    fsdp2_canonicalize_names,
     fsdp2_prepare_model,
     fsdp2_switch_optimizer_parameters,
     gather,
@@ -1442,10 +1443,8 @@ class Accelerator:
         if should_fix_optimizer:
             # 2. grabbing new model parameters
             new_named_params = self._get_named_parameters(*result)
-            if fsdp2_should_fix_optimizer and self.state.fsdp_plugin.activation_checkpointing:
-                new_named_params = {
-                    k.replace("._checkpoint_wrapped_module", ""): v for k, v in new_named_params.items()
-                }
+            if fsdp2_should_fix_optimizer:
+                new_named_params = fsdp2_canonicalize_names(new_named_params)
             # 3. building a map from the first to the second
             mapping = {p: new_named_params[n] for n, p in old_named_params.items()}
             # 4. using that map to update the parameters of the optimizer

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -220,6 +220,7 @@ from .fsdp_utils import (
     disable_fsdp_ram_efficient_loading,
     enable_fsdp_ram_efficient_loading,
     ensure_weights_retied,
+    fsdp2_canonicalize_names,
     fsdp2_load_full_state_dict,
     fsdp2_prepare_model,
     fsdp2_switch_optimizer_parameters,

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -735,3 +735,19 @@ def get_fsdp2_grad_scaler(**kwargs):
     from torch.amp.grad_scaler import GradScaler
 
     return GradScaler(**kwargs)
+
+
+def fsdp2_canonicalize_names(named_params: dict) -> dict:
+    """Removes parameter name modifiers in order to map them back to their original names.
+
+    See huggingface/accelerate#3554 for more context.
+
+    Args:
+        named_params (`dict`): The named parameters dictionary to canonicalize.
+
+    Returns:
+        `dict`: The canonicalized named parameters dictionary
+    """
+    named_params = {k.replace("._checkpoint_wrapped_module", ""): v for k, v in named_params.items()}
+    named_params = {k.replace("_orig_mod.", ""): v for k, v in named_params.items() if k.startswith("_orig_mod")}
+    return named_params


### PR DESCRIPTION


# What does this PR do?

Adds a utility function to strip the `_orig_mod.` prefix that gets added by torch.compile when fixing the optimizer in fsdp2. Fixes #3554.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

CC @S1ro1 