### PR TITLE
[Offloading] Support full disk offloading

### DIFF
--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -373,10 +373,10 @@ def dispatch_model(
     # in the unique device and the user can decide where to dispatch the model.
     # If the model is quantized, we always force-dispatch the model
     devices = set(device_map.values())
-    if (len(devices) > 1) or "disk" in devices or force_hooks:
+    if len(devices) > 1 or "disk" in devices or force_hooks:
         if main_device is None:
             non_offloaded_devices = devices - {"cpu", "disk"}
-            main_device = non_offloaded_devices[0] if non_offloaded_devices else "cpu"
+            main_device = list(non_offloaded_devices)[0] if non_offloaded_devices else "cpu"
 
         if main_device != "cpu":
             cpu_modules = [name for name, device in device_map.items() if device == "cpu"]
@@ -420,13 +420,16 @@ def dispatch_model(
         tied_params_map = {}
         for group in tied_params:
             for param_name in group:
-                # data_ptr() is enough here, as `find_tied_parameters` finds tied params simply by comparing `param1 is param2`, so we don't need
-                # to care about views of tensors through storage_offset.
-                data_ptr = recursive_getattr(model, param_name).data_ptr()
-                tied_params_map[data_ptr] = {}
+                offloaded_param = recursive_getattr(model, param_name)
 
                 # Note: To handle the disk offloading case, we can not simply use weights_map[param_name].data_ptr() as the reference pointer,
                 # as we have no guarantee that safetensors' `file.get_tensor()` will always give the same pointer.
+                # Therefore, we must skip and induce a runtime cost in the rare case that two tied disk-offloaded params are onloaded simultaneously
+                if offloaded_param.device.type != "meta":
+                    # data_ptr() is enough here, as `find_tied_parameters` finds tied params simply by comparing `param1 is param2`, so we don't need
+                    # to care about views of tensors through storage_offset.
+                    data_ptr = recursive_getattr(model, param_name).data_ptr()
+                    tied_params_map[data_ptr] = {}
 
         attach_align_device_hook_on_blocks(
             model,

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -428,7 +428,7 @@ def dispatch_model(
                 if offloaded_param.device.type != "meta":
                     # data_ptr() is enough here, as `find_tied_parameters` finds tied params simply by comparing `param1 is param2`, so we don't need
                     # to care about views of tensors through storage_offset.
-                    data_ptr = recursive_getattr(model, param_name).data_ptr()
+                    data_ptr = offloaded_param.data_ptr()
                     tied_params_map[data_ptr] = {}
 
         attach_align_device_hook_on_blocks(
@@ -511,7 +511,6 @@ def dispatch_model(
         elif is_neuron_available() and isinstance(device, int):
             device = f"neuron:{device}"
         else:
-            assert device != "disk"
             model.to(device)
     # Convert OrderedDict back to dict for easier usage
     model.hf_device_map = dict(device_map)

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -495,7 +495,7 @@ def dispatch_model(
                 "Please make sure to update your driver to the latest version which resolves this."
             )
     else:
-        device = list(device_map.values())[0]
+        device = list(devices)[0]
         # `torch.Tensor.to(<int num>)` is not supported by `torch_npu` (see this [issue](https://github.com/Ascend/pytorch/issues/16)).
         if is_npu_available() and isinstance(device, int):
             device = f"npu:{device}"
@@ -507,12 +507,9 @@ def dispatch_model(
             device = f"musa:{device}"
         elif is_neuron_available() and isinstance(device, int):
             device = f"neuron:{device}"
-        if device != "disk":
-            model.to(device)
         else:
-            raise ValueError(
-                "You are trying to offload the whole model to the disk. Please use the `disk_offload` function instead."
-            )
+            assert device != "disk"
+            model.to(device)
     # Convert OrderedDict back to dict for easier usage
     model.hf_device_map = dict(device_map)
     return model

--- a/src/accelerate/big_modeling.py
+++ b/src/accelerate/big_modeling.py
@@ -368,16 +368,15 @@ def dispatch_model(
         ):
             force_hooks = True
 
-    # We attach hooks if the device_map has at least 2 different devices or if
-    # force_hooks is set to `True`. Otherwise, the model in already loaded
+    # We attach hooks if there are least 2 different devices, one of the device is disk,
+    # or if force_hooks is set to `True`. Otherwise, the model in already loaded
     # in the unique device and the user can decide where to dispatch the model.
     # If the model is quantized, we always force-dispatch the model
-    if (len(set(device_map.values())) > 1) or force_hooks:
+    devices = set(device_map.values())
+    if (len(devices) > 1) or "disk" in devices or force_hooks:
         if main_device is None:
-            if set(device_map.values()) == {"cpu"} or set(device_map.values()) == {"cpu", "disk"}:
-                main_device = "cpu"
-            else:
-                main_device = [d for d in device_map.values() if d not in ["cpu", "disk"]][0]
+            non_offloaded_devices = devices - {"cpu", "disk"}
+            main_device = non_offloaded_devices[0] if non_offloaded_devices else "cpu"
 
         if main_device != "cpu":
             cpu_modules = [name for name, device in device_map.items() if device == "cpu"]

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -780,6 +780,7 @@ class BigModelingTester(unittest.TestCase):
     def test_dispatch_model_disk_only(self):
         model = ModelForTest()
 
+        # note: non-expanded device maps for disk offloading is not supported
         device_map = {"linear1": "disk", "batchnorm": "disk", "linear2": "disk"}
 
         x = torch.randn(2, 3)

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -777,6 +777,19 @@ class BigModelingTester(unittest.TestCase):
             output = model(x)
             torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
 
+    def test_dispatch_model_disk_only(self):
+        model = ModelForTest()
+
+        device_map = {"linear1": "disk", "batchnorm": "disk", "linear2": "disk"}
+
+        x = torch.randn(2, 3)
+        expected = model(x)
+
+        with TemporaryDirectory() as tmp_dir:
+            dispatch_model(model, device_map, offload_dir=tmp_dir)
+            output = model(x)
+            torch.testing.assert_close(expected, output.cpu(), atol=ATOL, rtol=RTOL)
+
     @require_non_cpu
     def test_dispatch_model_force_hooks(self):
         model = ModelForTest()

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -780,7 +780,7 @@ class BigModelingTester(unittest.TestCase):
     def test_dispatch_model_disk_only(self):
         model = ModelForTest()
 
-        device_map = {"linear1": "disk", "batchnorm": "disk", "linear2": "disk"}
+        device_map = {"": "disk"}
 
         x = torch.randn(2, 3)
         expected = model(x)

--- a/tests/test_big_modeling.py
+++ b/tests/test_big_modeling.py
@@ -780,7 +780,7 @@ class BigModelingTester(unittest.TestCase):
     def test_dispatch_model_disk_only(self):
         model = ModelForTest()
 
-        device_map = {"": "disk"}
+        device_map = {"linear1": "disk", "batchnorm": "disk", "linear2": "disk"}
 
         x = torch.randn(2, 3)
         expected = model(x)


### PR DESCRIPTION
## Purpose ##
* Support full disk offloading of an entire model
  * This is useful for testing and cases like [vllm-project/llm-compressor](https://github.com/vllm-project/llm-compressor) which heavily utilizes disk offloading to compress large models
* Add missing handling for when tied weights are disk offloaded
* This PR can be merged independently from https://github.com/huggingface/transformers/pull/46749

## Changes ##
* Force hook to be added if any modules are dispatched to disk (disk offloading relies on hooks)
* Do not add disk offloaded meta tensors to the `tied_params_map`. Because the data pointer for meta tensors is always `0`, this would cause all weights to share the same onloaded same weight value
  * This is a bug that was likely never encountered during testing, as embeddings are almost never disk offloaded
  * It is possible to share onloads between disk-offloaded params, but this current system doesn't support it, and the cases in which that's actually useful would be very rare

## Testing ##
* Added full disk offloading test
* Tested changes with `test_disk_offloading.py` in conjunction with https://github.com/huggingface/transformers/pull/46749

<details open><summary>test_disk_offloading.py</summary>

```python
import torch
import pytest

from transformers import AutoModelForCausalLM


# Qwen3-0.6B has tied weights, two copies in checkpoint
# Llama-3.2-1B-Instruct has tied weights, only one copy in checkpoint
# tinysmokeqwen3 has untied weights
@torch.no_grad()
@pytest.mark.parametrize("model_id,cpu_mem", [
    ("Qwen/Qwen3-0.6B", 0),
    ("Qwen/Qwen3-0.6B", 6e8),
    ("meta-llama/Llama-3.2-1B-Instruct", 0),
    ("meta-llama/Llama-3.2-1B-Instruct", 1e9),
    ("nm-testing/tinysmokeqwen3", 0),
    ("nm-testing/tinysmokeqwen3", 1.5e6),
])
def test_tied_in_checkpoint(model_id, cpu_mem):
    true_model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto")
    model = AutoModelForCausalLM.from_pretrained(
        model_id,
        device_map="auto",
        max_memory={"cpu": cpu_mem},
        offload_folder="./offload_folder",
    )

    inputs = {key: value.to(true_model.device) for key, value in model.dummy_inputs.items()}

    true_outputs = true_model(**model.dummy_inputs)
    outputs = model(**model.dummy_inputs)
    assert torch.nn.functional.mse_loss(true_outputs.logits, outputs.logits) < 1e-2
```

</details>