### PR TITLE
Docs: clarify MS-AMP limitations and alternatives

### DIFF
--- a/docs/source/concept_guides/low_precision_training.md
+++ b/docs/source/concept_guides/low_precision_training.md
@@ -16,7 +16,7 @@ rendered properly in your Markdown viewer.
 # Low precision training methods
 
 The release of new kinds of hardware led to the emergence of new training paradigms that better utilize them. Currently, this is in the form of training
-in 8-bit precision using packages such as [TransformersEngine](https://github.com/NVIDIA/TransformerEngine) (TE) or [MS-AMP](https://github.com/Azure/MS-AMP/tree/main).
+in 8-bit precision using packages such as [TransformersEngine](https://github.com/NVIDIA/TransformerEngine) (TE) or [torchao](https://github.com/pytorch/ao/tree/main/torchao/float8). There is also [MS-AMP](https://github.com/Azure/MS-AMP/tree/main), but it is no longer actively maintained.
 
 For an introduction to the topics discussed today, we recommend reviewing the [low-precision usage guide](../usage_guides/low_precision_training) as this documentation will reference it regularly. 
 

--- a/docs/source/usage_guides/low_precision_training.md
+++ b/docs/source/usage_guides/low_precision_training.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 # Low Precision Training Methods
 
-Accelerate provides integrations to train on lower precision methods using specified supported hardware through the `TransformersEngine`, `MS-AMP`, and `torchao` packages. This documentation will help guide you through what hardware is supported, how to configure your [`Accelerator`] to leverage the low precision methods, and what you can expect when training. 
+Accelerate provides integrations to train on lower precision methods using specified supported hardware through the `TransformersEngine`, `torchao`, and (legacy) `MS-AMP` packages. This documentation will help guide you through what hardware is supported, how to configure your [`Accelerator`] to leverage the low precision methods, and what you can expect when training.
 
 ## What training on FP8 means
 
@@ -69,7 +69,14 @@ fp8_config:
 
 <Tip warning={true}>
 
-MS-AMP is no longer actively maintained and has known compatibility issues with newer CUDA versions (12.x+) and PyTorch builds. We recommend using `TransformersEngine` or `torchao` instead for FP8 training.
+MS-AMP is no longer actively maintained and has known compatibility issues with newer CUDA versions (12.x+) and PyTorch builds.
+
+In practice, this commonly means:
+
+- The easiest way to use MS-AMP is via a container image that already includes it; the upstream images are often pinned to older CUDA versions (for example 11.8/12.1).
+- Multi-GPU FP8 can require MSCCL (a fork of NCCL) that may be out of date, leading to NCCL symbol/version conflicts with recent PyTorch wheels.
+
+For new projects, we recommend using `TransformersEngine` or `torchao` instead for FP8 training.
 
 </Tip>
 


### PR DESCRIPTION
This PR updates the low-precision training docs to reflect the current FP8 ecosystem.

- MS-AMP is treated as *legacy* (not actively maintained; frequent CUDA/PyTorch compatibility issues).
- Recommend `TransformersEngine` / `torchao` for new FP8 projects.
- Adds a short, concrete explanation of common MS-AMP failure modes (container pinning, MSCCL/NCCL conflicts).

Docs-only change; no code behavior changes.