### PR TITLE
Add already_sharded option to skip double-sharding of DataLoaders

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -2726,6 +2726,7 @@ class Accelerator:
             non_blocking=self.non_blocking,
             use_stateful_dataloader=self.use_stateful_dataloader,
             torch_device_mesh=device_mesh,
+            already_sharded=getattr(self.dataloader_config, "already_sharded", False),
         )
         self._dataloaders.append(prepared_data_loader)
         return prepared_data_loader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -552,6 +552,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         use_stateful_dataloader=False,
         _drop_last: bool = False,
         _non_blocking: bool = False,
+        _total_num_processes: int = 1,
         torch_device_mesh=None,
         **kwargs,
     ):
@@ -563,6 +564,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.gradient_state = GradientState()
         self._drop_last = _drop_last
         self._non_blocking = _non_blocking
+        self._total_num_processes = _total_num_processes
         self.iteration = 0
 
     def adjust_state_dict_for_prefetch(self):
@@ -640,11 +642,12 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
     @property
     def total_batch_size(self):
         batch_sampler = self.sampler if isinstance(self.sampler, BatchSampler) else self.batch_sampler
-        return (
-            batch_sampler.batch_size
-            if getattr(batch_sampler, "split_batches", False)
-            else (batch_sampler.batch_size * getattr(batch_sampler, "num_processes", 1))
-        )
+        if getattr(batch_sampler, "split_batches", False):
+            return batch_sampler.batch_size
+        # A `BatchSamplerShard` carries `num_processes`; an already-sharded dataloader keeps the user's plain
+        # batch sampler, so fall back to the process count captured at prepare time.
+        num_processes = getattr(batch_sampler, "num_processes", None) or self._total_num_processes
+        return batch_sampler.batch_size * num_processes
 
     @property
     def total_dataset_length(self):
@@ -1027,6 +1030,7 @@ def prepare_data_loader(
     non_blocking: bool = False,
     use_stateful_dataloader: bool = False,
     torch_device_mesh=None,
+    already_sharded: bool = False,
 ) -> DataLoader:
     """
     Wraps a PyTorch `DataLoader` to generate batches for one of the processes only.
@@ -1096,6 +1100,13 @@ def prepare_data_loader(
             This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed."
         torch_device_mesh (`torch.distributed.DeviceMesh`, *optional*, defaults to `None`):
             PyTorch device mesh.
+        already_sharded (`bool`, *optional*, defaults to `False`):
+            If set to `True`, Accelerate assumes the `dataloader` is already sharded across processes (e.g. via a
+            rank-aware `DistributedSampler`) and skips its own sharding, so the data is not split twice. The other
+            wrapper features (device placement, `set_epoch` forwarding, state tracking) are preserved. The user is
+            responsible for ensuring each process receives the correct shard. Accelerate's `even_batches` padding is
+            also skipped, so every process must iterate the same number of batches to avoid hangs. Incompatible with
+            `dispatch_batches` and `split_batches`.
 
 
     Returns:
@@ -1108,6 +1119,22 @@ def prepare_data_loader(
 
     </Tip>
     """
+    if already_sharded:
+        # Validate against the user-provided values before `dispatch_batches` is auto-resolved below.
+        if dispatch_batches:
+            raise ValueError(
+                "`already_sharded=True` is incompatible with `dispatch_batches=True`: dispatch mode iterates the "
+                "dataloader on the main process and redistributes batches, which conflicts with a dataloader that is "
+                "already sharded per process."
+            )
+        if split_batches:
+            raise ValueError(
+                "`already_sharded=True` is incompatible with `split_batches=True`: split mode would split each "
+                "process's local batch again."
+            )
+        # An already-sharded dataloader is iterated independently on each process, never dispatched.
+        dispatch_batches = False
+
     if dispatch_batches is None:
         if not put_on_device:
             dispatch_batches = False
