### PR TITLE
Fix to-fsdp2: drop REMOVED / NOT_YET_IMPLEMENTED FSDP1 keys instead of leaking them

### DIFF
--- a/src/accelerate/commands/to_fsdp2.py
+++ b/src/accelerate/commands/to_fsdp2.py
@@ -97,9 +97,11 @@ def convert_config_to_fsdp2(config: dict) -> dict:
 
     for key, value in fsdp_config.items():
         conversion_status = ARGUMENT_KEY_MAPPING.get(key, None)
-        if isinstance(conversion_status, ConversionStatus) or conversion_status is None:
-            conversion_status = key
-            new_fsdp_config[conversion_status] = value
+        # Key not in the mapping at all: carry it over unchanged. (ConversionStatus
+        # values must fall through to the REMOVED / NOT_YET_IMPLEMENTED handling
+        # below, otherwise those FSDP1-only keys would leak into the FSDP2 config.)
+        if conversion_status is None:
+            new_fsdp_config[key] = value
             continue
 
         if conversion_status == ConversionStatus.REMOVED:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,11 @@ import accelerate.commands.test as accelerate_test_cmd
 from accelerate.commands.config.config_args import BaseConfig, ClusterConfig, SageMakerConfig, load_config_from_file
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
 from accelerate.commands.launch import _validate_launch_command, launch_command, launch_command_parser
-from accelerate.commands.to_fsdp2 import to_fsdp2_command, to_fsdp2_command_parser
+from accelerate.commands.to_fsdp2 import (
+    convert_config_to_fsdp2,
+    to_fsdp2_command,
+    to_fsdp2_command_parser,
+)
 from accelerate.commands.tpu import tpu_command_launcher, tpu_command_parser
 from accelerate.test_utils.testing import (
     capture_call_output,
@@ -577,6 +581,36 @@ class ToFSDP2Tester(unittest.TestCase):
         with self.assertRaises(ValueError, msg="If --overwrite is not set, --output_file must be provided"):
             args = self.parser.parse_args(["--config_file", str(self.test_config_path / "latest_fsdp.yaml")])
             to_fsdp2_command(args)
+
+    def test_convert_config_drops_removed_and_unimplemented_keys(self):
+        config = {
+            "fsdp_config": {
+                "fsdp_backward_prefetch": "BACKWARD_PRE",  # REMOVED
+                "fsdp_use_orig_params": True,  # REMOVED
+                "fsdp_sync_module_states": True,  # REMOVED
+                "fsdp_forward_prefetch": True,  # NOT_YET_IMPLEMENTED
+                "fsdp_sharding_strategy": "FULL_SHARD",  # renamed + value-mapped
+                "fsdp_offload_params": True,  # carried over (maps to itself)
+                "some_unknown_key": 5,  # not in the mapping -> carried over
+            }
+        }
+        out = convert_config_to_fsdp2(config)["fsdp_config"]
+
+        # FSDP1-only keys must not leak into the FSDP2 config
+        for removed in (
+            "fsdp_backward_prefetch",
+            "fsdp_use_orig_params",
+            "fsdp_sync_module_states",
+            "fsdp_forward_prefetch",
+        ):
+            self.assertNotIn(removed, out)
+
+        # renamed key + value mapping, pass-through keys, and version bump
+        self.assertEqual(out["fsdp_reshard_after_forward"], True)
+        self.assertNotIn("fsdp_sharding_strategy", out)
+        self.assertEqual(out["fsdp_offload_params"], True)
+        self.assertEqual(out["some_unknown_key"], 5)
+        self.assertEqual(out["fsdp_version"], 2)
 
     @patch("pathlib.Path.exists")
     def test_overwrite_when_output_file_exists(self, mock_exists):


### PR DESCRIPTION
### Problem

`accelerate to-fsdp2` converts an FSDP1 config to FSDP2. In `convert_config_to_fsdp2`, the first branch of the per-key loop was:

```python
conversion_status = ARGUMENT_KEY_MAPPING.get(key, None)
if isinstance(conversion_status, ConversionStatus) or conversion_status is None:
    conversion_status = key
    new_fsdp_config[conversion_status] = value
    continue
```

This carries the key over and `continue`s for **both** "key not in the mapping" (`None`) **and** the `ConversionStatus` enum values (`REMOVED` / `NOT_YET_IMPLEMENTED`). As a result, the `REMOVED` / `NOT_YET_IMPLEMENTED` handling just below was **dead code**, and FSDP1-only keys — `fsdp_backward_prefetch`, `fsdp_sync_module_states`, `fsdp_use_orig_params` (REMOVED) and `fsdp_forward_prefetch` (NOT_YET_IMPLEMENTED) — leaked into the converted FSDP2 config instead of being dropped.

### Fix

Only carry over keys that are genuinely **absent** from the mapping (`conversion_status is None`); let `ConversionStatus` values fall through to the `REMOVED` / `NOT_YET_IMPLEMENTED` branches that drop them.

### Testing done (CPU)

Added `tests/test_cli.py::ToFSDP2Tester::test_convert_config_drops_removed_and_unimplemented_keys`:

```
1 passed
```

It asserts the four FSDP1-only keys are dropped, that a renamed+value-mapped key (`fsdp_sharding_strategy: FULL_SHARD` → `fsdp_reshard_after_forward: True`) and pass-through / unknown keys are preserved, and that `fsdp_version` is set to 2. `ruff` clean.
