### PR TITLE
Fix AttributeError when iterating IterableDatasetShard without set_epoch

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -324,6 +324,9 @@ class IterableDatasetShard(IterableDataset):
         self.num_processes = num_processes
         self.process_index = process_index
         self.split_batches = split_batches
+        # `__iter__` seeds the underlying dataset's generator with `self.epoch`,
+        # so it must exist even if `set_epoch` is never called.
+        self.epoch = 0
 
     def set_epoch(self, epoch):
         self.epoch = epoch

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -517,6 +517,24 @@ class DataLoaderTester(AccelerateTestCase):
         self.check_iterable_dataset_shards(dataset, seed, batch_size=4, drop_last=False, split_batches=True)
         self.check_iterable_dataset_shards(dataset, seed, batch_size=4, drop_last=True, split_batches=True)
 
+    def test_iterable_dataset_shard_without_set_epoch(self):
+        # `__iter__` seeds a dataset generator with `self.epoch`; iterating a
+        # fresh shard without ever calling `set_epoch` used to raise
+        # `AttributeError: 'IterableDatasetShard' object has no attribute 'epoch'`.
+        class GeneratorIterableDataset(IterableDataset):
+            def __init__(self):
+                self.generator = torch.Generator()
+
+            def __iter__(self):
+                yield from torch.randperm(8, generator=self.generator).tolist()
+
+        shard = IterableDatasetShard(GeneratorIterableDataset(), batch_size=2)
+
+        first_epoch = list(shard)
+        assert sorted(first_epoch) == list(range(8))
+        # Without `set_epoch`, iteration seeds with the default epoch 0 every time.
+        assert list(shard) == first_epoch
+
     def test_iterable_dataset_using_none_batch_size(self):
         dataset = SimpleIterableDataset(100)
         dataloader = DataLoader(dataset, batch_size=None)


### PR DESCRIPTION
# What does this PR do?

Iterating an `IterableDatasetShard` that wraps a dataset carrying a `torch.Generator` (and no `set_epoch` method) raises unless the caller happens to call `set_epoch` first:

```python
class GeneratorIterableDataset(IterableDataset):
    def __init__(self):
        self.generator = torch.Generator()
    def __iter__(self):
        yield from torch.randperm(8, generator=self.generator).tolist()

shard = IterableDatasetShard(GeneratorIterableDataset(), batch_size=2)
list(shard)  # AttributeError: 'IterableDatasetShard' object has no attribute 'epoch'
```

**Root cause:** `__init__` never initializes `self.epoch`; the only assignment lives in `set_epoch`. But `__iter__`'s first branch reads `self.epoch` to seed the generator for precisely this dataset shape (`hasattr(dataset, "generator")` and no `set_epoch`). Accelerate's own managed path calls `set_epoch` before iterating, which is why the crash only bites direct users of the class, a usage pattern the existing tests treat as supported (`check_iterable_dataset_shards` iterates shards directly; it only survives because its test dataset has no `generator` attribute).

**Fix:** initialize `self.epoch = 0` in `__init__`, matching `SeedableRandomSampler` in the same module (and transformers' `IterableDatasetShard`). Direct iteration now seeds with the default epoch 0; `set_epoch` semantics are unchanged.

**Test:** `test_iterable_dataset_shard_without_set_epoch` reproduces the exact shape (generator-carrying dataset, no `set_epoch` call): fails before with the `AttributeError` at `data_loader.py:346`, passes after; also asserts the default seeding is deterministic. Full `tests/test_data_loader.py`: 25 passed, 13 skipped. `ruff check` / `ruff format --check` clean on both files.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md)?
- [x] Did you write any new necessary tests?
