### PR TITLE
bug: fsdp cannot load optimizor state using dcp

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -311,7 +311,13 @@ def load_fsdp_optimizer(fsdp_plugin, accelerator, optimizer, model, input_dir, o
                 else input_dir
             )
             logger.info(f"Loading Optimizer from {ckpt_dir}")
-            optim_state = {"optimizer": optimizer.state_dict()}
+            if fsdp_plugin.fsdp_version == 2:
+                from torch.distributed.checkpoint.state_dict import get_optimizer_state_dict
+
+                optim_state = get_optimizer_state_dict(model, optimizer, options=sd_options)
+            else:
+                optim_state = FSDP.optim_state_dict(model, optimizer)
+            optim_state = {"optimizer": optim_state}
             dist_cp.load(
                 optim_state,
                 checkpoint_id=ckpt_dir,


### PR DESCRIPTION
# What does this PR do?

Fixes # (3896) partially. Fix bug when using dcp, the optimizor state cannot be loaded. Tested with fsdp2.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc