### PR TITLE
Fix stateful dataloader DDP 

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -557,6 +557,14 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self._non_blocking = _non_blocking
         self.iteration = 0
 
+    def adjust_state_dict_for_prefetch(self):
+        # DataLoaderShard does not need the DDP prefetch adjustment that DataLoaderDispatcher needs.
+        # In DataLoaderShard, each process has its own sharded base dataloader and the 1-batch
+        # look-ahead is already accounted for by the timing of _update_state_dict() calls
+        # (called before the inner next(), so the captured state already equals the number of
+        # batches yielded to the user).
+        pass
+
     def __iter__(self):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.synchronized_generator)

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -275,29 +275,26 @@ def test_data_loader(data_loader, accelerator):
     )
 
 
-def test_stateful_dataloader(accelerator):
+def _test_stateful_dataloader_resume(accelerator, iterable):
     """
-    Tests that a stateful dataloader can be iterated over, saved after a few batches using `load_state_dict`, and then
-    resumed from the saved state.
+    Helper: iterate a stateful dataloader, save state after a few batches using `load_state_dict`,
+    resume from the saved state, and verify the resumed batches match what was originally unseen.
 
-    The result should be the same as the rest of the data that iterated over after saving.
+    Saves early (after 3 batches) so many batches remain, exposing any off-by-one in state restoration.
+    Tested with both iterable and map-style datasets to cover different state_dict code paths.
     """
     old_dataloader_config = accelerator.dataloader_config
     try:
         accelerator.dataloader_config = DataLoaderConfiguration(use_stateful_dataloader=True)
         prepared_dl = create_dataloader(
-            accelerator, dataset_size=32 * accelerator.num_processes, batch_size=4, iterable=True, shuffle=True
+            accelerator, dataset_size=32 * accelerator.num_processes, batch_size=4, iterable=iterable, shuffle=True
         )
         untrained_batches = []
-        # Calculate what step that will be
-        total_batches = 32 * accelerator.num_processes // (4 * accelerator.num_processes)
-        last_batch_num = total_batches - 1
+        save_step = 2
         for step, batch in enumerate(prepared_dl):
-            # Step just before
-            if step == last_batch_num - 1:
+            if step == save_step:
                 state_dict = prepared_dl.state_dict()
-            if step >= last_batch_num:
-                # Otherwise grab the "unseen" batches
+            if step > save_step:
                 untrained_batches.append(batch)
         not_skipped_batches = accelerator.gather(untrained_batches)
         prepared_dl.load_state_dict(state_dict)
@@ -305,9 +302,58 @@ def test_stateful_dataloader(accelerator):
         for batch in prepared_dl:
             resumed_batches.append(batch)
         resumed_batches = accelerator.gather(resumed_batches)
+        assert len(not_skipped_batches) == len(resumed_batches), (
+            f"Expected {len(not_skipped_batches)} batches after resume, got {len(resumed_batches)}"
+        )
         for b1, b2 in zip(not_skipped_batches, resumed_batches):
             for v1, v2 in zip(b1, b2):
                 assert torch.equal(v1, v2), f"Batch {b1} and {b2} are not equal"
+    finally:
+        accelerator.dataloader_config = old_dataloader_config
+
+
+def test_stateful_dataloader(accelerator):
+    """
+    Tests that a stateful dataloader can be iterated over, saved after a few batches using `load_state_dict`, and then
+    resumed from the saved state.
+
+    The result should be the same as the rest of the data that iterated over after saving.
+    """
+    _test_stateful_dataloader_resume(accelerator, iterable=True)
+    _test_stateful_dataloader_resume(accelerator, iterable=False)
+
+
+def _test_stateful_dataloader_save_state_resume(accelerator, iterable):
+    """
+    Helper: iterate a stateful dataloader, save state after a few batches using `Accelerator.save_state`,
+    resume, and verify the resumed batches match what was originally unseen.
+    """
+    old_dataloader_config = accelerator.dataloader_config
+    try:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            accelerator.dataloader_config = DataLoaderConfiguration(use_stateful_dataloader=True)
+            prepared_dl = create_dataloader(
+                accelerator, dataset_size=32 * accelerator.num_processes, batch_size=4, iterable=iterable, shuffle=True
+            )
+            untrained_batches = []
+            save_step = 2
+            for step, batch in enumerate(prepared_dl):
+                if step == save_step:
+                    accelerator.save_state(tmpdir)
+                if step > save_step:
+                    untrained_batches.append(batch)
+            not_skipped_batches = accelerator.gather(untrained_batches)
+            accelerator.load_state(tmpdir)
+            resumed_batches = []
+            for batch in prepared_dl:
+                resumed_batches.append(batch)
+            resumed_batches = accelerator.gather(resumed_batches)
+            assert len(not_skipped_batches) == len(resumed_batches), (
+                f"Expected {len(not_skipped_batches)} batches after resume, got {len(resumed_batches)}"
+            )
+            for b1, b2 in zip(not_skipped_batches, resumed_batches):
+                for v1, v2 in zip(b1, b2):
+                    assert torch.equal(v1, v2), f"Batch {b1} and {b2} are not equal"
     finally:
         accelerator.dataloader_config = old_dataloader_config
 
