### PR TITLE
Fix fsdp2 load full state dict dtype mismatch

### DIFF
--- a/src/accelerate/test_utils/scripts/external_deps/test_performance.py
+++ b/src/accelerate/test_utils/scripts/external_deps/test_performance.py
@@ -105,6 +105,8 @@ def training_function(config, args):
         model_kwargs["tp_plan"] = args.tp_plan
     if args.tp_size is not None:
         model_kwargs["tp_size"] = args.tp_size
+    if args.model_dtype is not None:
+        model_kwargs["torch_dtype"] = getattr(torch, args.model_dtype)
 
     # Instantiate the model (we build the model here so that the seed also control new weights initialization)
     model = AutoModelForSequenceClassification.from_pretrained(model_name, return_dict=True, **model_kwargs)
@@ -289,6 +291,13 @@ def main():
         type=int,
         default=None,
         help="TP size to be used to shard the model",
+    )
+    parser.add_argument(
+        "--model_dtype",
+        type=str,
+        default=None,
+        choices=["bfloat16", "float16", "float32"],
+        help="Optional dtype to load the model in (defaults to the checkpoint dtype).",
     )
     args = parser.parse_args()
     config = {"lr": 2e-5, "num_epochs": args.num_epochs, "seed": 42, "batch_size": 16}

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -713,7 +713,7 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
                 upcasted_params.append(name)
                 param.data = param.data.to(torch.float32)
         if accelerator.is_main_process and upcasted_params:
-            warnings.warn(
+            logger.info(
                 "FSDP upcast of low precision parameters to fp32 (since mixed_precision != 'no') may affect the precision of model checkpoints. "
                 f"This effects {len(upcasted_params)} parameters: {upcasted_params}..."
             )

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -664,7 +664,6 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
 
     fsdp2_plugin.set_auto_wrap_policy(model)
 
-    original_sd = model.state_dict()
     mesh = getattr(accelerator, "torch_device_mesh", None)
 
     fsdp2_kwargs = {
@@ -718,6 +717,9 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
                 "FSDP upcast of low precision parameters to fp32 (since mixed_precision != 'no') may affect the precision of model checkpoints. "
                 f"This effects {len(upcasted_params)} parameters: {upcasted_params}..."
             )
+
+    # Capture after upcast so dtypes match what `fully_shard` will produce.
+    original_sd = model.state_dict()
 
     if fsdp2_plugin.cpu_ram_efficient_loading and not model_has_params4bit:
         # Context: `fully_shard` moves the model to GPU if it was on CPU, however it can also be on `meta` and then it stays there even after `fully_shard`

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -687,6 +687,32 @@ class FSDPIntegrationTest(TempDirTestCase):
 
         self.current_fsdp_version = 1
 
+    @require_fsdp2
+    def test_fsdp2_mixed_precision_bf16_with_bf16_model_loaded(self):
+        """FSDP2 + `mixed_precision=bf16` with the model loaded in bf16."""
+        cmd = get_launch_command(
+            num_processes=2,
+            num_machines=1,
+            machine_rank=0,
+            use_fsdp=True,
+            fsdp_version=2,
+            mixed_precision="bf16",
+        )
+        cmd.extend(
+            [
+                "--fsdp_reshard_after_forward=true",
+                "--fsdp_auto_wrap_policy=TRANSFORMER_BASED_WRAP",
+                "--fsdp_transformer_layer_cls_to_wrap=BertLayer",
+                "--fsdp_cpu_ram_efficient_loading=true",
+                str(self.test_scripts_folder / "test_performance.py"),
+                f"--output_dir={self.tmpdir}",
+                "--num_epochs=1",
+                "--model_dtype=bfloat16",
+            ]
+        )
+        # If the regression returns, this hangs forever — keep the test bounded.
+        execute_subprocess_async(cmd, timeout=180)
+
     @require_fp16
     def test_performance(self):
         self.test_file_path = self.test_scripts_folder / "test_performance.py"


### PR DESCRIPTION
# What does this PR do?

This PR fixes a regression due to upcasting the params earlier when using mixed precision + fsdp_cpu_ram_efficient_loading=true. The loading of the model was hanging since there were a state dict mistmatch. 