### PR TITLE
docs: fix parameter names and a ghost entry in docstrings

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3071,7 +3071,7 @@ class Accelerator:
         used for gathering the inputs and targets for metric calculation.
 
         Args:
-            input (`torch.Tensor`, `object`, a nested tuple/list/dictionary of `torch.Tensor`, or a nested tuple/list/dictionary of `object`):
+            input_data (`torch.Tensor`, `object`, a nested tuple/list/dictionary of `torch.Tensor`, or a nested tuple/list/dictionary of `object`):
                 The tensors or objects for calculating metrics across all processes
             use_gather_object(`bool`):
                 Whether to forcibly use gather_object instead of gather (which is already done if all objects passed do

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1150,7 +1150,7 @@ class DeepSpeedPlugin:
             `MixtralSparseMoeBlock`, `Qwen2MoeSparseMoeBlock`, `JetMoEAttention`, `JetMoEBlock`, etc.
         enable_msamp (`bool`, defaults to `None`):
             Flag to indicate whether to enable MS-AMP backend for FP8 training.
-        msasmp_opt_level (`Optional[Literal["O1", "O2"]]`, defaults to `None`):
+        msamp_opt_level (`Optional[Literal["O1", "O2"]]`, defaults to `None`):
             Optimization level for MS-AMP (defaults to 'O1'). Only applicable if `enable_msamp` is True. Should be one
             of ['O1' or 'O2'].
     """
@@ -2331,7 +2331,7 @@ class MegatronLMPlugin:
             Enable sequence parallelism.
         recompute_activations (`bool`, defaults to `None`):
             Enable selective activation recomputation.
-        use_distributed_optimizr (`bool`, defaults to `None`):
+        use_distributed_optimizer (`bool`, defaults to `None`):
             Enable distributed optimizer.
         pipeline_model_parallel_split_rank (`int`, defaults to `None`):
             Rank where encoder and decoder should be split.

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -447,9 +447,9 @@ def named_module_tensors(
     Args:
         module (`torch.nn.Module`):
             The module we want the tensors on.
-        include_buffer (`bool`, *optional*, defaults to `True`):
+        include_buffers (`bool`, *optional*, defaults to `True`):
             Whether or not to include the buffers in the result.
-        recurse (`bool`, *optional`, defaults to `False`):
+        recurse (`bool`, *optional*, defaults to `False`):
             Whether or not to go look in every submodule or just return the direct parameters and buffers.
         remove_non_persistent (`bool`, *optional*, defaults to `False`):
             Whether or not to remove the non persistent buffer from the buffers. Useful only when include_buffers =
@@ -2070,8 +2070,6 @@ def get_mixed_precision_context_manager(native_amp: bool = False, autocast_kwarg
     Args:
         native_amp (`bool`, *optional*, defaults to False):
             Whether mixed precision is actually enabled.
-        cache_enabled (`bool`, *optional*, defaults to True):
-            Whether the weight cache inside autocast should be enabled.
     """
     state = AcceleratorState()
     if autocast_kwargs is None:


### PR DESCRIPTION
## What does this PR do?

Audits docstring Args sections against the actual signatures/fields and fixes five drifts. These docstrings feed the rendered API reference, so the wrong names are what users see:

| Location | Problem | Fix |
|---|---|---|
| `DeepSpeedPlugin` | entry spelled `msasmp_opt_level` | → `msamp_opt_level` (the actual field) |
| `MegatronLMPlugin` | entry spelled `use_distributed_optimizr` | → `use_distributed_optimizer` |
| `Accelerator.gather_for_metrics` | Args entry says `input`; the parameter is `input_data` (the prose above already uses the correct name) | rename entry |
| `named_module_tensors` | entry says `include_buffer`; the parameter is `include_buffers` (the `remove_non_persistent` description below already spells it correctly); the `recurse` entry also has malformed `*optional\`` markup | rename entry + fix markup |
| `get_mixed_precision_context_manager` | documents a `cache_enabled` parameter; the signature is `(native_amp, autocast_kwargs)` — no such parameter | drop the ghost entry |

Docstring-only; +5 / −7 across 3 files, no behavior change.