### PR TITLE
add xpu support in TorchTensorParallelPlugin

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -2088,6 +2088,8 @@ class TorchTensorParallelPlugin:
         # support for other devices has to be investigated
         if is_hpu_available(init_hccl=True):
             device = "hpu"
+        elif is_xpu_availabe():
+            device = "xpu"
         else:
             device = "cuda"
 


### PR DESCRIPTION
with this `pytest -rA tests/tp/test_tp.py::TPIntegrationTest::test_working_of_tp` will pass on XPU.

@SunMarc, pls help review, thx.