### PR TITLE
fix(modeling): include named_buffers in module split expansion for infer_auto_device_map

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1246,7 +1246,7 @@ def fallback_allocate(
             continue
 
         # split is possible, add the children to the list of modules to search
-        modules_children = list(module.named_parameters(recurse=False)) + modules_children
+        modules_children = list(module.named_parameters(recurse=False)) + list(module.named_buffers(recurse=False)) + modules_children
         modules_to_search = [(f"{name}.{n}", v) for n, v in modules_children] + modules_to_search
 
     if not module_found:
@@ -1261,7 +1261,7 @@ def fallback_allocate(
         if parent_name in current_names:
             parent_module_idx = current_names.index(parent_name)
             _, parent_module = modules[parent_module_idx]
-            module_children = list(parent_module.named_parameters(recurse=False)) + list(
+            module_children = list(parent_module.named_parameters(recurse=False)) + list(parent_module.named_buffers(recurse=False)) + list(
                 parent_module.named_children()
             )
             modules = (
@@ -1462,7 +1462,7 @@ def infer_auto_device_map(
 
                 if verbose:
                     print(f"Splitting {tied_module_name}.")
-                tied_module_children = list(tied_module.named_parameters(recurse=False)) + tied_module_children
+                tied_module_children = list(tied_module.named_parameters(recurse=False)) + list(tied_module.named_buffers(recurse=False)) + tied_module_children
                 tied_module_children = [(f"{tied_module_name}.{n}", v) for n, v in tied_module_children]
                 tied_module_index = [i for i, (n, _) in enumerate(modules_to_treat) if n == tied_module_name][0]
 
@@ -1510,7 +1510,7 @@ def infer_auto_device_map(
                 # -> split, we replace the module studied by its children + parameters
                 if verbose:
                     print(f"Splitting {name}.")
-                modules_children = list(module.named_parameters(recurse=False)) + modules_children
+                modules_children = list(module.named_parameters(recurse=False)) + list(module.named_buffers(recurse=False)) + modules_children
                 modules_to_treat = [(f"{name}.{n}", v) for n, v in modules_children] + modules_to_treat
                 # Update the max layer size.
                 max_layer_size, max_layer_names = get_max_layer_size(


### PR DESCRIPTION
## Problem

 splits modules that don't fit on one device by expanding them into `named_parameters(recurse=False) + named_children()`. But it **omits `named_buffers(recurse=False)`**, so any `register_buffer` tensor on a layer never gets assigned a device.

`check_device_map` then raises:
```
ValueError: The device_map provided does not give any device for the following parameters:
  model.language_model.layers.8.layer_scalar
```

This breaks multi-GPU loading of **Gemma-4** (google/gemma-4-E4B-it), whose `Gemma4DecoderLayer` registers `layer_scalar` as a buffer:
```python
self.register_buffer("layer_scalar", torch.ones(1))  # transformers line 1347
```

Closes #4014

## Fix

Add `list(module.named_buffers(recurse=False))` in the **four** module-expansion sites inside `_infer_auto_device_map` / `fallback_allocate`:

| Site | Function |
|---|---|
| `fallback_allocate` module-split | line 1249 |
| `fallback_allocate` parent-expansion | line 1264 |
| `infer_auto_device_map` tied-module split | line 1465 |
| `infer_auto_device_map` main-module split | line 1513 |

Buffers are already included in `compute_module_sizes` (via `named_module_tensors`) and in the initial `modules_to_treat` construction — this patch makes the split-expansion paths consistent with both.

## Repro (before fix)

```python
from accelerate import infer_auto_device_map
from transformers import AutoConfig, AutoModelForCausalLM
from accelerate import init_empty_weights

config = AutoConfig.from_pretrained("google/gemma-4-E4B-it")
with init_empty_weights():
    model = AutoModelForCausalLM.from_config(config)

memalloc = {"cpu": "8GiB", 0: "48GiB", 1: "48GiB", 2: "0GiB", 3: "0GiB"}
from accelerate import get_balanced_memory
balanced = get_balanced_memory(model, max_memory=memalloc)
device_map = infer_auto_device_map(model, max_memory=balanced)
# -> ValueError: The device_map provided does not give any device for the
#    following parameters: model.language_model.layers.8.layer_scalar
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)