### PR TITLE
Bump pre-commit ruff hook to v0.13.1 to match the quality extra

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.1
+    rev: v0.13.1
     hooks:
       - id: ruff
         args:


### PR DESCRIPTION
# What does this PR do?

The `pre-commit` ruff hook is pinned at `v0.2.1`, which cannot parse the current `pyproject.toml`: it ignores the `UP045` and `UP035` rule selectors that ruff 0.2.1 does not recognize. As a result `pre-commit run` fails on a fresh checkout, before linting any file:

```
ruff.....................................................................Failed
- hook id: ruff
  Cause: TOML parse error at line 5, column 1
    |
  5 | [tool.ruff.lint]
    | ^^^^^^^^^^^^^^^^
  Unknown rule selector: `UP045`
```

`setup.py` already pins `extras["quality"] = ["ruff == 0.13.1"]`, so `make quality` works while the hooks are broken. This bumps the hook to `v0.13.1` to match the version the project targets, so `pre-commit` passes on a clean checkout.

Verified `pre-commit run ruff` passes after the bump.

Fixes #4088.

## Before submitting
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue? #4088.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@SunMarc