### PR TITLE
fix issue 4055

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -773,7 +773,7 @@ class PartialState:
             if is_mlu_available():
                 backend = "cncl"
                 distributed_type = DistributedType.MULTI_MLU
-            if is_sdaa_available():
+            elif is_sdaa_available():
                 backend = "tccl"
                 distributed_type = DistributedType.MULTI_SDAA
             elif is_musa_available():


### PR DESCRIPTION
 ---
  What does this PR do?

  Fixes a bug in PartialState._prepare_backend where the SDAA device check (is_sdaa_available()) used a standalone if instead of elif, causing it to always evaluate independently of the MLU check above it.

  When both MLU and SDAA conditions could be true, the SDAA branch would overwrite the previously set backend = "cncl" and distributed_type = MULTI_MLU with backend = "tccl" and distributed_type = MULTI_SDAA, incorrectly overriding the MLU backend selection.

  The fix changes if is_sdaa_available() → elif is_sdaa_available() so it properly chains with the existing if is_mlu_available() / elif is_musa_available() / elif is_npu_available() / elif is_xpu_available() / elif is_mlu_available() conditional chain, ensuring only
  one backend is selected.

  Fixes #4055

  Checklist

  - Contributor guidelines read
  - Changes described above
  - Tests added (N/A — minor conditional logic fix)
  - Documentation updated (N/A)