### PR TITLE
Fix megatron_lm bool launch flags parsing "False" as True

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import sys
+from functools import partial
 from pathlib import Path
 
 import torch
@@ -613,43 +614,43 @@ def launch_command_parser(subparsers=None):
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_use_custom_fsdp",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to use custom FSDP. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_no_load_optim",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to not load optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_eod_mask_loss",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to use eod mask loss. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_overlap_cpu_optimizer_d2h_h2d",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to overlap CPU optimizer step, gradients D2H and updated parameters H2D. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_no_save_optim",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to not save optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_optimizer_cpu_offload",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to use CPU offload for optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )
     megatron_lm_args.add_argument(
         "--megatron_lm_use_precision_aware_optimizer",
-        type=bool,
+        type=partial(str_to_bool, to_bool=True),
         default=False,
         help="Whether to use precision aware optimizer. (useful only when `use_megatron_lm` flag is passed).",
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -228,6 +228,21 @@ class LaunchArgTester(unittest.TestCase):
                 else:
                     assert bad_arg not in help_return, f"Found {bad_arg} in `accelerate launch -h`"
 
+    def test_megatron_lm_bool_flags(self):
+        # bool("False") is truthy, so these args need a real string->bool converter, not `type=bool`
+        for flag in ["megatron_lm_use_custom_fsdp", "megatron_lm_no_load_optim"]:
+            args = [f"--{flag}", "False", "test.py"]
+            result = self.parser.parse_args(args)
+            assert getattr(result, flag) is False
+
+            args = [f"--{flag}", "True", "test.py"]
+            result = self.parser.parse_args(args)
+            assert getattr(result, flag) is True
+
+            args = ["test.py"]
+            result = self.parser.parse_args(args)
+            assert getattr(result, flag) is False
+
 
 class ClusterConfigTester(unittest.TestCase):
     """


### PR DESCRIPTION
The seven `--megatron_lm_*` boolean launch flags (`use_custom_fsdp`, `no_load_optim`, `eod_mask_loss`, `overlap_cpu_optimizer_d2h_h2d`, `no_save_optim`, `optimizer_cpu_offload`, `use_precision_aware_optimizer`) are declared with `type=bool`. argparse applies the callable to the raw string, and `bool("False")` is `True`, so passing e.g. `--megatron_lm_no_save_optim False` wrongly *enables* the flag.

This switches each to `type=partial(str_to_bool, to_bool=True)`, matching the converter already used for other boolean CLI options. The value serializes via `str(...)` and is read back with `str_to_bool(...) == 1` downstream, so `"True"`/`"False"` round-trip correctly.

Same class of bug as #4102, which #4104 fixes only for `--parallelism_config_sp_seq_length_is_variable`; this completes it for the megatron flags.

### Test

Added `test_megatron_lm_bool_flags` in `tests/test_cli.py`, asserting `False`/`True`/default parse to the correct booleans.

```
pytest tests/test_cli.py -k megatron
```

Closes #4102.
