### PR TITLE
Fix TP-only parallelism config: always include dp_shard in device mesh

### DIFF
--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -236,8 +236,11 @@ class ParallelismConfig:
         )
         if self.dp_dim_names:
             device_mesh[self.dp_dim_names]._flatten("dp")
-        if self.dp_shard_cp_dim_names:
-            device_mesh[self.dp_shard_cp_dim_names]._flatten("dp_shard_cp")
+        # Always create dp_shard_cp submesh from available dims in the mesh
+        # (dp_shard is always present after _get_mesh, even when size == 1)
+        shard_cp_dims = [d for d in ["dp_shard", "cp"] if d in mesh_dim_names]
+        if shard_cp_dims:
+            device_mesh[shard_cp_dims]._flatten("dp_shard_cp")
         if self.dp_cp_dim_names:
             device_mesh[self.dp_cp_dim_names]._flatten("dp_cp")
 
@@ -262,6 +265,11 @@ class ParallelismConfig:
 
         # Build mesh dimensions dictionary
         mesh_dims = {parallelism: self._sizes[parallelism] for parallelism in self.active_mesh_dims}
+
+        # Always include dp_shard for composable parallelism so that FSDP2 has
+        # a valid submesh even when dp_shard_size == 1 (no-op shard).
+        if mesh_dims and "dp_shard" not in mesh_dims:
+            mesh_dims["dp_shard"] = self.dp_shard_size
 
         # Apply canonical ordering
         mesh_order = ["dp_replicate", "dp_shard", "cp", "sp", "tp"]


### PR DESCRIPTION
# What does this PR do?
Fixes a crash when using TP-only parallelism (e.g., [tp_size=8, dp_shard_size=1] with error of:
`KeyError: "Invalid mesh_dim_names ('dp_shard_cp',) specified. Valid mesh_dim_names are ['tp']."`

Root cause: _get_mesh() only includes dimensions with size > 1 in the mesh, so dp_shard is excluded when dp_shard_size=1. However, build_device_mesh() unconditionally tries to create a dp_shard_cp submesh from dp_shard + cp, which fails because neither dimension exists in the mesh.

Fix (two changes):
1. _get_mesh(): Always include dp_shard in the mesh dimensions (even when size == 1) so that FSDP2 has a valid submesh. A size-1 shard dimension is a no-op but keeps the composable API consistent.

2. build_device_mesh(): Build the dp_shard_cp submesh from dimensions actually present in the mesh instead of relying on dp_shard_cp_dim_names which assumes both dimensions exist.

Impact: 
No effect on existing FSDP-only or FSDP+TP configs (dp_shard was already present). Only fixes the TP-only case where dp_shard was missing.