### PR TITLE
fix: `model.set_requires_gradient_sync(False)` should be called to turn off gradient synchronization in FSDP2.

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1175,7 +1175,7 @@ class Accelerator:
                 yield
             finally:
                 model.set_requires_gradient_sync(True)
-        else:  
+        else:
             context = contextlib.nullcontext
             if self.use_distributed:
                 if self.distributed_type != DistributedType.DEEPSPEED or self.state.deepspeed_plugin.zero_stage < 2:


### PR DESCRIPTION
In FSDP2, the model(`FSDPModule`) does not have `no_sync()` and instead calls  `model.set_requires_gradient_sync(False)`  to turn off gradient synchronization. See at [torch.distributed.fsdp.FSDPModule.set_requires_gradient_sync](https://docs.pytorch.org/docs/stable/distributed.fsdp.fully_shard.html#torch.distributed.fsdp.FSDPModule.set_requires_gradient_sync)

