### PR TITLE
Fix sequence parallel bool parsing

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -963,7 +963,7 @@ def launch_command_parser(subparsers=None):
 
     parallelism_config_args.add_argument(
         "--parallelism_config_sp_seq_length_is_variable",
-        type=bool,
+        type=lambda value: str_to_bool(value, to_bool=True),
         default=True,
         help="If `True` will work with a sequence length that may change between batches, in which case `parallelism_config_sp_seq_length` value can be set to anything divisible by sp size or remain unset. If `False` then `parallelism_config_sp_seq_length` needs to match the batch's sequence length dimension. The default is `True`.",
     )

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -15,7 +15,36 @@
 import argparse
 import unittest
 
-from accelerate.utils.launch import prepare_multi_gpu_env
+from accelerate.commands.launch import launch_command_parser
+from accelerate.utils.launch import prepare_extend_env_parallelism_config, prepare_multi_gpu_env
+
+
+class TestLaunchParser(unittest.TestCase):
+    def test_parallelism_sp_fixed_sequence_length_parses_false(self):
+        parser = launch_command_parser()
+        args = parser.parse_args(["--parallelism_config_sp_seq_length_is_variable", "False", "train.py"])
+
+        self.assertFalse(args.parallelism_config_sp_seq_length_is_variable)
+
+    def test_parallelism_sp_fixed_sequence_length_env(self):
+        parser = launch_command_parser()
+        args = parser.parse_args(
+            [
+                "--use_parallelism_config",
+                "--parallelism_config_sp_size",
+                "2",
+                "--parallelism_config_sp_seq_length",
+                "128",
+                "--parallelism_config_sp_seq_length_is_variable",
+                "False",
+                "train.py",
+            ]
+        )
+
+        env = prepare_extend_env_parallelism_config(args, {})
+
+        self.assertEqual(env["PARALLELISM_CONFIG_SP_SEQ_LENGTH"], "128")
+        self.assertEqual(env["PARALLELISM_CONFIG_SP_SEQ_LENGTH_IS_VARIABLE"], "False")
 
 
 class TestPrepareMultiGpuEnv(unittest.TestCase):


### PR DESCRIPTION
﻿Summary
- parse `--parallelism_config_sp_seq_length_is_variable` with the existing boolean helper instead of `bool`
- add launch parser and env-bridge coverage for the `False` spelling

Tests
- `PYTHONPATH=src python -m pytest tests/test_launch.py -q`
- `python -m ruff format --check src/accelerate/commands/launch.py tests/test_launch.py`
- `python -m ruff check tests/test_launch.py`

Closes #4102
