### PR TITLE
Fix duplicate-word typos in user-facing strings

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -846,7 +846,7 @@ def get_cluster_input():
                         default=0,
                     )
                     fp8_config["override_linear_precision"] = _ask_field(
-                        "Do you want to to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision? [yes/NO]: ",
+                        "Do you want to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision? [yes/NO]: ",
                         _convert_yes_no_to_bool,
                         default=False,
                     )

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -262,7 +262,7 @@ def get_quantized_model_device_map(
                     )
                 else:
                     logger.info(
-                        "Some modules are are offloaded to the CPU or the disk. Note that these modules will be converted to 8-bit"
+                        "Some modules are offloaded to the CPU or the disk. Note that these modules will be converted to 8-bit"
                     )
         del device_map_without_some_modules
     return device_map


### PR DESCRIPTION
## What does this PR do?

Fixes two duplicate-word typos in user-visible strings:

1. **`src/accelerate/utils/bnb.py`** (line 265) — `logger.info` message:
   - Before: `"Some modules are are offloaded to the CPU or the disk..."`
   - After: `"Some modules are offloaded to the CPU or the disk..."`

2. **`src/accelerate/commands/config/cluster.py`** (line 849) — interactive `accelerate config` prompt:
   - Before: `"Do you want to to execute \`fprop\`, \`dgrad\`, and \`wgrad\` GEMMS in higher precision? [yes/NO]: "`
   - After: `"Do you want to execute \`fprop\`, \`dgrad\`, and \`wgrad\` GEMMS in higher precision? [yes/NO]: "`

Both are visible to users running `accelerate` — first via 8-bit quantization log output, second via the interactive FP8 config wizard.

## Why

Tiny polish — the second one in particular is a question users see when configuring FP8 training, so cleaning it up improves perceived quality of the CLI.

## How to test

Both are pure string-literal edits. No behavioral change.

```bash
grep -n "are are\|to to" src/accelerate/utils/bnb.py src/accelerate/commands/config/cluster.py
# (should return nothing)
```

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? N/A — typo fix
- [x] Did you make sure to update the documentation with your changes? N/A — only fixed strings
- [x] Did you write any new necessary tests? N/A — no behavioral change

## Who can review?

Anyone in the community is free to review. Tagging @muellerzr and @SunMarc as recent maintainers of these areas.