### PR TITLE
Fix in_order logging parameter (deadlock/ignored)

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import functools
 import logging
 import os
-from typing import Optional
 
 from .state import PartialState
 
@@ -36,6 +37,16 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         state = PartialState()
         return not main_process_only or (main_process_only and state.is_main_process)
 
+    def process(self, msg, kwargs):
+        msg, kwargs = super().process(msg, kwargs)
+
+        # set `stacklevel` to exclude ourself in `Logger.findCaller()` while respecting user's choice
+        kwargs.setdefault("stacklevel", 2)
+
+        state = PartialState()
+        msg = f"[RANK {state.process_index}] {msg}"
+        return msg, kwargs
+
     def log(self, level, msg, *args, **kwargs):
         """
         Delegates logger call after checking if we should log.
@@ -47,7 +58,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         read, but comes at the cost of sometimes needing to wait for the other processes. Default is `False` to not
         break with the previous behavior.
 
-        `in_order` is ignored if `main_process_only` is passed.
+        `main_process_only` is ignored if `in_order` is passed.
         """
         if PartialState._shared_state == {}:
             raise RuntimeError(
@@ -55,19 +66,16 @@ class MultiProcessAdapter(logging.LoggerAdapter):
             )
         main_process_only = kwargs.pop("main_process_only", True)
         in_order = kwargs.pop("in_order", False)
-        # set `stacklevel` to exclude ourself in `Logger.findCaller()` while respecting user's choice
-        kwargs.setdefault("stacklevel", 2)
 
         if self.isEnabledFor(level):
-            if self._should_log(main_process_only):
-                msg, kwargs = self.process(msg, kwargs)
+            msg, kwargs = self.process(msg, kwargs)
+            if not in_order and self._should_log(main_process_only):
                 self.logger.log(level, msg, *args, **kwargs)
 
             elif in_order:
                 state = PartialState()
                 for i in range(state.num_processes):
                     if i == state.process_index:
-                        msg, kwargs = self.process(msg, kwargs)
                         self.logger.log(level, msg, *args, **kwargs)
                     state.wait_for_everyone()
 
@@ -83,7 +91,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         self.warning(*args, **kwargs)
 
 
-def get_logger(name: str, log_level: Optional[str] = None):
+def get_logger(name: str, log_level: str | None = None):
     """
     Returns a `logging.Logger` for `name` that can handle multiprocessing.
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -56,6 +56,7 @@ def test_log_stack(caplog):
     )
 
     message = "Test"
+    expected_message, _ = logger.process(message, {})
     lineno = current_lineno() + 1  # the next line is the actual callsite
     logger.warning(message)
 
@@ -66,7 +67,7 @@ def test_log_stack(caplog):
     assert rec.name == __name__
     assert rec.lineno == lineno
     assert rec.funcName == test_log_stack.__name__
-    assert rec.message == message
+    assert rec.message == expected_message
 
 
 @pytest.mark.usefixtures("accelerator")
@@ -79,6 +80,7 @@ def test_custom_stacklevel(caplog):
     logger = CustomLogger(wrapped_logger, {})
 
     message = "Test"
+    expected_message, _ = wrapped_logger.process(message, {})
     lineno = current_lineno() + 1  # the next line is the actual callsite
     logger.warning(message)
 
@@ -91,4 +93,4 @@ def test_custom_stacklevel(caplog):
     assert rec.name == __name__
     assert rec.lineno == lineno
     assert rec.funcName == test_custom_stacklevel.__name__
-    assert rec.message == message
+    assert rec.message == expected_message


### PR DESCRIPTION
## Fix

Fixes #3939

### Problem
The `if/elif` structure in `MultiProcessAdapter.log()` makes `_should_log` and `in_order` mutually exclusive:

- **Case 1** (`main_process_only=True`, `in_order=True`): Deadlock. Rank 0 enters the `_should_log` branch and returns, while ranks 1-3 enter the `in_order` branch and wait forever on `wait_for_everyone()`.
- **Case 2** (`main_process_only=False`, `in_order=True`): `in_order` is silently ignored because `_should_log(False)` returns `True` for all ranks, so they all enter the first branch.

### Solution
- Check `in_order` first: when `in_order=True`, skip the `main_process_only` check and use sequential barrier-based logging
- Move `process()` to its own method override so messages are processed once (with rank prefix) before the branch logic
- Update docstring to reflect that `main_process_only` is ignored when `in_order` is passed

This is based on the approach from the previously approved PR #3280 which was unfortunately auto-closed by the stale bot before being merged.

### Tests
Updated existing tests in `tests/test_logging.py` to account for the new rank-prefixed messages from `process()`.