### PR TITLE
Fix FSDP2 + cpu_ram_efficient_loading for models with buffers (Fixes #3898)

### DIFF
--- a/tests/fsdp/test_fsdp2_cpu_ram_efficient_loading_buffers.py
+++ b/tests/fsdp/test_fsdp2_cpu_ram_efficient_loading_buffers.py
@@ -1,0 +1,150 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test that FSDP2 + cpu_ram_efficient_loading=True correctly loads models that have buffers.
+Regression test for https://github.com/huggingface/accelerate/issues/3898
+"""
+
+import argparse
+import unittest
+from typing import Any, Callable
+
+import torch
+from torch import distributed as dist
+from torch import nn
+
+from accelerate import Accelerator
+from accelerate.parallelism_config import ParallelismConfig
+from accelerate.test_utils import (
+    execute_subprocess_async,
+    get_torch_dist_unique_port,
+    require_multi_device,
+)
+from accelerate.test_utils.testing import (
+    require_fsdp2,
+    require_non_cpu,
+    require_non_torch_xla,
+    run_first,
+    slow,
+    torch_device,
+)
+from accelerate.utils import FullyShardedDataParallelPlugin
+from accelerate.utils.imports import is_hpu_available
+
+
+def manage_process_group(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Manage the creation and destruction of the distributed process group for the wrapped function."""
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        torch_accelerator_module = getattr(torch, torch_device, torch.cuda)
+        if torch_device == "hpu" and is_hpu_available(init_hccl=True):
+            dist.init_process_group(backend="hccl", world_size=torch_accelerator_module.device_count())
+        else:
+            dist.init_process_group(world_size=torch_accelerator_module.device_count())
+        try:
+            return func(*args, **kwargs)
+        finally:
+            dist.destroy_process_group()
+
+    return wrapped
+
+
+class TinyModelWithBuffer(nn.Module):
+    """Minimal model with both parameters and a buffer to exercise buffer loading in fsdp2_load_full_state_dict."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+        self.register_buffer("my_buffer", torch.ones(2, 2) * 42.0)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+@manage_process_group
+def _run_fsdp2_cpu_ram_efficient_loading_buffers():
+    torch_accelerator_module = getattr(torch, torch_device, torch.cuda)
+    torch_accelerator_module.set_device(device := torch.device(dist.get_rank()))
+
+    plugin = FullyShardedDataParallelPlugin(fsdp_version=2, cpu_ram_efficient_loading=True)
+    parallelism_config = ParallelismConfig(dp_shard_size=dist.get_world_size())
+    accelerator = Accelerator(fsdp_plugin=plugin, parallelism_config=parallelism_config)
+
+    model = TinyModelWithBuffer()
+    expected_buffer = model.my_buffer.detach().clone()
+
+    model = accelerator.prepare(model)
+
+    # Buffer should have been loaded correctly on all ranks (broadcast from rank 0).
+    # Use named_buffers() so we get the buffer regardless of FSDP wrapping (e.g. _fsdp_wrapped_module).
+    loaded_buffer = next((b for n, b in model.named_buffers() if n == "my_buffer"), None)
+    assert loaded_buffer is not None, "Buffer 'my_buffer' not found after prepare"
+    torch.testing.assert_close(
+        loaded_buffer.cpu(), expected_buffer.cpu(), msg="Buffer mismatch after FSDP2 prepare with cpu_ram_efficient_loading"
+    )
+
+
+class TestFSDP2CpuRamEfficientLoadingBuffersUnit(unittest.TestCase):
+    """Unit tests that run without multi-GPU: validate test model and that the test script is runnable."""
+
+    def test_tiny_model_has_buffer(self):
+        """TinyModelWithBuffer must have a buffer so fsdp2_load_full_state_dict sees both DTensor and Tensor."""
+        model = TinyModelWithBuffer()
+        self.assertIn("my_buffer", dict(model.named_buffers()))
+        expected = torch.ones(2, 2) * 42.0
+        torch.testing.assert_close(model.my_buffer, expected)
+
+    def test_script_accepts_fsdp2_buffers_arg(self):
+        """The test script must be invokable with --fsdp2_buffers (used by torchrun)."""
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--fsdp2_buffers", action="store_true")
+        args = parser.parse_args(["--fsdp2_buffers"])
+        self.assertTrue(args.fsdp2_buffers)
+
+
+@require_fsdp2
+@run_first
+@require_non_cpu
+@require_non_torch_xla
+@require_multi_device
+@slow
+class TestFSDP2CpuRamEfficientLoadingBuffers(unittest.TestCase):
+    """Regression test for issue #3898: FSDP2 + cpu_ram_efficient_loading with models that have buffers."""
+
+    def setUp(self):
+        self.torch_accelerator_module = getattr(torch, torch_device, torch.cuda)
+
+    def test_fsdp2_cpu_ram_efficient_loading_buffers(self):
+        """Runs the actual FSDP2 + cpu_ram_efficient_loading path with a model that has a buffer."""
+        execute_subprocess_async(
+            cmd=[
+                "torchrun",
+                f"--nproc_per_node={self.torch_accelerator_module.device_count()}",
+                f"--master_port={get_torch_dist_unique_port()}",
+                __file__,
+                "--fsdp2_buffers",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fsdp2_buffers", action="store_true", help="Run FSDP2 cpu_ram_efficient_loading buffers test")
+    args = parser.parse_args()
+
+    if args.fsdp2_buffers:
+        _run_fsdp2_cpu_ram_efficient_loading_buffers()
+    else:
+        raise ValueError("Pass --fsdp2_buffers to run the test")


### PR DESCRIPTION
# Fix FSDP2 + cpu_ram_efficient_loading for models with buffers

Fixes #3898

## Summary

When using FSDP2 with `cpu_ram_efficient_loading=True`, `fsdp2_load_full_state_dict` only handled state-dict entries that were **parameters** (sharded as `DTensor`). Models that use `register_buffer()` have **buffers** (plain `torch.Tensor`) in the state dict. Those entries were not handled, leading to failures or wrong behavior.

This PR branches on `isinstance(sharded_param, DTensor)`:
- **Parameters (DTensor)**: keep the existing flow (broadcast → distribute_tensor → sharded_sd).
- **Buffers (plain Tensor)**: broadcast from rank 0 and store as plain tensors in `sharded_sd`, reusing the same dtype/contiguity and cpu_offload handling for consistency.

Non-main ranks already had a matching loop for parameters; the same branching is added there so buffers are received via broadcast and stored, avoiding deadlock.

## Changes

- **`src/accelerate/utils/fsdp_utils.py`**
  - Updated `fsdp2_load_full_state_dict` docstring to document parameters vs buffers and to reference #3898.
  - In both main and non-main branches: if `meta_sharded_sd` entry is a `DTensor`, treat as parameter (existing logic); else treat as buffer (broadcast and store as plain tensor with same casting/offload behavior).

- **`tests/fsdp/test_fsdp2_cpu_ram_efficient_loading_buffers.py`** (new)
  - Regression test for #3898: minimal model with both parameters and a buffer, FSDP2 + `cpu_ram_efficient_loading=True`, `accelerator.prepare(model)` then assert the buffer is loaded correctly on all ranks.
  - Unit tests (no multi-GPU): `TinyModelWithBuffer` has the expected buffer; script accepts `--fsdp2_buffers`.
  - Integration test (multi-GPU): runs the above via torchrun, consistent with `test_load_checkpoint_and_dispatch_with_broadcast` and FSDP2 integration test conventions (`@run_first`, `@slow`, etc.).

## Design notes (preempting questions)

- **Why not distribute buffers?** Buffers are typically not sharded by FSDP2 (e.g. small stats); the sharded state dict from the model has them as plain tensors. Broadcasting keeps behavior correct and matches the “one copy from rank 0” idea of cpu_ram_efficient_loading.
- **Non-persistent buffers:** They are re-registered after load in the existing code path (`original_non_persistent_buffers`); this change only affects entries that appear in the (meta) sharded state dict, i.e. persistent buffers.
- **CPU offload:** Buffers use the same `cpu_offload` path as parameters (move to CPU after broadcast when enabled) so behavior stays consistent.
- **Order of keys:** We iterate `meta_sharded_sd.items()` in the same order on all ranks; the only difference is main vs non-main branch (who sends vs who receives). No ordering assumptions.

## Checklist

- [x] This PR fixes a bug (issue #3898).
- [x] I read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
- [x] I added tests that cover the fix (unit + integration for FSDP2 + cpu_ram_efficient_loading with buffers).
- [x] `make style` and `make quality` pass (or are N/A for docs-only).

## Who can review?

Fully-Sharded Data Parallelism: @SunMarc