### PR TITLE
Fix Accelerator.init_trackers error when dealing with custom objects …

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -118,6 +118,7 @@ from .utils import (
     recursively_apply,
     reduce,
     release_memory,
+    sanitize_config_values,
     save,
     save_fsdp_model,
     save_fsdp_optimizer,
@@ -3199,8 +3200,11 @@ class Accelerator:
             tracker.start()
 
         if config is not None:
+            # Sanitize config values before passing to trackers
+            from .utils import sanitize_config_values
+            sanitized_config = sanitize_config_values(config)
             for tracker in self.trackers:
-                tracker.store_init_configuration(config)
+                tracker.store_init_configuration(sanitized_config)
 
     def get_tracker(self, name: str, unwrap: bool = False):
         """

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -295,6 +295,7 @@ from .other import (
 from .random import set_seed, synchronize_rng_state, synchronize_rng_states
 from .torch_xla import install_xla
 from .tqdm import tqdm
+from .tracking import sanitize_config_values
 from .transformer_engine import (
     apply_fp8_autowrap,
     contextual_fp8_autocast,

--- a/src/accelerate/utils/tracking.py
+++ b/src/accelerate/utils/tracking.py
@@ -1,0 +1,47 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from typing import Any, Dict
+
+
+def sanitize_config_values(config: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Sanitize configuration values to ensure they are compatible with tracking systems.
+    
+    This function converts complex data types (like lists, dicts) to JSON strings
+    so they can be stored as hyperparameters in tracking systems that only support
+    basic types (int, float, str, bool).
+    
+    Args:
+        config (Dict[str, Any]): Configuration dictionary with potentially complex values
+        
+    Returns:
+        Dict[str, Any]: Configuration dictionary with sanitized values
+    """
+    sanitized_config = {}
+    
+    for key, value in config.items():
+        # Check if the value is of a supported type
+        if isinstance(value, (int, float, str, bool, type(None))):
+            sanitized_config[key] = value
+        # Convert complex types to JSON string representation
+        else:
+            try:
+                sanitized_config[key] = json.dumps(value)
+            except (TypeError, ValueError):
+                # If JSON serialization fails, convert to string
+                sanitized_config[key] = str(value)
+                
+    return sanitized_config

--- a/tests/test_init_trackers_with_list.py
+++ b/tests/test_init_trackers_with_list.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+import tempfile
+import traceback
+
+# Add the local accelerate directory to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+# Import the sanitize function directly from the file
+from accelerate.utils.tracking import sanitize_config_values
+from accelerate import Accelerator
+
+
+def test_sanitize_function():
+    """Test our sanitize_config_values function directly"""
+    # Create test data with list values
+    test_config = {
+        "int_value": 42,
+        "float_value": 3.14,
+        "str_value": "hello",
+        "bool_value": True,
+        "none_value": None,
+        "list_value": ["item1", "item2", "item3"],
+        "dict_value": {"key": "value"},
+        "nested_list": [["nested", "list"], ["another", "one"]]
+    }
+    
+    # Sanitize the config
+    sanitized = sanitize_config_values(test_config)
+    
+    # Check that all values are now basic types
+    for key, value in sanitized.items():
+        print(f"{key}: {value} (type: {type(value)})")
+        if not isinstance(value, (int, float, str, bool, type(None))):
+            print(f"ERROR: Value for {key} is not a basic type!")
+            return False
+    
+    print("SUCCESS: sanitize_config_values works correctly")
+    return True
+
+
+def test_init_trackers_with_list():
+    """Test that init_trackers works with list values in config."""
+    # Create an argument parser with a list argument
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--validation_prompt",
+        type=str,
+        default=["A photo of sks dog in a bucket", "A sks cat wearing a coat"],
+        nargs="*",
+        help="A prompt that is used during validation to verify that the model is learning.",
+    )
+    
+    # Parse the arguments
+    args = parser.parse_args([])
+    
+    # Show what the args look like
+    print("Original args:")
+    for key, value in vars(args).items():
+        print(f"  {key}: {value} (type: {type(value)})")
+    
+    # Show what happens after sanitization
+    sanitized = sanitize_config_values(vars(args))
+    print("\nSanitized args:")
+    for key, value in sanitized.items():
+        print(f"  {key}: {value} (type: {type(value)})")
+    
+    # Create a temporary directory for logging
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create accelerator with tensorboard logging
+        accelerator = Accelerator(log_with=["tensorboard"], project_dir=tmpdir)
+        
+        # Initialize trackers with config containing list values
+        # This should not raise an error
+        try:
+            accelerator.init_trackers("test_project", config=vars(args))
+            print("\nSUCCESS: init_trackers worked with list values in config")
+            accelerator.end_training()
+        except Exception as e:
+            print(f"\nFAILED: init_trackers failed with error: {e}")
+            traceback.print_exc()
+            return False
+    
+    return True
+
+
+if __name__ == "__main__":
+    print("Testing sanitize_config_values function:")
+    success1 = test_sanitize_function()
+    
+    print("\nTesting init_trackers with list values:")
+    success2 = test_init_trackers_with_list()
+    
+    if success1 and success2:
+        print("\nAll tests passed!")
+    else:
+        print("\nSome tests failed!")
+        exit(1)


### PR DESCRIPTION

# What does this PR do?
Convert complex data types to JSON strings before storing in tracking systems to ensure compatibility with tracking libraries that only support basic types (int, float, str, bool, None). Added sanitize_config_values utility function and updated all tracker implementations to use it.


Fixes #3727 

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface