### PR TITLE
refactor: Use  `with`  in Accelerator.autocast()instead of ` __enter__()` and` __exit__()` for more elegant style.

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -4076,10 +4076,8 @@ class Accelerator:
         if autocast_handler is None:
             autocast_handler = self.autocast_handler
         autocast_context = get_mixed_precision_context_manager(self.native_amp, autocast_handler)
-        autocast_context.__enter__()
-        # TODO: should the `yield` be in a try/finally block?
-        yield
-        autocast_context.__exit__(*sys.exc_info())
+        with autocast_context:
+            yield
 
     @contextmanager
     def profile(self, profile_handler: ProfileKwargs | None = None):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -21,7 +21,6 @@ import math
 import os
 import re
 import shutil
-import sys
 import warnings
 from collections import OrderedDict
 from contextlib import contextmanager


### PR DESCRIPTION
# What does this PR do?
refactor: Use  `with`  in Accelerator.autocast()instead of ` __enter__()` and` __exit__()` for more elegant style.