### PR TITLE
fix: megatron_lm launch flags parse "False" as True (type=bool)

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -88,6 +88,19 @@ def clean_option(option):
         return option[2:].replace("-", "_")
 
 
+def bool_arg(value: str) -> bool:
+    """
+    Argparse type function converting strings such as `true`/`false`, `yes`/`no`, `1`/`0` (case-insensitive) to a
+    `bool`. Needed because `type=bool` treats any non-empty string (including `"False"`) as `True`.
+    """
+    try:
+        return str_to_bool(value, to_bool=True)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"invalid boolean value: {value!r} (expected `true`/`false`, `yes`/`no` or `1`/`0`)"
+        )
+
+
 class CustomHelpFormatter(argparse.HelpFormatter):
     """
     This is a custom help formatter that will hide all arguments that are not used in the command line when the help is
@@ -613,43 +626,43 @@ def launch_command_parser(subparsers=None):
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_use_custom_fsdp",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to use custom FSDP. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_no_load_optim",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to not load optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_eod_mask_loss",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to use eod mask loss. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_overlap_cpu_optimizer_d2h_h2d",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to overlap CPU optimizer step, gradients D2H and updated parameters H2D. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_no_save_optim",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to not save optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_optimizer_cpu_offload",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to use CPU offload for optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_use_precision_aware_optimizer",
-        type=bool,
+        type=bool_arg,
         default=False,
         help="Whether to use precision aware optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,38 @@ class LaunchArgTester(unittest.TestCase):
                 else:
                     assert bad_arg not in help_return, f"Found {bad_arg} in `accelerate launch -h`"
 
+    bool_args = [
+        "megatron_lm_use_custom_fsdp",
+        "megatron_lm_no_load_optim",
+        "megatron_lm_eod_mask_loss",
+        "megatron_lm_overlap_cpu_optimizer_d2h_h2d",
+        "megatron_lm_no_save_optim",
+        "megatron_lm_optimizer_cpu_offload",
+        "megatron_lm_use_precision_aware_optimizer",
+    ]
+
+    def test_bool_args(self):
+        # These args used `type=bool`, which parses any non-empty string (including "False") as `True`
+        for arg in self.bool_args:
+            for value in ("False", "false", "0", "no"):
+                with self.subTest(arg=arg, value=value):
+                    result = self.parser.parse_args([f"--{arg}", value, "test.py"])
+                    assert getattr(result, arg) is False
+            for value in ("True", "true", "1", "yes"):
+                with self.subTest(arg=arg, value=value):
+                    result = self.parser.parse_args([f"--{arg}", value, "test.py"])
+                    assert getattr(result, arg) is True
+
+    def test_bool_args_defaults(self):
+        result = self.parser.parse_args(["test.py"])
+        for arg in self.bool_args:
+            assert getattr(result, arg) is False
+
+    def test_bool_args_invalid_value(self):
+        for arg in self.bool_args:
+            with self.subTest(arg=arg), self.assertRaises(SystemExit):
+                self.parser.parse_args([f"--{arg}", "maybe", "test.py"])
+
 
 class ClusterConfigTester(unittest.TestCase):
     """


### PR DESCRIPTION
# What does this PR do?

All seven `--megatron_lm_*` boolean flags in `accelerate launch` are declared with `type=bool`, so any non-empty string parses as `True` — `--megatron_lm_no_load_optim False` silently enables the option it's supposed to disable:

```
$ accelerate launch --megatron_lm_no_load_optim False script.py   # args.megatron_lm_no_load_optim == True
```

This is the same bug class as #4102; #4104 already covers the `--parallelism_config_sp_seq_length_is_variable` instance, so this PR fixes the remaining seven flags and deliberately leaves that one alone (happy to rebase either way if these race):

- `--megatron_lm_use_custom_fsdp`
- `--megatron_lm_no_load_optim`
- `--megatron_lm_eod_mask_loss`
- `--megatron_lm_overlap_cpu_optimizer_d2h_h2d`
- `--megatron_lm_no_save_optim`
- `--megatron_lm_optimizer_cpu_offload`
- `--megatron_lm_use_precision_aware_optimizer`

Fix: a small `bool_arg` converter wrapping the existing `accelerate.utils.environment.str_to_bool` (`to_bool=True`), raising `argparse.ArgumentTypeError` with a clear message on invalid values. Accepts `y/yes/t/true/on/1` / `n/no/f/false/off/0` case-insensitively; defaults and help text unchanged.

Tests: `LaunchArgTester` gains three tests parametrized over all seven flags (falsy strings parse `False`, truthy parse `True`, defaults preserved, invalid values exit with a parse error) — they fail on `main` and pass here. `grep -rn "type=bool" src/accelerate/commands/` is clean after this.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? Please add a link to it if that's the case. → #4102 (same root cause)
- [x] Did you make sure to update the documentation with your changes? → N/A (behavior now matches the documented `True`/`False` usage)
- [x] Did you write any new necessary tests?

## Who can review?

cc @SunMarc @S1ro1