### PR TITLE
Fix convert LayerNorm without bias to fp8

### DIFF
--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -50,7 +50,7 @@ def can_convert_te_model(from_config=False):
 
     accelerator = Accelerator(**accelerator_kwargs)
     dataloader = torch.utils.data.DataLoader(torch.randn(10, 32), batch_size=2)
-    model = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.Linear(32, 16))
+    model = torch.nn.Sequential(torch.nn.Linear(32, 32), torch.nn.LayerNorm(32, bias=False), torch.nn.Linear(32, 16))
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.1)
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR will fix an issue that occurs when converting LayerNorm without to FP8.  
For example, [answerdotai/ModernBERT-base](https://huggingface.co/answerdotai/ModernBERT-base) uses LayerNorm without bias.  

I have tested this in the following environments, but there should not be much environment dependency.

- Ubuntu 24.04
- Python 3.11.9
- torch==2.8.0+cu128
- torchao==0.12.0
- transformers==4.55.0
- transformer_engine==2.4.0, 2.5.0

Test Script:

```python
import torch

from accelerate import Accelerator
from accelerate.utils import (
    TERecipeKwargs,
)


accelerator_kwargs = {"mixed_precision": "fp8", "kwargs_handlers": [TERecipeKwargs()]}


accelerator = Accelerator(**accelerator_kwargs)
dataloader = torch.utils.data.DataLoader(torch.randn(10, 32), batch_size=2)
model = torch.nn.Sequential(torch.nn.LayerNorm(32, bias=False), torch.nn.Linear(32, 16))
optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.1)

model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
```

Before Fix:

```bash
python test_ln.py
Traceback (most recent call last):
  File "/home/mjun/workspace/accelerate/test_model.py", line 40, in <module>
    model, optimizer, dataloader, scheduler = accelerator.prepare(model, optimizer, dataloader, scheduler)
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjun/workspace/accelerate/src/accelerate/accelerator.py", line 1543, in prepare
    args = self._prepare_te(*args)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mjun/workspace/accelerate/src/accelerate/accelerator.py", line 2049, in _prepare_te
    convert_model(model)
  File "/home/mjun/workspace/accelerate/src/accelerate/utils/transformer_engine.py", line 71, in convert_model
    te_module.bias.copy_(module.bias)
TypeError: copy_(): argument 'other' (position 1) must be Tensor, not NoneType
```

After Fix:

```bash
python test_ln.py
# (No stdout)
```

The following tests were also run and confirmed to pass.

```python
python tests/test_fp8.py --test_te --test_ao
```

Furthermore, I am improving the test so that this case can be tested.

### References

<https://huggingface.co/answerdotai/ModernBERT-base>

<https://docs.pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html>

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@zach-huggingface 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- DeepSpeed: @SunMarc @zach-huggingface
- Command Line Interface: @SunMarc @zach-huggingface
- Documentation: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface

 -->