### PR TITLE
Initialize tensors with zeros

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -229,7 +229,7 @@ def initialize_tensors(data_structure):
     """
 
     def _initialize_tensor(tensor_info):
-        return torch.empty(*tensor_info.shape, dtype=tensor_info.dtype)
+        return torch.zeros(*tensor_info.shape, dtype=tensor_info.dtype)
 
     return recursively_apply(_initialize_tensor, data_structure, test_type=is_tensor_information)
 


### PR DESCRIPTION
# What does this PR do?

When initializing tensors with `torch.empty` the values are random, often large and near to the dtype range limits. The `initialize_tensors` function creates the tensors on CPU. When moving them to the destination device (using the `send_to_device` function), some devices will throw an error if the dtype is not supported and implicitly downcasted, e.g.: on Gaudi in lazy mode, the int64 dtype is not enabled by default, and if we create a int64 empty tensor, move it to "hpu", we will often get the following error message:

`RuntimeError: Error when trying to cast Long to Int, Input values range [9223372036854775807, 9223372036854775807] exceeds Int range [-2147483648, 2147483647]`

This commit changes the default initialization value of the tensors created using `initialize_tensors` to zero by replacing `torch.empty` with `torch.zeros`.

