### PR TITLE
Fix: prepare works even if nothing except tp specified (rare)

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1584,9 +1584,17 @@ class Accelerator:
         return result if len(result) > 1 else result[0]
 
     def _prepare_tp(self, *args):
+        # First pass: prepare everything except schedulers (and model, which is prepared separately below)
+        result = [
+            self._prepare_one(obj, first_pass=True) if not isinstance(obj, torch.nn.Module) else obj for obj in args
+        ]
+
+        # Second pass: prepare schedulers
+        result = [self._prepare_one(obj) if not isinstance(obj, torch.nn.Module) else obj for obj in result]
+
         device_mesh = self.torch_device_mesh
 
-        for arg in args:
+        for arg in result:
             if not isinstance(arg, torch.nn.Module):
                 continue
 


### PR DESCRIPTION
If we only had TP specified, the training would probably be still correct, though the optimizer/dataloader wouldn't be accelerator prepared (in some cases). This was and is a rare case, as pure TP is not fully supported yet anyway. Though this PR fixes atleast this.