### PR TITLE
chore: update doc-builder workflow SHA

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
     with:
       package_name: accelerate
     secrets:

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main


### PR DESCRIPTION
Update pinned SHA of the shared `upload_pr_documentation` workflow from doc-builder to include the migration to HF bucket storage for PR doc previews.

New upload pipeline pushes PR docs to `hf://buckets/hf-doc-build/doc-dev` (via `hf sync`) instead of the legacy zip → dataset flow.

This is part of the EFS → bucket migration for moon-ci-docs.