### PR TITLE
Fix async compatibility across python versions

### DIFF
--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -766,10 +766,8 @@ def execute_subprocess_async(cmd: list, env=None, stdin=None, timeout=180, quiet
     for i, c in enumerate(cmd):
         if isinstance(c, Path):
             cmd[i] = str(c)
-    loop = asyncio.get_event_loop()
-    result = loop.run_until_complete(
-        _stream_subprocess(cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo)
-    )
+
+    result = asyncio.run(_stream_subprocess(cmd, env=env, stdin=stdin, timeout=timeout, quiet=quiet, echo=echo))
 
     cmd_str = " ".join(cmd)
     if result.returncode > 0:


### PR DESCRIPTION
# What does this PR do?

This PR switches to use `asyncio.run` instead of `asyncio.get_event_loop()` + `result = loop.run_until_complete()`. This is better as starting from python3.14, `get_event_loop` returns a `RuntimeError` if there is no loop. Before, it was creating a loop if it didn't exist. 

Fixes https://github.com/huggingface/accelerate/issues/3899