### PR TITLE
Remove 8bit force hook for bnb

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -357,7 +357,7 @@ def dispatch_model(
     # We need to force hook for quantized model that can't be moved with to()
     if getattr(model, "quantization_method", "bitsandbytes") == "bitsandbytes":
         # since bnb 0.43.2, we can move 4-bit model
-        if getattr(model, "is_loaded_in_8bit", False and not is_bnb_available(min_version="0.48")) or (
+        if getattr(model, "is_loaded_in_8bit", False and not is_bnb_available(min_version="0.48.0")) or (
             getattr(model, "is_loaded_in_4bit", False) and not is_bnb_available(min_version="0.43.2")
         ):
             force_hooks = True


### PR DESCRIPTION
# What does this PR do?

Since 0.48.0, we can freely move bnb models. Hence we propagate the changes in this PR as we did for 4bit in the past. 