### PR TITLE
Fix implicit padding in `split_between_processes` when `apply_padding=False` and `num_samples < num_processes`

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -483,7 +483,7 @@ class PartialState:
 
                         # The tensor needs to be on the device before we can pad it
                         tensorized_result = send_to_device(result, self.device)
-                        result = pad_across_processes(tensorized_result, pad_index=inputs[-1])
+                        result = pad_across_processes(tensorized_result, pad_index=pad_index=send_to_device(inputs[-1], self.device))
                     else:
                         result += [inputs[-1]] * (num_samples_per_process + (1 if num_extras > 0 else 0) - len(result))
                 return result

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -483,7 +483,9 @@ class PartialState:
 
                         # The tensor needs to be on the device before we can pad it
                         tensorized_result = send_to_device(result, self.device)
-                        result = pad_across_processes(tensorized_result, pad_index=send_to_device(inputs[-1], self.device))
+                        result = pad_across_processes(
+                            tensorized_result, pad_index=send_to_device(inputs[-1], self.device)
+                        )
                     else:
                         result += [inputs[-1]] * (num_samples_per_process + (1 if num_extras > 0 else 0) - len(result))
                 return result
@@ -497,7 +499,7 @@ class PartialState:
 
                     if isinstance(inputs, Dataset):
                         clamped_start = min(start_index, len(inputs))
-                        clamped_end   = min(end_index,   len(inputs))
+                        clamped_end = min(end_index, len(inputs))
                         result_idcs = list(range(clamped_start, clamped_end))
                         if apply_padding:
                             result_idcs += [len(inputs) - 1] * (

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -483,7 +483,7 @@ class PartialState:
 
                         # The tensor needs to be on the device before we can pad it
                         tensorized_result = send_to_device(result, self.device)
-                        result = pad_across_processes(tensorized_result, pad_index=pad_index=send_to_device(inputs[-1], self.device))
+                        result = pad_across_processes(tensorized_result, pad_index=send_to_device(inputs[-1], self.device))
                     else:
                         result += [inputs[-1]] * (num_samples_per_process + (1 if num_extras > 0 else 0) - len(result))
                 return result

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -476,10 +476,7 @@ class PartialState:
 
         def _split_values(inputs, start_index, end_index):
             if isinstance(inputs, (list, tuple, torch.Tensor)):
-                if start_index >= len(inputs):
-                    result = inputs[-1:]
-                else:
-                    result = inputs[start_index:end_index]
+                result = inputs[start_index:end_index]
                 if apply_padding:
                     if isinstance(result, torch.Tensor):
                         from accelerate.utils import pad_across_processes, send_to_device
@@ -488,7 +485,7 @@ class PartialState:
                         tensorized_result = send_to_device(result, self.device)
                         result = pad_across_processes(tensorized_result, pad_index=inputs[-1])
                     else:
-                        result += [result[-1]] * (num_samples_per_process + (1 if num_extras > 0 else 0) - len(result))
+                        result += [inputs[-1]] * (num_samples_per_process + (1 if num_extras > 0 else 0) - len(result))
                 return result
             elif isinstance(inputs, dict):
                 for key in inputs.keys():
@@ -499,13 +496,11 @@ class PartialState:
                     from datasets import Dataset
 
                     if isinstance(inputs, Dataset):
-                        if start_index >= len(inputs):
-                            start_index = len(inputs) - 1
-                        if end_index > len(inputs):
-                            end_index = len(inputs)
-                        result_idcs = list(range(start_index, end_index))
+                        clamped_start = min(start_index, len(inputs))
+                        clamped_end   = min(end_index,   len(inputs))
+                        result_idcs = list(range(clamped_start, clamped_end))
                         if apply_padding:
-                            result_idcs += [end_index - 1] * (
+                            result_idcs += [len(inputs) - 1] * (
                                 num_samples_per_process + (1 if num_extras > 0 else 0) - len(result_idcs)
                             )
                         return inputs.select(result_idcs)


### PR DESCRIPTION
 

# What does this PR do?

Function `split_between_processes` applies implicit  padding even if     `apply_padding=False`. This results to redundant calculations during distributed inference since the same inference (i.e. prompt)  is called twice etc. Apart from wasting resources, this can cause conflicts among competing processes, for instance, disk I/O. 


The same bug is duplicated across two code branches  of the same function. Both stem from the identical incorrect assumption — *"a process always receives at least one element"* — and both produce identical wrong behaviour (silent padding when `apply_padding=False`). The only difference is syntax:

- Bug 1 (list/Tensor): guards with `result = inputs[-1:]`
- Bug 2 (Dataset): guards with `start_index = len(inputs) - 1`

## How to reproduce  
 

###  Example  with 1 sample and 2 GPUs
 

| Process | start_index | end_index | Normal slice |
|---------|-------------|-----------|--------------|
| 0       | 0           | 1         | `inputs[0:1]` → `[sample_0]` ✓ |
| 1       | 1           | 1         | `start_index >= len(inputs)` triggers! → `inputs[-1:]` = `[sample_0]` ✗ |

**Process 1's `start_index` (1) equals `len(inputs)` (1), triggering the guard.** Instead of returning an empty slice, it silently returns the last element — **regardless of `apply_padding`**.

```python 
def _split_values(inputs, start_index, end_index):
    if isinstance(inputs, (list, tuple, torch.Tensor)):
        if start_index >= len(inputs):      
            result = inputs[-1:]              # ← always returns last element
        else:
            result = inputs[start_index:end_index]
        if apply_padding:
            ...  
```

resolves  https://github.com/huggingface/accelerate/issues/4053

 

## Who can review?
 
  @BenjaminBossan @SunMarc
 
 