### PR TITLE
[FSDP2] Cast model to uniform dtype before fully_shard to fix mixed-dtype AssertionError

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -666,20 +666,19 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
             model_has_params4bit = True
             break
 
-    # FSDP2 requires uniform original parameter dtype within each param group.
-    # Norm/embedding weights stored in fp32 while the rest is bf16/fp16, causing _init_mp_dtypes() AssertionError.
+    # FSDP2 requires uniform orig_dtype among trainable params in each group.
+    # Upcast to fp32 master weights; MixedPrecisionPolicy.param_dtype handles compute cast.
     if accelerator.mixed_precision != "no" and not model_has_params4bit:
-        mp_policy = fsdp2_plugin.mixed_precision_policy
-        if mp_policy is not None and getattr(mp_policy, "param_dtype", None) is not None:
-            target_dtype = mp_policy.param_dtype
-        elif accelerator.mixed_precision == "bf16":
-            target_dtype = torch.bfloat16
-        elif accelerator.mixed_precision == "fp16":
-            target_dtype = torch.float16
-        else:
-            target_dtype = None
-        if target_dtype is not None:
-            model.to(target_dtype)
+        upcasted_params = []
+        for name, param in model.named_parameters():
+            if param.requires_grad and param.dtype != torch.float32:
+                upcasted_params.append(name)
+                param.data = param.data.to(torch.float32)
+        if accelerator.is_main_process and upcasted_params:
+            warnings.warn(
+                "FSDP upcast of low precision parameters to fp32 (since mixed_precision != 'no') may affect the precision of model checkpoints. "
+                f"This effects {len(upcasted_params)} parameters: {upcasted_params}..."
+            )
 
     if fsdp2_plugin.cpu_ram_efficient_loading and not model_has_params4bit:
         # Context: `fully_shard` moves the model to GPU if it was on CPU, however it can also be on `meta` and then it stays there even after `fully_shard`
@@ -742,22 +741,6 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         if hasattr(model, "tie_weights"):
             model.tie_weights()
 
-    # There is no `dtype` attribution for nn.Module
-    # Set it to None if it doesn't exist and do the upcast always
-    model_dtype = getattr(model, "dtype", None)
-    if accelerator.mixed_precision != "no" and (model_dtype is None or model_dtype != torch.float32):
-        # We upcast the trainable parameters according to `deepspeed`'s implementation
-        # More info about this can be found in `accelerator.py:prepare_model`s FSDP1 section
-        upcasted_params = []
-        for name, param in model.named_parameters():
-            if param.requires_grad and param.dtype != torch.float32:
-                upcasted_params.append(name)
-                param = param.to(torch.float32)
-        if accelerator.is_main_process and upcasted_params:
-            warnings.warn(
-                "FSDP upcast of low precision parameters to fp32 (since mixed_precision != 'no') may affect the precision of model checkpoints. "
-                f"This effects {len(upcasted_params)} parameters: {upcasted_params}..."
-            )
     return model
 
 

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -666,6 +666,21 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
             model_has_params4bit = True
             break
 
+    # FSDP2 requires uniform original parameter dtype within each param group.
+    # Norm/embedding weights stored in fp32 while the rest is bf16/fp16, causing _init_mp_dtypes() AssertionError.
+    if accelerator.mixed_precision != "no" and not model_has_params4bit:
+        mp_policy = fsdp2_plugin.mixed_precision_policy
+        if mp_policy is not None and getattr(mp_policy, "param_dtype", None) is not None:
+            target_dtype = mp_policy.param_dtype
+        elif accelerator.mixed_precision == "bf16":
+            target_dtype = torch.bfloat16
+        elif accelerator.mixed_precision == "fp16":
+            target_dtype = torch.float16
+        else:
+            target_dtype = None
+        if target_dtype is not None:
+            model.to(target_dtype)
+
     if fsdp2_plugin.cpu_ram_efficient_loading and not model_has_params4bit:
         # Context: `fully_shard` moves the model to GPU if it was on CPU, however it can also be on `meta` and then it stays there even after `fully_shard`
         # For this reason, we need to move the model to `meta` device, as then sharding happens on `meta` device

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -321,7 +321,7 @@ class FSDPPluginIntegration(AccelerateTestCase):
                 assert plugin.mixed_precision_policy == mp_policy
             with patch_environment(**env):
                 plugin = FullyShardedDataParallelPlugin(
-                    mixed_precision_policy={"param_dtype": dtype, "reduce_dtype": dtype, **{extra_arg: dtype}}
+                    mixed_precision_policy={"param_dtype": dtype, "reduce_dtype": dtype, extra_arg: dtype}
                 )
                 assert plugin.mixed_precision_policy == mp_policy
             with patch_environment(**env):
