### PR TITLE
Fix TrackioTracker.log() ignoring step parameter

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -484,7 +484,7 @@ class TrackioTracker(GeneralTracker):
             kwargs:
                 Additional key word arguments passed along to the `trackio.log` method.
         """
-        self.run.log(values, **kwargs)
+        self.run.log(values, step=step, **kwargs)
         logger.debug("Successfully logged to trackio")
 
     @on_main_process


### PR DESCRIPTION
TrackioTracker.log() accepts a step parameter but never passes it to trackio, so steps are silently auto-incremented instead of using the provided value. This adds step=step to match how every other tracker in the file handles it (WandB, SwanLab, etc.).

Closes #3963