### PR TITLE
Resolve logger warnings

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -390,7 +390,7 @@ def set_module_tensor_to_device(
                 device_index = torch.device(device).index if torch.device(device).type == "cuda" else None
                 if not getattr(module.weight, "quant_state", None) and device_index is not None:
                     module.weight = module.weight.cuda(device_index)
-    # clean pre and post foward hook
+    # clean pre and post forward hook
     if device != "cpu":
         clear_device_cache()
 
@@ -549,7 +549,7 @@ def check_tied_parameters_on_same_device(tied_params, device_map):
         for param in tie_param:
             tie_param_devices[param] = _get_param_device(param, device_map)
         if len(set(tie_param_devices.values())) > 1:
-            logger.warn(
+            logger.warning(
                 f"Tied parameters are on different devices: {tie_param_devices}. "
                 "Please modify your custom device map or set `device_map='auto'`. "
             )
@@ -1111,7 +1111,7 @@ def _init_infer_auto_device_map(
     module_sizes = compute_module_sizes(model, dtype=dtype, special_dtypes=special_dtypes)
     tied_parameters = find_tied_parameters(model)
     if check_tied_parameters_in_config(model) and len(tied_parameters) == 0:
-        logger.warn(
+        logger.warning(
             "The model weights are not tied. Please use the `tie_weights` method before using the `infer_auto_device` function."
         )
 
@@ -1629,7 +1629,7 @@ def load_state_dict(checkpoint_file, device_map=None):
             weight_names = f.keys()
 
         if metadata is None:
-            logger.warn(
+            logger.warning(
                 f"The safetensors archive passed at {checkpoint_file} does not contain metadata. "
                 "Make sure to save your model with the `save_pretrained` method. Defaulting to 'pt' metadata."
             )
@@ -1847,7 +1847,7 @@ def load_checkpoint_in_model(
     tied_params = find_tied_parameters(model)
 
     if check_tied_parameters_in_config(model) and len(tied_params) == 0:
-        logger.warn(
+        logger.warning(
             "The model weights are not tied. Please use the `tie_weights` method before using the `infer_auto_device` function."
         )
     if device_map is not None:


### PR DESCRIPTION
# What does this PR do?
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- DeepSpeed: @SunMarc @zach-huggingface
- Command Line Interface: @SunMarc @zach-huggingface
- Documentation: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface

 -->