### PR TITLE
Fix mutable default arguments in _filter_args and _ask_options

### DIFF
--- a/src/accelerate/commands/config/config_utils.py
+++ b/src/accelerate/commands/config/config_utils.py
@@ -57,7 +57,7 @@ def _ask_field(input_text, convert_value=None, default=None, error_message=None)
                 print(error_message)
 
 
-def _ask_options(input_text, options=[], convert_value=None, default=0):
+def _ask_options(input_text, options=(), convert_value=None, default=0):
     menu = BulletMenu(input_text, options)
     result = menu.run(default_choice=default)
     return convert_value(result) if convert_value is not None else result

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -43,7 +43,9 @@ from . import parse_flag_from_env
 from .dataclasses import DistributedType, SageMakerDistributedType
 
 
-def _filter_args(args, parser, default_args=[]):
+def _filter_args(args, parser, default_args=None):
+    if default_args is None:
+        default_args = []
     """
     Filters out all `accelerate` specific args
     """


### PR DESCRIPTION
# What does this PR do?

Fixes mutable default arguments that can cause shared state across function calls:

- `_filter_args(args, parser, default_args=[])`: replaced with `default_args=None` and initialized inside the function body, since the list is passed to `parse_known_args` which may modify it
- `_ask_options(input_text, options=[])`: replaced with `options=()` since the parameter is only iterated over, not mutated