### PR TITLE
Upcast FSDP2 parameters only if requires_grad

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -710,7 +710,7 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         # We upcast the trainable parameters according to `deepspeed`'s implementation
         # More info about this can be found in `accelerator.py:prepare_model`s FSDP1 section
         upcasted_params = []
-        for name, param in model.parameters():
+        for name, param in model.named_parameters():
             if param.requires_grad and param.dtype != torch.float32:
                 upcasted_params.append(name)
                 param.data = param.data.to(torch.float32)


### PR DESCRIPTION
# What does this PR do?

Fixes an unnecessary upcast of frozen parameters, particularly in the case of LoRA finetuning

Fixes https://github.com/huggingface/accelerate/issues/3844


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Fully-Sharded Data Parallism: @SunMarc @zach-huggingface
