### PR TITLE
Update dataset name from glue to nyu-mll/glue

### DIFF
--- a/benchmarks/fp8/ms_amp/fp8_utils.py
+++ b/benchmarks/fp8/ms_amp/fp8_utils.py
@@ -20,7 +20,7 @@ def get_dataloaders(model_name: str, batch_size: int = 16):
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/benchmarks/fp8/torchao/fp8_utils.py
+++ b/benchmarks/fp8/torchao/fp8_utils.py
@@ -20,7 +20,7 @@ def get_dataloaders(model_name: str, batch_size: int = 16):
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/benchmarks/fp8/transformer_engine/fp8_utils.py
+++ b/benchmarks/fp8/transformer_engine/fp8_utils.py
@@ -20,7 +20,7 @@ def get_dataloaders(model_name: str, batch_size: int = 16):
     from transformers import AutoTokenizer
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/automatic_gradient_accumulation.py
+++ b/examples/by_feature/automatic_gradient_accumulation.py
@@ -53,7 +53,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -63,7 +63,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/checkpointing.py
+++ b/examples/by_feature/checkpointing.py
@@ -54,7 +54,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -64,7 +64,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/cross_validation.py
+++ b/examples/by_feature/cross_validation.py
@@ -140,7 +140,7 @@ def training_function(config, args):
     # New Code #
     test_predictions = []
     # Download the dataset
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
     # Create our splits
     kfold = StratifiedKFold(n_splits=int(args.num_folds))
     # Initialize accelerator

--- a/examples/by_feature/ddp_comm_hook.py
+++ b/examples/by_feature/ddp_comm_hook.py
@@ -49,7 +49,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -59,7 +59,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/early_stopping.py
+++ b/examples/by_feature/early_stopping.py
@@ -48,7 +48,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -58,7 +58,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/fsdp_with_peak_mem_tracking.py
+++ b/examples/by_feature/fsdp_with_peak_mem_tracking.py
@@ -185,7 +185,7 @@ def training_function(config, args):
         accelerator.init_trackers("fsdp_glue_no_trainer", experiment_config)
 
     tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path)
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
     metric = evaluate.load("glue", "mrpc")
 
     def tokenize_function(examples):

--- a/examples/by_feature/gradient_accumulation.py
+++ b/examples/by_feature/gradient_accumulation.py
@@ -48,7 +48,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -58,7 +58,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/local_sgd.py
+++ b/examples/by_feature/local_sgd.py
@@ -51,7 +51,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -61,7 +61,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/memory.py
+++ b/examples/by_feature/memory.py
@@ -54,7 +54,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -64,7 +64,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/multi_process_metrics.py
+++ b/examples/by_feature/multi_process_metrics.py
@@ -55,7 +55,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -65,7 +65,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/profiler.py
+++ b/examples/by_feature/profiler.py
@@ -49,7 +49,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -59,7 +59,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/schedule_free.py
+++ b/examples/by_feature/schedule_free.py
@@ -56,7 +56,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -66,7 +66,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -53,7 +53,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -63,7 +63,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -86,7 +86,7 @@ def training_function(config, args):
         accelerator.init_trackers(run, config)
 
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
     metric = evaluate.load("glue", "mrpc")
 
     def tokenize_function(examples):

--- a/examples/nlp_example.py
+++ b/examples/nlp_example.py
@@ -46,7 +46,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset,
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset,
     using "bert-base-cased" as the tokenizer.
 
     Args:
@@ -56,7 +56,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16):
             The batch size for the train and validation DataLoaders.
     """
     tokenizer = AutoTokenizer.from_pretrained("bert-base-cased")
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/src/accelerate/test_utils/scripts/external_deps/test_checkpointing.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_checkpointing.py
@@ -32,7 +32,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: str = "bert-base-cased"):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset.
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset.
 
     Args:
         accelerator (`Accelerator`):
@@ -42,7 +42,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: 
         model_name (`str`, *optional*):
     """
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/src/accelerate/test_utils/scripts/external_deps/test_ds_multiple_model.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_ds_multiple_model.py
@@ -48,7 +48,7 @@ class NoiseModel(torch.nn.Module):
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: str = "bert-base-cased"):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset.
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset.
 
     Args:
         accelerator (`Accelerator`):
@@ -58,7 +58,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: 
         model_name (`str`, *optional*):
     """
     tokenizer = AutoTokenizer.from_pretrained(model_name)
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)

--- a/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_metrics.py
@@ -57,7 +57,7 @@ def get_basic_setup(accelerator, num_samples=82, batch_size=16):
 
 def get_dataloader(accelerator: Accelerator, use_longest=False):
     tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/mrpc-bert-base-cased")
-    dataset = load_dataset("glue", "mrpc", split="validation")
+    dataset = load_dataset("nyu-mll/glue", "mrpc", split="validation")
 
     def tokenize_function(examples):
         outputs = tokenizer(examples["sentence1"], examples["sentence2"], truncation=True, max_length=None)

--- a/src/accelerate/test_utils/scripts/external_deps/test_peak_memory_usage.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_peak_memory_usage.py
@@ -120,7 +120,7 @@ def get_dataloaders(
     n_val: int = 160,
 ):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset.
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset.
 
     Args:
         accelerator (`Accelerator`):
@@ -136,7 +136,7 @@ def get_dataloaders(
     """
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     datasets = load_dataset(
-        "glue", "mrpc", split={"train": f"train[:{n_train}]", "validation": f"validation[:{n_val}]"}
+        "nyu-mll/glue", "mrpc", split={"train": f"train[:{n_train}]", "validation": f"validation[:{n_val}]"}
     )
 
     def tokenize_function(examples):

--- a/src/accelerate/test_utils/scripts/external_deps/test_performance.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_performance.py
@@ -36,7 +36,7 @@ EVAL_BATCH_SIZE = 32
 
 def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: str = "bert-base-cased"):
     """
-    Creates a set of `DataLoader`s for the `glue` dataset.
+    Creates a set of `DataLoader`s for the `nyu-mll/glue` dataset.
 
     Args:
         accelerator (`Accelerator`):
@@ -47,7 +47,7 @@ def get_dataloaders(accelerator: Accelerator, batch_size: int = 16, model_name: 
     """
     tokenizer = AutoTokenizer.from_pretrained(model_name)
 
-    datasets = load_dataset("glue", "mrpc")
+    datasets = load_dataset("nyu-mll/glue", "mrpc")
 
     def tokenize_function(examples):
         # max_length=None => use the model max length (it's actually the default)


### PR DESCRIPTION
The glue dataset short name has been deprecated on Hugging Face Hub.
The [address](https://huggingface.co/api/datasets/glue) using `glue` shows 
```json
{"error":"Sorry, we can't find the page you are looking for."}
```

This PR updates all references to use the full namespace `nyu-mll/glue` instead.

Verified with the following tests:
- src/accelerate/test_utils/scripts/external_deps/test_metrics.py
- src/accelerate/test_utils/scripts/external_deps/test_performance.py
- src/accelerate/test_utils/scripts/external_deps/test_checkpointing.py
- src/accelerate/test_utils/scripts/external_deps/test_peak_memory_usage.py
- examples/nlp_example.py
- examples/complete_nlp_example.py
- examples/by_feature/*.py (14 example scripts)