### PR TITLE
fix: correct dictionary unpacking in recursively_apply function

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -116,7 +116,7 @@ def recursively_apply(func, data, *args, test_type=is_torch_tensor, error_on_oth
         )
     elif isinstance(data, Mapping):
         return type(data)(
-            {
+            **{
                 k: recursively_apply(
                     func, v, *args, test_type=test_type, error_on_other_type=error_on_other_type, **kwargs
                 )


### PR DESCRIPTION
```python
from transformers.modeling_outputs import CausalLMOutputWithPast
from accelerate.utils import convert_to_fp32
import torch

lm_output = CausalLMOutputWithPast(logits=torch.ones(2, 3, 4))
print(convert_to_fp32(lm_output))
```

before:

```
CausalLMOutputWithPast(loss={'logits': tensor([[[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]],

        [[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]]])}, logits=tensor([[[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]],

        [[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]]]), past_key_values=None, hidden_states=None, attentions=None)
```

after

```
CausalLMOutputWithPast(loss=None, logits=tensor([[[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]],

        [[1., 1., 1., 1.],
         [1., 1., 1., 1.],
         [1., 1., 1., 1.]]]), past_key_values=None, hidden_states=None, attentions=None)
````

