### PR TITLE
Add `materialize_meta_tensors` to reverse `dispatch_model` (#3866)

### DIFF
--- a/docs/source/package_reference/big_modeling.md
+++ b/docs/source/package_reference/big_modeling.md
@@ -37,6 +37,10 @@ rendered properly in your Markdown viewer.
 
 [[autodoc]] big_modeling.dispatch_model
 
+### materialize_meta_tensors
+
+[[autodoc]] big_modeling.materialize_meta_tensors
+
 ### load_checkpoint_and_dispatch
 
 [[autodoc]] big_modeling.load_checkpoint_and_dispatch

--- a/src/accelerate/__init__.py
+++ b/src/accelerate/__init__.py
@@ -22,6 +22,7 @@ from .big_modeling import (
     init_empty_weights,
     init_on_device,
     load_checkpoint_and_dispatch,
+    materialize_meta_tensors,
 )
 from .data_loader import skip_first_batches
 from .inference import prepare_pippy

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -26,10 +26,12 @@ from .hooks import (
     AlignDevicesHook,
     CpuOffload,
     LayerwiseCastingHook,
+    SequentialHook,
     UserCpuOffloadHook,
     add_hook_to_module,
     attach_align_device_hook,
     attach_align_device_hook_on_blocks,
+    remove_hook_from_module,
 )
 from .utils import (
     OffloadedWeightsLoader,
@@ -47,9 +49,11 @@ from .utils import (
     is_sdaa_available,
     is_xpu_available,
     load_checkpoint_in_model,
+    named_module_tensors,
     offload_state_dict,
     parse_flag_from_env,
     retie_parameters,
+    set_module_tensor_to_device,
 )
 from .utils.constants import SUPPORTED_PYTORCH_LAYERS_FOR_UPCASTING
 from .utils.other import recursive_getattr
@@ -517,6 +521,75 @@ def dispatch_model(
     # Convert OrderedDict back to dict for easier usage
     model.hf_device_map = dict(device_map)
     return model
+
+
+def materialize_meta_tensors(model: nn.Module, target_device: Union[int, str, torch.device] = "cpu"):
+    """
+    Reverses [`dispatch_model`]: loads all the weights offloaded to the CPU or the disk back onto `target_device`,
+    removes all the hooks added by Accelerate and places the model on `target_device`. The model then no longer has
+    any parameter on the meta device and can be moved freely with `model.to()`, for instance to park it in CPU RAM
+    while another model uses the GPU, then move it back.
+
+    Note that this requires enough memory on `target_device` to fit the whole model.
+
+    Args:
+        model (`torch.nn.Module`):
+            The model dispatched with [`dispatch_model`] or [`load_checkpoint_and_dispatch`].
+        target_device (`int`, `str` or `torch.device`, *optional*, defaults to `"cpu"`):
+            The device on which to load the offloaded weights and place the model.
+
+    Returns:
+        `torch.nn.Module`: The same model, with all its weights materialized on `target_device` (the model is
+        modified in place, so the result can be discarded).
+
+    Example:
+
+    ```python
+    >>> from accelerate import dispatch_model, materialize_meta_tensors
+
+    >>> model = dispatch_model(model, device_map=device_map, offload_dir=offload_dir)
+    >>> # ... run inference, then free the execution device for another model
+    >>> model = materialize_meta_tensors(model, target_device="cpu")
+    >>> # The model can now be moved freely
+    >>> model = model.to("cuda:0")
+    ```
+    """
+    # Materializing the offloaded weights breaks the ties between them, so we keep track of the tied parameters to
+    # retie them at the end.
+    tied_params = find_tied_parameters(model)
+
+    # Keep a handle on the offloading hooks before removing them, as we need their `weights_map` to load back the
+    # weights that `detach_hook` leaves on the meta device (those that were already on the meta device before the
+    # hooks were attached, for instance with `load_checkpoint_and_dispatch`).
+    offloaded_modules = []
+    for module in model.modules():
+        module_hook = getattr(module, "_hf_hook", None)
+        hooks = module_hook.hooks if isinstance(module_hook, SequentialHook) else [module_hook]
+        for hook in hooks:
+            if isinstance(hook, AlignDevicesHook) and hook.offload and hook.weights_map is not None:
+                offloaded_modules.append((module, hook))
+
+    # Detach all the hooks: this restores the weights that were offloaded from a real device and removes the wrappers
+    # `dispatch_model` added on `to`, `cuda`, etc.
+    remove_hook_from_module(model, recurse=True)
+
+    # Load the weights still on the meta device from the offloaded values, mirroring `AlignDevicesHook.pre_forward`.
+    for module, hook in offloaded_modules:
+        for name, tensor in named_module_tensors(
+            module, include_buffers=hook.offload_buffers, recurse=hook.place_submodules, remove_non_persistent=True
+        ):
+            if tensor.device != torch.device("meta"):
+                continue
+            value = hook.weights_map[name]
+            fp16_statistics = hook._maybe_get_fp16_statistics(name, value)
+            set_module_tensor_to_device(module, name, target_device, value=value, fp16_statistics=fp16_statistics)
+
+    retie_parameters(model, tied_params)
+    if hasattr(model, "hf_device_map"):
+        del model.hf_device_map
+
+    # Move the parts that were not offloaded (e.g. kept on the execution device) to `target_device` as well.
+    return model.to(target_device)
 
 
 def load_checkpoint_and_dispatch(

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -32,6 +32,7 @@ from accelerate.big_modeling import (
     init_empty_weights,
     init_on_device,
     load_checkpoint_and_dispatch,
+    materialize_meta_tensors,
 )
 from accelerate.hooks import remove_hook_from_submodules
 from accelerate.test_utils import (
@@ -701,6 +702,92 @@ class BigModelingTester(unittest.TestCase):
             with self.assertRaises(RuntimeError):
                 x = torch.randn(2, 3)
                 model(x)
+
+    def test_materialize_meta_tensors(self):
+        model = ModelForTest()
+        device_map = {"linear1": "cpu", "batchnorm": "cpu", "linear2": "disk"}
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir)
+            assert model.linear2.weight.device == torch.device("meta")
+            # A dispatched model with offloaded modules cannot be moved.
+            with self.assertRaises(RuntimeError):
+                model.to("cpu")
+
+            materialize_meta_tensors(model, target_device="cpu")
+
+        assert all(t.device == torch.device("cpu") for t in itertools.chain(model.parameters(), model.buffers()))
+        assert all(not hasattr(module, "_hf_hook") for module in model.modules())
+        assert not hasattr(model, "hf_device_map")
+        # The model can now be moved freely, without any warning.
+        with self.assertLogs(level="WARNING") as cm:
+            # We want to assert there are no warnings, but the 'assertLogs' method does not support that.
+            # Therefore, we are adding a dummy warning, and then we will assert it is the only warning.
+            model.to(torch_device)
+            logger.warning("Dummy warning")
+        assert len(cm.records) == 1
+        assert "Dummy warning" in cm.records[0].message
+        output = model(x.to(torch_device))
+        torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
+
+    def test_materialize_meta_tensors_load_checkpoint_and_dispatch(self):
+        # Here the offloaded weights were never on a real device, so they can only be loaded from the offload folder.
+        model = ModelForTest()
+        device_map = {"linear1": "cpu", "batchnorm": "cpu", "linear2": "disk"}
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            checkpoint = os.path.join(tmp_dir, "pt_model.bin")
+            torch.save(model.state_dict(), checkpoint)
+
+            with init_empty_weights():
+                new_model = ModelForTest()
+            new_model = load_checkpoint_and_dispatch(
+                new_model, checkpoint, device_map=device_map, offload_folder=tmp_dir
+            )
+            assert new_model.linear2.weight.device == torch.device("meta")
+
+            materialize_meta_tensors(new_model, target_device="cpu")
+
+        assert all(
+            t.device == torch.device("cpu") for t in itertools.chain(new_model.parameters(), new_model.buffers())
+        )
+        output = new_model(x)
+        torch.testing.assert_close(expected, output, atol=ATOL, rtol=RTOL)
+
+    def test_materialize_meta_tensors_tied_weights(self):
+        model = ModelForTestTiedWeights()
+        model.linear1.weight = model.linear2.weight
+        device_map = {"linear1": "cpu", "batchnorm": "cpu", "linear2": "disk"}
+        x = torch.randn(2, 4)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir)
+            materialize_meta_tensors(model, target_device="cpu")
+
+        assert model.linear1.weight is model.linear2.weight
+        assert all(t.device == torch.device("cpu") for t in itertools.chain(model.parameters(), model.buffers()))
+        output = model(x)
+        torch.testing.assert_close(expected, output, atol=ATOL, rtol=RTOL)
+
+    def test_materialize_meta_tensors_offload_buffers(self):
+        model = ModelForTestNonPersistentBuffers()
+        device_map = {"linear1": "cpu", "batchnorm": "cpu", "linear2": "disk"}
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir, offload_buffers=True)
+            assert model.linear2.weight.device == torch.device("meta")
+            materialize_meta_tensors(model, target_device="cpu")
+
+        assert all(t.device == torch.device("cpu") for t in itertools.chain(model.parameters(), model.buffers()))
+        output = model(x)
+        torch.testing.assert_close(expected, output, atol=ATOL, rtol=RTOL)
 
     @slow
     @require_non_hpu  # hpu does not support device indexing "hpu:1"


### PR DESCRIPTION
# What does this PR do?

Fixes #3866.

The blocker is twofold: `AlignDevicesHook.init_hook` keeps the real values of offloaded weights only in `hook.weights_map` and leaves meta placeholders on the module, and `dispatch_model` wraps `model.to` to raise as soon as any parameter is on meta. Notably, removing the hooks is not enough: `AlignDevicesHook.detach_hook` only restores weights that were on a real device before dispatch, so for models whose weights went straight from the checkpoint to the offload folder (`load_checkpoint_and_dispatch`, `from_pretrained(device_map=...)`) the offloaded weights stay on meta with no public way back.

This PR adds `materialize_meta_tensors(model, target_device="cpu")` in `big_modeling.py`: it detaches all hooks (which also unwraps `to`/`cuda`), loads the weights still on meta from each offload hook's `weights_map` (mirroring `AlignDevicesHook.pre_forward`, including the int8 fp16 statistics), reties tied parameters, drops `hf_device_map`, and moves the model to `target_device`. The model is then a regular module again and `.to()` works for the CPU-parking round-trip described in the issue.

Four new CPU-runnable tests in `tests/test_big_modeling.py` cover the `dispatch_model` and `load_checkpoint_and_dispatch` flows, tied weights, and `offload_buffers=True`; outputs match the un-dispatched reference and `.to()` no longer raises or warns afterwards.

On the API shape: @SunMarc suggested a context manager or a `dispatch_model` flag — I went with the plain function from the issue since it is the primitive both of those can be built on (a context manager only needs to re-dispatch with the saved device map on exit). Happy to add either on top if preferred.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/huggingface/accelerate/issues/3866
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

@SunMarc
