### PR TITLE
Fix: Adds missing model_has_params4bit guard to match the existing guard pattern in the same function.

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -696,7 +696,7 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     if not isinstance(model, FSDPModule):
         fully_shard(model, **fsdp2_kwargs)
 
-    if fsdp2_plugin.cpu_ram_efficient_loading:
+    if fsdp2_plugin.cpu_ram_efficient_loading and not model_has_params4bit:
         # If `cpu_ram_efficient_loading` is enabled, only rank 0 loads the weights
         # Other ranks have an empty model on `meta` device, so we need to distribute the weights properly
         # When CPU offloading is enabled, parameters need to stay on CPU after distribution


### PR DESCRIPTION
# What does this PR do?

Adds missing `model_has_params4bit` guard to the `fsdp2_load_full_state_dict` call in `fsdp2_prepare_model()`.

When `cpu_ram_efficient_loading=True` with a BnB 4-bit quantized model (e.g. QLoRA), the function correctly skips the meta device move (line 669) and buffer re-registration (line 709) using `and not model_has_params4bit`, but the `fsdp2_load_full_state_dict` call (line 699) is missing this guard.

This is problematic because:
- `fsdp2_load_full_state_dict` assumes the model was moved to meta device, but Params4bit models skip that move
- The function uses `zip(full_sd.items(), meta_sharded_sd.values())` which breaks when BnB adds extra state dict entries (`weight.quant_state.*`, `weight.absmax`, etc.)
- This results in deadlocks (mismatched `dist.broadcast` calls across ranks) or crashes


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc