### PR TITLE
feature: CpuOffload pre_forward don't attempt to move if already on device

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -712,7 +712,7 @@ class CpuOffload(ModelHook):
 
     def init_hook(self, module):
         return module.to("cpu")
-    
+
     def pre_forward(self, module, *args, **kwargs):
         if self.prev_module_hook is not None and isinstance(self.prev_module_hook, UserCpuOffloadHook):
             prev_module = self.prev_module_hook.model

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -712,11 +712,22 @@ class CpuOffload(ModelHook):
 
     def init_hook(self, module):
         return module.to("cpu")
-
+    
     def pre_forward(self, module, *args, **kwargs):
-        if self.prev_module_hook is not None:
-            self.prev_module_hook.offload()
-            clear_device_cache()
+        if self.prev_module_hook is not None and isinstance(self.prev_module_hook, UserCpuOffloadHook):
+            prev_module = self.prev_module_hook.model
+            prev_device = next(prev_module.parameters()).device
+
+            # Only offload the previous module if it is not already on CPU.
+            if prev_device != torch.device("cpu"):
+                self.prev_module_hook.offload()
+                clear_device_cache()
+
+        # If the current device is already the self.execution_device, we can skip the transfer.
+        current_device = next(module.parameters()).device
+        if current_device == self.execution_device:
+            return args, kwargs
+
         module.to(self.execution_device)
         return send_to_device(args, self.execution_device), send_to_device(kwargs, self.execution_device)
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -82,9 +82,7 @@ class HooksModelTester(unittest.TestCase):
                         self.assertEqual(tensor.dtype, loading_type)
                 continue
 
-            if patterns_to_check and any(
-                re.search(pat, name) for pat in patterns_to_check
-            ):
+            if patterns_to_check and any(re.search(pat, name) for pat in patterns_to_check):
                 expected = loading_type
             else:
                 expected = storage_dtype
@@ -206,9 +204,7 @@ class HooksModelTester(unittest.TestCase):
         assert model.linear1.weight.device == torch.device(torch_device)
         assert model.batchnorm.weight.device == torch.device(torch_device)
         assert model.batchnorm.running_mean.device == torch.device(torch_device)
-        assert model.linear2.weight.device == torch.device(
-            torch_device.replace(":0", ":1")
-        )
+        assert model.linear2.weight.device == torch.device(torch_device.replace(":0", ":1"))
 
         # We can still make a forward pass. The input does not need to be on any particular device
         x = torch.randn(2, 3)
@@ -316,9 +312,7 @@ class HooksModelTester(unittest.TestCase):
         assert model.linear2.weight.device == torch.device("cpu")
 
         # Now test with buffers included in the offload
-        attach_align_device_hook(
-            model, execution_device=execution_device, offload=True, offload_buffers=True
-        )
+        attach_align_device_hook(model, execution_device=execution_device, offload=True, offload_buffers=True)
 
         # Parameters have been offloaded, so on the meta device, buffers included
         assert model.linear1.weight.device == torch.device("meta")
@@ -347,10 +341,7 @@ class HooksModelTester(unittest.TestCase):
         # This will move each submodule on different devices
         execution_device = torch_device
         attach_align_device_hook(
-            model,
-            execution_device=execution_device,
-            offload=True,
-            weights_map=model.state_dict(),
+            model, execution_device=execution_device, offload=True, weights_map=model.state_dict()
         )
 
         # Parameters have been offloaded, so on the meta device
@@ -425,10 +416,7 @@ class HooksModelTester(unittest.TestCase):
 
             graph_model.graph.inserting_after(linear2_node)
             new_node = graph_model.graph.create_node(
-                op="call_function",
-                target=torch.sigmoid,
-                args=(linear2_node,),
-                name="relu",
+                op="call_function", target=torch.sigmoid, args=(linear2_node,), name="relu"
             )
 
             output_node = None
@@ -454,9 +442,7 @@ class HooksModelTester(unittest.TestCase):
             (torch.float8_e4m3fn, torch.float32, ["batchnorm"]),
         ]
     )
-    def test_layerwise_upcasting_inference(
-        self, storage_dtype, compute_dtype, skip_modules_pattern=None
-    ):
+    def test_layerwise_upcasting_inference(self, storage_dtype, compute_dtype, skip_modules_pattern=None):
         test_model = ModelForTest()
         loading_dtype = next(test_model.parameters()).data.dtype
         inputs = torch.randn(2, 3)
@@ -469,9 +455,7 @@ class HooksModelTester(unittest.TestCase):
             skip_modules_pattern=skip_modules_pattern,
         )
         patterns_to_check = skip_modules_pattern if skip_modules_pattern else None
-        self.check_dtype_for_layerwise_upcasting(
-            test_model, storage_dtype, loading_dtype, patterns_to_check
-        )
+        self.check_dtype_for_layerwise_upcasting(test_model, storage_dtype, loading_dtype, patterns_to_check)
 
         with torch.no_grad():
             _ = test_model(inputs)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -482,7 +482,6 @@ class HooksModelTester(unittest.TestCase):
         assert model.batchnorm.weight.device == gpu_device
         assert model.linear2.weight.device == gpu_device
 
-
     def test_cpu_offload_hook_with_prev_module(self):
         if not torch.cuda.is_available():
             self.skipTest("CUDA not available for offload test.")
@@ -494,7 +493,7 @@ class HooksModelTester(unittest.TestCase):
 
         hook1 = CpuOffload(execution_device=gpu_device)
         add_hook_to_module(model1, hook1)
-        user_hook1 = UserCpuOffloadHook(model1, hook1) 
+        user_hook1 = UserCpuOffloadHook(model1, hook1)
 
         hook2 = CpuOffload(execution_device=gpu_device, prev_module_hook=user_hook1)
         add_hook_to_module(model2, hook2)
@@ -515,4 +514,3 @@ class HooksModelTester(unittest.TestCase):
         assert model2.linear1.weight.device == gpu_device
         assert model2.batchnorm.weight.device == gpu_device
         assert model2.linear2.weight.device == gpu_device
-


### PR DESCRIPTION
# What does this PR do?

Added optimisation to not attempt to move devices if already on that the device. This is more noticeable in large step iterations on diffusion loops when the **pre_forward** can get called many times

Possibly the there is a better way than using **next()** and noticed it's possibly to set the **prev_module_hook** to invalid object so added an additional check. Glad for any feedback to improve. Or perhaps there's an even better way.


Fixes # (issue)

Issue was not as bad as I initially thought. But from speaking with maintainers there was some smaller gains found.  Mainly noticeable in large loops

https://github.com/huggingface/diffusers/issues/11872

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- DeepSpeed: @SunMarc @zach-huggingface
- Command Line Interface: @SunMarc @zach-huggingface
- Documentation: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface

 -->