### PR TITLE
Fix: properly error when DDP + Dtensor model

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -108,6 +108,7 @@ from .utils import (
     is_xpu_available,
     load_fsdp_model,
     load_fsdp_optimizer,
+    model_has_dtensor,
     pad_across_processes,
     parse_choice_from_env,
     recursively_apply,
@@ -1620,6 +1621,10 @@ class Accelerator:
                 DistributedType.MULTI_XPU,
                 DistributedType.MULTI_HPU,
             ):
+                if model_has_dtensor(model):
+                    raise ValueError(
+                        "Your model contains `DTensor` parameters, which is incompatible with DDP. Maybe you loaded your model with `device_map='auto'`?"
+                    )
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
                     # TODO: Look at enabling native TP training directly with a proper config

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1623,7 +1623,7 @@ class Accelerator:
             ):
                 if model_has_dtensor(model):
                     raise ValueError(
-                        "Your model contains `DTensor` parameters, which is incompatible with DDP. Maybe you loaded your model with `device_map='auto'`?"
+                        "Your model contains `DTensor` parameters, which is incompatible with DDP. Maybe you loaded your model with `device_map='auto'`? Specify `device_map='cuda'` or 'cpu' instead."
                     )
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -281,6 +281,7 @@ from .other import (
     is_port_in_use,
     load,
     merge_dicts,
+    model_has_dtensor,
     recursive_getattr,
     save,
     wait_for_everyone,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -205,20 +205,13 @@ def model_has_dtensor(model: torch.nn.Module) -> bool:
     Returns:
         `bool`: Whether the model has DTensor parameters.
     """
-    dtensor_available = False
-    # We have to do this disgusting import dance because DTensor changed location in 2.5.0
-    try:
+    if is_torch_version(">=", "2.5.0"):
         from torch.distributed.tensor import DTensor
+    else:
+        # from torch 2.0.0 (oldest supported accelerate torch version), DTensor is in torch.distributed._tensor
+        from torch.distributed._tensor import DTensor
 
-        dtensor_available = True
-    except ImportError:
-        try:
-            from torch.distributed._tensor import DTensor
-
-            dtensor_available = True
-        except ImportError:
-            pass
-    return dtensor_available and any(isinstance(p, DTensor) for p in model.parameters())
+    return any(isinstance(p, DTensor) for p in model.parameters())
 
 
 def extract_model_from_parallel(


### PR DESCRIPTION
A rather tiny PR, "fixes" or more likely errors properly on an issue introduced in #3628. The issue is that DDP doesn't work if model has DTensors which it has if it was loaded with device_map="auto" (it applies TP). Now we properly raise an Error.

Snippet to test:

```python
from transformers import AutoModelForCausalLM

from accelerate import Accelerator


model_id = "NousResearch/Hermes-3-Llama-3.1-8B"
accelerator = Accelerator()

model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto")

model = accelerator.prepare(model)
```

Before: 
`[rank0]: AssertionError: found no DeviceMesh from dtensor args for c10d.broadcast_.default!`

After:
`[rank0]: ValueError: Your model contains `DTensor` parameters, which is incompatible with DDP. Maybe you loaded your model with `device_map='auto'`?`

cc @SunMarc 