### PR TITLE
fix(tracking): default step=None on tracker.log and accept extra kwargs in MLflowTracker

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -144,7 +144,6 @@ class GeneralTracker:
         Lazy initialization of the tracker inside Accelerator to avoid initializing PartialState before
         InitProcessGroupKwargs.
         """
-        pass
 
     def store_init_configuration(self, values: dict):
         """
@@ -156,9 +155,8 @@ class GeneralTracker:
                 Values to be stored as initial hyperparameters as key-value pairs. The values need to have type `bool`,
                 `str`, `float`, `int`, or `None`.
         """
-        pass
 
-    def log(self, values: dict, step: Optional[int], **kwargs):
+    def log(self, values: dict, step: Optional[int] = None, **kwargs):
         """
         Logs `values` to the current run. Base `log` implementations of a tracking API should go in here, along with
         special behavior for the `step parameter.
@@ -169,14 +167,12 @@ class GeneralTracker:
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
         """
-        pass
 
     def finish(self):
         """
         Should run any finalizing functions within the tracking API. If the API should not have one, just don't
         overwrite that method.
         """
-        pass
 
 
 class TensorBoardTracker(GeneralTracker):
@@ -269,7 +265,7 @@ class TensorBoardTracker(GeneralTracker):
         logger.debug("Successfully logged to TensorBoard")
 
     @on_main_process
-    def log_images(self, values: dict, step: Optional[int], **kwargs):
+    def log_images(self, values: dict, step: Optional[int] = None, **kwargs):
         """
         Logs `images` to the current run.
 
@@ -637,7 +633,7 @@ class AimTracker(GeneralTracker):
         self.writer["hparams"] = values
 
     @on_main_process
-    def log(self, values: dict, step: Optional[int], **kwargs):
+    def log(self, values: dict, step: Optional[int] = None, **kwargs):
         """
         Logs `values` to the current run.
 
@@ -813,7 +809,7 @@ class MLflowTracker(GeneralTracker):
         logger.debug("Stored initial configuration hyperparameters to MLflow")
 
     @on_main_process
-    def log(self, values: dict, step: Optional[int]):
+    def log(self, values: dict, step: Optional[int] = None, **kwargs):
         """
         Logs `values` to the current run.
 
@@ -822,6 +818,8 @@ class MLflowTracker(GeneralTracker):
                 Values to be logged as key-value pairs.
             step (`int`, *optional*):
                 The run step. If included, the log will be affiliated with this step.
+            kwargs:
+                Additional key word arguments passed along to the `mlflow.log_metrics` method.
         """
         metrics = {}
         for k, v in values.items():
@@ -834,7 +832,7 @@ class MLflowTracker(GeneralTracker):
                 )
         import mlflow
 
-        mlflow.log_metrics(metrics, step=step)
+        mlflow.log_metrics(metrics, step=step, **kwargs)
         logger.debug("Successfully logged to mlflow")
 
     @on_main_process

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -75,7 +75,7 @@ if is_comet_ml_available():
 if is_tensorboard_available():
     import struct
 
-    import tensorboard.compat.proto.event_pb2 as event_pb2
+    from tensorboard.compat.proto import event_pb2
 
 if is_dvclive_available():
     from dvclive.plots.metric import Metric
@@ -321,6 +321,28 @@ class MLflowTrackingTest(unittest.TestCase):
                 for artifact in mlflow.artifacts.list_artifacts(run_id=run_id, artifact_path="artifact_dir")
             ],
         )
+
+    def test_log_without_step(self):
+        """`MLflowTracker.log` should treat `step` as optional, matching the docstring."""
+        tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
+        accelerator = Accelerator(log_with=tracker)
+        accelerator.init_trackers(project_name="test_exp")
+        # Should not raise; previously raised TypeError because `step` had no default.
+        tracker.log({"loss": 0.1})
+        accelerator.end_training()
+
+    def test_log_accepts_extra_kwargs(self):
+        """`MLflowTracker.log` should accept extra kwargs forwarded by `Accelerator.log(log_kwargs=...)`.
+
+        Previously the signature omitted `**kwargs`, so any per-tracker kwarg (e.g. `synchronous`)
+        passed via `log_kwargs={"mlflow": {...}}` raised TypeError.
+        """
+        tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
+        accelerator = Accelerator(log_with=tracker)
+        accelerator.init_trackers(project_name="test_exp")
+        # `synchronous` is a real mlflow.log_metrics kwarg; the tracker must forward it.
+        accelerator.log({"loss": 0.1}, step=1, log_kwargs={"mlflow": {"synchronous": True}})
+        accelerator.end_training()
 
 
 @require_comet_ml
@@ -678,7 +700,7 @@ class MyCustomTracker(GeneralTracker):
         logger.info("Call init")
         self.writer.writerow(values)
 
-    def log(self, values: dict, step: Optional[int]):
+    def log(self, values: dict, step: Optional[int] = None):
         logger.info("Call log")
         self.writer.writerow(values)
 
@@ -770,7 +792,7 @@ class DVCLiveTrackingTest(unittest.TestCase):
             assert latest.pop("step") == 3
             assert latest == values
             scalars = os.path.join(live.plots_dir, Metric.subfolder)
-            for val in values.keys():
+            for val in values:
                 val_path = os.path.join(scalars, f"{val}.tsv")
                 steps = [int(row["step"]) for row in logs[val_path]]
                 assert steps == [0, 1, 3]

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -335,14 +335,24 @@ class MLflowTrackingTest(unittest.TestCase):
         """`MLflowTracker.log` should accept extra kwargs forwarded by `Accelerator.log(log_kwargs=...)`.
 
         Previously the signature omitted `**kwargs`, so any per-tracker kwarg (e.g. `synchronous`)
-        passed via `log_kwargs={"mlflow": {...}}` raised TypeError.
+        passed via `log_kwargs={"mlflow": {...}}` raised TypeError. Beyond not raising, the kwarg
+        must reach `mlflow.log_metrics` so it actually changes mlflow's behavior.
         """
         tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
         accelerator = Accelerator(log_with=tracker)
         accelerator.init_trackers(project_name="test_exp")
         # `synchronous` is a real mlflow.log_metrics kwarg; the tracker must forward it.
-        accelerator.log({"loss": 0.1}, step=1, log_kwargs={"mlflow": {"synchronous": True}})
+        with mock.patch("mlflow.log_metrics") as mock_log_metrics:
+            accelerator.log({"loss": 0.1}, step=1, log_kwargs={"mlflow": {"synchronous": True}})
         accelerator.end_training()
+        mock_log_metrics.assert_called_once()
+        call_kwargs = mock_log_metrics.call_args.kwargs
+        assert call_kwargs.get("synchronous") is True, (
+            f"expected synchronous=True forwarded to mlflow.log_metrics, got kwargs={call_kwargs}"
+        )
+        assert call_kwargs.get("step") == 1, (
+            f"expected step=1 forwarded to mlflow.log_metrics, got kwargs={call_kwargs}"
+        )
 
 
 @require_comet_ml


### PR DESCRIPTION
Closes #4041.

## What does this PR do?

Two related bugs in `src/accelerate/tracking.py`:

**1. `tracker.log()` raises `TypeError` when `step` is omitted.**

Every tracker subclass declares `step: Optional[int]` with no default value:

```python
def log(self, values: dict, step: Optional[int]):
    ...
