### PR TITLE
enable 2 model hook ut cases on XPU

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -461,56 +461,52 @@ class HooksModelTester(unittest.TestCase):
             _ = test_model(inputs)
 
     def test_cpu_offload_hook_moves_model(self):
-        if not torch.cuda.is_available():
-            self.skipTest("CUDA not available for offload test.")
 
         model = ModelForTest()
-        gpu_device = torch.device("cuda:0")
-        hook = CpuOffload(execution_device=gpu_device)
+        device = torch.device(torch_device)
+        hook = CpuOffload(execution_device=device)
         add_hook_to_module(model, hook)
 
-        x = torch.randn(2, 3).to(gpu_device)
+        x = torch.randn(2, 3).to(device)
         output = model(x)
-        self.assertEqual(output.device, gpu_device)
+        self.assertEqual(output.device, device)
 
         remove_hook_from_module(model)
         output2 = model(x)
-        self.assertEqual(output2.device, gpu_device)
+        self.assertEqual(output2.device, device)
 
-        # should be on the gpu
-        assert model.linear1.weight.device == gpu_device
-        assert model.batchnorm.weight.device == gpu_device
-        assert model.linear2.weight.device == gpu_device
+        # should be on the device
+        assert model.linear1.weight.device == device
+        assert model.batchnorm.weight.device == device
+        assert model.linear2.weight.device == device
 
     def test_cpu_offload_hook_with_prev_module(self):
-        if not torch.cuda.is_available():
-            self.skipTest("CUDA not available for offload test.")
 
         model1 = ModelForTest()
         model2 = ModelForTest()
-        gpu_device = torch.device("cuda:0")
+        device = torch.device(torch_device)
         cpu_device = torch.device("cpu")
 
-        hook1 = CpuOffload(execution_device=gpu_device)
+        hook1 = CpuOffload(execution_device=device)
         add_hook_to_module(model1, hook1)
         user_hook1 = UserCpuOffloadHook(model1, hook1)
 
-        hook2 = CpuOffload(execution_device=gpu_device, prev_module_hook=user_hook1)
+        hook2 = CpuOffload(execution_device=device, prev_module_hook=user_hook1)
         add_hook_to_module(model2, hook2)
 
-        x = torch.randn(2, 3).to(gpu_device)
+        x = torch.randn(2, 3).to(device)
         output1 = model1(x)
-        self.assertEqual(output1.device, gpu_device)
+        self.assertEqual(output1.device, device)
 
         output2 = model2(x)
-        self.assertEqual(output2.device, gpu_device)
+        self.assertEqual(output2.device, device)
 
         # should be on the cpu
         assert model1.linear1.weight.device == cpu_device
         assert model1.batchnorm.weight.device == cpu_device
         assert model1.linear2.weight.device == cpu_device
 
-        # should be on the gpu still
-        assert model2.linear1.weight.device == gpu_device
-        assert model2.batchnorm.weight.device == gpu_device
-        assert model2.linear2.weight.device == gpu_device
+        # should be on the device still
+        assert model2.linear1.weight.device == device
+        assert model2.batchnorm.weight.device == device
+        assert model2.linear2.weight.device == device

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -34,6 +34,7 @@ from accelerate.hooks import (
     remove_hook_from_submodules,
 )
 from accelerate.test_utils import require_multi_device, require_non_hpu, torch_device
+from accelerate.utils import is_xpu_available
 from accelerate.utils.constants import SUPPORTED_PYTORCH_LAYERS_FOR_UPCASTING
 
 
@@ -461,6 +462,8 @@ class HooksModelTester(unittest.TestCase):
             _ = test_model(inputs)
 
     def test_cpu_offload_hook_moves_model(self):
+        if not torch.cuda.is_available() and not is_xpu_available():
+            self.skipTest("CUDA or XPU not available for offload test.")
 
         model = ModelForTest()
         device = torch.device(torch_device)
@@ -481,6 +484,8 @@ class HooksModelTester(unittest.TestCase):
         assert model.linear2.weight.device == device
 
     def test_cpu_offload_hook_with_prev_module(self):
+        if not torch.cuda.is_available() and not is_xpu_available():
+            self.skipTest("CUDA or XPU not available for offload test.")
 
         model1 = ModelForTest()
         model2 = ModelForTest()


### PR DESCRIPTION
```
pytest -rA tests/test_hooks.py::HooksModelTester::test_cpu_offload_hook_moves_model
pytest -rA tests/test_hooks.py::HooksModelTester::test_cpu_offload_hook_with_prev_module
```
both pass w/ this PR.

@S1ro1, pls help review, thx very much.