### PR TITLE
remove mlflow from testing 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ extras["test_trackers"] = [
     "comet-ml",
     "tensorboard",
     "dvclive",
-    "mlflow",
+    # "mlflow", too many deps that lead to download a very old version of the lib
     "matplotlib",
     "swanlab",
     "trackio",


### PR DESCRIPTION
# What does this PR do?

This PR removes mlflow from the setup so that we don't test it anymore. The tests are failing because we are installing a very old version due to conflicting dependencies. 