### PR TITLE
fix: correct typo 'guarentee' to 'guarantee'

### DIFF
--- a/examples/by_feature/automatic_gradient_accumulation.py
+++ b/examples/by_feature/automatic_gradient_accumulation.py
@@ -234,7 +234,7 @@ def main():
     parser.add_argument("--cpu", action="store_true", help="If passed, will train on the CPU.")
     args = parser.parse_args()
     # New Code #
-    # We modify the starting batch size to be an observed batch size of 256, to guarentee an initial device OOM
+    # We modify the starting batch size to be an observed batch size of 256, to guarantee an initial device OOM
     config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 256}
     training_function(config, args)
 


### PR DESCRIPTION
Fixed typo in automatic_gradient_accumulation.py example comment.