### PR TITLE
Docs: index distributed inference examples

### DIFF
--- a/docs/source/usage_guides/distributed_inference.md
+++ b/docs/source/usage_guides/distributed_inference.md
@@ -142,7 +142,12 @@ with distributed_state.split_between_processes(["a dog", "a cat", "a chicken"], 
 On the first GPU, the prompts will be `["a dog", "a cat"]`, and on the second GPU it will be `["a chicken", "a chicken"]`.
 Make sure to drop the final sample, as it will be a duplicate of the previous one.
 
-You can find more complex examples [here](https://github.com/huggingface/accelerate/tree/main/examples/inference/distributed) such as how to use it with LLMs.
+You can find more complex examples in the [distributed inference examples folder](https://github.com/huggingface/accelerate/tree/main/examples/inference/distributed), including:
+
+- LLM text generation (`phi2.py`)
+- Diffusers image generation (`stable_diffusion.py`, `distributed_image_generation.py`)
+- Image captioning (`florence2.py`)
+- Speech generation / TTS (`distributed_speech_generation.py`)
 
 ## Memory-efficient pipeline parallelism (experimental)
 

--- a/examples/inference/distributed/README.md
+++ b/examples/inference/distributed/README.md
@@ -23,3 +23,17 @@ Or:
 ```bash
 torchrun --nproc-per-node {NUM_GPUS} phi2.py
 ```
+
+## Available examples
+
+These scripts all use the same high-level strategy: each process loads a full copy of the model on its device, and
+`PartialState.split_between_processes` is used to split work across ranks.
+
+- **`phi2.py`**: text generation with an LLM (Phi-2).
+- **`stable_diffusion.py` / `distributed_image_generation.py`**: image generation with Diffusers.
+- **`florence2.py`**: image captioning with Florence-2 (supports streaming WebDataset inputs and threaded result saving).
+- **`distributed_speech_generation.py`**: TTS / speech generation example with threaded audio + metadata saving.
+- **`llava_next_video.py`**: multimodal / video inference example.
+
+Most of the examples support an `--output_path` to write artifacts (images/audio/JSON) to disk. When relevant, the
+writing is done on a background thread to avoid blocking GPU compute.


### PR DESCRIPTION
Improve discoverability of the distributed inference examples.

- Replace the vague “more complex examples here” link with a short list of what’s available.
- Add an index section to `examples/inference/distributed/README.md` describing each script.

Docs-only change.