### PR TITLE
ci: pin GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/build_and_run_tests.yml
+++ b/.github/workflows/build_and_run_tests.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       changed: ${{ steps.was_changed.outputs.changed }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with: 
           fetch-depth: "2"
       

--- a/.github/workflows/build_docker_images.yml
+++ b/.github/workflows/build_docker_images.yml
@@ -17,9 +17,9 @@ jobs:
       group: aws-general-8-plus
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -28,7 +28,7 @@ jobs:
         run: |
           echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
       - name: Build and Push CPU
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: docker/accelerate-cpu/Dockerfile
           push: true
@@ -42,9 +42,9 @@ jobs:
       group: aws-g6-4xlarge-plus
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
       - name: Build and Push GPU
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: docker/accelerate-gpu/Dockerfile
           push: true
@@ -67,9 +67,9 @@ jobs:
       group: aws-g6-4xlarge-plus
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "date=$(date '+%Y-%m-%d')" >> $GITHUB_ENV
       - name: Build and Push GPU
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: docker/accelerate-gpu-deepspeed/Dockerfile
           push: true
@@ -92,9 +92,9 @@ jobs:
       group: aws-g6-4xlarge-plus
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to DockerHub
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -106,7 +106,7 @@ jobs:
           echo "base_year=$(date -d 'last month' '+%y')" >> $GITHUB_ENV
           echo "base_month=$(date -d 'last month' '+%m')" >> $GITHUB_ENV
       - name: Build and Push GPU
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           file: benchmarks/fp8/transformer_engine/Dockerfile
           push: true

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,9 +6,9 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up Python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,10 +16,10 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     
     - name: Setup Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,9 @@ jobs:
           test_rest
         ]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.10'
         cache: 'pip'

--- a/.github/workflows/test_imports.yml
+++ b/.github/workflows/test_imports.yml
@@ -26,9 +26,9 @@ jobs:
           minimum,
         ]
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Set up python 3.10
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.10'
         cache: 'pip'


### PR DESCRIPTION
## Summary

Pins all GitHub Actions across 6 workflow files to full immutable commit SHAs (21 pins total).

## Vulnerability

Using mutable version tags (`@v4`, `@v6`, `@v7`) means any action author (or attacker who compromises an action repo) can silently push malicious code that runs in CI. The Docker workflows are especially sensitive as they push images to registries.

## Changes

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | `v6` | `df4cb1c` |
| `actions/setup-python` | `v6` | `ece7cb0` |
| `docker/build-push-action` | `v7` | `f9f3042` |
| `docker/login-action` | `v4` | `650006c` |
| `docker/setup-buildx-action` | `v4` | `d7f5e7f` |

All pins point to the exact same version — no behaviour change.

## References
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- [tj-actions supply chain incident (2025)](https://www.bleepingcomputer.com/news/security/popular-github-action-tjactionschanged-files-compromised-in-supply-chain-attack/)