### PR TITLE
change to use torch.device

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -406,7 +406,7 @@ def merge_fsdp_weights(
     state.wait_for_everyone()
 
 
-def ensure_weights_retied(param_init_fn, model: torch.nn.Module, device: torch.cuda.device):
+def ensure_weights_retied(param_init_fn, model: torch.nn.Module, device: torch.device):
     _tied_names = getattr(model, "_tied_weights_keys", None)
     if not _tied_names:
         # if no tied names just passthrough


### PR DESCRIPTION
@SunMarc @IlyasMoutawwakil i searched the `accelerate` code base, and this is the only place which uses `torch.cuda.device`, so I suppose it's safe to change to its device-agnostic `torch.device`, pls help review, thx.