### PR TITLE
Add register_tracker_class to register custom trackers by name

### DIFF
--- a/docs/source/package_reference/tracking.md
+++ b/docs/source/package_reference/tracking.md
@@ -19,6 +19,10 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] tracking.GeneralTracker
 
+## register_tracker_class
+
+[[autodoc]] tracking.register_tracker_class
+
 ## TensorBoardTracker
 
 [[autodoc]] tracking.TensorBoardTracker

--- a/docs/source/usage_guides/tracking.md
+++ b/docs/source/usage_guides/tracking.md
@@ -170,6 +170,25 @@ tracker = MyCustomTracker("some_run_name")
 accelerator = Accelerator(log_with=[tracker, "all"])
 ```
 
+### Registering a custom tracker by name
+
+Instead of passing an instance, you can register a custom tracker class so it can be selected by its `name`, just like the built-in trackers. This is handy when the trackers to use are read from a config file or the command line:
+
+```python
+from accelerate import Accelerator
+from accelerate.tracking import GeneralTracker, register_tracker_class
+
+
+class MyCustomTracker(GeneralTracker):
+    name = "my_tracker"
+    requires_logging_directory = False
+    # ... implement the rest of the `GeneralTracker` interface
+
+
+register_tracker_class(MyCustomTracker)
+accelerator = Accelerator(log_with="my_tracker")
+```
+
 ## Accessing the internal tracker 
 
 If some custom interactions with a tracker might be wanted directly, you can quickly access one using the 

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -18,6 +18,7 @@
 import json
 import os
 import time
+import warnings
 from functools import wraps
 from typing import Any, Optional, Union
 
@@ -1300,7 +1301,7 @@ def register_tracker_class(tracker_class: type[GeneralTracker]):
             "Set it to `True` if the tracker needs a logging directory, or `False` otherwise."
         )
     if tracker_class.name in LOGGER_TYPE_TO_CLASS:
-        logger.warning(
+        warnings.warn(
             f"A tracker with the name '{tracker_class.name}' is already registered and will be overwritten by "
             f"{tracker_class}. This is especially significant when shadowing a built-in tracker."
         )

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -1341,17 +1341,7 @@ def filter_trackers(
         if not isinstance(log_with, (list, tuple)):
             log_with = [log_with]
         if "all" in log_with or LoggerType.ALL in log_with:
-            loggers = [o for o in log_with if issubclass(type(o), GeneralTracker)]
-            # Also keep custom trackers registered via `register_tracker_class` that are named alongside "all".
-            # Apply the same logging-dir guard as the explicit-name branch for consistency.
-            for custom_name in log_with:
-                if custom_name not in LoggerType and custom_name in LOGGER_TYPE_TO_CLASS:
-                    tracker_init = LOGGER_TYPE_TO_CLASS[str(custom_name)]
-                    if tracker_init.requires_logging_directory and logging_dir is None:
-                        raise ValueError(f"Logging with `{custom_name}` requires a `logging_dir` to be passed in.")
-                    if custom_name not in loggers:
-                        loggers.append(custom_name)
-            loggers += get_available_trackers()
+            loggers = [o for o in log_with if issubclass(type(o), GeneralTracker)] + get_available_trackers()
         else:
             for log_type in log_with:
                 if (

--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -1257,6 +1257,56 @@ LOGGER_TYPE_TO_CLASS = {
 }
 
 
+def register_tracker_class(tracker_class: type[GeneralTracker]):
+    """
+    Registers a custom [`GeneralTracker`] subclass so it can be referenced by its `name` in the `log_with` argument of
+    [`Accelerator`], the same way as the built-in trackers.
+
+    The tracker must be registered before instantiating the [`Accelerator`] that uses it.
+
+    Args:
+        tracker_class (subclass of [`GeneralTracker`]):
+            The tracker class to register. It must subclass [`GeneralTracker`] and define a non-empty `name` class
+            attribute and a `requires_logging_directory` class attribute. The class is instantiated with the
+            `project_name` passed to [`Accelerator.init_trackers`] as the first positional argument. When
+            `requires_logging_directory` is `True`, the logging directory is passed as the second positional argument
+            (matching the built-in tracker convention). Tracker-specific keyword arguments from `init_kwargs` are
+            forwarded as `**kwargs`.
+
+    Example:
+
+    ```python
+    from accelerate import Accelerator
+    from accelerate.tracking import GeneralTracker, register_tracker_class
+
+
+    class MyTracker(GeneralTracker):
+        name = "my_tracker"
+        requires_logging_directory = False
+        # ... implement the rest of the `GeneralTracker` interface
+
+
+    register_tracker_class(MyTracker)
+    accelerator = Accelerator(log_with="my_tracker")
+    ```
+    """
+    if not (isinstance(tracker_class, type) and issubclass(tracker_class, GeneralTracker)):
+        raise ValueError(f"`tracker_class` must be a subclass of `GeneralTracker`, but got {tracker_class}.")
+    if not getattr(tracker_class, "name", None):
+        raise ValueError("The tracker class to register must define a non-empty `name` attribute.")
+    if not hasattr(tracker_class, "requires_logging_directory"):
+        raise ValueError(
+            "The tracker class to register must define a `requires_logging_directory` class attribute. "
+            "Set it to `True` if the tracker needs a logging directory, or `False` otherwise."
+        )
+    if tracker_class.name in LOGGER_TYPE_TO_CLASS:
+        logger.warning(
+            f"A tracker with the name '{tracker_class.name}' is already registered and will be overwritten by "
+            f"{tracker_class}. This is especially significant when shadowing a built-in tracker."
+        )
+    LOGGER_TYPE_TO_CLASS[tracker_class.name] = tracker_class
+
+
 def filter_trackers(
     log_with: list[Union[str, LoggerType, GeneralTracker]],
     logging_dir: Optional[Union[str, os.PathLike]] = None,
@@ -1291,14 +1341,28 @@ def filter_trackers(
         if not isinstance(log_with, (list, tuple)):
             log_with = [log_with]
         if "all" in log_with or LoggerType.ALL in log_with:
-            loggers = [o for o in log_with if issubclass(type(o), GeneralTracker)] + get_available_trackers()
+            loggers = [o for o in log_with if issubclass(type(o), GeneralTracker)]
+            # Also keep custom trackers registered via `register_tracker_class` that are named alongside "all".
+            # Apply the same logging-dir guard as the explicit-name branch for consistency.
+            for custom_name in log_with:
+                if custom_name not in LoggerType and custom_name in LOGGER_TYPE_TO_CLASS:
+                    tracker_init = LOGGER_TYPE_TO_CLASS[str(custom_name)]
+                    if tracker_init.requires_logging_directory and logging_dir is None:
+                        raise ValueError(f"Logging with `{custom_name}` requires a `logging_dir` to be passed in.")
+                    if custom_name not in loggers:
+                        loggers.append(custom_name)
+            loggers += get_available_trackers()
         else:
             for log_type in log_with:
-                if log_type not in LoggerType and not issubclass(type(log_type), GeneralTracker):
+                if (
+                    log_type not in LoggerType
+                    and not issubclass(type(log_type), GeneralTracker)
+                    and str(log_type) not in LOGGER_TYPE_TO_CLASS
+                ):
                     raise ValueError(f"Unsupported logging capability: {log_type}. Choose between {LoggerType.list()}")
                 if issubclass(type(log_type), GeneralTracker):
                     loggers.append(log_type)
-                else:
+                elif log_type in LoggerType:
                     log_type = LoggerType(log_type)
                     if log_type not in loggers:
                         if log_type in get_available_trackers():
@@ -1311,5 +1375,12 @@ def filter_trackers(
                             loggers.append(log_type)
                         else:
                             logger.debug(f"Tried adding logger {log_type}, but package is unavailable in the system.")
+                else:
+                    # Custom tracker class registered via `register_tracker_class`
+                    if log_type not in loggers:
+                        tracker_init = LOGGER_TYPE_TO_CLASS[str(log_type)]
+                        if tracker_init.requires_logging_directory and logging_dir is None:
+                            raise ValueError(f"Logging with `{log_type}` requires a `logging_dir` to be passed in.")
+                        loggers.append(log_type)
 
     return loggers

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -50,6 +50,7 @@ from accelerate.test_utils.testing import (
     skip,
 )
 from accelerate.tracking import (
+    LOGGER_TYPE_TO_CLASS,
     AimTracker,
     ClearMLTracker,
     CometMLTracker,
@@ -60,6 +61,8 @@ from accelerate.tracking import (
     TensorBoardTracker,
     TrackioTracker,
     WandBTracker,
+    filter_trackers,
+    register_tracker_class,
 )
 from accelerate.utils import (
     ProjectConfiguration,
@@ -804,6 +807,124 @@ class CustomTrackerTestCase(unittest.TestCase):
             values = {"total_loss": 0.1}
             # Passing log_kwargs=None must not raise AttributeError
             accelerator.log(values, step=0, log_kwargs=None)
+            accelerator.end_training()
+
+
+class MyRegisteredTracker(GeneralTracker):
+    "Minimal tracker following the built-in `(run_name, **kwargs)` convention, used to test class registration."
+
+    name = "my_registered_tracker"
+    requires_logging_directory = False
+
+    def __init__(self, run_name: str, **kwargs):
+        super().__init__()
+        self.run_name = run_name
+        self.config = {}
+        self.values = {}
+
+    @property
+    def tracker(self):
+        return self
+
+    def store_init_configuration(self, values: dict):
+        self.config.update(values)
+
+    def log(self, values: dict, step: Optional[int] = None, **kwargs):
+        self.values.update(values)
+
+
+class MyDirRegisteredTracker(GeneralTracker):
+    "Registered tracker that requires a logging directory, used to test the logging-directory path."
+
+    name = "my_dir_registered_tracker"
+    requires_logging_directory = True
+
+    def __init__(self, run_name: str, logging_dir: str, **kwargs):
+        super().__init__()
+        self.run_name = run_name
+        self.logging_dir = logging_dir
+
+    @property
+    def tracker(self):
+        return self
+
+
+class RegisterTrackerClassTest(unittest.TestCase):
+    def setUp(self):
+        self._registry_snapshot = dict(LOGGER_TYPE_TO_CLASS)
+        super().setUp()
+
+    def tearDown(self):
+        LOGGER_TYPE_TO_CLASS.clear()
+        LOGGER_TYPE_TO_CLASS.update(self._registry_snapshot)
+        super().tearDown()
+
+    def test_register_and_use_by_name(self):
+        register_tracker_class(MyRegisteredTracker)
+        assert MyRegisteredTracker.name in LOGGER_TYPE_TO_CLASS
+
+        accelerator = Accelerator(log_with=MyRegisteredTracker.name)
+        config = {"num_iterations": 12, "learning_rate": 1e-2}
+        accelerator.init_trackers("some_project", config)
+        accelerator.log({"total_loss": 0.1}, step=0)
+        tracker = accelerator.get_tracker(MyRegisteredTracker.name)
+        accelerator.end_training()
+
+        assert isinstance(tracker, MyRegisteredTracker)
+        assert tracker.config == config
+        assert tracker.values == {"total_loss": 0.1}
+
+    def test_register_with_all(self):
+        register_tracker_class(MyRegisteredTracker)
+        loggers = filter_trackers([MyRegisteredTracker.name, "all"])
+        assert MyRegisteredTracker.name in loggers
+
+        # A registered tracker that requires a logging directory still enforces it alongside "all".
+        register_tracker_class(MyDirRegisteredTracker)
+        with self.assertRaises(ValueError):
+            filter_trackers([MyDirRegisteredTracker.name, "all"])
+
+    def test_register_invalid_class_raises(self):
+        with self.assertRaises(ValueError):
+            register_tracker_class(dict)
+
+        class NamelessTracker(GeneralTracker):
+            requires_logging_directory = False
+
+        with self.assertRaises(ValueError):
+            register_tracker_class(NamelessTracker)
+
+        class NoFlagTracker(GeneralTracker):
+            name = "no_flag_tracker"
+
+        with self.assertRaises(ValueError):
+            register_tracker_class(NoFlagTracker)
+
+    def test_register_overwrite_warns(self):
+        register_tracker_class(MyRegisteredTracker)
+
+        class ShadowTracker(GeneralTracker):
+            name = MyRegisteredTracker.name
+            requires_logging_directory = False
+
+        with mock.patch("accelerate.tracking.logger") as mock_logger:
+            register_tracker_class(ShadowTracker)
+            mock_logger.warning.assert_called_once()
+            assert MyRegisteredTracker.name in mock_logger.warning.call_args[0][0]
+
+    def test_register_requires_logging_directory(self):
+        register_tracker_class(MyDirRegisteredTracker)
+
+        with self.assertRaises(ValueError):
+            Accelerator(log_with=MyDirRegisteredTracker.name)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            accelerator = Accelerator(log_with=MyDirRegisteredTracker.name, project_dir=tmpdir)
+            accelerator.init_trackers("dir_project")
+            tracker = accelerator.get_tracker(MyDirRegisteredTracker.name)
+            assert isinstance(tracker, MyDirRegisteredTracker)
+            assert tracker.run_name == "dir_project"
+            assert tracker.logging_dir == tmpdir
             accelerator.end_training()
 
 

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -896,10 +896,9 @@ class RegisterTrackerClassTest(unittest.TestCase):
             name = MyRegisteredTracker.name
             requires_logging_directory = False
 
-        with mock.patch("accelerate.tracking.logger") as mock_logger:
+        with self.assertWarns(UserWarning) as cm:
             register_tracker_class(ShadowTracker)
-            mock_logger.warning.assert_called_once()
-            assert MyRegisteredTracker.name in mock_logger.warning.call_args[0][0]
+        assert MyRegisteredTracker.name in str(cm.warning)
 
     def test_register_requires_logging_directory(self):
         register_tracker_class(MyDirRegisteredTracker)

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -61,7 +61,6 @@ from accelerate.tracking import (
     TensorBoardTracker,
     TrackioTracker,
     WandBTracker,
-    filter_trackers,
     register_tracker_class,
 )
 from accelerate.utils import (
@@ -873,16 +872,6 @@ class RegisterTrackerClassTest(unittest.TestCase):
         assert isinstance(tracker, MyRegisteredTracker)
         assert tracker.config == config
         assert tracker.values == {"total_loss": 0.1}
-
-    def test_register_with_all(self):
-        register_tracker_class(MyRegisteredTracker)
-        loggers = filter_trackers([MyRegisteredTracker.name, "all"])
-        assert MyRegisteredTracker.name in loggers
-
-        # A registered tracker that requires a logging directory still enforces it alongside "all".
-        register_tracker_class(MyDirRegisteredTracker)
-        with self.assertRaises(ValueError):
-            filter_trackers([MyDirRegisteredTracker.name, "all"])
 
     def test_register_invalid_class_raises(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
# What does this PR do?

Adds `register_tracker_class`, a small public API to register a custom `GeneralTracker` subclass into the internal `LOGGER_TYPE_TO_CLASS` registry, so it can be selected by string name in `Accelerator(log_with=...)`, exactly like the built-in trackers.

This removes the boilerplate described in #2734, where users currently have to special-case custom trackers when building `log_with`:

```python
trackers = [name if name != "custom" else CustomTracker() for name in args.tracker_names]
accelerator = Accelerator(log_with=trackers)
```

With this change:

```python
from accelerate.tracking import register_tracker_class

register_tracker_class(MyTracker)  # MyTracker.name == "my_tracker"
accelerator = Accelerator(log_with="my_tracker")
```

The API matches what was agreed in the issue thread (`name` taken from the class attribute, per @muellerzr's suggestion). It is exposed as a module-level `register_tracker_class` in `accelerate.tracking`.

## Details

- Validates that the class subclasses `GeneralTracker` and defines `name` and `requires_logging_directory`.
- Warns (does not raise) when a registration overwrites an existing name, so shadowing a built-in is intentional but visible.
- Extends `filter_trackers` so registered names resolve through the registry, including when combined with `"all"`, with the same logging-directory guard applied to the built-in trackers.
- Adds tests covering registration, use-by-name end to end, the `requires_logging_directory` path, overwrite warnings, validation errors, and the `"all"` combination, plus usage-guide and API-reference docs.

Fixes #2734

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [x] Was this discussed/approved via a GitHub issue or the forum? Yes, #2734 (the API was approved by @muellerzr and @SunMarc in the issue thread).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc @BenjaminBossan
