### PR TITLE
Expose force_recompute_fp8_weight_in_bwd on AORecipeKwargs

### DIFF
--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -893,6 +893,11 @@ def get_cluster_input():
                         _convert_yes_no_to_bool,
                         default=True,
                     )
+                    fp8_config["force_recompute_fp8_weight_in_bwd"] = _ask_field(
+                        "Do you want to recompute the FP8 all-gathered weight in the backward pass instead of stashing it? This trades compute for memory savings and is only useful with FSDP2 float8 all gather. [yes/NO]: ",
+                        _convert_yes_no_to_bool,
+                        default=False,
+                    )
 
     if use_dynamo and mixed_precision == "no" and not use_cpu:
         print(

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -851,6 +851,13 @@ def launch_command_parser(subparsers=None):
         type=str_to_bool,
         help="Whether to pad the inner dimension for FP8 GEMMs (useful only when `--fp8_backend=ao` is passed).",
     )
+    fp8_args.add_argument(
+        "--fp8_force_recompute_fp8_weight_in_bwd",
+        default="false",
+        type=str_to_bool,
+        help="Whether to recompute the FP8 all-gathered weight in the backward pass instead of stashing it, "
+        "trading compute for memory savings (useful only when `--fp8_backend=ao` is passed).",
+    )
 
     # AWS arguments
     aws_args = parser.add_argument_group("AWS Arguments", "Arguments related to AWS.")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -323,6 +323,8 @@ class AORecipeKwargs(KwargsHandler):
               operations to prevent runtime errors.
             - `enable_fsdp_float8_all_gather=True`: Enables FP8 all-gather for FSDP2. This provides memory bandwidth
               savings by casting parameters before the all-gather operation, saving 50% bandwidth compared to BF16.
+            - `force_recompute_fp8_weight_in_bwd=False`: Recomputes the FP8 cast for FSDP2 all-gathered weights
+              during the backward pass instead of stashing the casted weight, trading compute for memory savings.
 
             You can override these defaults by providing your own `Float8LinearConfig` instance.
         module_filter_func (`Callable`, *optional*, default to `None`):
@@ -335,6 +337,7 @@ class AORecipeKwargs(KwargsHandler):
     module_filter_func: Optional[Callable] = None
     pad_inner_dim: Optional[bool] = None
     enable_fsdp_float8_all_gather: Optional[bool] = None
+    force_recompute_fp8_weight_in_bwd: Optional[bool] = None
 
     def __post_init__(self):
         env_prefix = "ACCELERATE_FP8_"
@@ -351,9 +354,14 @@ class AORecipeKwargs(KwargsHandler):
                 self.enable_fsdp_float8_all_gather = parse_flag_from_env(
                     env_prefix + "ENABLE_FSDP_FLOAT8_ALL_GATHER", default=True
                 )
+            if self.force_recompute_fp8_weight_in_bwd is None:
+                self.force_recompute_fp8_weight_in_bwd = parse_flag_from_env(
+                    env_prefix + "FORCE_RECOMPUTE_FP8_WEIGHT_IN_BWD", default=False
+                )
             self.config = Float8LinearConfig(
                 pad_inner_dim=self.pad_inner_dim,
                 enable_fsdp_float8_all_gather=self.enable_fsdp_float8_all_gather,
+                force_recompute_fp8_weight_in_bwd=self.force_recompute_fp8_weight_in_bwd,
             )
 
 

--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -239,6 +239,7 @@ class TestTorchAO(unittest.TestCase):
                       backend: AO
                       pad_inner_dim: true
                       enable_fsdp_float8_all_gather: false
+                      force_recompute_fp8_weight_in_bwd: true
                     """
                 )
             )

--- a/tests/test_kwargs_handlers.py
+++ b/tests/test_kwargs_handlers.py
@@ -27,10 +27,12 @@ from accelerate.test_utils import (
     require_fp16,
     require_multi_device,
     require_non_cpu,
+    require_torchao,
     run_first,
 )
 from accelerate.test_utils.testing import AccelerateTestCase, slow
 from accelerate.utils import (
+    AORecipeKwargs,
     AutocastKwargs,
     KwargsHandler,
     ProfileKwargs,
@@ -54,6 +56,27 @@ class KwargsHandlerTester(AccelerateTestCase):
         assert MockClass(a=2).to_kwargs() == {"a": 2}
         assert MockClass(a=2, b=True).to_kwargs() == {"a": 2, "b": True}
         assert MockClass(a=2, c=2.25).to_kwargs() == {"a": 2, "c": 2.25}
+
+    @require_torchao
+    def test_ao_recipe_kwargs_force_recompute_fp8_weight_in_bwd_default(self):
+        # torchao's `Float8LinearConfig.force_recompute_fp8_weight_in_bwd` defaults to `False`.
+        recipe_handler = AORecipeKwargs()
+        assert recipe_handler.force_recompute_fp8_weight_in_bwd is False
+        assert recipe_handler.config.force_recompute_fp8_weight_in_bwd is False
+
+    @require_torchao
+    def test_ao_recipe_kwargs_force_recompute_fp8_weight_in_bwd_explicit(self):
+        recipe_handler = AORecipeKwargs(force_recompute_fp8_weight_in_bwd=True)
+        assert recipe_handler.force_recompute_fp8_weight_in_bwd is True
+        assert recipe_handler.config.force_recompute_fp8_weight_in_bwd is True
+
+    @require_torchao
+    def test_ao_recipe_kwargs_force_recompute_fp8_weight_in_bwd_env_override(self):
+        with clear_environment():
+            os.environ["ACCELERATE_FP8_FORCE_RECOMPUTE_FP8_WEIGHT_IN_BWD"] = "true"
+            recipe_handler = AORecipeKwargs()
+            assert recipe_handler.force_recompute_fp8_weight_in_bwd is True
+            assert recipe_handler.config.force_recompute_fp8_weight_in_bwd is True
 
     @require_fp16
     @require_non_cpu


### PR DESCRIPTION
# What does this PR do?

The force_recompute_fp8_weight_in_bwd is an option to tradeoff extra compute to save memory when training in fp8.

Mirrors the existing enable_fsdp_float8_all_gather field so downstreams (axolotl) no longer need to hand-build a Float8LinearConfig just to set this one flag. Default is False, matching torchao's Float8LinearConfig default, so behavior is unchanged unless explicitly set or overridden via ACCELERATE_FP8_FORCE_RECOMPUTE_FP8_WEIGHT_IN_BWD.

Also adds parallel accelerate launch CLI (--fp8_force_recompute_fp8_weight_in_bwd) and config wizard plumbing, mirroring the sibling flag's exposure.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc
- DeepSpeed: @SunMarc
- Command Line Interface: @SunMarc
- Documentation: @SunMarc
- Core parts of the library: @BenjaminBossan @SunMarc
- Maintained examples: @SunMarc

 -->