### PR TITLE
Remove is_torch_xpu_tensor

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -46,18 +46,6 @@ def is_torch_tensor(tensor):
     return isinstance(tensor, torch.Tensor)
 
 
-def is_torch_xpu_tensor(tensor):
-    return isinstance(
-        tensor,
-        torch.xpu.FloatTensor,
-        torch.xpu.ByteTensor,
-        torch.xpu.IntTensor,
-        torch.xpu.LongTensor,
-        torch.xpu.HalfTensor,
-        torch.xpu.DoubleTensor,
-        torch.xpu.BFloat16Tensor,
-    )
-
 
 def is_tensor_information(tensor_info):
     return isinstance(tensor_info, TensorInformation)


### PR DESCRIPTION
# What does this PR do?

is_torch_xpu_tensor is removed because its checks are wrong and not used.