### PR TITLE
Fix --parallelism_config_sp_seq_length_is_variable parsing "False" as "True"

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import sys
+from functools import partial
 from pathlib import Path
 
 import torch
@@ -963,7 +964,7 @@ def launch_command_parser(subparsers=None):
 
     parallelism_config_args.add_argument(
         "--parallelism_config_sp_seq_length_is_variable",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=True,
         help="If `True` will work with a sequence length that may change between batches, in which case `parallelism_config_sp_seq_length` value can be set to anything divisible by sp size or remain unset. If `False` then `parallelism_config_sp_seq_length` needs to match the batch's sequence length dimension. The default is `True`.",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,20 @@ class LaunchArgTester(unittest.TestCase):
                 else:
                     assert bad_arg not in help_return, f"Found {bad_arg} in `accelerate launch -h`"
 
+    def test_parallelism_config_sp_seq_length_is_variable(self):
+        # bool("False") is truthy, so this arg needs a real string->bool converter, not `type=bool`
+        args = ["--parallelism_config_sp_seq_length_is_variable", "False", "test.py"]
+        result = self.parser.parse_args(args)
+        assert result.parallelism_config_sp_seq_length_is_variable is False
+
+        args = ["--parallelism_config_sp_seq_length_is_variable", "True", "test.py"]
+        result = self.parser.parse_args(args)
+        assert result.parallelism_config_sp_seq_length_is_variable is True
+
+        args = ["test.py"]
+        result = self.parser.parse_args(args)
+        assert result.parallelism_config_sp_seq_length_is_variable is True
+
 
 class ClusterConfigTester(unittest.TestCase):
     """

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -15,7 +15,8 @@
 import argparse
 import unittest
 
-from accelerate.utils.launch import prepare_multi_gpu_env
+from accelerate.commands.launch import launch_command_parser
+from accelerate.utils.launch import prepare_extend_env_parallelism_config, prepare_multi_gpu_env
 
 
 class TestPrepareMultiGpuEnv(unittest.TestCase):
@@ -71,3 +72,25 @@ class TestPrepareMultiGpuEnv(unittest.TestCase):
         self.assertIn("master_port", args.__dict__)
         self.assertNotEqual(args.master_port, "0")
         self.assertTrue(args.master_port.isdigit())
+
+
+class TestPrepareExtendEnvParallelismConfig(unittest.TestCase):
+    def test_sp_seq_length_is_variable_false(self):
+        # Parse real CLI args, rather than building the Namespace by hand, so this
+        # also covers the parser's own string->bool conversion, not just serialization.
+        parser = launch_command_parser()
+        args = parser.parse_args(
+            [
+                "--use_parallelism_config",
+                "--parallelism_config_sp_size",
+                "2",
+                "--parallelism_config_sp_seq_length",
+                "128",
+                "--parallelism_config_sp_seq_length_is_variable",
+                "False",
+                "test.py",
+            ]
+        )
+
+        env = prepare_extend_env_parallelism_config(args, {})
+        self.assertEqual(env["PARALLELISM_CONFIG_SP_SEQ_LENGTH_IS_VARIABLE"], "False")


### PR DESCRIPTION
Fixes #4102

This fixes a bug in the `accelerate launch` CLI where passing `--parallelism_config_sp_seq_length_is_variable False` was silently parsed as `True`.

The argument used `type=bool`, and `bool()` on a string only checks whether the string is empty, so `bool("False")` is `True`. Any non-empty value was being read as `True`, with no way to actually turn this option off from the command line.

I switched it to `str_to_bool`, which is already used elsewhere in this file for boolean flags. The parsed value later gets written to an environment variable and compared against the literal string "true" in `dataclasses.py`, so I used `partial(str_to_bool, to_bool=True)` to get a real bool back instead of `str_to_bool`'s default int, keeping that comparison correct.

Added a test in `tests/test_cli.py` covering the explicit `False`, explicit `True`, and omitted cases.
