### PR TITLE
decouple backward and step in accelerator/deepspeed

### DIFF
--- a/tests/test_backward_step_decoupled.py
+++ b/tests/test_backward_step_decoupled.py
@@ -1,0 +1,60 @@
+import torch
+from accelerate import Accelerator
+import deepspeed
+
+deepspeed.ops.op_builder.FusedAdamBuilder().is_compatible = lambda: False
+
+# Suppose your patched wrapper is imported like:
+# from accelerate.deepspeed_utils import DeepSpeedEngineWrapper
+# (adjust path to your local Accelerate fork)
+from accelerate.utils import DeepSpeedEngineWrapper
+
+# Define a minimal model and data
+model = torch.nn.Linear(10, 2)
+optimizer = torch.optim.AdamW(model.parameters(), lr=1e-3)
+
+# Minimal DeepSpeed config (disable internal clipping)
+ds_config = {
+    "train_batch_size": 4,
+    "gradient_accumulation_steps": 1,
+    "fp16": {"enabled": False},
+    "gradient_clipping": 0.0,
+}
+
+accelerator = Accelerator()
+
+# Initialize DeepSpeed
+model_engine, optimizer, _, _ = deepspeed.initialize(
+    model=model,
+    optimizer=optimizer,
+    config=ds_config,
+)
+
+# Wrap your DeepSpeed engine manually for test
+wrapper = DeepSpeedEngineWrapper(model_engine)
+
+# Create dummy input/output
+x = torch.randn(4, 10, device=accelerator.device)
+y = torch.randint(0, 2, (4,), device=accelerator.device)
+criterion = torch.nn.CrossEntropyLoss()
+
+# --- Test backward ---
+optimizer.zero_grad()
+outputs = wrapper.engine(x)
+loss = criterion(outputs, y)
+wrapper.backward(loss)  # Should only compute grads
+# Check if grads exist but not yet stepped
+for p in wrapper.engine.module.parameters():
+    assert p.grad is not None, "Gradient not computed!"
+
+# --- Test gradient inspection/modification ---
+for p in wrapper.engine.module.parameters():
+    p.grad = p.grad * 0  # Zero out grads manually
+
+# --- Test step ---
+wrapper.step(sync_gradients=True, gradient_clipping=0.5)
+
+# Check grads are zeroed after step (DeepSpeed does this)
+for p in wrapper.engine.module.parameters():
+    assert p.grad is None or torch.all(p.grad == 0), "Gradients not zeroed!"
+print("✅ Test passed — backward and step decoupled successfully.")


### PR DESCRIPTION
# What does this PR do?

Addressing this issue: https://github.com/huggingface/accelerate/issues/2951

This PR enables user to debug model gradient after backward+gradient_clipping and before optimizer.step().

To achieve this functionality, we move the gradient clipping logic from deepspeed engine (another public repo) to accelerator. As a result, self.engine.set_gradient_clipping(0.0) must be set in the user's config. Or add an extra line:

`self.engine.set_gradient_clipping(0.0)`  in the step() function. 

We didn't replace amp logic with normal pytorch.cuda.amp for clipping fp16 gradient. As a result, you might need to manually clone the apex repo to use amp.

```
git clone https://github.com/NVIDIA/apex
cd apex
pip install -v --disable-pip-version-check --no-cache-dir ./
```

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
https://github.com/huggingface/accelerate/issues/2951

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
- DeepSpeed: @SunMarc @zach-huggingface
- Command Line Interface: @SunMarc @zach-huggingface
- Documentation: @SunMarc @zach-huggingface
- Core parts of the library: @BenjaminBossan @SunMarc @zach-huggingface 
- Maintained examples: @SunMarc or  @zach-huggingface

 -->