### PR TITLE
Integrate SwanLab for offline/online experiment tracking for Accelerate

### DIFF
--- a/docs/source/package_reference/tracking.md
+++ b/docs/source/package_reference/tracking.md
@@ -48,3 +48,8 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] tracking.ClearMLTracker
     - __init__
+
+## SwanLabTracker
+
+[[autodoc]] tracking.SwanLabTracker
+    - __init__

--- a/examples/by_feature/deepspeed_with_config_support.py
+++ b/examples/by_feature/deepspeed_with_config_support.py
@@ -218,7 +218,7 @@ def parse_args():
         default="all",
         help=(
             'The integration to report the results and logs to. Supported platforms are `"tensorboard"`,'
-            ' `"wandb"`, `"comet_ml"`, and `"dvclive"`. Use `"all"` (default) to report to all integrations.'
+            ' `"wandb"`, `"comet_ml"`, `"dvclive"`, and `"swanlab"`. Use `"all"` (default) to report to all integrations.'
             "Only applicable when `--with_tracking` is passed."
         ),
     )

--- a/examples/by_feature/megatron_lm_gpt_pretraining.py
+++ b/examples/by_feature/megatron_lm_gpt_pretraining.py
@@ -215,7 +215,7 @@ def parse_args():
         default="all",
         help=(
             'The integration to report the results and logs to. Supported platforms are `"tensorboard"`,'
-            ' `"wandb"`, `"comet_ml"`, and `"dvclive"`. Use `"all"` (default) to report to all integrations.'
+            ' `"wandb"`, `"comet_ml"`, and `"dvclive"`, and `"swanlab"`. Use `"all"` (default) to report to all integrations.'
             "Only applicable when `--with_tracking` is passed."
         ),
     )

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,15 @@ extras["deepspeed"] = ["deepspeed"]
 extras["rich"] = ["rich"]
 
 extras["test_fp8"] = ["torchao"]  # note: TE for now needs to be done via pulling down the docker image directly