@@ -319,35 +365,8 @@ def test_stateful_dataloader_save_state(accelerator):
 
     The result should be the same as the rest of the data that iterated over after saving.
     """
-    old_dataloader_config = accelerator.dataloader_config
-    try:
-        with tempfile.TemporaryDirectory() as tmpdir:
-            accelerator.dataloader_config = DataLoaderConfiguration(use_stateful_dataloader=True)
-            prepared_dl = create_dataloader(
-                accelerator, dataset_size=32 * accelerator.num_processes, batch_size=4, iterable=True, shuffle=True
-            )
-            untrained_batches = []
-            # Calculate what step that will be
-            total_batches = 32 * accelerator.num_processes // (4 * accelerator.num_processes)
-            last_batch_num = total_batches - 1
-            for step, batch in enumerate(prepared_dl):
-                # Step just before
-                if step == last_batch_num - 1:
-                    accelerator.save_state(tmpdir)
-                if step >= last_batch_num:
-                    # Otherwise grab the "unseen" batches
-                    untrained_batches.append(batch)
-            not_skipped_batches = accelerator.gather(untrained_batches)
-            accelerator.load_state(tmpdir)
-            resumed_batches = []
-            for batch in prepared_dl:
-                resumed_batches.append(batch)
-            resumed_batches = accelerator.gather(resumed_batches)
-            for b1, b2 in zip(not_skipped_batches, resumed_batches):
-                for v1, v2 in zip(b1, b2):
-                    assert torch.equal(v1, v2), f"Batch {b1} and {b2} are not equal"
-    finally:
-        accelerator.dataloader_config = old_dataloader_config
+    _test_stateful_dataloader_save_state_resume(accelerator, iterable=True)
+    _test_stateful_dataloader_save_state_resume(accelerator, iterable=False)
 
 
 def main():


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/accelerate/issues/3938. The tests we had didn't catch the issue that the user was having, so i changed it. Here's the summary of the changes: 

  - Fix a bug where DataLoaderShard.adjust_state_dict_for_prefetch() incorrectly subtracted num_processes - 1 from state dict counters  (_sampler_iter_yielded, _num_yielded) in DDP, causing the resumed dataloader to replay already-consumed batches
  - The num_processes - 1 correction in the base class DataLoaderAdapter is  only valid for DataLoaderDispatcher (which fetches num_processes batches per step from process 0), not for DataLoaderShard (where each process has
  its own sharded iterator with a single 1-batch look-ahead)
  - Strengthen existing test_stateful_dataloader and test_stateful_dataloader_save_state tests: save state earlier (after 3 batches instead of second-to-last), add length assertion, and test both iterable and map-style datasets

  Root cause

 - In DataLoaderShard.__iter__, _update_state_dict() is called before the inner next(), so the captured state already equals the number of batches yielded to the user — no DDP adjustment is needed. The base class adjustment of num_processes - 1 caused the resume point to be 1 batch too early, producing duplicate data.

 -  The bug only affects map-style datasets with use_stateful_dataloader=True in multi-process DDP. Iterable datasets were unaffected because their _sampler_iter_state provides correct resume info independently of _num_yielded. The previous tests didn't catch this because they (a) only  used iterable datasets, (b) saved state at the second-to-last batch leaving only 1 batch remaining, and (c) used zip without a length check.