@@ -476,6 +476,7 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         when mixed_precision='bf16'. Many HF models (Llama, Mistral) store norm weights in fp32,
         and FSDP2 requires uniform orig_dtype among trainable params within each FSDP group."""
         from unittest.mock import Mock, patch
+
         from accelerate.utils.fsdp_utils import fsdp2_prepare_model
 
         # Create model with mixed dtypes: linear=bf16, norm=fp32 (simulates HF Llama)
@@ -517,6 +518,7 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         """Test that fsdp2_prepare_model upcasts mixed-dtype trainable params to fp32 master weights
         when mixed_precision='fp16'."""
         from unittest.mock import Mock, patch
+
         from accelerate.utils.fsdp_utils import fsdp2_prepare_model
 
         model = torch.nn.Sequential(
@@ -556,6 +558,7 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
     def test_fsdp2_no_dtype_cast_when_no_mixed_precision(self):
         """Test that no dtype cast happens when mixed_precision='no', preserving original model dtypes."""
         from unittest.mock import Mock, patch
+
         from accelerate.utils.fsdp_utils import fsdp2_prepare_model
 
         model = torch.nn.Sequential(
@@ -594,6 +597,7 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         """Test that dtype cast is skipped when model has Params4bit (QLoRA),
         to avoid destroying quantized weights."""
         from unittest.mock import Mock, patch
+
         from accelerate.utils.fsdp_utils import fsdp2_prepare_model
 
         model = torch.nn.Sequential(

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -471,9 +471,10 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
 
         AcceleratorState._reset_state(True)
 
-    def test_fsdp2_uniform_dtype_cast_bf16(self):
-        """Test that fsdp2_prepare_model casts mixed-dtype model to uniform bf16 before fully_shard
-        when mixed_precision='bf16'. Many HF models (Llama, Mistral) store norm weights in fp32."""
+    def test_fsdp2_uniform_dtype_upcast_bf16(self):
+        """Test that fsdp2_prepare_model upcasts mixed-dtype trainable params to fp32 master weights
+        when mixed_precision='bf16'. Many HF models (Llama, Mistral) store norm weights in fp32,
+        and FSDP2 requires uniform orig_dtype among trainable params within each FSDP group."""
         from unittest.mock import Mock, patch
         from accelerate.utils.fsdp_utils import fsdp2_prepare_model
 
@@ -510,10 +511,11 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
             result = fsdp2_prepare_model(mock_accelerator, model)
 
         dtypes_after = {p.dtype for p in result.parameters()}
-        assert dtypes_after == {torch.bfloat16}, f"Expected all bf16, got {dtypes_after}"
+        assert dtypes_after == {torch.float32}, f"Expected all fp32 master weights, got {dtypes_after}"
 
-    def test_fsdp2_uniform_dtype_cast_fp16(self):
-        """Test that fsdp2_prepare_model casts mixed-dtype model to uniform fp16 when mixed_precision='fp16'."""
+    def test_fsdp2_uniform_dtype_upcast_fp16(self):
+        """Test that fsdp2_prepare_model upcasts mixed-dtype trainable params to fp32 master weights
+        when mixed_precision='fp16'."""
         from unittest.mock import Mock, patch
         from accelerate.utils.fsdp_utils import fsdp2_prepare_model
 
@@ -549,7 +551,7 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
             result = fsdp2_prepare_model(mock_accelerator, model)
 
         dtypes_after = {p.dtype for p in result.parameters()}
-        assert dtypes_after == {torch.float16}, f"Expected all fp16, got {dtypes_after}"
+        assert dtypes_after == {torch.float32}, f"Expected all fp32 master weights, got {dtypes_after}"
 
     def test_fsdp2_no_dtype_cast_when_no_mixed_precision(self):
         """Test that no dtype cast happens when mixed_precision='no', preserving original model dtypes."""

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -471,6 +471,172 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
 
         AcceleratorState._reset_state(True)
 
+    def test_fsdp2_uniform_dtype_cast_bf16(self):
+        """Test that fsdp2_prepare_model casts mixed-dtype model to uniform bf16 before fully_shard
+        when mixed_precision='bf16'. Many HF models (Llama, Mistral) store norm weights in fp32."""
+        from unittest.mock import Mock, patch
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        # Create model with mixed dtypes: linear=bf16, norm=fp32 (simulates HF Llama)
+        model = torch.nn.Sequential(
+            torch.nn.Linear(4, 4),
+            torch.nn.LayerNorm(4),
+        )
+        model[0].to(torch.bfloat16)
+        dtypes_before = {p.dtype for p in model.parameters()}
+        assert dtypes_before == {torch.bfloat16, torch.float32}
+
+        mock_accelerator = Mock()
+        mock_accelerator.mixed_precision = "bf16"
+        mock_accelerator.torch_device_mesh = None
+        mock_accelerator.device = torch.device("cpu")
+        mock_accelerator.is_main_process = True
+
+        mock_mp_policy = Mock()
+        mock_mp_policy.param_dtype = torch.bfloat16
+        mock_plugin = Mock()
+        mock_plugin.mixed_precision_policy = mock_mp_policy
+        mock_plugin.reshard_after_forward = True
+        mock_plugin.cpu_offload = None
+        mock_plugin.cpu_ram_efficient_loading = False
+        mock_plugin.ignored_modules = None
+        mock_accelerator.state.fsdp_plugin = mock_plugin
+
+        with (
+            patch("torch.distributed.fsdp.fully_shard"),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch("accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy", return_value=None),
+        ):
+            result = fsdp2_prepare_model(mock_accelerator, model)
+
+        dtypes_after = {p.dtype for p in result.parameters()}
+        assert dtypes_after == {torch.bfloat16}, f"Expected all bf16, got {dtypes_after}"
+
+    def test_fsdp2_uniform_dtype_cast_fp16(self):
+        """Test that fsdp2_prepare_model casts mixed-dtype model to uniform fp16 when mixed_precision='fp16'."""
+        from unittest.mock import Mock, patch
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        model = torch.nn.Sequential(
+            torch.nn.Linear(4, 4),
+            torch.nn.LayerNorm(4),
+        )
+        model[0].to(torch.float16)
+        dtypes_before = {p.dtype for p in model.parameters()}
+        assert dtypes_before == {torch.float16, torch.float32}
+
+        mock_accelerator = Mock()
+        mock_accelerator.mixed_precision = "fp16"
+        mock_accelerator.torch_device_mesh = None
+        mock_accelerator.device = torch.device("cpu")
+        mock_accelerator.is_main_process = True
+
+        mock_mp_policy = Mock()
+        mock_mp_policy.param_dtype = torch.float16
+        mock_plugin = Mock()
+        mock_plugin.mixed_precision_policy = mock_mp_policy
+        mock_plugin.reshard_after_forward = True
+        mock_plugin.cpu_offload = None
+        mock_plugin.cpu_ram_efficient_loading = False
+        mock_plugin.ignored_modules = None
+        mock_accelerator.state.fsdp_plugin = mock_plugin
+
+        with (
+            patch("torch.distributed.fsdp.fully_shard"),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch("accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy", return_value=None),
+        ):
+            result = fsdp2_prepare_model(mock_accelerator, model)
+
+        dtypes_after = {p.dtype for p in result.parameters()}
+        assert dtypes_after == {torch.float16}, f"Expected all fp16, got {dtypes_after}"
+
+    def test_fsdp2_no_dtype_cast_when_no_mixed_precision(self):
+        """Test that no dtype cast happens when mixed_precision='no', preserving original model dtypes."""
+        from unittest.mock import Mock, patch
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        model = torch.nn.Sequential(
+            torch.nn.Linear(4, 4),
+            torch.nn.LayerNorm(4),
+        )
+        model[0].to(torch.bfloat16)
+        dtypes_before = {p.dtype for p in model.parameters()}
+        assert dtypes_before == {torch.bfloat16, torch.float32}
+
+        mock_accelerator = Mock()
+        mock_accelerator.mixed_precision = "no"
+        mock_accelerator.torch_device_mesh = None
+        mock_accelerator.device = torch.device("cpu")
+        mock_accelerator.is_main_process = True
+
+        mock_plugin = Mock()
+        mock_plugin.mixed_precision_policy = None
+        mock_plugin.reshard_after_forward = True
+        mock_plugin.cpu_offload = None
+        mock_plugin.cpu_ram_efficient_loading = False
+        mock_plugin.ignored_modules = None
+        mock_accelerator.state.fsdp_plugin = mock_plugin
+
+        with (
+            patch("torch.distributed.fsdp.fully_shard"),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch("accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy", return_value=None),
+        ):
+            result = fsdp2_prepare_model(mock_accelerator, model)
+
+        dtypes_after = {p.dtype for p in result.parameters()}
+        assert dtypes_after == {torch.bfloat16, torch.float32}, f"Expected mixed dtypes preserved, got {dtypes_after}"
+
+    def test_fsdp2_no_dtype_cast_with_params4bit(self):
+        """Test that dtype cast is skipped when model has Params4bit (QLoRA),
+        to avoid destroying quantized weights."""
+        from unittest.mock import Mock, patch
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        model = torch.nn.Sequential(
+            torch.nn.Linear(4, 4),
+            torch.nn.LayerNorm(4),
+        )
+        model[0].to(torch.bfloat16)
+        dtypes_before = {p.dtype for p in model.parameters()}
+        assert dtypes_before == {torch.bfloat16, torch.float32}
+
+        # Simulate Params4bit by renaming one parameter's class
+        original_class = model[0].weight.__class__
+        model[0].weight.__class__ = type("Params4bit", (torch.nn.Parameter,), {})
+
+        mock_accelerator = Mock()
+        mock_accelerator.mixed_precision = "bf16"
+        mock_accelerator.torch_device_mesh = None
+        mock_accelerator.device = torch.device("cpu")
+        mock_accelerator.is_main_process = True
+
+        mock_mp_policy = Mock()
+        mock_mp_policy.param_dtype = torch.bfloat16
+        mock_plugin = Mock()
+        mock_plugin.mixed_precision_policy = mock_mp_policy
+        mock_plugin.reshard_after_forward = True
+        mock_plugin.cpu_offload = None
+        mock_plugin.cpu_ram_efficient_loading = False
+        mock_plugin.ignored_modules = None
+        mock_accelerator.state.fsdp_plugin = mock_plugin
+
+        try:
+            with (
+                patch("torch.distributed.fsdp.fully_shard"),
+                patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+                patch("accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy", return_value=None),
+            ):
+                result = fsdp2_prepare_model(mock_accelerator, model)
+
+            dtypes_after = {p.dtype for p in result.parameters()}
+            assert dtypes_after == {torch.bfloat16, torch.float32}, (
+                f"Expected mixed dtypes preserved (Params4bit skip), got {dtypes_after}"
+            )
+        finally:
+            model[0].weight.__class__ = original_class
+
 
 @run_first
 # Skip this test when TorchXLA is available because accelerate.launch does not support TorchXLA FSDP.


### PR DESCRIPTION
# What does this PR do?

When `mixed_precision` is enabled, casts model parameters to uniform dtype before `fully_shard()` to prevent `_init_mp_dtypes()` AssertionError.


## Problem

FSDP2's `_init_mp_dtypes()` requires uniform `orig_dtype` across all trainable parameters in a param group. With mixed dtypes, the first forward call crashes:
```
AssertionError: FSDP expects uniform original parameter dtype but got {torch.bfloat16, torch.float32}
```

FSDP2's `fsdp2_prepare_model()` currently passes the mixed-dtype model directly to `fully_shard()` without normalizing dtypes.


## Fix

Cast all parameters to the mixed precision `param_dtype` before `fully_shard()`, after `model_has_params4bit` detection. Params4bit models are skipped to avoid destroying quantized weights.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

@SunMarc