### PR TITLE
Fix region compilation fsdpv2

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -129,7 +129,7 @@ from .utils.constants import (
     SCALER_NAME,
 )
 from .utils.modeling import get_state_dict_offloaded_model
-from .utils.other import compile_regions, compile_regions_deepspeed, is_compiled_module
+from .utils.other import compile_regions, compile_regions_deepspeed, compile_regions_fsdp2, is_compiled_module
 
 
 if is_deepspeed_available():
@@ -1697,10 +1697,9 @@ class Accelerator:
             model = fsdp2_apply_ac(self, model)
 
         # Apply compile if needed, has to be *after* applying AC
-        # Copied from: `accelerator.prepare_model` ~ L1804
         if self.state.dynamo_plugin.backend != DynamoBackend.NO and not is_compiled_module(model):
             if self.state.dynamo_plugin.use_regional_compilation:
-                model = compile_regions(model, **self.state.dynamo_plugin.to_kwargs())
+                model = compile_regions_fsdp2(model, **self.state.dynamo_plugin.to_kwargs())
             else:
                 model = torch.compile(model, **self.state.dynamo_plugin.to_kwargs())
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1699,6 +1699,11 @@ class Accelerator:
         # Apply compile if needed, has to be *after* applying AC
         if self.state.dynamo_plugin.backend != DynamoBackend.NO and not is_compiled_module(model):
             if self.state.dynamo_plugin.use_regional_compilation:
+                # Match torchtitan's per-block compile recipe: needed for MoE token-choice dispatch
+                # (data-dependent dynamic shapes) and to keep the AC + compile boundary consistent
+                # by skipping replay of forward python side effects in backward.
+                torch._dynamo.config.capture_scalar_outputs = True
+                torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
                 model = compile_regions_fsdp2(model, **self.state.dynamo_plugin.to_kwargs())
             else:
                 model = torch.compile(model, **self.state.dynamo_plugin.to_kwargs())

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1265,6 +1265,8 @@ def _validate_launch_command(args):
                             key = "fsdp_" + key
                         elif name == "fp8_config" and not key.startswith("fp8"):
                             key = "fp8_" + key
