### PR TITLE
fix: use key-based matching in fsdp2_load_full_state_dict

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -511,7 +511,13 @@ def fsdp2_load_full_state_dict(accelerator, model: torch.nn.Module, full_sd: dic
         return tensor
 
     if accelerator.is_main_process:
-        for (param_name, full_param), sharded_param in zip(full_sd.items(), meta_sharded_sd.values()):
+        for param_name, sharded_param in meta_sharded_sd.items():
+            if param_name not in full_sd:
+                raise KeyError(
+                    f"Parameter '{param_name}' found in sharded model state dict but missing from full state dict. "
+                    f"Full state dict has {len(full_sd)} keys, sharded has {len(meta_sharded_sd)} keys."
+                )
+            full_param = full_sd[param_name]
             device_mesh = sharded_param.device_mesh
             full_param = full_param.detach().to(device_mesh.device_type)
             if isinstance(full_param, DTensor):


### PR DESCRIPTION
# What does this PR do?
Replaces positional (`zip`) matching with key-based matching in `fsdp2_load_full_state_dict()` on rank 0, preventing deadlocks when `full_sd` and `meta_sharded_sd` have different numbers of keys.

## Problem

`fsdp2_load_full_state_dict()` currently uses different iteration strategies per rank:

- **Rank 0:** `zip(full_sd.items(), meta_sharded_sd.values())` — positional
- **Other ranks:** `meta_sharded_sd.items()` — key-based

This assumes `full_sd` and `meta_sharded_sd` have identical key counts and ordering. When they don't, `dist.broadcast` calls become misaligned across ranks, causing a **deadlock** (all ranks hang indefinitely).

### When does this break?

Models whose `state_dict()` contains extra sidecar entries not present in the sharded model's state dict. A concrete example is BnB QLoRA (`Params4bit`) with `cpu_ram_efficient_loading=True`:
```
meta_sharded_sd (after fully_shard, all ranks):
  model.layers.0.self_attn.q_proj.weight          # DTensor
  model.layers.0.self_attn.q_proj.lora_A.weight    # DTensor
  model.layers.0.self_attn.q_proj.lora_B.weight    # DTensor
  ... (N keys total)

full_sd (original state dict, rank 0 only):
  model.layers.0.self_attn.q_proj.weight
  model.layers.0.self_attn.q_proj.weight.absmax           # BnB sidecar
  model.layers.0.self_attn.q_proj.weight.quant_map         # BnB sidecar
  model.layers.0.self_attn.q_proj.weight.quant_state.bitsandbytes__nf4  # BnB sidecar
  model.layers.0.self_attn.q_proj.lora_A.weight
  model.layers.0.self_attn.q_proj.lora_B.weight
  ... (N + M keys total, M = sidecar entries)
```

### How the deadlock happens

With `zip` on rank 0, iteration is positional — the i-th entry from `full_sd` is paired with the i-th entry from `meta_sharded_sd`. When `full_sd` has extra sidecar keys interleaved, the pairing shifts:
```
Step 1:
  Rank 0 broadcasts: full_sd["q_proj.weight"]          (correct)
  Rank 1 expects:    meta_sharded_sd["q_proj.weight"]   (correct)

Step 2:
  Rank 0 broadcasts: full_sd["q_proj.weight.absmax"]    (sidecar!)
  Rank 1 expects:    meta_sharded_sd["q_proj.lora_A.weight"]   MISMATCH

→ broadcast tensor sizes differ across ranks → NCCL error or infinite hang
```

After N iterations (matching `meta_sharded_sd` size), `zip` stops on rank 0, but the data that was broadcast was wrong from step 2 onward. In practice, the size/dtype mismatch causes NCCL to hang waiting for matching collectives.

## Fix

Use the same iteration strategy on all ranks — iterate over `meta_sharded_sd.items()` and look up `full_sd` by key:
```python
# Before (rank 0): positional — breaks with extra keys
for (param_name, full_param), sharded_param in zip(full_sd.items(), meta_sharded_sd.values()):

# After (rank 0): key-based — matches other ranks' iteration
for param_name, sharded_param in meta_sharded_sd.items():
    full_param = full_sd[param_name]
```

This also adds a clear `KeyError` message when a sharded key is missing from `full_sd`, instead of a silent mismatch or cryptic broadcast error.

For the normal case (no extra keys), behavior is identical — same keys, same order, same broadcasts.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc