### PR TITLE
update typo in bnb quantisation 4bit flag docstring

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -2768,7 +2768,7 @@ class BnbQuantizationConfig:
             Enable 8bit quantization.
         llm_int8_threshold (`float`, defaults to `6.0`):
             Value of the outliner threshold. Only relevant when `load_in_8bit=True`.
-        load_in_4_bit (`bool`, defaults to `False`):
+        load_in_4bit (`bool`, defaults to `False`):
             Enable 4bit quantization.
         bnb_4bit_quant_type (`str`, defaults to `fp4`):
             Set the quantization data type in the `bnb.nn.Linear4Bit` layers. Options are {'fp4','np4'}.


### PR DESCRIPTION
# What does this PR do?

Current stable (v11.1.0) docs at https://huggingface.co/docs/accelerate/v1.11.0/en/package_reference/utilities#accelerate.utils.BnbQuantizationConfig reference the 4 bit quantisation flag as `load_in_4_bit` instead of `load_in_4bit` as in the class constructor, example code, and `transformers.BitsAndBytesConfig`.

Note that the source code expects and uses `load_in_4bit` in the actual constructor, and the only reference I found matching `load_in_4_bit` was in the docstring for BnBQuantizationConfig in src/accelerate/utils/dataclasses.py.

Very minor change, but hoping to save others a quick moment of of puzzle, initially was confused as to why the `transformers.BitsAndBytesConfig` would have subtly different named kwargs, but turned out to be a non issue, as the underlying kwargs I was relying on were actually the same.

I thought it would be easier to raise a PR than an issue, but let me know if this was inappropriate.

I haven't run the tests as changes were only in the docstring, but did verify parsing via `python -m compileall src/accelerate/utils/dataclasses.py` and also ran `make style` without issues.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Tagging from the suggested list,
- Documentation/Maintained example: @SunMarc, @zach-huggingface 

Thanks, let me know if I have missed anything, appreciate the work you all do!