### PR TITLE
fix segmentation fault

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1028,6 +1028,10 @@ def multi_gpu_launcher(args):
                 console.print_exception(suppress=[__file__], show_locals=False)
             else:
                 raise
+        else:
+            if is_xpu_available():
+                import os as _os
+                _os._exit(0)
 
 
 def deepspeed_launcher(args):


### PR DESCRIPTION
# What does this PR do?
This PR fixes  SIGSEGV (exit code 139) on XPU.

When using accelerate launch on Intel XPU, the parent process crashes with SIGSEGV (exit code 139) after all worker processes complete successfully. The root cause is a C++ static destruction order fiasco in libccl.so (Intel oneCCL). The parent process loads libccl.so as a side effect of import torch (line 26 of launch.py), which registers ~30+ file-scope std::map objects, a logger singleton, and other global C++ objects with non-trivial destructors. The parent never initializes or uses oneCCL — it only spawns workers via torch.distributed.run and waits for them. However, when the parent's Python interpreter shuts down, it triggers C++ static destructors across all loaded shared libraries, and the interdependencies among oneCCL's global objects cause a use-after-free crash. This does not occur on CUDA because libnccl.so's global objects have simpler destruction semantics. The fix calls os._exit(0) in the success path of multi_gpu_launcher() when XPU is available, which immediately terminates the parent process without running Python finalizers or C++ static destructors — this is safe because the parent has no remaining work after workers exit, and os._exit() is the standard pattern for avoiding teardown-order crashes in launcher processes (e.g., multiprocessing forkserver uses the same approach).


