### PR TITLE
Update dynamic env handling to preserve None when USE_DYNAMIC is unset

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1021,7 +1021,8 @@ class TorchDynamoPlugin(KwargsHandler):
         if self.fullgraph is None:
             self.fullgraph = str_to_bool(os.environ.get(prefix + "USE_FULLGRAPH", "False")) == 1
         if self.dynamic is None:
-            self.dynamic = str_to_bool(os.environ.get(prefix + "USE_DYNAMIC", "False")) == 1
+            env_value = os.environ.get(prefix + "USE_DYNAMIC")
+            self.dynamic = (str_to_bool(env_value) == 1) if env_value is not None else None
 
     def to_dict(self):
         dynamo_config = copy.deepcopy(self.__dict__)

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1020,9 +1020,8 @@ class TorchDynamoPlugin(KwargsHandler):
             self.mode = os.environ.get(prefix + "MODE", "default")
         if self.fullgraph is None:
             self.fullgraph = str_to_bool(os.environ.get(prefix + "USE_FULLGRAPH", "False")) == 1
-        if self.dynamic is None:
-            env_value = os.environ.get(prefix + "USE_DYNAMIC")
-            self.dynamic = (str_to_bool(env_value) == 1) if env_value is not None else None
+        if self.dynamic is None and os.environ.get(prefix + "USE_DYNAMIC", None) is not None:
+            self.dynamic = str_to_bool(os.environ.get(prefix + "USE_DYNAMIC", "False")) == 1
 
     def to_dict(self):
         dynamo_config = copy.deepcopy(self.__dict__)


### PR DESCRIPTION
# What does this PR do?

Modified the logic for setting `self.dynamic` to explicitly preserve `None` when the `USE_DYNAMIC` environment variable is not set, aligning with the behavior described in the PyTorch documentation for torch.compile (https://docs.pytorch.org/stable/generated/torch.compile.html). The documentation notes that `dynamic=None` has distinct semantics from `dynamic=False`, where `None` indicates a different configuration state. Previously, the code defaulted to `False` when the environment variable was unset, which could lead to incorrect behavior.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- DeepSpeed: @SunMarc @zach-huggingface
- Command Line Interface: @SunMarc @zach-huggingface
- Documentation: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface

 -->