### PR TITLE
preserve parameter keys when removing  prefix

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -755,5 +755,5 @@ def fsdp2_canonicalize_names(named_params: dict) -> dict:
         `dict`: The canonicalized named parameters dictionary
     """
     named_params = {k.replace("._checkpoint_wrapped_module", ""): v for k, v in named_params.items()}
-    named_params = {k.replace("_orig_mod.", ""): v for k, v in named_params.items() if k.startswith("_orig_mod")}
+    named_params = {k.replace("_orig_mod.", "") if k.startswith("_orig_mod.") else k: v for k, v in named_params.items()}
     return named_params

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -755,5 +755,7 @@ def fsdp2_canonicalize_names(named_params: dict) -> dict:
         `dict`: The canonicalized named parameters dictionary
     """
     named_params = {k.replace("._checkpoint_wrapped_module", ""): v for k, v in named_params.items()}
-    named_params = {k.replace("_orig_mod.", "") if k.startswith("_orig_mod.") else k: v for k, v in named_params.items()}
+    named_params = {
+        k.replace("_orig_mod.", "") if k.startswith("_orig_mod.") else k: v for k, v in named_params.items()
+    }
     return named_params


### PR DESCRIPTION
# What does this PR do?

Earlier PR https://github.com/huggingface/accelerate/pull/3560 broke FSDP2 for non-compiled models due to omitted keys from the `named_params` dict. This change fixes the mistake in the if-replace logic, by conditionally stripping the "_orig_mod." prefix only when it's present as intended.

Fixes https://github.com/huggingface/accelerate/issues/3554

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
-  [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@S1ro1, @SunMarc 



 