@@ -1217,8 +1244,12 @@ def prepare_data_loader(
         generator.manual_seed(seed)
         dataloader.generator = generator
         dataloader.sampler.generator = generator
-    # No change if no multiprocess
-    if (num_processes != 1 or state.distributed_type == DistributedType.MEGATRON_LM) and not dispatch_batches:
+    # No change if no multiprocess, or if the dataloader is already sharded by the user
+    if (
+        (num_processes != 1 or state.distributed_type == DistributedType.MEGATRON_LM)
+        and not dispatch_batches
+        and not already_sharded
+    ):
         if is_datasets_available():
             from datasets import IterableDataset as DatasetsIterableDataset
         if (
@@ -1303,6 +1334,7 @@ def prepare_data_loader(
             rng_types=rng_types,
             _drop_last=dataloader.drop_last,
             _non_blocking=non_blocking,
+            _total_num_processes=num_processes if already_sharded else 1,
             synchronized_generator=synchronized_generator,
             use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
@@ -1316,6 +1348,7 @@ def prepare_data_loader(
             synchronized_generator=synchronized_generator,
             _drop_last=dataloader.drop_last,
             _non_blocking=non_blocking,
+            _total_num_processes=num_processes if already_sharded else 1,
             use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
         )

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -852,6 +852,12 @@ class DataLoaderConfiguration:
             If set to `True`, the dataloader prepared by the Accelerator will be backed by
             [torchdata.StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader).
             This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed.
+        already_sharded (`bool`, defaults to `False`):
+            If set to `True`, Accelerate assumes each process's `DataLoader` is already sharded (e.g. via a rank-aware
+            `DistributedSampler`) and skips its own sharding so the data is not split twice, while preserving the other
+            wrapper features (device placement, `set_epoch` forwarding, state tracking). Accelerate's `even_batches`
+            padding is also skipped, so every process must iterate the same number of batches. Incompatible with
+            `dispatch_batches` and `split_batches`.
     """
 
     split_batches: bool = field(
@@ -908,6 +914,14 @@ class DataLoaderConfiguration:
         metadata={
             "help": "If set to `True`, the dataloader prepared by the Accelerator will be backed by "
             "[torchdata.StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader). This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed."
+        },
+    )
+    already_sharded: bool = field(
+        default=False,
+        metadata={
+            "help": "If set to `True`, Accelerate assumes each process's `DataLoader` is already sharded (e.g. via a"
+            " rank-aware `DistributedSampler`) and skips its own sharding so the data is not split twice, while"
+            " preserving the other wrapper features. Incompatible with `dispatch_batches` and `split_batches`."
         },
     )
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -459,6 +459,41 @@ class DataLoaderTester(AccelerateTestCase):
         with pytest.raises(ValueError, match="round multiple"):
             BatchSamplerShard(batch_sampler, 2, 0, split_batches=True)
 
+    def test_already_sharded_skips_resharding(self):
+        """`already_sharded=True` must not split a dataloader a second time (issues #3520/#4062/#4075)."""
+        from torch.utils.data.distributed import DistributedSampler
+
+        dataset = list(range(16))
+        # Without already_sharded, accelerate shards across the 2 processes -> length is halved.
+        resharded = prepare_data_loader(DataLoader(dataset, batch_size=4), num_processes=2, process_index=0)
+        assert len(resharded) == 2
+
+        # With already_sharded, the user's own DistributedSampler is preserved (no second split): across the two
+        # ranks the data is covered exactly once, with no overlap, and total_batch_size accounts for all processes.
+        seen = []
+        for rank in range(2):
+            sampler = DistributedSampler(dataset, num_replicas=2, rank=rank, shuffle=False)
+            dl = prepare_data_loader(
+                DataLoader(dataset, batch_size=4, sampler=sampler),
+                num_processes=2,
+                process_index=rank,
+                already_sharded=True,
+            )
+            assert len(dl) == 2  # 8 samples / batch_size 4, not re-split down to 1
+            assert dl.total_batch_size == 8  # batch_size 4 * 2 processes, not the per-process 4
+            seen.append([int(x) for batch in dl for x in batch])
+        assert set(seen[0]).isdisjoint(seen[1])
+        assert sorted(seen[0] + seen[1]) == list(range(16))
+
+    def test_already_sharded_rejects_incompatible_options(self):
+        dataset = list(range(16))
+        with pytest.raises(ValueError, match="dispatch_batches"):
+            prepare_data_loader(
+                DataLoader(dataset, batch_size=4), already_sharded=True, dispatch_batches=True, put_on_device=True
+            )
+        with pytest.raises(ValueError, match="split_batches"):
+            prepare_data_loader(DataLoader(dataset, batch_size=4), already_sharded=True, split_batches=True)
+
     def check_iterable_dataset_shards(
         self, dataset, seed, batch_size, drop_last=False, num_processes=2, split_batches=False
     ):


### PR DESCRIPTION
# What does this PR do?

When a user already shards their DataLoader across processes (for example with a rank-aware `DistributedSampler`), `Accelerator.prepare` shards it a second time. The data ends up split twice, so each process only iterates a fraction of the samples it should. This is a recurring report: #3520, #4062, #4075.

This adds an `already_sharded` option to `DataLoaderConfiguration` (threaded through to `prepare_data_loader`). When set, Accelerate assumes each process's DataLoader is already sharded and skips its own sharding, while still keeping the rest of the wrapper behaviour: device placement, `set_epoch` forwarding, and dataloader state tracking.

```python
from accelerate import Accelerator
from accelerate.utils import DataLoaderConfiguration

accelerator = Accelerator(
    dataloader_config=DataLoaderConfiguration(already_sharded=True)
)

sampler = DistributedSampler(dataset, num_replicas=accelerator.num_processes, rank=accelerator.process_index)
dataloader = DataLoader(dataset, batch_size=batch_size, sampler=sampler)
dataloader = accelerator.prepare(dataloader)  # not split a second time
```

`already_sharded=True` is rejected together with `dispatch_batches=True` or `split_batches=True`, since both conflict with a dataloader that is already split per process. Accelerate's `even_batches` padding is also skipped in this mode, so the user is responsible for each process iterating the same number of batches.

Fixes #4075 (also addresses #3520 and #4062).

## Before submitting
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue? Linked above (#4075).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc