### PR TITLE
DOC: document missing parameters in load_accelerator_state, find_executable_batch_size, and send_to_device

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -204,6 +204,8 @@ def load_accelerator_state(
             A list of optimizer instances
         schedulers (`List[torch.optim.lr_scheduler._LRScheduler]`):
             A list of learning rate schedulers
+        dataloaders (`List[torch.utils.data.DataLoader]`):
+            A list of dataloader instances used in your program
         process_index (`int`):
             The current process index in the Accelerator state
         scaler (`torch.amp.GradScaler`, *optional*):

--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -132,6 +132,10 @@ def find_executable_batch_size(
             A function to wrap
         starting_batch_size (`int`, *optional*):
             The batch size to try and fit into memory
+        reduce_batch_size_fn (`callable`, *optional*):
+            A function to determine the new batch size after an out-of-memory error. If not
+            provided, the batch size is multiplied by 0.9 on each failure. The function takes
+            no arguments and should return the new (reduced) batch size as an `int`.
 
     Example:
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -142,6 +142,12 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             The data to send to a given device.
         device (`torch.device`):
             The device to send the data to.
+        non_blocking (`bool`, *optional*, defaults to `False`):
+            If `True`, the transfer to the device is performed asynchronously, which can overlap
+            data movement with computation. Only effective when the device supports it (e.g. CUDA).
+        skip_keys (`str` or `List[str]`, *optional*):
+            A key or list of keys in a dictionary `tensor` whose values should not be sent to
+            the given `device`. Entries with these keys are left on their original device.
 
     Returns:
         The same data structure as `tensor` with all tensors sent to the proper device.


### PR DESCRIPTION
## What this fixes

Three public API functions had parameters present in their signatures but missing from their docstrings.

### `load_accelerator_state()` — missing `dataloaders`
`dataloaders` is a **required** parameter (no default value) but was completely absent from the `Args` section, unlike the equivalent `save_accelerator_state()` which documents it correctly.

### `find_executable_batch_size()` — missing `reduce_batch_size_fn`
Allows users to provide a custom batch size reduction strategy instead of the default multiply-by-0.9 behavior on OOM. Undocumented means users can't discover or use this customization point.

### `send_to_device()` — missing `non_blocking` and `skip_keys`
- `non_blocking`: enables async GPU transfers, useful for overlapping data movement with computation
- `skip_keys`: excludes specific dict keys from device transfer

## Files changed
- `src/accelerate/checkpointing.py`
- `src/accelerate/utils/memory.py`
- `src/accelerate/utils/operations.py`
