### PR TITLE
Prevent double-wrapping models in prepare_model()

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2060,6 +2060,7 @@ class Accelerator:
                 model = compile_regions(model, **self.state.dynamo_plugin.to_kwargs())
             else:
                 model = torch.compile(model, **self.state.dynamo_plugin.to_kwargs())
+        model._is_accelerate_prepared = True
         return model
 
     def _prepare_ao(self, *args):

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -473,9 +473,7 @@ class AcceleratorTester(AccelerateTestCase):
         assert len(accelerator._models) == num_models_before, (
             "prepare_model should not add duplicate entries to _models"
         )
-        assert reprepared_model is prepared_model, (
-            "prepare_model should return the same object when called twice"
-        )
+        assert reprepared_model is prepared_model, "prepare_model should return the same object when called twice"
 
     @require_cuda_or_xpu
     @slow


### PR DESCRIPTION
`prepare_model()` doesn't check if a model has already been prepared, so calling `prepare()` twice on the same model wraps it in a nested DDP, corrupts the `_models` registry, and breaks checkpoint save/load with key mismatches like `module.module.weight`.

Dataloaders, optimizers, and schedulers already have this guard via `_is_accelerate_prepared`. This adds the same check to `prepare_model()`.

Closes #3967