### PR TITLE
docs(operations): add missing docstrings to predicate utility functions

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -43,10 +43,29 @@ if is_torch_distributed_available():
 
 
 def is_torch_tensor(tensor):
+    """
+    Checks whether `tensor` is a `torch.Tensor`.
+
+    Args:
+        tensor: The object to check.
+
+    Returns:
+        `bool`: `True` if `tensor` is a `torch.Tensor`, `False` otherwise.
+    """
     return isinstance(tensor, torch.Tensor)
 
 
 def is_torch_xpu_tensor(tensor):
+    """
+    Checks whether `tensor` is one of the XPU tensor types provided by PyTorch.
+
+    Args:
+        tensor: The object to check.
+
+    Returns:
+        `bool`: `True` if `tensor` is an XPU tensor (FloatTensor, ByteTensor, IntTensor,
+        LongTensor, HalfTensor, DoubleTensor, or BFloat16Tensor on XPU), `False` otherwise.
+    """
     return isinstance(
         tensor,
         torch.xpu.FloatTensor,
@@ -60,6 +79,15 @@ def is_torch_xpu_tensor(tensor):
 
 
 def is_tensor_information(tensor_info):
+    """
+    Checks whether `tensor_info` is a `TensorInformation` instance.
+
+    Args:
+        tensor_info: The object to check.
+
+    Returns:
+        `bool`: `True` if `tensor_info` is a `TensorInformation` instance, `False` otherwise.
+    """
     return isinstance(tensor_info, TensorInformation)
 
 
@@ -363,8 +391,6 @@ class DistributedOperationException(Exception):
     An exception class for distributed operations. Raised if the operation cannot be performed due to the shape of the
     tensors.
     """
-
-    pass
 
 
 def verify_operation(function):


### PR DESCRIPTION
## Summary

Three small public predicate functions in `src/accelerate/utils/operations.py` had no docstrings, making their purpose, expected input type, and return value invisible to IDE tooling and contributors:

| Function | What was added |
|----------|---------------|
| `is_torch_tensor` | `Args` + `Returns` |
| `is_torch_xpu_tensor` | `Args` + `Returns` (lists all 7 XPU tensor types checked) |
| `is_tensor_information` | `Args` + `Returns` |

The docstring style follows the existing pattern used throughout `operations.py` (e.g. `is_namedtuple`, `honor_type`, `recursively_apply`).

## No logic changes

Documentation only — no behaviour was modified.

## CI

- `ruff check` (with project config) ✅
- `ruff format --check` ✅