### PR TITLE
[Checkpointing] Persist DataLoaderShard epoch counter across save/load_state

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -143,6 +143,18 @@ def save_accelerator_state(
             output_dataloader_state_dict_file = output_dir.joinpath(dataloader_state_dict_name)
             state_dict = dataloader.state_dict()
             torch.save(state_dict, output_dataloader_state_dict_file)
+        # Persist the epoch counter so that deterministic per-epoch shuffles
+        # (e.g. SeedableRandomSampler) resume with the correct seed rather
+        # than replaying the shuffle order from epoch 0.
+        if hasattr(dataloader, "iteration"):
+            iteration_name = "dl_iteration.bin" if i == 0 else f"dl_iteration_{i}.bin"
+            output_iteration_file = output_dir.joinpath(iteration_name)
+            save(
+                dataloader.iteration,
+                output_iteration_file,
+                save_on_each_node=save_on_each_node,
+                safe_serialization=False,
+            )
         logger.info(f"Sampler state for dataloader {i} saved in {output_sampler_file}")
 
     # GradScaler state
@@ -278,6 +290,18 @@ def load_accelerator_state(
             if input_dataloader_state_dict_file.exists():
                 state_dict = load(input_dataloader_state_dict_file, **load_kwargs)
                 dataloader.load_state_dict(state_dict)
+        # Restore the epoch counter so that deterministic per-epoch shuffles
+        # (e.g. SeedableRandomSampler) resume with the correct seed rather
+        # than replaying the shuffle order from epoch 0.
+        if hasattr(dataloader, "iteration"):
+            iteration_name = "dl_iteration.bin" if i == 0 else f"dl_iteration_{i}.bin"
+            input_iteration_file = input_dir.joinpath(iteration_name)
+            if input_iteration_file.exists():
+                iteration = load(input_iteration_file, **load_kwargs)
+                if hasattr(dataloader, "set_epoch"):
+                    dataloader.set_epoch(iteration)
+                else:
+                    dataloader.iteration = iteration
     logger.info("All dataloader sampler states loaded successfully")
 
     # GradScaler state

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -386,6 +386,76 @@ class CheckpointTest(AccelerateTestCase):
         with patch_environment(**env_kwargs):
             execute_subprocess_async(cmd)
 
+    def test_dataloader_iteration_counter_is_persisted(self):
+        # Regression test for https://github.com/huggingface/accelerate/issues/3996
+        # The per-epoch `iteration` counter on DataLoaderShard / DataLoaderDispatcher is
+        # what seeds SeedableRandomSampler for the next epoch. If the counter is not
+        # round-tripped through save_state/load_state the resumed run replays the
+        # epoch-0 shuffle order, which breaks deterministic resumption.
+        from accelerate.checkpointing import load_accelerator_state, save_accelerator_state
+
+        class _FakeDataLoader:
+            def __init__(self, iteration):
+                self.iteration = iteration
+                self.dataset = object()  # not an IterableDatasetShard
+
+            def set_epoch(self, epoch):
+                self.iteration = epoch
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            saved = _FakeDataLoader(iteration=7)
+            save_accelerator_state(
+                output_dir=tmpdir,
+                model_states=[],
+                optimizers=[],
+                schedulers=[],
+                dataloaders=[saved],
+                process_index=0,
+                step=0,
+                safe_serialization=self.use_safetensors,
+            )
+            assert os.path.exists(os.path.join(tmpdir, "dl_iteration.bin"))
+
+            restored = _FakeDataLoader(iteration=0)
+            load_accelerator_state(
+                input_dir=tmpdir,
+                models=[],
+                optimizers=[],
+                schedulers=[],
+                dataloaders=[restored],
+                process_index=0,
+            )
+            assert restored.iteration == 7
+
+    def test_load_state_tolerates_missing_iteration_file(self):
+        # Backward compatibility: checkpoints written by older accelerate versions
+        # do not contain dl_iteration.bin. Loading must not raise and the
+        # dataloader iteration should be left at its initial value.
+        from accelerate.checkpointing import load_accelerator_state
+
+        class _FakeDataLoader:
+            def __init__(self):
+                self.iteration = 0
+                self.dataset = object()
+
+            def set_epoch(self, epoch):
+                self.iteration = epoch
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Write the RNG state file so load_accelerator_state's try/except
+            # for random states does not mask other errors.
+            torch.save({"step": 0}, os.path.join(tmpdir, "random_states_0.pkl"))
+            dl = _FakeDataLoader()
+            load_accelerator_state(
+                input_dir=tmpdir,
+                models=[],
+                optimizers=[],
+                schedulers=[],
+                dataloaders=[dl],
+                process_index=0,
+            )
+            assert dl.iteration == 0
+
 
 if __name__ == "__main__":
     use_safetensors = os.environ.get("USE_SAFETENSORS", "False") == "True"


### PR DESCRIPTION
## What does this PR do?

Fixes #3996.

`accelerator.save_state` / `accelerator.load_state` previously round-tripped
samplers and (when `use_stateful_dataloader=True`) the dataloader `state_dict`,
but did not persist the per-epoch `iteration` counter on
`DataLoaderShard` / `DataLoaderDispatcher`.

That counter is what seeds `SeedableRandomSampler` on the next epoch (via
`set_epoch()` → `sampler.set_epoch(epoch)` → deterministic shuffle seed), so a
resumed run replayed the epoch-0 shuffle order instead of the correct epoch's
permutation. This reproduces exactly the "shuffle sequence replays from
iteration 0" behavior reported in the issue with `use_seedable_sampler=True`.

### Fix

Extend `save_accelerator_state` / `load_accelerator_state` to write a small
`dl_iteration.bin` sibling file per dataloader when the dataloader exposes an
`iteration` attribute, and restore it on load via `set_epoch` so samplers and
`IterableDataset.set_epoch` hooks stay in sync.

* Save path is unconditional on `hasattr(dataloader, "iteration")` — so it also
  covers the non-stateful path (`use_stateful_dataloader=False`).
* Load path checks `input_iteration_file.exists()`, keeping backward
  compatibility with checkpoints produced by older accelerate versions.
* Restoration uses `set_epoch(iteration)` rather than direct assignment so
  downstream samplers / datasets receive the epoch change.

### Tests

Added unit tests to `tests/test_state_checkpointing.py`:

* `test_dataloader_iteration_counter_is_persisted` — round-trips `iteration` through save/load.
* `test_load_state_tolerates_missing_iteration_file` — backward compatibility.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@muellerzr @BenjaminBossan