```

The docstrings all describe `step` as *optional*. Users following the docstring hit:

```
TypeError: log() missing 1 required positional argument: 'step'
```

Fix: set `step: Optional[int] = None` on `GeneralTracker.log`, `TensorBoardTracker.log_images`, `AimTracker.log`, `MLflowTracker.log`, and the `MyCustomTracker` test fixture (which was propagating the broken signature into test scaffolding).

**2. `MLflowTracker.log` swallows `log_kwargs`.**

`Accelerator.log(values, log_kwargs={"mlflow": {"synchronous": True}})` is documented to forward provider-specific kwargs through to each tracker. `MLflowTracker.log` doesn't accept `**kwargs`, so the call raises:

```
TypeError: log() got an unexpected keyword argument 'synchronous'
```

Fix: accept `**kwargs` in `MLflowTracker.log` and forward to `mlflow.log_metrics`.

## How was this tested?

Two regression tests under `MLflowTrackingTest`:

- `test_log_without_step` — `tracker.log({"loss": 0.1})` with no `step`.
- `test_log_accepts_extra_kwargs` — `accelerator.log({"loss": 0.1}, step=1, log_kwargs={"mlflow": {"synchronous": True}})` and assert `mlflow.log_metrics` was called with `synchronous=True`.

Before (against `upstream/main`):

```
$ pytest tests/test_tracking.py::MLflowTrackingTest::test_log_without_step -v --tb=short
tests/test_tracking.py::MLflowTrackingTest::test_log_without_step FAILED
=================================== FAILURES ===================================
___________________ MLflowTrackingTest.test_log_without_step ___________________
tests/test_tracking.py:331: in test_log_without_step
    tracker.log({"loss": 0.1})
src/accelerate/tracking.py:89: in execute_on_main_process
    return PartialState().on_main_process(function)(self, *args, **kwargs)
E   TypeError: MLflowTracker.log() missing 1 required positional argument: 'step'
1 failed in 3.95s

$ pytest tests/test_tracking.py::MLflowTrackingTest::test_log_accepts_extra_kwargs -v --tb=short
tests/test_tracking.py::MLflowTrackingTest::test_log_accepts_extra_kwargs FAILED
=================================== FAILURES ===================================
_______________ MLflowTrackingTest.test_log_accepts_extra_kwargs _______________
tests/test_tracking.py:346: in test_log_accepts_extra_kwargs
    accelerator.log({"loss": 0.1}, step=1, log_kwargs={"mlflow": {"synchronous": True}})
src/accelerate/accelerator.py:3381: in log
    tracker.log(values, step=step, **log_kwargs.get(tracker.name, {}))
src/accelerate/tracking.py:89: in execute_on_main_process
    return PartialState().on_main_process(function)(self, *args, **kwargs)
E   TypeError: MLflowTracker.log() got an unexpected keyword argument 'synchronous'
1 failed in 3.08s
```

After (this PR):

```
$ pytest tests/test_tracking.py::MLflowTrackingTest::test_log_without_step tests/test_tracking.py::MLflowTrackingTest::test_log_accepts_extra_kwargs -v
tests/test_tracking.py::MLflowTrackingTest::test_log_without_step PASSED
tests/test_tracking.py::MLflowTrackingTest::test_log_accepts_extra_kwargs PASSED
2 passed in 4.18s
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (if so, you can skip checks)
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Closes #4041.
- [x] Did you make sure to update the documentation with your changes? No doc change — docstrings already declared `step` optional, the code now matches.
- [x] Did you write any new necessary tests?
