### PR TITLE
Remove unused checkpointing_steps argument from cv_example.py

### DIFF
--- a/examples/cv_example.py
+++ b/examples/cv_example.py
@@ -193,12 +193,6 @@ def main():
         "between fp16 and bf16 (bfloat16). Bf16 requires PyTorch >= 1.10."
         "and an Nvidia Ampere GPU.",
     )
-    parser.add_argument(
-        "--checkpointing_steps",
-        type=str,
-        default=None,
-        help="Whether the various states should be saved at the end of every n steps, or 'epoch' for each epoch.",
-    )
     parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
     args = parser.parse_args()
     config = {"lr": 3e-2, "num_epochs": 3, "seed": 42, "batch_size": 64, "image_size": 224}


### PR DESCRIPTION
# Description 

This PR removes an unused argument ( `--checkpointing_steps`) from `cv_example.py` example.  Defining an unused argument can be confusing for new users. 


# Who can review?
 @SunMarc

 