### PR TITLE
enable test_dispatch_model_tied_weights_memory_with_nested_offload_cpu on xpu

### DIFF
--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -536,7 +536,7 @@ class BigModelingTester(unittest.TestCase):
 
     # This test fails because sometimes data_ptr() of compute2.weight is the same as compute1.weight.
     # I checked that the values are not the same but it gives the same address. This does not happen on my local machine.
-    @require_cuda
+    @require_cuda_or_xpu
     @unittest.skip(
         "Flaky test, we should have enough coverage with test_dispatch_model_tied_weights_memory_with_nested_offload_cpu test"
     )

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -47,7 +47,7 @@ from accelerate.test_utils import (
 )
 from accelerate.utils import is_hpu_available, offload_state_dict
 from accelerate.utils.versions import is_torch_version
-
+from accelerate.utils.memory import clear_device_cache
 
 logger = logging.getLogger(__name__)
 torch_device_type = torch_device
@@ -378,7 +378,7 @@ class BigModelingTester(unittest.TestCase):
 
         torch_accelerator_module = getattr(torch, torch_device_type)
 
-        torch_accelerator_module.empty_cache()  # Needed in case we run several tests in a row.
+        clear_device_cache()  # Needed in case we run several tests in a row.
 
         model = nn.Sequential(
             OrderedDict(
@@ -442,7 +442,7 @@ class BigModelingTester(unittest.TestCase):
         # Test that we do not duplicate tied weights at any point during dispatch_model call.
 
         torch_accelerator_module = getattr(torch, torch_device_type)
-        torch_accelerator_module.empty_cache()  # Needed in case we run several tests in a row.
+        clear_device_cache()  # Needed in case we run several tests in a row.
 
         class SubModule(torch.nn.Module):
             def __init__(self, ref_to_parameter):
@@ -520,7 +520,7 @@ class BigModelingTester(unittest.TestCase):
 
         torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
 
-        torch_accelerator_module.empty_cache()
+        clear_device_cache()
 
         free_memory_bytes_after_infer = torch_accelerator_module.mem_get_info(torch_device)[0]
 
@@ -544,7 +544,7 @@ class BigModelingTester(unittest.TestCase):
 
         torch_accelerator_module = getattr(torch, torch_device_type)
 
-        torch_accelerator_module.empty_cache()  # Needed in case we run several tests in a row.
+        clear_device_cache()  # Needed in case we run several tests in a row.
 
         class SubModule(torch.nn.Module):
             def __init__(self, ref_to_parameter):
@@ -624,7 +624,7 @@ class BigModelingTester(unittest.TestCase):
 
             torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
 
-            torch_accelerator_module.empty_cache()
+            clear_device_cache()
 
             free_memory_bytes_after_infer = torch_accelerator_module.mem_get_info(device_0)[0]
 

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -46,8 +46,9 @@ from accelerate.test_utils import (
     torch_device,
 )
 from accelerate.utils import is_hpu_available, offload_state_dict
-from accelerate.utils.versions import is_torch_version
 from accelerate.utils.memory import clear_device_cache
+from accelerate.utils.versions import is_torch_version
+
 
 logger = logging.getLogger(__name__)
 torch_device_type = torch_device

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -36,7 +36,6 @@ from accelerate.big_modeling import (
 from accelerate.hooks import remove_hook_from_submodules
 from accelerate.test_utils import (
     require_bnb,
-    require_cuda,
     require_cuda_or_xpu,
     require_multi_device,
     require_multi_gpu_or_xpu,
@@ -542,7 +541,7 @@ class BigModelingTester(unittest.TestCase):
     )
     def test_dispatch_model_tied_weights_memory_with_nested_offload_disk(self):
         # Test that we do not duplicate tied weights at any point during dispatch_model call.
-      
+
         torch_accelerator_module = getattr(torch, torch_device_type)
 
         torch_accelerator_module.empty_cache()  # Needed in case we run several tests in a row.
@@ -608,7 +607,11 @@ class BigModelingTester(unittest.TestCase):
 
             assert (free_memory_bytes_after_dispatch - free_memory_bytes_before_dispatch) * 1e-6 < 130
 
-            oom_error = torch.OutOfMemoryError if hasattr(torch, "OutOfMemoryError") else torch_accelerator_module.OutOfMemoryError
+            oom_error = (
+                torch.OutOfMemoryError
+                if hasattr(torch, "OutOfMemoryError")
+                else torch_accelerator_module.OutOfMemoryError
+            )
             with torch.no_grad():
                 try:
                     output = model(x)

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import gc
 import tempfile
 import unittest
 

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -543,8 +543,7 @@ class MixedInt8LoaddedModelTest(unittest.TestCase):
         del self.model_fp16
         del self.model_8bit
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        clear_device_cache(garbage_collection=True)
 
     def test_memory_footprint(self):
         r"""
@@ -663,8 +662,7 @@ class Bnb4BitEmptyModelTest(unittest.TestCase):
         del self.model_fp16
         del self.model_4bit
 
-        gc.collect()
-        torch.cuda.empty_cache()
+        clear_device_cache(garbage_collection=True)
 
     def test_memory_footprint(self):
         r"""


### PR DESCRIPTION
test passed.