### PR TITLE
fix: mixed_precision param from accelerate config should be used for FSDP mp

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -1005,6 +1005,7 @@ class AcceleratorState:
                     self.parallelism_config is not None and self.parallelism_config.cp_enabled
                 ):
                     self.distributed_type = DistributedType.FSDP
+                    self._mixed_precision = mixed_precision
                     if self._mixed_precision != "no" and fsdp_plugin is not None:
                         fsdp_plugin.set_mixed_precision(self._mixed_precision)
                     self.fsdp_plugin = fsdp_plugin


### PR DESCRIPTION
# What does this PR do?

For some reason, previous code uses `self._mixed_precision` to set which is not being set before, instead it should be using the `mixed_precision` param that is being passed to that function. This would then allow us to use accelerate config's `mixed_precision` param directly to set FSDPv1/v2 MP.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc 