### PR TITLE
Fix: tp size wouldn't read from env

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -788,7 +788,7 @@ class Accelerator:
                 parallelism_config = PartialState().parallelism_config
             else:
                 # TODO: Remove after deprecating tp_plugin
-                tp_size = 1 if torch_tp_plugin is None else torch_tp_plugin.tp_size
+                tp_size = None if torch_tp_plugin is None else torch_tp_plugin.tp_size
                 parallelism_config = ParallelismConfig(tp_size=tp_size)
 
         return parallelism_config


### PR DESCRIPTION
With change in #3700 where we default to None, passing 1 as tp_size would result in env vars not being read.