### PR TITLE
Specify device_ids in torch.distributed.barrier for PartialState

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -400,7 +400,7 @@ class PartialState:
             DistributedType.DEEPSPEED,
             DistributedType.FSDP,
         ):
-            torch.distributed.barrier()
+            torch.distributed.barrier(device_ids=[self.process_index])
         elif self.distributed_type == DistributedType.XLA:
             xm.rendezvous("accelerate.utils.wait_for_everyone")
 


### PR DESCRIPTION
To avoid this warning

```
/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.12/site-packages/torch/distributed/distributed_c10d.py:4631: UserWarning: No device id is provided via `init_process_group` or `barrier `. Using the current device set by the user. 
  warnings.warn(  # warn only once
```

when using

```python
PartialState().main_process_first()
```