### PR TITLE
Protect import for device_mesh 

### DIFF
--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -17,7 +17,7 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from accelerate.utils import is_torch_version
+from accelerate.utils.versions import is_torch_version
 from accelerate.utils.dataclasses import TorchContextParallelConfig, TorchTensorParallelConfig
 
 

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -17,8 +17,8 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from accelerate.utils.versions import is_torch_version
 from accelerate.utils.dataclasses import TorchContextParallelConfig, TorchTensorParallelConfig
+from accelerate.utils.versions import is_torch_version
 
 
 if TYPE_CHECKING:

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -17,8 +17,7 @@ import warnings
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional, Union
 
-from torch.distributed.device_mesh import init_device_mesh
-
+from accelerate.utils import is_torch_version
 from accelerate.utils.dataclasses import TorchContextParallelConfig, TorchTensorParallelConfig
 
 
@@ -178,6 +177,11 @@ class ParallelismConfig:
         Args:
             device_type (`str`): The type of device for which to build the mesh, e
         """
+        if is_torch_version(">=", "2.2.0"):
+            from torch.distributed.device_mesh import init_device_mesh
+        else:
+            raise RuntimeError("Building a device_mesh requires to have torch>=2.2.0")
+
         mesh = self._get_mesh()
         if len(mesh) == 0:
             return None

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -76,7 +76,7 @@ class TestParallelismConfig:
 
             return mesh
 
-        with patch("accelerate.parallelism_config.init_device_mesh", side_effect=mock_init_mesh):
+        with patch("torch.distributed.device_mesh.init_device_mesh", side_effect=mock_init_mesh):
             yield mock_init_mesh
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue with an import related to device_mesh as it requires to have torch 2.2.0. 