### PR TITLE
Save model-only feature in `save_state`

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3639,6 +3639,8 @@ class Accelerator:
         os.makedirs(output_dir, exist_ok=True)
         logger.info(f"Saving current state to {output_dir}")
 
+        save_model_only = save_model_func_kwargs.pop("save_model_only", False)
+
         if self.distributed_type == DistributedType.XLA:
             # Finish running the previous step before checkpointing
             xm.mark_step()
@@ -3664,23 +3666,25 @@ class Accelerator:
 
         # Save the optimizers taking care of FSDP and DeepSpeed nuances
         optimizers = []
-        if self.distributed_type == DistributedType.FSDP:
-            for i, opt in enumerate(self._optimizers):
-                logger.info("Saving FSDP Optimizer")
-                save_fsdp_optimizer(self.state.fsdp_plugin, self, opt, self._models[i], output_dir, i)
-                logger.info(f"FSDP Optimizer saved to output dir {output_dir}")
-        elif self.distributed_type not in [DistributedType.DEEPSPEED, DistributedType.MEGATRON_LM]:
-            optimizers = self._optimizers
+        if not save_model_only:
+            if self.distributed_type == DistributedType.FSDP:
+                for i, opt in enumerate(self._optimizers):
+                    logger.info("Saving FSDP Optimizer")
+                    save_fsdp_optimizer(self.state.fsdp_plugin, self, opt, self._models[i], output_dir, i)
+                    logger.info(f"FSDP Optimizer saved to output dir {output_dir}")
+            elif self.distributed_type not in [DistributedType.DEEPSPEED, DistributedType.MEGATRON_LM]:
+                optimizers = self._optimizers
 
         # Save the lr schedulers taking care of DeepSpeed nuances
         schedulers = []
-        if self.distributed_type == DistributedType.DEEPSPEED:
-            for i, scheduler in enumerate(self._schedulers):
-                if isinstance(scheduler, DeepSpeedSchedulerWrapper):
-                    continue
-                schedulers.append(scheduler)
-        elif self.distributed_type not in [DistributedType.MEGATRON_LM]:
-            schedulers = self._schedulers
+        if not save_model_only:
+            if self.distributed_type == DistributedType.DEEPSPEED:
+                for i, scheduler in enumerate(self._schedulers):
+                    if isinstance(scheduler, DeepSpeedSchedulerWrapper):
+                        continue
+                    schedulers.append(scheduler)
+            elif self.distributed_type not in [DistributedType.MEGATRON_LM]:
+                schedulers = self._schedulers
 
         # Save the samplers of the dataloaders
         dataloaders = self._dataloaders
@@ -3701,6 +3705,7 @@ class Accelerator:
             self.scaler,
             save_on_each_node=self.project_configuration.save_on_each_node,
             safe_serialization=safe_serialization,
+            save_model_only=save_model_only
         )
         for i, obj in enumerate(self._custom_objects):
             save_custom_state(obj, output_dir, i, save_on_each_node=self.project_configuration.save_on_each_node)

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -71,6 +71,7 @@ def save_accelerator_state(
     scaler: Optional[GradScaler] = None,
     save_on_each_node: bool = False,
     safe_serialization: bool = True,
+    save_model_only: bool = False,
 ):
     """
     Saves the current states of the models, optimizers, scaler, and RNG generators to a given directory.
@@ -113,6 +114,10 @@ def save_accelerator_state(
         output_model_file = output_dir.joinpath(weights_name)
         save(state, output_model_file, save_on_each_node=save_on_each_node, safe_serialization=safe_serialization)
         logger.info(f"Model weights saved in {output_model_file}")
+
+    if save_model_only:
+        return output_dir
+
     # Optimizer states
     for i, opt in enumerate(optimizers):
         state = opt.state_dict()

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -297,6 +297,21 @@ class AcceleratorTester(AccelerateTestCase):
             assert abs(model_signature - get_signature(model)) < 1e-3
 
     @parameterized.expand([True, False], name_func=parameterized_custom_name_func)
+    def test_save_state_model_only(self, use_safetensors):
+        accelerator = Accelerator()
+        model = torch.nn.Linear(10, 10)
+        model = accelerator.prepare(model)
+
+        model_signature = get_signature(model)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            accelerator.save_state(tmpdirname, safe_serialization=use_safetensors, save_model_only=True)
+            # make sure only the model was saved
+            assert os.listdir(tmpdirname) == ['model.safetensors' if use_safetensors else 'pytorch_model.bin']
+            # make sure loaded weights match
+            load_checkpoint_in_model(model, tmpdirname)
+            assert abs(model_signature - get_signature(model)) < 1e-3
+
+    @parameterized.expand([True, False], name_func=parameterized_custom_name_func)
     def test_save_sharded_model(self, use_safetensors):
         accelerator = Accelerator()
         inputs = torch.randn(3, 3)


### PR DESCRIPTION
# What does this PR do?

Add   _save-model-only_ feature to `save_state`.

By leveraging the existing `save_state` implementation -which already correctly handles complex sub-cases like `FSDP`, `DeepSpeed`, and` Multi-GPU`- we can extend it to save only the model weights. The current `save_model` function does not appear to handle these cases (and more) efficiently; for instance, using `save_model` ([link](https://github.com/huggingface/accelerate/blob/0d8ca1a44f85a35df62499eb2174608e0f3473f8/src/accelerate/accelerator.py#L3423)) in anything other than _single-process_  vanilla runs can cause bugs.

Additionally, it feels more natural to have a unified function for both state and model use cases, rather than explicitly passing `model: torch.nn.Module` as required by the current `save_model` implementation.

Let me know if you agree with this approach. If so, I will proceed with adding the documentation and can discuss the future of the existing `save_model` function.

resolves #3990

## Benchmark 
I conducted experiments where the `model.safetensors` is `12G` and `optimizer.bin` is `22G` and the `save_state` time was reduced by `70.44%`  (save all: `393.67 sec` against model_only: `116.35 sec`).

 

## Who can review?

 
- Core parts of the library: @BenjaminBossan @SunMarc
 