### PR TITLE
Fix StatefulDataLoader KeyError with num_workers > 0

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -472,11 +472,13 @@ class DataLoaderAdapter:
         # so we need to adjust it here
         if PartialState().distributed_type != DistributedType.NO:
             factor = PartialState().num_processes - 1
-            if self.dl_state_dict["_sampler_iter_yielded"] > 0:
+            # When num_workers > 0, StatefulDataLoader uses _MultiProcessingDataLoaderIter
+            # which may not have _sampler_iter_yielded or _num_yielded in its state_dict
+            if "_sampler_iter_yielded" in self.dl_state_dict and self.dl_state_dict["_sampler_iter_yielded"] > 0:
                 self.dl_state_dict["_sampler_iter_yielded"] -= factor
-            if self.dl_state_dict["_num_yielded"] > 0:
+            if "_num_yielded" in self.dl_state_dict and self.dl_state_dict["_num_yielded"] > 0:
                 self.dl_state_dict["_num_yielded"] -= factor
-            if self.dl_state_dict["_index_sampler_state"] is not None:
+            if self.dl_state_dict.get("_index_sampler_state") is not None:
                 if (
                     "samples_yielded" in self.dl_state_dict["_index_sampler_state"]
                     and self.dl_state_dict["_index_sampler_state"]["samples_yielded"] > 0


### PR DESCRIPTION
When using `StatefulDataLoader` with `num_workers > 0`, iterating through the dataloader crashes with:

```
KeyError: '_sampler_iter_yielded'
```

This happens because `adjust_state_dict_for_prefetch` directly accesses `_sampler_iter_yielded` and `_num_yielded` keys from the state dict, but these keys are only present when `num_workers=0` (single-process `DataLoaderIter`). With `num_workers > 0`, `StatefulDataLoader` uses `_MultiProcessingDataLoaderIter` which has a different state dict structure.

The fix adds key existence checks (`in`) before accessing these entries, so the adjustment is simply skipped when the keys aren't present.

Fixes #3110