### PR TITLE
fix crash in optimizer.step when fsdp2 is enabled and model is bfloat16

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -713,7 +713,7 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         for name, param in model.named_parameters():
             if param.requires_grad and param.dtype != torch.float32:
                 upcasted_params.append(name)
-                param.data = param.data.to(torch.float32)
+                param = param.to(torch.float32)
         if accelerator.is_main_process and upcasted_params:
             warnings.warn(
                 "FSDP upcast of low precision parameters to fp32 (since mixed_precision != 'no') may affect the precision of model checkpoints. "


### PR DESCRIPTION
@SunMarc 
accelerate launch --config-file configs/tp_hsdp.yaml nd_parallel_trainer.py --sequence-length 1024
after apply https://github.com/huggingface/transformers/pull/43226 anther crash happen. seee the backtrace.

[rank0]: Traceback (most recent call last):
[rank0]:   File "/mnt/disk3/wangyi/accelerate/examples/torch_native_parallelism/nd_parallel_trainer.py", line 82, in <module>
[rank0]:     main()
[rank0]:   File "/mnt/disk3/wangyi/accelerate/examples/torch_native_parallelism/nd_parallel_trainer.py", line 77, in main
[rank0]:     trainer.train()
[rank0]:   File "/mnt/disk3/wangyi/transformers/src/transformers/trainer.py", line 2174, in train
[rank0]:     return inner_training_loop(
[rank0]:            ^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk3/wangyi/transformers/src/transformers/trainer.py", line 2596, in _inner_training_loop
[rank0]:     self.optimizer.step()
[rank0]:   File "/mnt/disk3/wangyi/accelerate/src/accelerate/optimizer.py", line 179, in step
[rank0]:     self.optimizer.step(closure)
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/lr_scheduler.py", line 133, in wrapper
[rank0]:     return func.__get__(opt, opt.__class__)(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 517, in wrapper
[rank0]:     out = func(*args, **kwargs)
[rank0]:           ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 82, in _use_grad
[rank0]:     ret = func(*args, **kwargs)
[rank0]:           ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/adam.py", line 247, in step
[rank0]:     adam(
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 150, in maybe_fallback
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/adam.py", line 956, in adam
[rank0]:     func(
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/adam.py", line 830, in _fused_adam
[rank0]:     grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
[rank0]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 546, in _group_tensors_by_device_and_dtype
[rank0]:     return _group_tensors_by_device_and_dtype(tensorlistlist, with_indices)  # type: ignore[return-value, arg-type]
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
[rank0]:     return func(*args, **kwargs)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/utils/_foreach_utils.py", line 55, in _group_tensors_by_device_and_dtype
[rank0]:     return torch._C._group_tensors_by_device_and_dtype(tensorlistlist, with_indices)
[rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: RuntimeError: Tensors of the same index must be on the same device and the same dtype except `step` tensors that can be CPU and float32/64 notwithstanding
[rank3]: Traceback (most recent call last):
[rank3]:   File "/mnt/disk3/wangyi/accelerate/examples/torch_native_parallelism/nd_parallel_trainer.py", line 82, in <module>
[rank3]:     main()
[rank3]:   File "/mnt/disk3/wangyi/accelerate/examples/torch_native_parallelism/nd_parallel_trainer.py", line 77, in main
[rank3]:     trainer.train()
[rank3]:   File "/mnt/disk3/wangyi/transformers/src/transformers/trainer.py", line 2174, in train
[rank3]:     return inner_training_loop(
[rank3]:            ^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk3/wangyi/transformers/src/transformers/trainer.py", line 2596, in _inner_training_loop
[rank3]:     self.optimizer.step()
[rank3]:   File "/mnt/disk3/wangyi/accelerate/src/accelerate/optimizer.py", line 179, in step
[rank3]:     self.optimizer.step(closure)
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/lr_scheduler.py", line 133, in wrapper
[rank3]:     return func.__get__(opt, opt.__class__)(*args, **kwargs)
[rank3]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 517, in wrapper
[rank3]:     out = func(*args, **kwargs)
[rank3]:           ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 82, in _use_grad
[rank3]:     ret = func(*args, **kwargs)
[rank3]:           ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/adam.py", line 247, in step
[rank3]:     adam(
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 150, in maybe_fallback
[rank3]:     return func(*args, **kwargs)
[rank3]:            ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/adam.py", line 956, in adam
[rank3]:     func(
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/adam.py", line 830, in _fused_adam
[rank3]:     grouped_tensors = Optimizer._group_tensors_by_device_and_dtype(
[rank3]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/optim/optimizer.py", line 546, in _group_tensors_by_device_and_dtype
[rank3]:     return _group_tensors_by_device_and_dtype(tensorlistlist, with_indices)  # type: ignore[return-value, arg-type]
[rank3]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
[rank3]:     return func(*args, **kwargs)
[rank3]:            ^^^^^^^^^^^^^^^^^^^^^
[rank3]:   File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/utils/_foreach_utils.py", line 55, in _group_tensors_by_device_and_dtype
[rank3]:     return torch._C._group_tensors_by_device_and_dtype(tensorlistlist, with_indices)
[rank3]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank3]: RuntimeError: Tensors of the same index must be on the same device and the same dtype except `step` tensors that can be CPU and float32/64 notwithstanding
  0%|                                                                                                              

