### PR TITLE
fix FSDP2 test case failure on XPU

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -570,7 +570,9 @@ class Accelerator:
             self.native_amp = True
             supported_device = ("xpu", "cuda", "npu", "xla", "mlu", "musa", "hpu", "sdaa", "mps")
             if self.device.type not in supported_device or is_torch_xla_available(check_is_tpu=True):
-                raise ValueError(f"fp16 mixed precision requires a device in {supported_device} (not {self.device.type!r}).")
+                raise ValueError(
+                    f"fp16 mixed precision requires a device in {supported_device} (not {self.device.type!r})."
+                )
             if self.device.type == "mps" and not is_torch_version(">=", "2.5.0"):
                 raise ValueError("fp16 mixed precision with MPS device requires a Pytorch >= 2.5.0")
             kwargs = self.scaler_handler.to_kwargs() if self.scaler_handler is not None else {}


### PR DESCRIPTION
# bug
when run `pytest -rA tests/fsdp/test_fsdp.py::FSDP2IntegrationTest::test_checkpointing` on XPU, fail message as

> stderr: [rank1]:     main()
> stderr: [rank1]:   File "/opt/venv/lib/python3.12/site-packages/accelerate/test_utils/scripts/external_deps/test_checkpointing.py", line 265, in main
> stderr: [rank1]:     training_function(config, args)
> stderr: [rank1]:   File "/opt/venv/lib/python3.12/site-packages/accelerate/test_utils/scripts/external_deps/test_checkpointing.py", line 171, in training_function
> stderr: [rank1]:     accelerator.load_state(args.resume_from_checkpoint)
> stderr: [rank1]:   File "/opt/venv/lib/python3.12/site-packages/accelerate/accelerator.py", line 3714, in load_state
> stderr: [rank1]:     self.scaler._lazy_init_scale_growth_tracker(self.scaler._device)
> stderr: [rank1]:   File "/opt/venv/lib/python3.12/site-packages/torch/amp/grad_scaler.py", line 171, in _lazy_init_scale_growth_tracker
> stderr: [rank1]:     assert self._growth_tracker is None, "_growth_tracker initialized before _scale"
> stderr: [rank1]:            ^^^^^^^^^^^^^^^^^^^^
> stderr: [rank1]: AttributeError: 'GradScaler' object has no attribute '_growth_tracker'. Did you mean: '_get_growth_tracker'?

# root cause
when instantiate `GradScaler` in [`get_fsdp2_grad_scaler`](https://github.com/huggingface/accelerate/blob/main/src/accelerate/utils/fsdp_utils.py#L772), the `device` is not passed, and will not because `device` is not in [`GradScalerKwargs`](https://github.com/huggingface/accelerate/blob/main/src/accelerate/utils/dataclasses.py#L240) either. In this case, PyTorch will [defaultly set device to `cuda`](https://github.com/pytorch/pytorch/blob/582d278983b28a91ac0cedd035183f2495bb6887/torch/amp/grad_scaler.py#L123), and lead to this issue.

# fix
explicitly pass `device` in.

# result
pass