### PR TITLE
fix(state): make MLU backend part of the _prepare_backend elif chain (#4055)

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -773,7 +773,7 @@ class PartialState:
             if is_mlu_available():
                 backend = "cncl"
                 distributed_type = DistributedType.MULTI_MLU
-            if is_sdaa_available():
+            elif is_sdaa_available():
                 backend = "tccl"
                 distributed_type = DistributedType.MULTI_SDAA
             elif is_musa_available():


### PR DESCRIPTION
## What

In `PartialState._prepare_backend`, the MLU branch was guarded by a standalone `if`, immediately followed by a *separate* `if is_sdaa_available(): ... elif is_musa_available(): ...` chain:

```python
if is_mlu_available():
    backend = "cncl"
    distributed_type = DistributedType.MULTI_MLU
if is_sdaa_available():        # <- new chain, not part of the MLU check
    ...
elif is_musa_available():
    ...
elif torch.cuda.is_available():
    ...
```

Because MLU sits outside the mutually-exclusive chain, on an MLU host the `cncl` / `MULTI_MLU` selection is not final: execution falls through into the second chain and a later branch (e.g. `torch.cuda.is_available()`) can silently overwrite `backend`/`distributed_type`. Every other accelerator (SDAA, MUSA, NPU, HPU, CUDA, XPU, NEURON) is already part of one `if/elif` chain — MLU is the lone outlier.

## Fix

Change the second `if is_sdaa_available()` to `elif`, so all backends form a single mutually-exclusive chain with MLU as the head. This matches the structure already used by `default_device`.

- Non-MLU hosts: `is_mlu_available()` is `False`, so the `elif` is evaluated exactly as the old `if` was — no behavior change.
- MLU hosts: the chain now short-circuits correctly instead of being able to fall through to CUDA.

Closes #4055

🤖 Generated with [Claude Code](https://claude.com/claude-code)
