### PR TITLE
enable torchao and pippy test cases on XPU

### DIFF
--- a/src/accelerate/test_utils/scripts/external_deps/test_pippy.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_pippy.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     state = PartialState()
     state.print("Testing pippy integration...")
     try:
-        if state.distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_HPU]:
+        if state.distributed_type in [DistributedType.MULTI_GPU, DistributedType.MULTI_XPU, DistributedType.MULTI_HPU]:
             state.print("Testing GPT2...")
             test_gpt2()
             # Issue: When modifying the tokenizer for batch GPT2 inference, there's an issue

--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -22,11 +22,9 @@ from accelerate import Accelerator
 from accelerate.state import AcceleratorState
 from accelerate.test_utils import (
     get_launch_command,
-    require_cuda,
     require_cuda_or_hpu,
     require_huggingface_suite,
     require_multi_device,
-    require_multi_gpu,
     require_torchao,
     require_transformer_engine,
     run_first,

--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -75,8 +75,8 @@ def can_convert_ao_model():
 
 
 @run_first
-@require_cuda_or_hpu
 @require_transformer_engine
+@require_cuda_or_hpu
 class TestTransformerEngine(unittest.TestCase):
     def test_can_prepare_model_single_gpu(self):
         command = get_launch_command(num_processes=1, monitor_interval=0.1)
@@ -125,21 +125,20 @@ class TestTransformerEngine(unittest.TestCase):
 @require_torchao
 @require_huggingface_suite
 class TestTorchAO(unittest.TestCase):
-    @require_cuda
-    def test_can_prepare_model_single_gpu(self):
+    def test_can_prepare_model_single_accelerator(self):
         command = get_launch_command(num_processes=1, monitor_interval=0.1)
         command += ["-m", "tests.test_fp8"]
         run_command(command)
 
-    @require_multi_gpu
-    def test_can_prepare_model_multi_gpu(self):
+    @require_multi_device
+    def test_can_prepare_model_multi_accelerator(self):
         command = get_launch_command(num_processes=2, monitor_interval=0.1)
         command += ["-m", "tests.test_fp8"]
         run_command(command)
 
     @require_deepspeed
-    @require_multi_gpu
-    def test_can_prepare_model_multigpu_deepspeed(self):
+    @require_multi_device
+    def test_can_prepare_model_multi_accelerator_deepspeed(self):
         for zero_stage in [1, 2, 3]:
             os.environ["ZERO_STAGE"] = str(zero_stage)
             ds_config = {

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -30,7 +30,6 @@ from accelerate.test_utils import (
     require_multi_device,
     require_non_hpu,
     require_non_torch_xla,
-    require_non_xpu,
     require_pippy,
     require_torchvision,
     run_first,

--- a/tests/test_multigpu.py
+++ b/tests/test_multigpu.py
@@ -49,7 +49,7 @@ class MultiDeviceTester(unittest.TestCase):
     @run_first
     @require_multi_device
     def test_multi_device(self):
-        print(f"Found {device_count} devices.")
+        print(f"Found {device_count} {torch_device} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.test_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd)
@@ -57,7 +57,7 @@ class MultiDeviceTester(unittest.TestCase):
     @run_first
     @require_multi_device
     def test_multi_device_ops(self):
-        print(f"Found {device_count} devices.")
+        print(f"Found {device_count} {torch_device} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.operation_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd)
@@ -65,7 +65,7 @@ class MultiDeviceTester(unittest.TestCase):
     @run_first
     @require_multi_device
     def test_pad_across_processes(self):
-        print(f"Found {device_count} devices.")
+        print(f"Found {device_count} {torch_device} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [inspect.getfile(self.__class__)]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd)
@@ -74,7 +74,7 @@ class MultiDeviceTester(unittest.TestCase):
     @require_non_hpu  # Synapse detected a device critical error that requires a restart
     @require_multi_device
     def test_multi_device_merge_fsdp_weights(self):
-        print(f"Found {device_count} devices.")
+        print(f"Found {device_count} {torch_device} devices.")
         cmd = DEFAULT_LAUNCH_COMMAND + [self.merge_weights_file_path]
 
         env_kwargs = dict(omp_num_threads=1)
@@ -109,7 +109,6 @@ class MultiDeviceTester(unittest.TestCase):
 
     @run_first
     @require_pippy
-    @require_non_xpu
     @require_torchvision
     @require_multi_device
     @require_huggingface_suite
@@ -117,7 +116,7 @@ class MultiDeviceTester(unittest.TestCase):
         """
         Checks the integration with the pippy framework
         """
-        print(f"Found {device_count} devices")
+        print(f"Found {device_count} {torch_device} devices")
         cmd = get_launch_command(multi_gpu=True, num_processes=device_count) + [self.pippy_file_path]
         with patch_environment(omp_num_threads=1):
             execute_subprocess_async(cmd)


### PR DESCRIPTION
torchao has xpu support since 0.11.0, so enable torchao cases. ALL cases passed.
enable pippy cases on XPU, ALL passed.

@SunMarc , pls help review.

Till now, all existing accelerate ut cases which are valid on XPU are enabled, thx very much @SunMarc @IlyasMoutawwakil for your great support! 