### PR TITLE
Raise ValueError instead of a bare string in ParallelismConfig.get_device_mesh

### DIFF
--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -248,7 +248,7 @@ class ParallelismConfig:
             if device_type is not None:
                 self.device_mesh = self.build_device_mesh(device_type)
             else:
-                raise ("You need to pass a device_type e.g cuda to build the device mesh")
+                raise ValueError("You need to pass a device_type e.g cuda to build the device mesh")
         else:
             if device_type is not None:
                 if self.device_mesh.device_type != device_type:


### PR DESCRIPTION
### Problem

`ParallelismConfig.get_device_mesh` raises a **bare string** when `device_type` is missing:

```python
raise ("You need to pass a device_type e.g cuda to build the device mesh")
```

In Python 3 you can only raise exception instances, so this throws
`TypeError: exceptions must derive from BaseException` instead of surfacing the
intended message — confusing for anyone who forgets to pass `device_type`.

### Fix

Raise `ValueError` with the same message.

### Testing done (CPU)

```
BEFORE  raise <str>        -> TypeError: exceptions must derive from BaseException
AFTER   raise ValueError   -> ValueError: You need to pass a device_type ...
REAL get_device_mesh(None) -> ValueError (good)
```

`ruff` clean.
