### PR TITLE
Adding import to avoid circular import

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1290,6 +1290,7 @@ class Accelerator:
         return obj
 
     def prepare(self, *args, device_placement=None):
+        from accelerate.utils import is_torch_version
         """
         Prepare all objects passed in `args` for distributed training and mixed precision, then return them in the same
         order.

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1290,7 +1290,6 @@ class Accelerator:
         return obj
 
     def prepare(self, *args, device_placement=None):
-        from accelerate.utils import is_torch_version
         """
         Prepare all objects passed in `args` for distributed training and mixed precision, then return them in the same
         order.
@@ -1336,6 +1335,7 @@ class Accelerator:
         ... )
         ```
         """
+        from accelerate.utils import is_torch_version
         if device_placement is None:
             device_placement = [None for _ in args]
         elif self.distributed_type in (DistributedType.DEEPSPEED, DistributedType.MEGATRON_LM):


### PR DESCRIPTION
Fixes https://github.com/huggingface/accelerate/issues/3641

This pull request introduces a minor change to the `prepare` method in `src/accelerate/accelerator.py`. The change imports the `is_torch_version` utility from `accelerate.utils` to potentially use it within the method. 

- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 


