### PR TITLE
Remove warning for `cpu_ram_efficient_loading`

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1913,7 +1913,7 @@ class FullyShardedDataParallelPlugin:
             )
         else:
             # We still need to set it for transformers
-            os.environ[env_prefix+ "CPU_RAM_EFFICIENT_LOADING"] = str(self.cpu_ram_efficient_loading)
+            os.environ[env_prefix + "CPU_RAM_EFFICIENT_LOADING"] = str(self.cpu_ram_efficient_loading)
         # There's no need to specify sync_module_states in FSDP2
         if self.fsdp_version == 1 and self.cpu_ram_efficient_loading and not self.sync_module_states:
             warnings.warn(


### PR DESCRIPTION
# What does this PR do?

This PR removes `cpu_ram_efficient_loading` warning when it is not set. This kind of information doesn't need to require a warning tbh. 