### PR TITLE
Fix KMP_AFFINITY incorrectly set for non-CPU training 

### DIFF
--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import torch
 
+from . import parse_flag_from_env
 from ..commands.config.config_args import SageMakerConfig
 from ..utils import (
     DynamoBackend,
@@ -157,7 +158,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> tuple[list[str]
     if (num_processes is not None and num_processes > 1) or num_machines > 1:
         current_env["MASTER_ADDR"] = args.main_process_ip if args.main_process_ip is not None else "127.0.0.1"
         current_env["MASTER_PORT"] = str(args.main_process_port) if args.main_process_port is not None else "29500"
-    if current_env["ACCELERATE_USE_CPU"]:
+    if parse_flag_from_env(current_env["ACCELERATE_USE_CPU"], False):
         current_env["KMP_AFFINITY"] = "granularity=fine,compact,1,0"
         current_env["KMP_BLOCKTIME"] = str(1)
 


### PR DESCRIPTION
# What does this PR do?
Fix for #3911
 
The string "False" is truthy in Python, so `if current_env["ACCELERATE_USE_CPU"]:` always evaluates to True. Use parse_flag_from_env() for proper boolean parsing.