### PR TITLE
change the default value of fsdp_min_num_params to int

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -526,7 +526,7 @@ def launch_command_parser(subparsers=None):
     fsdp_args.add_argument(
         "--fsdp_min_num_params",
         type=int,
-        default=1e8,
+        default=int(1e8),
         help="FSDP's minimum number of parameters for Default Auto Wrapping. (useful only when `use_fsdp` flag is passed).",
     )
     # We enable this for backwards compatibility, throw a warning if this is set in `FullyShardedDataParallelPlugin`


### PR DESCRIPTION
# What does this PR do?

So `fsdp_min_num_params`'s default value was float which was causing this error when not mentioning in config file under fsdp 
error:- `ValueError: invalid literal for int() with base 10: '100000000.0'`
so this PR changes that to int. I have reproduced the error at default state then i have tested the fix too 
Fixes #3854 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc 