### PR TITLE
WIP: initial implementation

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1620,6 +1620,10 @@ class Accelerator:
         from torch.distributed.tensor.experimental import context_parallel
         from torch.distributed.tensor.experimental._attention import set_rotate_method
 
+        if not self.is_fsdp2:
+            # deepspeed handles cp other way
+            return args
+
         cp_comm_strategy = self.parallelism_config.cp_handler.cp_comm_strategy
         set_rotate_method(cp_comm_strategy)
 
@@ -2074,6 +2078,10 @@ class Accelerator:
 
         is_dataloader_present = any(isinstance(obj, torch.utils.data.DataLoader) for obj in args)
         tp_size = deepspeed_plugin.deepspeed_config.get("tensor_parallel", {}).get("autotp_size", 0)
+
+        cp_size = self.parallelism_config.cp_size if self.parallelism_config else 1
+        cp_handler = self.parallelism_config.cp_handler if self.parallelism_config else None
+
         if tp_size > 1:
             if not compare_versions("deepspeed", ">=", "0.16.4"):
                 raise ImportError(
@@ -2145,7 +2153,7 @@ class Accelerator:
         if batch_size_per_device is not None:
             config_kwargs["train_micro_batch_size_per_gpu"] = batch_size_per_device
             config_kwargs["train_batch_size"] = (
-                batch_size_per_device * deepspeed_plugin.get_value("gradient_accumulation_steps") * self.num_processes
+                batch_size_per_device * deepspeed_plugin.get_value("gradient_accumulation_steps") * self.num_processes // cp_size
             )
 
         model = None
@@ -2160,6 +2168,24 @@ class Accelerator:
                 type(obj).__name__ in deepspeed.runtime.lr_schedules.VALID_LR_SCHEDULES
             ):
                 scheduler = obj
+
+        mpu = None
+        if cp_size > 1:
+            if is_dataloader_present and model is None:
+                raise ValueError(
+                    "You cannot pass a dataloader to `accelerate.prepare()` without passing a model when using Context Parallelism."
+                )
+
+            from deepspeed.runtime.sequence_parallel.ulysses_sp import UlyssesSPAttentionHF, UlyssesSPDataLoaderAdapter
+            from deepspeed.utils import groups
+
+            mpu = UlyssesSPAttentionHF.register_with_transformers(
+                model_name_or_path=model,
+                sequence_parallel_size=cp_size,
+                max_length=cp_handler.max_length,
+                core_attn_implementation=cp_handler.attn_implementation or model.config.attn_implementation,
+                micro_batch_size=batch_size_per_device,
+            )
 
         if optimizer is not None:
             if "optimizer" in deepspeed_plugin.deepspeed_config and not isinstance(optimizer, (DummyOptim)):
@@ -2265,7 +2291,7 @@ class Accelerator:
                     )
             deepspeed_plugin.deepspeed_config_process(must_match=False, **config_kwargs)
             self.deepspeed_config = deepspeed_plugin.deepspeed_config
-            kwargs = dict(model=model, config_params=self.deepspeed_config)
+            kwargs = dict(model=model, config_params=self.deepspeed_config, mpu=mpu)
             if optimizer is not None:
                 if isinstance(optimizer, (DummyOptim)):
                     kwargs["model_parameters"] = optimizer.params
@@ -2322,6 +2348,20 @@ class Accelerator:
                     type(result[i]).__name__ in deepspeed.runtime.lr_schedules.VALID_LR_SCHEDULES
                 ):
                     result[i] = scheduler
+                elif isinstance(result[i], torch.utils.data.DataLoader):
+                    if cp_size > 1:
+                        cp_group = groups._get_sequence_parallel_group()
+                        cp_world_size = groups._get_sequence_parallel_world_size()
+                        cp_rank = groups._get_sequence_parallel_rank()
+                        print(cp_group)
+                        result[i] = UlyssesSPDataLoaderAdapter(
+                            result[i],
+                            sp_rank=cp_rank,
+                            sp_group=cp_group,
+                            sp_world_size=cp_world_size,
+                            device=model.device,
+                        )
+
             # pointing for deepspeed_engine_wrapped.backward()
             if self.deepspeed_engine_wrapped is None:
                 self.deepspeed_engine_wrapped = DeepSpeedEngineWrapper(engine)


### PR DESCRIPTION
cc @stas00 

```python
from accelerate import Accelerator
from accelerate.utils import ParallelismConfig
from deepspeed.runtime.utils import move_to_device
from accelerate.utils.dataclasses import DeepSpeedContextParallelConfig
from torch import tensor
from transformers import AutoModelForCausalLM
import torch

MODEL_ID = "hf-internal-testing/tiny-random-LlamaForCausalLM"
MICRO_BATCH_SIZE = 1

parallelism_config = ParallelismConfig(
    flavour="deepspeed",
    cp_size=2,
    dp_shard_size=4,
    cp_handler=DeepSpeedContextParallelConfig(
        max_length=64, attn_implementation="sdpa"
    ),
)

accelerator = Accelerator(parallelism_config=parallelism_config)

input_ids = tensor(
    [[1, 10, 10, 10, 2, 2], [1, 20, 20, 20, 2, 2]],
)
position_ids = tensor([[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]])
ds = torch.utils.data.TensorDataset(input_ids, position_ids)


def collate_fn(batch):
    input_ids, position_ids = batch[0]
    return dict(
        input_ids=input_ids.unsqueeze(0),
        position_ids=position_ids.unsqueeze(0),
        labels=input_ids.unsqueeze(0),
        shift_labels=input_ids.unsqueeze(0),
    )


model = AutoModelForCausalLM.from_pretrained(MODEL_ID)
optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
dl = torch.utils.data.DataLoader(ds, batch_size=MICRO_BATCH_SIZE, collate_fn=collate_fn)

model, optimizer, dl = accelerator.prepare(model, optimizer, dl)

sp_group = accelerator.torch_device_mesh["cp"].get_group()
sp_world_size = parallelism_config.cp_size

# Normal training loop
for iter, batch in enumerate(dl):
    batch = move_to_device(batch, model.device)
    outputs = model(**batch)

    shift_labels = batch["shift_labels"]
    loss = model.module.loss_function(
        logits=outputs.logits,
        labels=None,
        shift_labels=shift_labels,
        vocab_size=model.module.config.vocab_size,
    )

    # differentiable weighted per-shard-loss aggregation across ranks
    losses_per_rank = torch.distributed.nn.functional.all_gather(loss, group=sp_group)
    # special dealing with SFT that has prompt tokens that aren't used in loss computation
    good_tokens = (shift_labels != -100).view(-1).sum()
    good_tokens_per_rank = torch.distributed.nn.functional.all_gather(
        good_tokens, group=sp_group
    )
    total_loss = sum(
        losses_per_rank[rank] * good_tokens_per_rank[rank]
        for rank in range(sp_world_size)
    )
    total_good_tokens = sum(good_tokens_per_rank)
    loss = total_loss / max(total_good_tokens, 1)

    accelerator.print(f"{iter}: {loss=}")

    model.backward(loss)
 ```