### PR TITLE
fix xpu 8bit value loading

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -305,8 +305,8 @@ def set_module_tensor_to_device(
         # # fix the case where the device is meta, we don't want to put it on cpu because there is no data =0
         if (
             param is not None
-            and param.device.type != "cuda"
-            and torch.device(device).type == "cuda"
+            and param.device.type not in ("cuda", "xpu")
+            and torch.device(device).type in ("cuda", "xpu")
             and param_cls.__name__ in ["Int8Params", "FP4Params", "Params4bit"]
         ):
             device_quantization = device


### PR DESCRIPTION
We should enable the same logic on XPU as cuda to correct loading the 8bit value. Set device to cpu first so we can trigger the quantization, otherwise we will get the float weight inside linear8bit.

Fix failed test:
`pytest -rA tests/test_quantization.py::MixedInt8EmptyModelTest::test_linear_are_8bit `
error message:
```
AssertionError: assert torch.float16 == torch.int8
```