+                        elif name == "dynamo_config" and not key.startswith("dynamo_"):
+                            key = "dynamo_" + key
                         if hasattr(args, "nondefault") and key not in args.nondefault:
                             setattr(args, key, value)
                 elif (

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -278,6 +278,7 @@ from .other import (
     clean_state_dict_for_safetensors,
     compile_regions,
     compile_regions_deepspeed,
+    compile_regions_fsdp2,
     convert_bytes,
     extract_model_from_parallel,
     get_module_children_bottom_up,

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -214,12 +214,6 @@ def compile_regions_fsdp2(module: torch.nn.Module, **compile_kwargs) -> torch.nn
         **compile_kwargs:
             Additional keyword arguments to pass to `module.compile()`.
     """
-    # Match torchtitan's per-block compile recipe: needed for MoE token-choice dispatch
-    # (data-dependent dynamic shapes) and to keep the AC + compile boundary consistent
-    # by skipping replay of forward python side effects in backward.
-    torch._dynamo.config.capture_scalar_outputs = True
-    torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
-
     if is_repeated_blocks(module):
         for submodule in module:
             submodule.compile(**compile_kwargs)

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -199,6 +199,32 @@ def compile_regions_deepspeed(module: torch.nn.Module, **compile_kwargs):
         module.compile(**compile_kwargs)
 
 
+def compile_regions_fsdp2(module: torch.nn.Module, **compile_kwargs) -> torch.nn.Module:
+    """
+    Like `compile_regions`, but uses the in-place `module.compile()` instead of `torch.compile(module)`.
+
+    Needed for the FSDP2 prepare path: `torch.compile(module)` returns an `OptimizedModule` whose `__call__`
+    bypasses `nn.Module._call_impl`, so forward/pre hooks added later by `fully_shard` never fire and per-layer
+    all-gather/reshard is lost. The in-place `module.compile()` keeps `_call_impl` (and its runtime hook check)
+    on the call path, so FSDP hooks installed afterwards still run.
+
+    Args:
+        module (`torch.nn.Module`):
+            The model to compile.
+        **compile_kwargs:
+            Additional keyword arguments to pass to `module.compile()`.
+    """
+    if is_repeated_blocks(module):
+        for submodule in module:
+            submodule.compile(**compile_kwargs)
+    elif has_repeated_blocks(module):
+        for child in module.children():
+            compile_regions_fsdp2(child, **compile_kwargs)
+    else:  # leaf node
+        module.compile(**compile_kwargs)
+    return module
+
+
 def model_has_dtensor(model: torch.nn.Module) -> bool:
     """
     Check if the model has DTensor parameters.

--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -214,6 +214,12 @@ def compile_regions_fsdp2(module: torch.nn.Module, **compile_kwargs) -> torch.nn
         **compile_kwargs:
             Additional keyword arguments to pass to `module.compile()`.
     """
+    # Match torchtitan's per-block compile recipe: needed for MoE token-choice dispatch
+    # (data-dependent dynamic shapes) and to keep the AC + compile boundary consistent
+    # by skipping replay of forward python side effects in backward.
+    torch._dynamo.config.capture_scalar_outputs = True
+    torch._dynamo.config.skip_fwd_side_effects_in_bwd_under_checkpoint = True
+
     if is_repeated_blocks(module):
         for submodule in module:
             submodule.compile(**compile_kwargs)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -643,6 +643,49 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         finally:
             model[0].weight.__class__ = original_class
 
+    def test_compile_regions_fsdp2_preserves_block_class(self):
+        """`compile_regions_fsdp2` must use in-place `module.compile()` so module classes are preserved.
+
+        `fsdp2_prepare_model`'s auto_wrap_policy uses `isinstance(module, transformer_cls_to_wrap)`. If
+        `OptimizedModule`-wrapped blocks were used (as `compile_regions` does), the isinstance check would
+        miss them and only the root model would get FSDP-sharded — losing per-layer all-gather/compute overlap.
+        """
+        from accelerate.utils import compile_regions_fsdp2
+
+        class Block(torch.nn.Module):
+            def __init__(self, dim):
+                super().__init__()
+                self.linear = torch.nn.Linear(dim, dim)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        class Model(torch.nn.Module):
+            def __init__(self, dim, n_blocks):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([Block(dim) for _ in range(n_blocks)])
+                self.head = torch.nn.Linear(dim, dim)
+
+            def forward(self, x):
+                for layer in self.layers:
+                    x = layer(x)
+                return self.head(x)
+
+        model = Model(dim=8, n_blocks=4)
+        block_cls_before = type(model.layers[0])
+
+        result = compile_regions_fsdp2(model, backend="inductor")
+
+        # In-place: same Python object returned, no wrapper
+        assert result is model
+        # Class identity preserved on each repeated block (the FSDP2 auto_wrap invariant)
+        assert all(type(b) is block_cls_before for b in model.layers)
+        assert all(isinstance(b, Block) for b in model.layers)
+        assert not any(isinstance(b, torch._dynamo.eval_frame.OptimizedModule) for b in model.layers)
+        # And each block + non-repeated leaf is compiled in-place
+        assert all(getattr(b, "_compiled_call_impl", None) is not None for b in model.layers)
+        assert getattr(model.head, "_compiled_call_impl", None) is not None
+
 
 @run_first
 # Skip this test when TorchXLA is available because accelerate.launch does not support TorchXLA FSDP.


### PR DESCRIPTION
# What does this PR do?

This PR fixes region compilation with FSDPv2. `compile_regions` rebuilds each repeated block as `torch.compile(submodule)` → returns an `OptimizedModule` wrapper. That wrapper's __call__ bypasses `nn.Module._call_impl`, so the forward/pre hooks `fully_shard` adds afterwards never fire → no per-layer all-gather/reshard → no overlap. Basically the same thing we did for deepspeed.

Compiling the whole model doesn't lead to speed-up, maybe we should do this as the default path ?