### PR TITLE
use reset_peak_memory_stats on xpu

### DIFF
--- a/src/accelerate/test_utils/scripts/external_deps/test_peak_memory_usage.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_peak_memory_usage.py
@@ -69,7 +69,7 @@ class TorchTracemalloc:
             self.begin = torch.npu.memory_allocated()
         elif is_xpu_available():
             torch.xpu.empty_cache()
-            torch.xpu.reset_max_memory_allocated()  # reset the peak gauge to zero
+            torch.xpu.reset_peak_memory_stats()  # reset the peak gauge to zero
             self.begin = torch.xpu.memory_allocated()
         elif is_hpu_available():
             # torch.hpu.empty_cache() # not available on hpu as it reserves all device memory for the current process


### PR DESCRIPTION
## bug
below 2 UT cases failed on XPU
```
pytest -rA tests/fsdp/test_fsdp.py::FSDP2IntegrationTest::test_peak_memory_usage
pytest -rA tests/fsdp/test_fsdp.py::FSDPIntegrationTest::test_peak_memory_usage
```
w/ error message

> [rank0]: AttributeError: module 'torch.xpu' has no attribute 'reset_max_memory_allocated'. Did you mean: 'max_memory_allocated'?

## root cause
PT is deprecating `reset_max_memory_allocated` and switch to `reset_peak_memory_stats`, so XPU only implemented `reset_peak_memory_stats` API

## fix
switch to use `torch.xpu.reset_peak_memory_stats()`

## result
pass