### PR TITLE
feat: add ignored_params support for fsdp2

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1564,7 +1564,7 @@ class FullyShardedDataParallelPlugin:
             `torch.distributed.fsdp.fully_sharded_data_parallel.CPUOffloadPolicy` if `fsdp_version` is set to 2.
         ignored_modules (`Optional[Union[Iterable[torch.nn.Module], str]]`, defaults to `None`):
             A list of modules to ignore when wrapping with FSDP. When passing a string, will match the modules by name
-            using regex fullmatch.
+            using regex fullmatch. If `fsdp_version` is set to 2, the modules are converted to parameters and used.
         state_dict_type (`Union[str, torch.distributed.fsdp.StateDictType]`, defaults to `'FULL_STATE_DICT'`):
             State dict type to use. If a string, it must be one of `full_state_dict`, `local_state_dict`, or
             `sharded_state_dict`.

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -14,13 +14,14 @@
 import copy
 import functools
 import os
+import re
 import shutil
 import warnings
 from collections import defaultdict
+from collections.abc import Iterable
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Callable, Union, Iterable, List
-import re
+from typing import Callable, Set, Union
 
 import torch
 
@@ -794,7 +795,8 @@ def fsdp2_canonicalize_names(named_params: dict) -> dict:
     named_params = {k.replace("._orig_mod", ""): v for k, v in named_params.items()}
     return named_params
 
-def get_parameters_from_modules(modules: Union[Iterable[torch.nn.Module], str], model, device) -> List[torch.nn.Parameter]:
+
+def get_parameters_from_modules(modules: Union[Iterable[torch.nn.Module], str], model, device) -> Set[torch.nn.Parameter]:
     """Converts modules to parameters where modules can be a string or list of torch.nn.Module
     Args:
         modules (`Union[Iterable[torch.nn.Module], str]`): List of modules
@@ -814,4 +816,4 @@ def get_parameters_from_modules(modules: Union[Iterable[torch.nn.Module], str], 
         modules = mapped_modules
     for module in modules:
         parameters.extend(list(module.parameters()))
-    return parameters
+    return set(parameters)

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import nullcontext
 from pathlib import Path
-from typing import Callable, Set, Union
+from typing import Callable, Union
 
 import torch
 
@@ -630,7 +630,7 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         # `fully_shard` doesn't accept `None` in case of `MixedPrecisionPolicy`
         "mp_policy": fsdp2_plugin.mixed_precision_policy or MixedPrecisionPolicy(),
         "mesh": mesh[tuple(accelerator.parallelism_config.fsdp_dim_names)] if mesh is not None else None,
-        "ignored_params": get_parameters_from_modules(fsdp2_plugin.ignored_modules, model, accelerator.device)
+        "ignored_params": get_parameters_from_modules(fsdp2_plugin.ignored_modules, model, accelerator.device),
     }
 
     model_has_params4bit = False
@@ -796,8 +796,11 @@ def fsdp2_canonicalize_names(named_params: dict) -> dict:
     return named_params
 
 
-def get_parameters_from_modules(modules: Union[Iterable[torch.nn.Module], str], model, device) -> Set[torch.nn.Parameter]:
+def get_parameters_from_modules(
+    modules: Union[Iterable[torch.nn.Module], str], model, device
+) -> set[torch.nn.Parameter]:
     """Converts modules to parameters where modules can be a string or list of torch.nn.Module
+
     Args:
         modules (`Union[Iterable[torch.nn.Module], str]`): List of modules
 


### PR DESCRIPTION
# What does this PR do?

This allows reusing `ignored_modules` user facing FSDP API for FSDP v2 to set `ignored_params`.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @zach-huggingface
