### PR TITLE
Add support for standalone mode when default port is occupied on single node

### DIFF
--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -19,6 +19,7 @@ import sys
 from ast import literal_eval
 from shutil import which
 from typing import Any
+import warnings
 
 import torch
 
@@ -225,10 +226,13 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
     # for some reasons like splitting log files.
     need_port_check = num_machines <= 1 or int(args.machine_rank) == 0
     if need_port_check and is_port_in_use(main_process_port):
-        raise ConnectionError(
-            f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
-            "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
-            " and rerun your script. To automatically use the next open port (on a single node), you can set this to `0`."
+        args.standalone = True
+        warnings.warn(
+            f"Port `{main_process_port}` is already in use. "
+            "Accelerate will attempt to launch in a standalone-like mode by finding an open port automatically for this session. "
+            "If this current attempt fails, or for more control in future runs, please specify a different port "
+            "(e.g., `--main_process_port <your_chosen_port>`) or use `--main_process_port 0` for automatic selection "
+            "in your launch command or Accelerate config file."
         )
 
     if args.module and args.no_python:
@@ -408,10 +412,13 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> tuple[list[str], dict
     # for some reasons like splitting log files.
     need_port_check = num_machines <= 1 or int(args.machine_rank) == 0
     if need_port_check and is_port_in_use(main_process_port):
-        raise ConnectionError(
-            f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
-            "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
-            " and rerun your script. To automatically use the next open port (on a single node), you can set this to `0`."
+        args.standalone = True
+        warnings.warn(
+            f"Port `{main_process_port}` is already in use. "
+            "Accelerate will attempt to launch in a standalone-like mode by finding an open port automatically for this session. "
+            "If this current attempt fails, or for more control in future runs, please specify a different port "
+            "(e.g., `--main_process_port <your_chosen_port>`) or use `--main_process_port 0` for automatic selection "
+            "in your launch command or Accelerate config file."
         )
 
     if args.module and args.no_python:

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -226,14 +226,21 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
     # for some reasons like splitting log files.
     need_port_check = num_machines <= 1 or int(args.machine_rank) == 0
     if need_port_check and is_port_in_use(main_process_port):
-        args.standalone = True
-        warnings.warn(
-            f"Port `{main_process_port}` is already in use. "
-            "Accelerate will attempt to launch in a standalone-like mode by finding an open port automatically for this session. "
-            "If this current attempt fails, or for more control in future runs, please specify a different port "
-            "(e.g., `--main_process_port <your_chosen_port>`) or use `--main_process_port 0` for automatic selection "
-            "in your launch command or Accelerate config file."
-        )
+        if num_machines <= 1:
+            args.standalone = True
+            warnings.warn(
+                f"Port `{main_process_port}` is already in use. "
+                "Accelerate will attempt to launch in a standalone-like mode by finding an open port automatically for this session. "
+                "If this current attempt fails, or for more control in future runs, please specify a different port "
+                "(e.g., `--main_process_port <your_chosen_port>`) or use `--main_process_port 0` for automatic selection "
+                "in your launch command or Accelerate config file."
+            )
+        else:
+            raise ConnectionError(
+                f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
+                "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
+                " and rerun your script. To automatically use the next open port (on a single node), you can set this to `0`."
+            )
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")
@@ -412,14 +419,21 @@ def prepare_deepspeed_cmd_env(args: argparse.Namespace) -> tuple[list[str], dict
     # for some reasons like splitting log files.
     need_port_check = num_machines <= 1 or int(args.machine_rank) == 0
     if need_port_check and is_port_in_use(main_process_port):
-        args.standalone = True
-        warnings.warn(
-            f"Port `{main_process_port}` is already in use. "
-            "Accelerate will attempt to launch in a standalone-like mode by finding an open port automatically for this session. "
-            "If this current attempt fails, or for more control in future runs, please specify a different port "
-            "(e.g., `--main_process_port <your_chosen_port>`) or use `--main_process_port 0` for automatic selection "
-            "in your launch command or Accelerate config file."
-        )
+        if num_machines <= 1:
+            args.standalone = True
+            warnings.warn(
+                f"Port `{main_process_port}` is already in use. "
+                "Accelerate will attempt to launch in a standalone-like mode by finding an open port automatically for this session. "
+                "If this current attempt fails, or for more control in future runs, please specify a different port "
+                "(e.g., `--main_process_port <your_chosen_port>`) or use `--main_process_port 0` for automatic selection "
+                "in your launch command or Accelerate config file."
+            )
+        else:
+            raise ConnectionError(
+                f"Tried to launch distributed communication on port `{main_process_port}`, but another process is utilizing it. "
+                "Please specify a different port (such as using the `--main_process_port` flag or specifying a different `main_process_port` in your config file)"
+                " and rerun your script. To automatically use the next open port (on a single node), you can set this to `0`."
+            )
 
     if args.module and args.no_python:
         raise ValueError("--module and --no_python cannot be used together")

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -16,10 +16,10 @@ import argparse
 import os
 import subprocess
 import sys
+import warnings
 from ast import literal_eval
 from shutil import which
 from typing import Any
-import warnings
 
 import torch
 


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the `--standalone` mode in Accelerate, addressing [issue #3175](https://github.com/huggingface/accelerate/issues/3175) and building upon the work in [PR #3501 by @hellobiondi](https://github.com/huggingface/accelerate/pull/3501).
While the documentation notes that setting the port to `0` will automatically select an available port, this PR leverages the built-in `--standalone` functionality from [torch.distributed.run](https://github.com/pytorch/pytorch/blob/9785b32189583abb4cc2e369389575568e384a68/torch/distributed/run.py#L451-L458) and propagates the argument to the underlying `torch.distributed.run` launcher without raising a connection error, reducing the likelihood of port conflicts when running multiple distributed jobs on the same machine ([see also](https://github.com/pytorch/pytorch/blob/9785b32189583abb4cc2e369389575568e384a68/torch/distributed/run.py#L866-L880)).
The user is informed of the port conflict and the fallback to standalone mode, with guidance for future runs.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc or  @zach-huggingface This relates to the Command Line Interface and distributed training/inference functionality on a single node