### PR TITLE
fix(modeling): reject sharded-checkpoint weight_map entries that escape the checkpoint folder (#4067)

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1925,7 +1925,21 @@ def load_checkpoint_in_model(
         if "weight_map" in index:
             index = index["weight_map"]
         checkpoint_files = sorted(list(set(index.values())))
-        checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
+        # Guard against path traversal: a malicious or corrupted sharded-checkpoint index may
+        # map weights to filenames that escape `checkpoint_folder` (e.g. "../../etc/passwd" or
+        # an absolute path), which `os.path.join` would happily resolve outside the checkpoint
+        # folder and load as a shard. Reject any entry that does not stay inside the folder.
+        checkpoint_folder_abs = os.path.abspath(checkpoint_folder)
+        safe_checkpoint_files = []
+        for shard_file in checkpoint_files:
+            resolved = os.path.abspath(os.path.join(checkpoint_folder, shard_file))
+            if resolved != checkpoint_folder_abs and not resolved.startswith(checkpoint_folder_abs + os.sep):
+                raise ValueError(
+                    f"Invalid sharded checkpoint index: weight map entry {shard_file!r} resolves outside "
+                    f"the checkpoint folder. Refusing to load a potentially malicious checkpoint."
+                )
+            safe_checkpoint_files.append(resolved)
+        checkpoint_files = safe_checkpoint_files
 
     # Logic for missing/unexpected keys goes here.
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -430,6 +430,21 @@ class ModelingUtilsTester(unittest.TestCase):
             self.shard_test_model(model, tmp_dir)
             load_checkpoint_in_model(model, tmp_dir)
 
+    def test_load_checkpoint_in_model_rejects_path_traversal(self):
+        # Regression test: a malicious or corrupted sharded-checkpoint index must not be able to
+        # load shards from outside the checkpoint folder (e.g. "../escaped_shard.bin" or an absolute
+        # path). Such an entry must be rejected before any file is opened.
+        model = ModelForTest()
+        for malicious_target in ("../escaped_shard.bin", os.path.join(os.sep, "tmp", "escaped_shard.bin")):
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                index = {name: malicious_target for name in model.state_dict()}
+                index_file = os.path.join(tmp_dir, "weight_map.index.json")
+                with open(index_file, "w") as f:
+                    json.dump(index, f)
+                with self.assertRaises(ValueError) as cm:
+                    load_checkpoint_in_model(model, index_file)
+                self.assertIn("outside", str(cm.exception))
+
     @require_non_cpu
     def test_load_checkpoint_in_model_one_gpu(self):
         device_map = {"linear1": 0, "batchnorm": "cpu", "linear2": "cpu"}


### PR DESCRIPTION
### What this fixes

Closes #4067 (path-traversal half of the report).

`load_checkpoint_in_model` builds the list of shard files to load directly from the **untrusted** `weight_map` of a sharded-checkpoint index (`*.index.json`):

```python
checkpoint_files = sorted(list(set(index.values())))
checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
```

The values come straight from the model author. Because `os.path.join` resolves `..` segments and discards the prefix entirely when given an absolute path, a malicious or corrupted index can point a "shard" anywhere on the filesystem:

```json
{"weight_map": {"w": "../../../../etc/passwd"}}      // escapes via traversal
{"weight_map": {"w": "/etc/shadow"}}                  // absolute path wins in os.path.join
```

The file is then opened and parsed as a checkpoint shard, which is a path-traversal / arbitrary-file-read primitive (and an easy DoS vector when pointed at a large or special file).

### The fix

After resolving each entry against `checkpoint_folder`, verify it still lives inside that folder and raise `ValueError` otherwise. Legitimate sharded checkpoints (HF `save_pretrained` output) always reference plain sibling filenames, so they are unaffected.

```python
checkpoint_folder_abs = os.path.abspath(checkpoint_folder)
for shard_file in checkpoint_files:
    resolved = os.path.abspath(os.path.join(checkpoint_folder, shard_file))
    if resolved != checkpoint_folder_abs and not resolved.startswith(checkpoint_folder_abs + os.sep):
        raise ValueError(...)
```

The containment check (`startswith(folder + os.sep)`) also rejects absolute paths and, on Windows, paths on a different drive.

### Scope note

This targets the **path-traversal** vector specifically. The "malicious-model DoS" angle in the title (unbounded shard size / count) is broader and policy-dependent — happy to follow up separately if maintainers want bounds there too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
