### PR TITLE
Tolerate unwrapping model compiled by users themselves

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -177,7 +177,7 @@ def extract_model_from_parallel(
 
     if is_compiled or has_compiled:
         compiled_model = model
-        model = model._orig_mod
+        model = getattr(model, "_orig_mod", model)
 
     if is_deepspeed_available():
         from deepspeed import DeepSpeedEngine


### PR DESCRIPTION
# What does this PR do?

The current implementation throws an unnecessary error when the user compiles the model themselves (in my case at least). It takes the following operation sequence to produce the crash:

1. Instantiate model class
2. Compile model
3. Prepare by `Accelerator.prepare()`
4. Load checkpoint by `Accelerator.load_state()`

And it get you `'DistributedDataParallel' object has no attribute '_orig_mod'`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 