### PR TITLE
goodbye torch_ccl

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -32,7 +32,6 @@ from .utils import (
     check_cuda_fp8_capability,
     check_cuda_p2p_ib_support,
     deepspeed_required,
-    get_ccl_version,
     get_cpu_distributed_information,
     get_int_from_env,
     is_ccl_available,
@@ -797,10 +796,7 @@ class PartialState:
                 and is_ccl_available()
                 and (get_int_from_env(["CCL_WORKER_COUNT"], 0) > 0 or distributed_type == DistributedType.MULTI_XPU)
             ):
-                if get_ccl_version() >= "1.12":
-                    import oneccl_bindings_for_pytorch  # noqa: F401
-                else:
-                    import torch_ccl  # noqa: F401
+                import oneccl_bindings_for_pytorch  # noqa: F401
 
                 backend = "ccl"
             elif backend in (None, "mpi") and torch.distributed.is_mpi_available():

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -78,14 +78,11 @@ def is_ccl_available():
         pass
     except ImportError:
         print(
-            "Intel(R) oneCCL Bindings for PyTorch* is required to run DDP on Intel(R) GPUs, but it is not"
+            "Intel(R) oneCCL Bindings for PyTorch* is required to run DDP on Intel(R) XPUs, but it is not"
             " detected. If you see \"ValueError: Invalid backend: 'ccl'\" error, please install Intel(R) oneCCL"
             " Bindings for PyTorch*."
         )
-    return (
-        importlib.util.find_spec("torch_ccl") is not None
-        or importlib.util.find_spec("oneccl_bindings_for_pytorch") is not None
-    )
+    return importlib.util.find_spec("oneccl_bindings_for_pytorch") is not None
 
 
 def get_ccl_version():


### PR DESCRIPTION
`torch_ccl` supports `torch < 1.12` and now torch already evolve to 2.7, time to say goodbye.