### PR TITLE
Avoid using nvidia-smi on a CPU-only Colab instance

### DIFF
--- a/src/accelerate/launchers.py
+++ b/src/accelerate/launchers.py
@@ -149,7 +149,7 @@ def notebook_launcher(
         launcher = PrepareForLaunch(function, distributed_type="XLA")
         print("Launching a training on TPU cores.")
         xmp.spawn(launcher, args=args, start_method="fork")
-    elif in_colab and get_gpu_info()[1] < 2:
+    elif in_colab and (not torch.cuda.is_available() or get_gpu_info()[1] < 2):
         # No need for a distributed launch otherwise as it's either CPU or one GPU.
         if torch.cuda.is_available():
             print("Launching training on one GPU.")


### PR DESCRIPTION
# What does this PR do?

On a CPU-only Colab notebook, nvidia-smi is not available. Running notebook_launcher was running into an error because of that, assuming that we were using Colab with a GPU. 

The fix check first if torch has detected a GPU, if so it goes on with the usual check with nvidia-smi, if there is no GPU, the code does not run nvidia-smi as it is not available.

Not sure how to add tests here as it is in a specific env, open to suggestions :)

Fixes #3871 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc ?