-extras["test_trackers"] = ["wandb", "comet-ml", "tensorboard", "dvclive", "mlflow", "matplotlib"]
+extras["test_trackers"] = [
+    "wandb",
+    "comet-ml",
+    "tensorboard",
+    "dvclive",
+    "mlflow",
+    "matplotlib",
+    "swanlab",
+]
 extras["dev"] = extras["quality"] + extras["testing"] + extras["rich"]
 
 extras["sagemaker"] = [

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -229,6 +229,7 @@ class Accelerator:
             - `"tensorboard"`
             - `"wandb"`
             - `"comet_ml"`
+            - `"swanlab"`
             If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can
             also accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         project_config ([`~utils.ProjectConfiguration`], *optional*):

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -487,9 +487,7 @@ def require_swanlab(test_case):
     """
     Decorator marking a test that requires swanlab installed. These tests are skipped when swanlab isn't installed
     """
-    return unittest.skipUnless(is_swanlab_available(), "test requires swanlab")(
-        test_case
-    )
+    return unittest.skipUnless(is_swanlab_available(), "test requires swanlab")(test_case)
 
 
 def require_pandas(test_case):
@@ -546,8 +544,7 @@ def require_matplotlib(test_case):
 
 
 _atleast_one_tracker_available = (
-    any([is_wandb_available(), is_tensorboard_available(), is_swanlab_available()])
-    and not is_comet_ml_available()
+    any([is_wandb_available(), is_tensorboard_available(), is_swanlab_available()]) and not is_comet_ml_available()
 )
 
 

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -61,6 +61,7 @@ from ..utils import (
     is_pytest_available,
     is_schedulefree_available,
     is_sdaa_available,
+    is_swanlab_available,
     is_tensorboard_available,
     is_timm_available,
     is_torch_version,
@@ -482,6 +483,15 @@ def require_dvclive(test_case):
     return unittest.skipUnless(is_dvclive_available(), "test requires dvclive")(test_case)
 
 
+def require_swanlab(test_case):
+    """
+    Decorator marking a test that requires swanlab installed. These tests are skipped when swanlab isn't installed
+    """
+    return unittest.skipUnless(is_swanlab_available(), "test requires swanlab")(
+        test_case
+    )
+
+
 def require_pandas(test_case):
     """
     Decorator marking a test that requires pandas installed. These tests are skipped when pandas isn't installed
@@ -536,7 +546,8 @@ def require_matplotlib(test_case):
 
 
 _atleast_one_tracker_available = (
-    any([is_wandb_available(), is_tensorboard_available()]) and not is_comet_ml_available()
+    any([is_wandb_available(), is_tensorboard_available(), is_swanlab_available()])
+    and not is_comet_ml_available()
 )
 
 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -1122,9 +1122,8 @@ class SwanLabTracker(GeneralTracker):
 
         Args:
         data : Dict[str, DataType]
-            Data must be a dict.
-            The key must be a string with 0-9, a-z, A-Z, " ", "_", "-", "/".
-            The value must be a `float`, `float convertible object`, `int` or `swanlab.data.BaseType`.
+            Data must be a dict. The key must be a string with 0-9, a-z, A-Z, " ", "_", "-", "/". The value must be a
+            `float`, `float convertible object`, `int` or `swanlab.data.BaseType`.
         step : int, optional
             The step number of the current data, if not provided, it will be automatically incremented.
         If step is duplicated, the data will be ignored.

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -34,6 +34,7 @@ from .utils import (
     is_comet_ml_available,
     is_dvclive_available,
     is_mlflow_available,
+    is_swanlab_available,
     is_tensorboard_available,
     is_wandb_available,
     listify,
@@ -62,6 +63,9 @@ if is_clearml_available():
 
 if is_dvclive_available():
     _available_trackers.append(LoggerType.DVCLIVE)
+
+if is_swanlab_available():
+    _available_trackers.append(LoggerType.SWANLAB)
 
 logger = get_logger(__name__)
 
@@ -1061,6 +1065,107 @@ class DVCLiveTracker(GeneralTracker):
         self.live.end()
 
 
+class SwanLabTracker(GeneralTracker):
+    """
+    A `Tracker` class that supports `swanlab`. Should be initialized at the start of your script.
+
+    Args:
+        run_name (`str`):
+            The name of the experiment run.
+        **kwargs (additional keyword arguments, *optional*):
+            Additional key word arguments passed along to the `swanlab.init` method.
+    """
+
+    name = "swanlab"
+    requires_logging_directory = False
+    main_process_only = False
+
+    def __init__(self, run_name: str, **kwargs):
+        super().__init__()
+        self.run_name = run_name
+        self.init_kwargs = kwargs
+
+    @on_main_process
+    def start(self):
+        import swanlab
+
+        self.run = swanlab.init(project=self.run_name, **self.init_kwargs)
+        swanlab.config["FRAMEWORK"] = "accelerate"  # add accelerate logo in config
+        logger.debug(f"Initialized SwanLab project {self.run_name}")
+        logger.debug(
+            "Make sure to log any initial configurations with `self.store_init_configuration` before training!"
+        )
+
+    @property
+    def tracker(self):
+        return self.run
+
+    @on_main_process
+    def store_init_configuration(self, values: dict):
+        """
+        Logs `values` as hyperparameters for the run. Should be run at the beginning of your experiment.
+
+        Args:
+            values (Dictionary `str` to `bool`, `str`, `float` or `int`):
+                Values to be stored as initial hyperparameters as key-value pairs. The values need to have type `bool`,
+                `str`, `float`, `int`, or `None`.
+        """
+        import swanlab
+
+        swanlab.config.update(values, allow_val_change=True)
+        logger.debug("Stored initial configuration hyperparameters to SwanLab")
+
+    @on_main_process
+    def log(self, values: dict, step: Optional[int] = None, **kwargs):
+        """
+        Logs `values` to the current run.
+
+        Args:
+        data : Dict[str, DataType]
+            Data must be a dict.
+            The key must be a string with 0-9, a-z, A-Z, " ", "_", "-", "/".
+            The value must be a `float`, `float convertible object`, `int` or `swanlab.data.BaseType`.
+        step : int, optional
+            The step number of the current data, if not provided, it will be automatically incremented.
+        If step is duplicated, the data will be ignored.
+            kwargs:
+                Additional key word arguments passed along to the `swanlab.log` method. Likes:
+                    print_to_console : bool, optional
+                        Whether to print the data to the console, the default is False.
+        """
+        self.run.log(values, step=step, **kwargs)
+        logger.debug("Successfully logged to SwanLab")
+
+    @on_main_process
+    def log_images(self, values: dict, step: Optional[int] = None, **kwargs):
+        """
+        Logs `images` to the current run.
+
+        Args:
+            values (Dictionary `str` to `List` of `np.ndarray` or `PIL.Image`):
+                Values to be logged as key-value pairs. The values need to have type `List` of `np.ndarray` or
+            step (`int`, *optional*):
+                The run step. If included, the log will be affiliated with this step.
+            kwargs:
+                Additional key word arguments passed along to the `swanlab.log` method. Likes:
+                    print_to_console : bool, optional
+                        Whether to print the data to the console, the default is False.
+        """
+        import swanlab
+
+        for k, v in values.items():
+            self.log({k: [swanlab.Image(image) for image in v]}, step=step, **kwargs)
+        logger.debug("Successfully logged images to SwanLab")
+
+    @on_main_process
+    def finish(self):
+        """
+        Closes `swanlab` writer
+        """
+        self.run.finish()
+        logger.debug("SwanLab run closed")
+
+
 LOGGER_TYPE_TO_CLASS = {
     "aim": AimTracker,
     "comet_ml": CometMLTracker,
@@ -1069,6 +1174,7 @@ LOGGER_TYPE_TO_CLASS = {
     "wandb": WandBTracker,
     "clearml": ClearMLTracker,
     "dvclive": DVCLiveTracker,
+    "swanlab": SwanLabTracker,
 }
 
 
@@ -1093,6 +1199,7 @@ def filter_trackers(
             - `"comet_ml"`
             - `"mlflow"`
             - `"dvclive"`
+            - `"swanlab"`
             If `"all"` is selected, will pick up all available trackers in the environment and initialize them. Can
             also accept implementations of `GeneralTracker` for custom trackers, and can be combined with `"all"`.
         logging_dir (`str`, `os.PathLike`, *optional*):

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -1090,7 +1090,7 @@ class SwanLabTracker(GeneralTracker):
         import swanlab
 
         self.run = swanlab.init(project=self.run_name, **self.init_kwargs)
-        swanlab.config["FRAMEWORK"] = "accelerate"  # add accelerate logo in config
+        swanlab.config["FRAMEWORK"] = "🤗Accelerate"  # add accelerate logo in config
         logger.debug(f"Initialized SwanLab project {self.run_name}")
         logger.debug(
             "Make sure to log any initial configurations with `self.store_init_configuration` before training!"

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -121,6 +121,7 @@ from .imports import (
     is_sagemaker_available,
     is_schedulefree_available,
     is_sdaa_available,
+    is_swanlab_available,
     is_tensorboard_available,
     is_timm_available,
     is_torch_xla_available,

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -701,6 +701,7 @@ class LoggerType(BaseEnum):
         - **WANDB** -- wandb as an experiment tracker
         - **COMETML** -- comet_ml as an experiment tracker
         - **DVCLIVE** -- dvclive as an experiment tracker
+        - **SWANLAB** -- swanlab as an experiment tracker
     """
 
     ALL = "all"
@@ -711,6 +712,7 @@ class LoggerType(BaseEnum):
     MLFLOW = "mlflow"
     CLEARML = "clearml"
     DVCLIVE = "dvclive"
+    SWANLAB = "swanlab"
 
 
 class PrecisionType(str, BaseEnum):

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -281,6 +281,10 @@ def is_comet_ml_available():
     return _is_package_available("comet_ml")
 
 
+def is_swanlab_available():
+    return _is_package_available("swanlab")
+
+
 def is_boto3_available():
     return _is_package_available("boto3")
 


### PR DESCRIPTION

<img width="2923" alt="Frame 4478" src="https://github.com/user-attachments/assets/4b863058-be22-467b-87a9-33e7d8e6e011" />

# What does this PR do?

This PR introduces [SwanLab](https://github.com/SwanHubX/SwanLab), a lightweight open-source experiment tracking tool, as a new logging option for the training framework. The integration provides both online and offline tracking capabilities, along with a local dashboard for visualizing results.

SwanLab has previously supported:
- Tracking via Transformers' `report_to` parameter ([documentation](https://huggingface.co/docs/transformers/v4.52.3/en/main_classes/callback#transformers.integrations.SwanLabCallback))
- The Accelerate training framework through external callbacks ([documentation](https://docs.swanlab.cn/en/guide_cloud/integration/integration-huggingface-accelerate.html))

We've received numerous requests from the community to add native Accelerate support (see [here](https://github.com/SwanHubX/SwanLab/issues/1014)), and we're excited to officially integrate with this excellent project to provide a more seamless experience for developers. This integration is particularly valuable for users in regions with limited network connectivity (such as China), offering them robust experiment tracking capabilities.

![image](https://github.com/user-attachments/assets/767696e0-355f-4d7b-a462-f3237c9dde5c)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),  Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (see [here](https://github.com/SwanHubX/SwanLab/issues/1014))
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [X] Did you write any new necessary tests? (I don't see any tests for any of the callbacks but please let me know if I missed them somewhere. )

## Who can review?

@SunMarc  I noticed that you recently reviewed some related PRs—would you mind helping review my PR as well? Thank you! (I believe you also reviewed the Hugging Face Transformers integration previously—looking forward to collaborating again! 😄)

---

## Additional information about this PR

### Usage guidline

**Step 0: Set Up Accelerate and example environment**

Following the **accelerate** official cv example (pet image classification task):

```bash
# prepare code and environments
git clone https://github.com/huggingface/accelerate
cd accelerate
pip install -e .
pip install timm     # use in example
```


**Step 1: Set Up SwanLab Online Tracking**

Install:

```bash
pip install swanlab
```

To use SwanLab's online tracking, log in to the [SwanLab website](https://swanlab.cn/) and obtain your API key from the [Settings page](https://swanlab.cn/space/~/settings). Then, authenticate using the following command:

```bash
swanlab login
```

If you prefer offline mode, skip this step and install local dashboard:

```bash
pip install swanlab[dashboard]
```

**Step 2: download *Oxford-IIT Pet Dataset* used in example code**

You can find download link [here](https://www.robots.ox.ac.uk/~vgg/data/pets/)

**Step 3: run offical example script in accelerate projects**

```bash
python examples/complete_cv_example.py  --data_dir <DOWNLOAD DATA PATH> --with_tracking
```

<img width="1290" alt="Screenshot 2025-06-03 at 21 12 01" src="https://github.com/user-attachments/assets/af50af16-3861-4792-87f6-254e6cbd0be8" />

<img width="2062" alt="Screenshot 2025-06-03 at 21 06 48" src="https://github.com/user-attachments/assets/47049909-f10c-4f8a-b956-de8cb04308e7" />

<img width="2052" alt="Screenshot 2025-06-03 at 21 12 33" src="https://github.com/user-attachments/assets/b1f23975-a2ae-48f0-98d5-a6c8671b6cb8" />

[visualization demo here](https://swanlab.cn/@ShaohonChen/complete_cv_example/runs/5kuj38hkwytm0oob9uis2/chart)

Since my server is offline, I changed the `pretrain` parameter to `false` in the `create_model` code to avoid downloading the model online, which led to very poor accuracy after just 3 epochs 😂.

### test suite passes

<img width="1297" alt="Screenshot 2025-06-03 at 21 01 04" src="https://github.com/user-attachments/assets/0af4a78f-f6b9-4c34-a8cc-4cef47bb9000" />

Since my AI training server couldn't connect to Hugging Face, some tests failed during the automated testing process.😭
