### PR TITLE
Fix: Conditionally import `torch.distributed.algorithms.join` in `accelerator.py`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -154,7 +154,8 @@ if is_megatron_lm_available():
         megatron_lm_prepare_model_optimizer_scheduler,
     )
 
-from torch.distributed.algorithms.join import Join
+if torch.distributed.is_available():
+    from torch.distributed.algorithms.join import Join
 
 
 if is_torch_xla_available():


### PR DESCRIPTION
# What does this PR do?

`torch.distributed` is not available in all PyTorch builds (for example, Windows ROCm). Importing `torch.distributed.algorithms.join.Join` unconditionally at the top level of `accelerator.py` causes an immediate crash with:
```
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
```
This makes `import accelerate` fail entirely on those builds, even for users who have no intention of using distributed training.

## Changes
- Wrapped `from torch.distributed.algorithms.join import Join` in `if torch.distributed.is_available():`
- `Join` is only used inside `join_uneven_inputs()` which is documented as multi-GPU DDP only, so this guard is safe and consistent with how the rest of the file handles optional distributed functionality

## Prior art
The same fix was applied to `huggingface/diffusers` in:
- [huggingface/diffusers#12420](https://github.com/huggingface/diffusers/pull/12420)
- [huggingface/diffusers#12425](https://github.com/huggingface/diffusers/pull/12425)

A previous fix for the same class of issue in `huggingface/transformers` was made in:
- [huggingface/transformers#40038](https://github.com/huggingface/transformers/pull/40038)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc