### PR TITLE
fix: pass step parameter in TrackioTracker.log()

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -484,7 +484,7 @@ class TrackioTracker(GeneralTracker):
             kwargs:
                 Additional key word arguments passed along to the `trackio.log` method.
         """
-        self.run.log(values, **kwargs)
+        self.run.log(values, step=step, **kwargs)
         logger.debug("Successfully logged to trackio")
 
     @on_main_process


### PR DESCRIPTION
# What does this PR do?

`TrackioTracker.log()` accepts a `step` parameter but never forwards it to `self.run.log()`, causing step values to be silently auto-incremented instead of using the user-provided values.

All other trackers (WandB, TensorBoard, CometML, Aim, MLflow, SwanLab) correctly pass `step=step` to their respective logging backends. This was simply missed when `TrackioTracker` was added.

## Fix

One-line change: pass `step=step` to `self.run.log()` in `TrackioTracker.log()`.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md), Pull Request section?
- [x] Was this discussed/approved via a Github issue? Yes, #3963.

Fixes #3963
