### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/source/package_reference/logging.md
+++ b/docs/source/package_reference/logging.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 # Logging
 
-Refer to the [Troubleshooting guide](../usage_guides/troubleshooting#logging) or to the example below to learn 
+Refer to the [Troubleshooting guide](../basic_tutorials/troubleshooting#logging) or to the example below to learn 
 how to use Accelerate's logger. 
 
 [[autodoc]] logging.get_logger

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -103,7 +103,7 @@ These are classes which can be configured and passed through to the appropriate 
 
 These are environmental variables that can be enabled for different use cases
 
-* `ACCELERATE_DEBUG_MODE` (`str`): Whether to run accelerate in debug mode. More info available [here](../usage_guides/debug.md).
+* `ACCELERATE_DEBUG_MODE` (`str`): Whether to run accelerate in debug mode. More info available [here](../basic_tutorials/troubleshooting#mismatched-tensor-shapes).
 
 
 

--- a/docs/source/usage_guides/deepspeed.md
+++ b/docs/source/usage_guides/deepspeed.md
@@ -69,7 +69,7 @@ Inference:
 
 1. DeepSpeed ZeRO Inference supports ZeRO stage 3 with ZeRO-Infinity. It uses the same ZeRO protocol as training, but
    it doesn't use an optimizer and a lr scheduler and only stage 3 is relevant. For more details see:
-   [deepspeed-zero-inference](#deepspeed-zero-inference).
+   [ZeRO Inference](#zero-inference).
 
 
 ## How it works?


### PR DESCRIPTION
## What does this PR do?

Fixes three broken links in the docs:

| File | Before | After |
|------|--------|-------|
| `package_reference/logging.md` | `../usage_guides/troubleshooting#logging` | `../basic_tutorials/troubleshooting#logging` |
| `package_reference/utilities.md` | `../usage_guides/debug.md` | `../basic_tutorials/troubleshooting#mismatched-tensor-shapes` |
| `usage_guides/deepspeed.md` | `[deepspeed-zero-inference](#deepspeed-zero-inference)` | `[ZeRO Inference](#zero-inference)` |

- `troubleshooting.md` lives under `basic_tutorials/`, not `usage_guides/`, so the logging link 404'd.
- `usage_guides/debug.md` doesn't exist; debug mode (`ACCELERATE_DEBUG_MODE`) is documented in the troubleshooting guide's "Mismatched tensor shapes" section.
- The DeepSpeed page's same-page anchor pointed to `#deepspeed-zero-inference`, but the heading is `## ZeRO Inference` (anchor `#zero-inference`).

Docs-only.

## Before submitting

- [x] Did you read the [contributor guidelines](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md)?
