### PR TITLE
Fix hf_device_map device index comparison in prepare_model

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1811,10 +1811,11 @@ class Accelerator:
                 else:
                     current_device_index = current_device
 
+                current_device_index = int(current_device_index) if current_device_index is not None else None
                 if self.device.type == "cpu" and is_bitsandbytes_multi_backend_available():
                     # bnb with multi-backend supports CPU which don't need to check index.
                     pass
-                elif torch.device(current_device_index) != self.device:
+                elif torch.device(self.device.type, current_device_index) != self.device:
                     # if on the first device (GPU 0) we don't care
                     if (self.device.index is not None) or (current_device_index != 0):
                         raise ValueError(


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue where a `TypeError` is raised if the base model is loaded without specifying device index (e.g. `device_map="auto"` or `device_map="cuda"` instead of `device_map="cuda:0"`) for models loaded in 8-bit/4-bit precision with an `hf_device_map`. The exception is raised in `prepare_model()` because`torch.device(device_index)` is called with `device_index=None`. 

The fix constructs the device using `torch.device(device_type, device_index)` instead, which works even when `device_index=None`. 

Added a test to cover the 8-bit/4-bit + `hf_device_map` path when the model is loaded on CPU (`hf_device_map={"": "cpu"}`), but the test should also work for other device types as well.

Fixes #3758 and #2357 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @jiqing-feng 