### PR TITLE
add a `synchronize` call for xpu in `_gpu_gather`

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -316,6 +316,10 @@ def _gpu_gather(tensor):
     state = PartialState()
     gather_op = torch.distributed.all_gather_into_tensor
 
+    # FIXME: the below 2 lines are added to work-aound a bug related to INT64 collectives in oneCCL. Remove them once pytorch-2.9 is released.
+    if state.device.type == "xpu":
+        torch.xpu.synchronize()
+
     def _gpu_gather_one(tensor):
         if tensor.ndim == 0:
             tensor = tensor.clone()[None]


### PR DESCRIPTION
## What does this PR do?
There is a bug related to INT64 collectives in oneCCL on XPU. This bug will be fixed in PyTorch-2.9. However, this bug impacts many code examples when running in distributed mode, e.g., below are the predicted labels of `nlp_examples.py`:

```bash
 =========tensor([                   1,                    0,                    0,
                           1,                    0,                    1,
                           1,                    1,                    1,
                           1,                    1,                    0,
                           0,                    1,                    1,
                           0,                    1,                    0,
                           1,                    0,                    0,
                           1,                    0,                    1,
                           1,                    0,                    1,
                           1,                    1,                    1,
                           0,                    1, -4763119552675512320,
        -4766215777419132928, -4852910070239199232, -4828703222243852288,
        -4622663539326255104, -4603523240919826432, -4711609631944015872,
        -4868672668934144000, -4615063714957819904, -4820821922896740352,
        -4640114987875631104, -4620411739513421824, -4675017884978315264,
        -4857132194889465856, -4833769771824316416, -4612530440168210432,
        -4821666347826741248, -4823918147640229888, -4743134829331218432,
        -4807311124015677440, -4822229297780097024, -4838273371451359232,
        -4861072844563218432, -4824762572570230784, -4676988209814700032,
        -4864169069306904576, -4862761694423416832, -4796052124948037632,
        -4819977497966673920, -4719490931290537984, -4860791369586507776,
        -4709357832130723840], device='xpu:0')
=========tensor([ 4590785695020072807,  4613304161316028365, -4640889495023173838,
         4615837775396453961,  4613304056071733148, -4682266389616181702,
         4616400575022382831, -4652711660932972544,  4612178231343103911,
         4593600977363451611,  4609082204167389103,  4613304109775241221,
         4618089472120864287,  4580934693613453281,  4572489078510043055,
         4562073997567901665,                    1,                    0,
                           1,                    0,                    0,
                           1,                    0,                    1,
                           1,                    0,                    1,
                           1,                    1,                    1,
                           0,                    1,                    1,
                           1,                    1,                    1,
                           0,                    0,                    1,
                           1,                    0,                    1,
                           0,                    0,                    1,
                           1,                    1,                    0,
                           1,                    1,                    1,
                           1,                    1,                    1,
                           1,                    1,                    1,
                           1,                    1,                    1,
                           1,                    1,                    1,
                           1], device='xpu:1')
```


Since there are at least 5 months till the release of PyTorch-2.9, we would like to add a workaround for xpu for now. Once PyTorch-2.9 is released, we will remove them.