### PR TITLE
fix(utils): don't crash check_os_kernel on non-standard kernel release strings

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -536,7 +536,13 @@ def check_os_kernel():
     if system != "Linux":
         return
 
-    _, version, *_ = re.split(r"(\d+\.\d+\.\d+)", info.release)
+    # Some kernels report a release string without a full X.Y.Z version (e.g. custom builds,
+    # certain containers/WSL). In that case we cannot meaningfully compare versions, so we skip
+    # the check rather than raising -- this function is only meant to emit a best-effort warning.
+    match = re.search(r"\d+\.\d+\.\d+", info.release)
+    if match is None:
+        return
+    version = match.group()
     min_version = "5.5.0"
     if Version(version) < Version(min_version):
         msg = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -290,6 +290,17 @@ class UtilsTester(unittest.TestCase):
             assert "5.4.0" in ctx.records[0].msg
             assert "5.5.0" in ctx.records[0].msg
 
+    def test_check_os_kernel_no_crash_on_nonstandard_release(self):
+        # Some Linux kernels report a release string without a full X.Y.Z version (e.g. custom
+        # builds, certain containers/WSL). check_os_kernel() is called during Accelerator init and
+        # must never raise just because it cannot parse the version -- it should degrade gracefully.
+        for release in ("5.15", "6.1-arch1", "unknown"):
+            with (
+                patch("platform.uname", return_value=Mock(release=release, system="Linux")),
+                warnings.catch_warnings(record=True),
+            ):
+                check_os_kernel()
+
     @require_non_torch_xla
     def test_save_safetensor_shared_memory(self):
         class Model(nn.Module):


### PR DESCRIPTION
## Summary
`check_os_kernel()` aborts `Accelerator` initialization with an opaque `ValueError: not enough values to unpack` on Linux hosts whose kernel release string doesn't contain a full `X.Y.Z` version — e.g. custom kernels, some containers/WSL reporting `"5.15"`, `"6.1-arch1"`, or `"unknown"`. The cause is `_, version, *_ = re.split(r"(\d+\.\d+\.\d+)", info.release)`, which yields too few parts when there's no `X.Y.Z` match.

## Fix
Use `re.search` for the `X.Y.Z` pattern and return early (skip the version warning) when no standard version is present. On standard release strings the extracted version is identical to before — no behavior change.

## Tests
Regression test covering non-standard release strings (RED before / GREEN after). `tests/test_utils.py`: 46 passed; ruff clean.

*AI-assisted contribution.*
