### PR TITLE
docs: add deprecation notice for MS-AMP in CLI docs

### DIFF
--- a/docs/source/package_reference/cli.md
+++ b/docs/source/package_reference/cli.md
@@ -244,7 +244,7 @@ The following arguments are only useful when `use_megatron_lm` is passed or Mega
 * `--fp8_amax_history_len` (`int`) -- The length of the history to use for the scaling factor computation (useful only when `--fp8_backend=te` is passed).
 * `--fp8_amax_compute_algo` (`str`) -- The algorithm to use for the scaling factor computation. (useful only when `--fp8_backend=te` is passed).
 * `--fp8_override_linear_precision` (`Tuple[bool, bool, bool]`) -- Whether or not to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision.
-* `--fp8_opt_level` (`str`) -- What level of 8-bit collective communication should be used with MS-AMP (useful only when `--fp8_backend=msamp` is passed)
+* `--fp8_opt_level` (`str`) -- What level of 8-bit collective communication should be used with MS-AMP (useful only when `--fp8_backend=msamp` is passed). **Deprecated:** MS-AMP is no longer actively maintained. Use `--fp8_backend=te` instead.
 
 **AWS SageMaker Arguments**:
 


### PR DESCRIPTION
## What does this PR do?

Adds a deprecation notice to the CLI documentation for the `--fp8_opt_level` option, indicating that MS-AMP is no longer actively maintained and users should use `--fp8_backend=te` instead.

## Background

MS-AMP has known compatibility issues with newer CUDA versions (12.x+) and PyTorch builds. The usage guide and concept guide docs already have deprecation warnings, but the CLI docs were missing this notice.

## Changes

- Added **Deprecated:** notice to `--fp8_opt_level` option in CLI docs
- Points users to use `--fp8_backend=te` instead

Related to #3639