### PR TITLE
Add `minimum_batch_size` parameter and OOM retry logging to `find_executable_batch_size`

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -20,6 +20,7 @@ A collection of utilities for ensuring that training can always occur. Heavily i
 import functools
 import gc
 import inspect
+import logging
 from typing import Optional
 
 import torch
@@ -116,9 +117,13 @@ def should_reduce_batch_size(exception: Exception) -> bool:
     return False
 
 
+logger = logging.getLogger(__name__)
+
+
 def find_executable_batch_size(
     function: Optional[callable] = None,
     starting_batch_size: int = 128,
+    minimum_batch_size: int = 1,
     reduce_batch_size_fn: Optional[callable] = None,
 ):
     """
@@ -132,23 +137,30 @@ def find_executable_batch_size(
             A function to wrap
         starting_batch_size (`int`, *optional*):
             The batch size to try and fit into memory
+        minimum_batch_size (`int`, *optional*, defaults to 1):
+            The minimum batch size to try. If the batch size is reduced below this value, a `RuntimeError` is raised
+            immediately rather than continuing to reduce toward zero.
 
     Example:
 
-    ```python
+```python
     >>> from accelerate.utils import find_executable_batch_size
 
 
-    >>> @find_executable_batch_size(starting_batch_size=128)
+    >>> @find_executable_batch_size(starting_batch_size=128, minimum_batch_size=8)
     ... def train(batch_size, model, optimizer):
     ...     ...
 
 
     >>> train(model, optimizer)
-    ```
+```
     """
     if function is None:
-        return functools.partial(find_executable_batch_size, starting_batch_size=starting_batch_size)
+        return functools.partial(
+            find_executable_batch_size,
+            starting_batch_size=starting_batch_size,
+            minimum_batch_size=minimum_batch_size,
+        )
 
     batch_size = starting_batch_size
     if reduce_batch_size_fn is None:
@@ -172,12 +184,20 @@ def find_executable_batch_size(
         while True:
             if batch_size == 0:
                 raise RuntimeError("No executable batch size found, reached zero.")
+            if batch_size < minimum_batch_size:
+                raise RuntimeError(
+                    f"No executable batch size found, minimum batch size ({minimum_batch_size}) reached."
+                )
             try:
                 return function(batch_size, *args, **kwargs)
             except Exception as e:
                 if should_reduce_batch_size(e):
                     clear_device_cache(garbage_collection=True)
                     batch_size = reduce_batch_size_fn()
+                    logger.warning(
+                        f"Batch size {batch_size * (10 // 9 + 1)} failed with OOM. "  # approximate previous
+                        f"Retrying with batch size {batch_size}."
+                    )
                 else:
                     raise
 

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -166,6 +166,33 @@ class MemoryTest(unittest.TestCase):
             mock_training_loop_function()
             assert "Oops, we had an error!" in cm.exception.args[0]
 
+    def test_minimum_batch_size(self):
+        @find_executable_batch_size(starting_batch_size=128, minimum_batch_size=32)
+        def mock_training_loop_function(batch_size):
+            if batch_size > 8:
+                raise_fake_out_of_memory()
+
+        with self.assertRaises(RuntimeError) as cm:
+            mock_training_loop_function()
+        assert "minimum batch size (32) reached" in cm.exception.args[0]
+
+    def test_minimum_batch_size_logging(self):
+        import logging
+
+        with self.assertLogs("accelerate.utils.memory", level=logging.WARNING) as log_cm:
+
+            @find_executable_batch_size(starting_batch_size=64, minimum_batch_size=32)
+            def mock_training_loop_function(batch_size):
+                if batch_size > 8:
+                    raise_fake_out_of_memory()
+
+            try:
+                mock_training_loop_function()
+            except RuntimeError:
+                pass
+
+        assert any("Retrying with batch size" in msg for msg in log_cm.output)
+
     @require_non_cpu
     @require_non_torch_xla
     def test_release_memory(self):


### PR DESCRIPTION
# What does this PR do?

Extends `find_executable_batch_size` in `utils/memory.py` with two
practical improvements for production training runs:

1. **`minimum_batch_size` parameter** — the current implementation only
   stops when `batch_size` hits exactly `0`, which means a user who knows
   their model cannot meaningfully train below e.g. batch size 8 has no
   way to express that floor. The loop also risks an infinite cycle if a
   custom `reduce_batch_size_fn` ever stalls above zero. The new parameter
   (default `1`, fully backward-compatible) raises a clear `RuntimeError`
   the moment the batch size would cross the floor, instead of grinding
   silently to zero.

2. **OOM retry logging** — every retry currently happens in total silence,
   making distributed jobs appear frozen and giving operators no signal
   about progress. A `logging.warning` is emitted on each OOM reduction,
   visible via Python's standard logging machinery with no overhead on the
   success path.

Both changes are covered by new unit tests in `tests/test_memory_utils.py`.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?

## Who can review?

@BenjaminBossan @SunMarc