### PR TITLE
[Deepspeed] skip device mesh creation when deepspeed and sp_size >1

### DIFF
--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -215,6 +215,11 @@ class ParallelismConfig:
         Args:
             device_type (`str`): The type of device for which to build the mesh, e
         """
+        # Skip mesh creation for DeepSpeed SP - DeepSpeed handles its own SP groups
+        # Only skip when SP is actually enabled (sp_size > 1), otherwise user might still want TP/CP/FSDP
+        if self.sp_backend == "deepspeed" and self.sp_size > 1:
+            return None
+
         if is_torch_version(">=", "2.2.0"):
             from torch.distributed.device_mesh import init_device_mesh
         else:


### PR DESCRIPTION
# What does this PR do?

Accelerate should skip DeviceMesh creation when `sp_backend == "deepspeed"` because DeepSpeed handles all SP groups internally through `UlyssesSPAttentionHF.register_with_transformers()`.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc
- DeepSpeed: @SunMarc
- Command Line Interface: @SunMarc
- Documentation: @SunMarc
- Core parts of the library: @BenjaminBossan @SunMarc
- Maintained examples: @SunMarc

 -->