### PR TITLE
fix: auto-detect submodule params in cpu_offload for MultiheadAttention

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -503,11 +503,25 @@ def attach_align_device_hook(
     """
     # Attach the hook on this module if it has any direct tensor.
     directs = named_module_tensors(module)
+    directs_list = list(directs)
     full_offload = (
         offload and preload_module_classes is not None and module.__class__.__name__ in preload_module_classes
     )
 
-    if len(list(directs)) > 0 or full_offload:
+    # Auto-detect modules that have both direct parameters and child submodules with
+    # their own parameters (e.g. torch.nn.MultiheadAttention whose out_proj is a child
+    # module but its weights are accessed directly in forward via F.multi_head_attention_forward).
+    # In this case child forward hooks never fire, so the parent must load child weights too.
+    place_submodules = full_offload
+    if offload and not full_offload and len(directs_list) > 0:
+        has_child_params = any(
+            any(p is not None for p in child.parameters(recurse=False))
+            for child in module.children()
+        )
+        if has_child_params:
+            place_submodules = True
+
+    if len(directs_list) > 0 or full_offload:
         if weights_map is not None:
             prefix = f"{module_name}." if len(module_name) > 0 else ""
             prefixed_weights_map = PrefixedDataset(weights_map, prefix)
@@ -518,7 +532,7 @@ def attach_align_device_hook(
             offload=offload,
             weights_map=prefixed_weights_map,
             offload_buffers=offload_buffers,
-            place_submodules=full_offload,
+            place_submodules=place_submodules,
             skip_keys=skip_keys,
             tied_params_map=tied_params_map,
         )

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -242,6 +242,27 @@ class BigModelingTester(unittest.TestCase):
         output = model(x)
         torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
 
+    def test_cpu_offload_with_multihead_attention(self):
+        """Test that cpu_offload works with nn.MultiheadAttention without requiring preload_module_classes.
+
+        MultiheadAttention has out_proj as a child submodule, but accesses out_proj.weight and
+        out_proj.bias directly in forward via F.multi_head_attention_forward. This means the child
+        hook never fires, so the parent hook must load child weights. See issue #3542.
+        """
+        embed_dim = 4
+        num_heads = 2
+        mha = nn.MultiheadAttention(embed_dim=embed_dim, num_heads=num_heads, batch_first=True)
+        x = torch.randn(1, 3, embed_dim)
+        expected, _ = mha(x, x, x)
+
+        device = torch.device(torch_device)
+
+        # Without the fix for #3542, this forward call would raise:
+        # RuntimeError: Tensor on device meta is not on the expected device cuda:0!
+        cpu_offload(mha, execution_device=device)
+        output, _ = mha(x, x, x)
+        torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
+
     @slow
     @require_non_cpu
     def test_cpu_offload_gpt2(self):


### PR DESCRIPTION
Fixes #3542

`nn.MultiheadAttention` has `out_proj` as a child submodule, but accesses `out_proj.weight` and `out_proj.bias` directly via `F.multi_head_attention_forward` instead of calling `out_proj.forward()`. This means the child hook's `pre_forward` never fires, and `out_proj` weights stay on `meta` device when using `cpu_offload` without `preload_module_classes`.

In `attach_align_device_hook`, when a module has both direct parameters and child submodules with their own parameters, set `place_submodules=True` so `pre_forward`/`post_forward` recurse into children. This is separate from `full_offload` -- it only controls which weights get loaded, not where they live.

Added a test that exercises `cpu_offload` on `nn.MultiheadAttention` without `preload_module_classes`. Without this fix, it crashes with `RuntimeError: Tensor on device meta is not on the expected device cuda:0!`.