### PR TITLE
Remove `ParallelismConfig` from `PartialState`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -453,7 +453,9 @@ class Accelerator:
 
         # TODO: Remove after deprecating tp_plugin
         if parallelism_config is None:
-            parallelism_config = ParallelismConfig(tp_size = None if torch_tp_plugin is None else torch_tp_plugin.tp_size)
+            parallelism_config = ParallelismConfig(
+                tp_size=None if torch_tp_plugin is None else torch_tp_plugin.tp_size
+            )
 
         kwargs = self.init_handler.to_kwargs() if self.init_handler is not None else {}
         self.state = AcceleratorState(

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -451,11 +451,12 @@ class Accelerator:
                 if "recipe_handler" in handler_attr and not self.has_fp8_handler:
                     self.has_fp8_handler = True
 
-        # TODO: Remove after deprecating tp_plugin
         if parallelism_config is None:
-            parallelism_config = ParallelismConfig(
-                tp_size=None if torch_tp_plugin is None else torch_tp_plugin.tp_size
-            )
+            # TODO: Remove after deprecating tp_plugin
+            if torch_tp_plugin is not None:
+                parallelism_config = ParallelismConfig(tp_size=torch_tp_plugin.tp_size)
+            elif os.environ.get("ACCELERATE_USE_PARALLELISM_CONFIG", "false").lower() == "true":
+                parallelism_config = ParallelismConfig()
 
         kwargs = self.init_handler.to_kwargs() if self.init_handler is not None else {}
         self.state = AcceleratorState(

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -25,11 +25,6 @@ from accelerate.utils.dataclasses import TorchContextParallelConfig, TorchTensor
 if TYPE_CHECKING:
     from accelerate import Accelerator
 
-from .logging import get_logger
-
-
-logger = get_logger(__name__)
-
 
 @dataclass
 class ParallelismConfig:
@@ -210,7 +205,7 @@ class ParallelismConfig:
         else:
             if device_type is not None:
                 if self.device_mesh.device_type != device_type:
-                    logger.warning(
+                    raise ValueError(
                         f"The device_mesh is already created with device type {self.device_mesh.device_type}. However, you are trying to get a device mesh with device_type {device_type}. Please check if you correctly initialized your device_mesh"
                     )
         return self.device_mesh

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -25,6 +25,11 @@ from accelerate.utils.dataclasses import TorchContextParallelConfig, TorchTensor
 if TYPE_CHECKING:
     from accelerate import Accelerator
 
+from .logging import get_logger
+
+
+logger = get_logger(__name__)
+
 
 @dataclass
 class ParallelismConfig:
@@ -180,7 +185,7 @@ class ParallelismConfig:
         """
         mesh = self._get_mesh()
         if len(mesh) == 0:
-            return
+            return None
         mesh_dim_names, mesh_shape = mesh
         device_mesh = init_device_mesh(
             device_type,
@@ -202,6 +207,12 @@ class ParallelismConfig:
                 self.device_mesh = self.build_device_mesh(device_type)
             else:
                 raise ("You need to pass a device_type e.g cuda to build the device mesh")
+        else:
+            if device_type is not None:
+                if self.device_mesh.device_type != device_type:
+                    logger.warning(
+                        f"The device_mesh is already created with device type {self.device_mesh.device_type}. However, you are trying to get a device mesh with device_type {device_type}. Please check if you correctly initialized your device_mesh"
+                    )
         return self.device_mesh
 
     def _get_mesh(self) -> tuple[tuple[int, ...], tuple[str, ...]]:

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -15,7 +15,7 @@
 import os
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from torch.distributed.device_mesh import init_device_mesh
 
@@ -195,15 +195,15 @@ class ParallelismConfig:
             device_mesh[self.dp_cp_dim_names]._flatten("dp_cp")
 
         return device_mesh
-    
+
     def get_device_mesh(self, device_type: Optional[str] = None):
         if self.device_mesh is None:
             if device_type is not None:
                 self.device_mesh = self.build_device_mesh(device_type)
             else:
-                raise("You need to pass a device_type e.g cuda to build the device mesh")
+                raise ("You need to pass a device_type e.g cuda to build the device mesh")
         return self.device_mesh
-        
+
     def _get_mesh(self) -> tuple[tuple[int, ...], tuple[str, ...]]:
         """Generate mesh shape and dimension names for torch.distributed.init_device_mesh()."""
 

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -15,7 +15,7 @@
 import os
 import warnings
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Optional
 
 from torch.distributed.device_mesh import init_device_mesh
 
@@ -65,6 +65,8 @@ class ParallelismConfig:
     # we use Union because we might support other x parallel plugins (i.e. deepspeed, etc)
     tp_handler: Union[None, TorchTensorParallelConfig] = None
     cp_handler: Union[None, TorchContextParallelConfig] = None
+
+    device_mesh = None
 
     def __repr__(self):
         return (
@@ -193,7 +195,15 @@ class ParallelismConfig:
             device_mesh[self.dp_cp_dim_names]._flatten("dp_cp")
 
         return device_mesh
-
+    
+    def get_device_mesh(self, device_type: Optional[str] = None):
+        if self.device_mesh is None:
+            if device_type is not None:
+                self.device_mesh = self.build_device_mesh(device_type)
+            else:
+                raise("You need to pass a device_type e.g cuda to build the device mesh")
+        return self.device_mesh
+        
     def _get_mesh(self) -> tuple[tuple[int, ...], tuple[str, ...]]:
         """Generate mesh shape and dimension names for torch.distributed.init_device_mesh()."""
 

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -180,8 +180,6 @@ class PartialState:
         if not self.initialized:
             self._cpu = cpu
             self.backend = None
-            self.parallelism_config = kwargs.pop("parallelism_config", None)
-            self.device_mesh = kwargs.pop("device_mesh", None)
             env_device = os.environ.get("ACCELERATE_TORCH_DEVICE", None)
             self.device = torch.device(env_device) if env_device is not None else None
             self.debug = parse_flag_from_env("ACCELERATE_DEBUG_MODE")

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -917,6 +917,7 @@ class AcceleratorState:
             self.use_ipex = None
             self.torch_tp_plugin = torch_tp_plugin
             self.parallelism_config = parallelism_config
+            self.device_mesh = None
             mixed_precision = (
                 parse_choice_from_env("ACCELERATE_MIXED_PRECISION", "no")
                 if mixed_precision is None

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -355,6 +355,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
 
     prefix = "PARALLELISM_CONFIG_"
     if args.use_parallelism_config:
+        current_env["ACCELERATE_USE_PARALLELISM_CONFIG"] = "true"
         current_env[prefix + "DP_REPLICATE_SIZE"] = str(args.parallelism_config_dp_replicate_size)
         current_env[prefix + "TP_SIZE"] = str(args.parallelism_config_tp_size)
         current_env[prefix + "CP_SIZE"] = str(args.parallelism_config_cp_size)

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -355,7 +355,6 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
 
     prefix = "PARALLELISM_CONFIG_"
     if args.use_parallelism_config:
-        current_env["ACCELERATE_USE_PARALLELISM_CONFIG"] = "true"
         current_env[prefix + "DP_REPLICATE_SIZE"] = str(args.parallelism_config_dp_replicate_size)
         current_env[prefix + "TP_SIZE"] = str(args.parallelism_config_tp_size)
         current_env[prefix + "CP_SIZE"] = str(args.parallelism_config_cp_size)


### PR DESCRIPTION
# What does this PR do?

Since we moved `ParallelismConfig` to AcceleratorState, it should be fine to remove that in `PartialState`. Trainer in transformers actually reset `PartialState` so we shouldn't keep it there as we can't reconstruct if we don't create global var.
Apart from that, we don't initialize `parallelismconfig` if it is not passed or we didn't set any env var. 