### PR TITLE
Fix int8 offload hook detachment statistics restoration

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -342,7 +342,7 @@ class AlignDevicesHook(ModelHook):
 
         return module
 
-    def _get_fp16_statistics(self, name, value):
+    def _maybe_get_fp16_statistics(self, name, value):
         # Some quantized weights keep scale statistics as separate state-dict entries rather than
         # parameters or buffers. When materializing an int8 weight from `weights_map`, pass those
         # statistics along so the restored parameter does not keep stale meta-device attributes.
@@ -369,7 +369,7 @@ class AlignDevicesHook(ModelHook):
                 remove_non_persistent=True,
             ):
                 value = self.weights_map[name]
-                fp16_statistics = self._get_fp16_statistics(name, value)
+                fp16_statistics = self._maybe_get_fp16_statistics(name, value)
 
                 # In case we are using offloading with tied weights, we need to keep track of the offloaded weights
                 # that are loaded on device at this point, as we will need to remove them as well from the dictionary
@@ -435,7 +435,7 @@ class AlignDevicesHook(ModelHook):
             for name, device in self.original_devices.items():
                 if device != torch.device("meta"):
                     value = self.weights_map.get(name, None)
-                    fp16_statistics = self._get_fp16_statistics(name, value)
+                    fp16_statistics = self._maybe_get_fp16_statistics(name, value)
                     set_module_tensor_to_device(
                         module, name, device, value=value, fp16_statistics=fp16_statistics
                     )

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -342,6 +342,19 @@ class AlignDevicesHook(ModelHook):
 
         return module
 
+    def _get_fp16_statistics(self, name, value):
+        # Some quantized weights keep scale statistics as separate state-dict entries rather than
+        # parameters or buffers. When materializing an int8 weight from `weights_map`, pass those
+        # statistics along so the restored parameter does not keep stale meta-device attributes.
+        if value is None or value.dtype != torch.int8 or "weight" not in name:
+            return None
+
+        statistics_name = name.replace("weight", "SCB")
+        if statistics_name in self.weights_map:
+            return self.weights_map[statistics_name]
+
+        return None
+
     @_compiler_disable
     def pre_forward(self, module, *args, **kwargs):
         if self.io_same_device:
@@ -355,11 +368,8 @@ class AlignDevicesHook(ModelHook):
                 recurse=self.place_submodules,
                 remove_non_persistent=True,
             ):
-                fp16_statistics = None
                 value = self.weights_map[name]
-                if "weight" in name and name.replace("weight", "SCB") in self.weights_map.keys():
-                    if value.dtype == torch.int8:
-                        fp16_statistics = self.weights_map[name.replace("weight", "SCB")]
+                fp16_statistics = self._get_fp16_statistics(name, value)
 
                 # In case we are using offloading with tied weights, we need to keep track of the offloaded weights
                 # that are loaded on device at this point, as we will need to remove them as well from the dictionary
@@ -424,7 +434,11 @@ class AlignDevicesHook(ModelHook):
         if self.offload:
             for name, device in self.original_devices.items():
                 if device != torch.device("meta"):
-                    set_module_tensor_to_device(module, name, device, value=self.weights_map.get(name, None))
+                    value = self.weights_map.get(name, None)
+                    fp16_statistics = self._get_fp16_statistics(name, value)
+                    set_module_tensor_to_device(
+                        module, name, device, value=value, fp16_statistics=fp16_statistics
+                    )
         return module
 
 

--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -436,9 +436,7 @@ class AlignDevicesHook(ModelHook):
                 if device != torch.device("meta"):
                     value = self.weights_map.get(name, None)
                     fp16_statistics = self._maybe_get_fp16_statistics(name, value)
-                    set_module_tensor_to_device(
-                        module, name, device, value=value, fp16_statistics=fp16_statistics
-                    )
+                    set_module_tensor_to_device(module, name, device, value=value, fp16_statistics=fp16_statistics)
         return module
 
 


### PR DESCRIPTION
## Summary

Fix `AlignDevicesHook.detach_hook()` so removing offload hooks restores bitsandbytes int8 weights together with their fp16 quantization statistics.

Sequential CPU offload stores module weights in `weights_map` and moves parameters to the meta device. For bnb int8 modules, the `SCB` statistics are saved as extra state-dict entries instead of regular parameters or buffers. `pre_forward()` already passed those statistics back into `set_module_tensor_to_device()`, but `detach_hook()` did not. As a result, removing hooks could restore the int8 weight while leaving `weight.SCB` on the meta device, causing the next offload pass to fail with:

```text
NotImplementedError: Cannot copy out of meta tensor; no data!
```

This change centralizes the lookup of int8 fp16 statistics in `AlignDevicesHook._get_fp16_statistics()` and uses it from both `pre_forward()` and `detach_hook()`. The existing forward path keeps the same behavior, while hook removal now materializes int8 weights with their matching statistics.

## Reproduction

This is a minimal reproduction of the failing sequence: enable sequential CPU offload, remove hooks recursively, then enable sequential CPU offload again.

```python
import torch
from transformers import T5EncoderModel
from diffusers import FluxTransformer2DModel, DiffusionPipeline
from accelerate.hooks import remove_hook_from_module

model_id = 'hf-internal-testing/flux.1-dev-int8-pkg'

t5_8bit = T5EncoderModel.from_pretrained(model_id, subfolder='text_encoder_2')
transformer_8bit = FluxTransformer2DModel.from_pretrained(model_id, subfolder='transformer')
pipe = DiffusionPipeline.from_pretrained(
    'black-forest-labs/FLUX.1-dev',
    text_encoder_2=t5_8bit,
    transformer=transformer_8bit,
    torch_dtype=torch.float16,
)

pipe.enable_sequential_cpu_offload()

for _, component in pipe.components.items():
    if isinstance(component, torch.nn.Module) and hasattr(component, '_hf_hook'):
        remove_hook_from_module(component, recurse=True)

print('meta_after_remove')
for name, component in pipe.components.items():
    if isinstance(component, torch.nn.Module):
        meta = [n for n, p in component.state_dict().items() if p.device == torch.device('meta')]
        print(name, len(meta), meta[:3])

pipe.enable_sequential_cpu_offload()
print('reoffload_ok')
```

Expected output:

```text
meta_after_remove
vae 0 []
text_encoder 0 []
text_encoder_2 0 []
transformer 0 []
reoffload_ok
```
