### PR TITLE
fix(checkpointing): save/restore SeedableRandomSampler for map-style datasets

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -131,13 +131,12 @@ def save_accelerator_state(
     for i, dataloader in enumerate(dataloaders):
         sampler_name = f"{SAMPLER_NAME}.bin" if i == 0 else f"{SAMPLER_NAME}_{i}.bin"
         output_sampler_file = output_dir.joinpath(sampler_name)
-        # Only save if we have our custom sampler
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
+        # Save SeedableRandomSampler state for both IterableDataset and map-style datasets
+        from .data_loader import SeedableRandomSampler
 
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
+        sampler = dataloader.get_sampler()
+        if isinstance(sampler, SeedableRandomSampler):
+            save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             output_dataloader_state_dict_file = output_dir.joinpath(dataloader_state_dict_name)
@@ -265,13 +264,12 @@ def load_accelerator_state(
     for i, dataloader in enumerate(dataloaders):
         sampler_name = f"{SAMPLER_NAME}.bin" if i == 0 else f"{SAMPLER_NAME}_{i}.bin"
         input_sampler_file = input_dir.joinpath(sampler_name)
-        # Only load if we have our custom sampler
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
+        # Load SeedableRandomSampler state for both IterableDataset and map-style datasets
+        from .data_loader import SeedableRandomSampler
 
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                sampler = dataloader.set_sampler(load(input_sampler_file))
+        sampler = dataloader.get_sampler()
+        if isinstance(sampler, SeedableRandomSampler) and input_sampler_file.exists():
+            sampler = dataloader.set_sampler(load(input_sampler_file))
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)


### PR DESCRIPTION
## Problem

Fixes #3996.

When using `use_seedable_sampler=True` with a **map-style** (non-iterable) dataset, `save_state()` / `load_state()` silently drops the `SeedableRandomSampler.epoch` counter. On resume the counter resets to 0, so the sampler re-derives the same seed sequence (`initial_seed + 0`, `initial_seed + 1`, …) that was already used before the checkpoint — the model trains on the exact same shuffle order it already saw.

## Root cause

`save_state()` and `load_state()` both gate sampler persistence on:

```python
if isinstance(dataloader.dataset, IterableDatasetShard):
    ...
```

`SeedableRandomSampler` is attached to **both** iterable and map-style dataloaders (when `use_seedable_sampler=True`), but the guard prevents it from being saved for the map-style case.

## Fix

Remove the `IterableDatasetShard` guard and persist any `SeedableRandomSampler`, regardless of dataset type. On the load side, add an `input_sampler_file.exists()` guard for backwards-compat with older checkpoints that do not contain a sampler file.

```diff
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
-
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                save(sampler, output_sampler_file, ...)
+        from .data_loader import SeedableRandomSampler
+
+        sampler = dataloader.get_sampler()
+        if isinstance(sampler, SeedableRandomSampler):
+            save(sampler, output_sampler_file, ...)
```

The fix is identical in shape for both `save_state` and `load_state`; the load path additionally checks `input_sampler_file.exists()` to stay compatible with checkpoints produced before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)