### PR TITLE
fix: wandb config not saved in offline mode

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -336,7 +336,16 @@ class WandBTracker(GeneralTracker):
         """
         import wandb
 
-        wandb.config.update(values, allow_val_change=True)
+        if os.environ.get("WANDB_MODE") == "offline":
+            # In offline mode, restart wandb with config included
+            if hasattr(self, 'run') and self.run:
+                self.run.finish()
+
+            init_kwargs = self.init_kwargs.copy()
+            init_kwargs['config'] = values
+            self.run = wandb.init(project=self.run_name, **init_kwargs)
+        else:
+            wandb.config.update(values, allow_val_change=True)
         logger.debug("Stored initial configuration hyperparameters to WandB")
 
     @on_main_process

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -338,11 +338,11 @@ class WandBTracker(GeneralTracker):
 
         if os.environ.get("WANDB_MODE") == "offline":
             # In offline mode, restart wandb with config included
-            if hasattr(self, 'run') and self.run:
+            if hasattr(self, "run") and self.run:
                 self.run.finish()
 
             init_kwargs = self.init_kwargs.copy()
-            init_kwargs['config'] = values
+            init_kwargs["config"] = values
             self.run = wandb.init(project=self.run_name, **init_kwargs)
         else:
             wandb.config.update(values, allow_val_change=True)


### PR DESCRIPTION
Pass config during wandb.init() in offline mode instead of using
config.update() 
Fixes #3607 
similar [https://github.com/huggingface/transformers/issues/38968](https://github.com/huggingface/transformers/issues/38968)


## Before submitting
- [X] Was this discussed/approved via a Github issue or the forum? Please add a link
      to it if that's the case.


## Who can review?
@SunMarc
