### PR TITLE
Fix dtype_byte_size for FP8 fnuz / e8m0fnu dtypes

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -169,7 +169,17 @@ def dtype_byte_size(dtype: torch.dtype):
         return 1 / 2
     elif dtype == CustomDtype.FP8:
         return 1
-    elif is_torch_version(">=", "2.1.0") and dtype in [torch.float8_e4m3fn, torch.float8_e5m2]:
+    elif is_torch_version(">=", "2.1.0") and dtype in [
+        getattr(torch, name)
+        for name in (
+            "float8_e4m3fn",
+            "float8_e5m2",
+            "float8_e4m3fnuz",
+            "float8_e5m2fnuz",
+            "float8_e8m0fnu",
+        )
+        if hasattr(torch, name)
+    ]:
         return 1
     bit_search = re.search(r"[^\d](\d+)$", str(dtype))
     if bit_search is None:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -41,6 +41,7 @@ from accelerate.utils.modeling import (
     compute_module_sizes,
     compute_module_total_buffer_size,
     convert_file_size_to_int,
+    dtype_byte_size,
     find_tied_parameters,
     get_balanced_memory,
     get_module_size_with_ties,
@@ -110,6 +111,25 @@ def sequential_model(num_layers):
 
 
 class ModelingUtilsTester(unittest.TestCase):
+    def test_dtype_byte_size(self):
+        self.assertEqual(dtype_byte_size(torch.bool), 1 / 8)
+        self.assertEqual(dtype_byte_size(torch.float16), 2)
+        self.assertEqual(dtype_byte_size(torch.bfloat16), 2)
+        self.assertEqual(dtype_byte_size(torch.float32), 4)
+        self.assertEqual(dtype_byte_size(torch.float64), 8)
+        # All 1-byte FP8 dtypes available in this torch should report 1 byte.
+        # Previously only e4m3fn/e5m2 were handled; the *fnuz and e8m0fnu
+        # variants fell through to a regex with no trailing digit and raised.
+        for name in (
+            "float8_e4m3fn",
+            "float8_e5m2",
+            "float8_e4m3fnuz",
+            "float8_e5m2fnuz",
+            "float8_e8m0fnu",
+        ):
+            if hasattr(torch, name):
+                self.assertEqual(dtype_byte_size(getattr(torch, name)), 1, msg=name)
+
     def check_set_module_tensor_for_device(self, model, device1, device2):
         assert model.linear1.weight.device == torch.device(device1)
 


### PR DESCRIPTION
### Problem

`dtype_byte_size` only special-cases `torch.float8_e4m3fn` and `torch.float8_e5m2`. The other 1-byte FP8 dtypes — `float8_e4m3fnuz`, `float8_e5m2fnuz`, and `float8_e8m0fnu` — fall through to:

```python
bit_search = re.search(r"[^\d](\d+)$", str(dtype))
```

Their string forms end in `...fnuz` / `...fnu` (no trailing digit), so `bit_search is None` and the function raises `ValueError: dtype is not a valid dtype`. This breaks anything that sizes such tensors — `compute_module_sizes`, `infer_auto_device_map`, `estimate-memory`, etc. — for models stored in those dtypes.

### Fix

Handle all available 1-byte FP8 dtypes, guarded with `hasattr` so it stays correct on older torch where some variants don't exist.

### Testing done (CPU)

Added `tests/test_modeling_utils.py::ModelingUtilsTester::test_dtype_byte_size`. With torch 2.12:

```
float8_e4m3fn      after-fix=1   before(regex)=RAISED
float8_e5m2        after-fix=1
float8_e4m3fnuz    after-fix=1   before(regex)=RAISED
float8_e5m2fnuz    after-fix=1   before(regex)=RAISED
float8_e8m0fnu     after-fix=1   before(regex)=RAISED
```

Standard dtypes unchanged (`float32=4`, `float16/bfloat16=2`, `int8=1`, `float64=8`, `bool=1/8`). `ruff check` / `ruff format --check` clean.

```
tests/test_modeling_utils.py::ModelingUtilsTester::test_dtype_byte_size PASSED
```
