### PR TITLE
Fix duplicated words in user-facing messages

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -824,7 +824,7 @@ def get_cluster_input():
                         default=0,
                     )
                     fp8_config["interval"] = _ask_field(
-                        "What interval should be used for for how often the scaling factor is recomputed? [1]: ",
+                        "What interval should be used for how often the scaling factor is recomputed? [1]: ",
                         int,
                         default=1,
                     )
@@ -846,7 +846,7 @@ def get_cluster_input():
                         default=0,
                     )
                     fp8_config["override_linear_precision"] = _ask_field(
-                        "Do you want to to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision? [yes/NO]: ",
+                        "Do you want to execute `fprop`, `dgrad`, and `wgrad` GEMMS in higher precision? [yes/NO]: ",
                         _convert_yes_no_to_bool,
                         default=False,
                     )

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -1251,7 +1251,7 @@ def _validate_launch_command(args):
 
         if len(args.gpu_ids.split(",")) < 2 and (args.gpu_ids != "all") and args.multi_gpu and args.num_machines <= 1:
             raise ValueError(
-                "Less than two GPU ids were configured and tried to run on on multiple GPUs. "
+                "Less than two GPU ids were configured and tried to run on multiple GPUs. "
                 "Please ensure at least two are specified for `--gpu_ids`, or use `--gpu_ids='all'`."
             )
         if defaults.compute_environment == ComputeEnvironment.LOCAL_MACHINE:

--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -271,7 +271,7 @@ def get_quantized_model_device_map(
                     )
                 else:
                     logger.info(
-                        "Some modules are are offloaded to the CPU or the disk. Note that these modules will be converted to 8-bit"
+                        "Some modules are offloaded to the CPU or the disk. Note that these modules will be converted to 8-bit"
                     )
         del device_map_without_some_modules
     return device_map


### PR DESCRIPTION
# What does this PR do?

Spotted a few doubled words in messages that get shown to users while reading through the code. Nothing functional, just tidying up the wording:

- accelerate config: "used for for how often..." → "used for how often...", and "Do you want to to execute..." → "Do you want to execute..." (FP8 prompts)
- launch: "tried to run on on multiple GPUs" → "tried to run on multiple GPUs" (error message)
- bnb: "Some modules are are offloaded..." → "Some modules are offloaded..." (log warning)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

@SunMarc