### PR TITLE
Fix gloo backend error in test_load_checkpoint_and_dispatch_with_broa…

### DIFF
--- a/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
+++ b/tests/test_load_checkpoint_and_dispatch_with_broadcast.py
@@ -53,6 +53,10 @@ def manage_process_group(func: Callable[..., Any]) -> Callable[..., Any]:
         if not dist.is_initialized():
             if torch_device == "hpu" and is_hpu_available(init_hccl=True):
                 dist.init_process_group(backend="hccl", world_size=torch_accelerator_module.device_count())
+            elif torch_device == "xpu":
+                dist.init_process_group(
+                    backend="cpu:gloo,xpu:xccl", world_size=torch_accelerator_module.device_count()
+                )
             else:
                 dist.init_process_group(world_size=torch_accelerator_module.device_count())
             initialized_here = True


### PR DESCRIPTION
In test case: `tests/test_load_checkpoint_and_dispatch_with_broadcast.py::TestLoadCheckpointAndDispatchWithBroadcast::test_load_checkpoint_and_dispatch_ddp`
the DDP test only registered xccl(using default backend), but DDP's logger requires a gloo backend on the PG (which xccl doesn't fall back to, unlike NCCL), so init now uses the hybrid `cpu:gloo,xpu:xccl` — matching the FSDP setup already in state.py: [L243](https://github.com/huggingface/accelerate/blob/507ea7b29903546f7c773dbe36c8ca128f7c78bb/src/accelerate/state.py#L243)