### PR TITLE
Fix `keep_in_fp32_modules` not working for tied weights in `load_and_quantize_model`

### DIFF
--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -138,6 +138,12 @@ def load_and_quantize_model(
                 param.data = param.data.to(torch.float32)
             elif torch.is_floating_point(param):
                 param.data = param.data.to(dtype)
+        # Second pass: ensure keep_in_fp32 modules are in fp32 even when their weights are tied
+        # to other modules (named_parameters() deduplicates tied params, so the first pass may miss them)
+        for name, module in model.named_modules():
+            if any(module_to_keep_in_fp32 in name for module_to_keep_in_fp32 in keep_in_fp32_modules):
+                for param in module.parameters(recurse=False):
+                    param.data = param.data.to(torch.float32)
         if model_device.type == "cuda":
             model.cuda(torch.cuda.current_device())
             torch.cuda.empty_cache()


### PR DESCRIPTION
## Problem

`MixedInt8LoaddedModelTest::test_fp32_8bit_conversion` and `Bnb4BitTestLoadedModel::test_fp32_4bit_conversion` fail with:

```
AssertionError: assert torch.float16 == torch.float32
```

When quantizing an already-loaded model (not on meta device), modules specified in `keep_in_fp32_modules` (e.g. `lm_head`) are not correctly kept in fp32.

## Root Cause

In BLOOM, `lm_head.weight` is tied to `transformer.word_embeddings.weight` (same Parameter object). `model.named_parameters()` deduplicates by parameter id and yields each parameter only once. Since `transformer.word_embeddings.weight` is encountered first in DFS traversal, it is the only one yielded — and the check `"lm_head" in "transformer.word_embeddings.weight"` is `False`, so the parameter stays in fp16. `lm_head.weight` is never iterated over.

## Fix

Add a second pass using `model.named_modules()` to explicitly convert parameters of `keep_in_fp32_modules` to fp32. This is not affected by `named_parameters()` deduplication since we access the module's parameters directly.
