### PR TITLE
Add per-module fp32 precision for norms under FSDP2

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1618,6 +1618,18 @@ class FullyShardedDataParallelPlugin:
         ignored_modules (`Optional[Union[Iterable[torch.nn.Module], str]]`, defaults to `None`):
             A list of modules to ignore when wrapping with FSDP. When passing a string, will match the modules by name
             using regex fullmatch. If `fsdp_version` is set to 2, the modules are converted to parameters and used.
+        fp32_modules (`Optional[List[str]]`, defaults to `None`):
+            A list of class-name patterns (e.g. norm layers) to pre-shard with their own fp32 `MixedPrecisionPolicy`
+            before the rest of the model is wrapped, so they don't get folded into a lower-precision `fully_shard`
+            group. A pattern without a `.` matches as a suffix of the class name (`"RMSNorm"` matches
+            `LlamaRMSNorm`); a pattern with a `.` must exactly match `f"{cls.__module__}.{cls.__name__}"`.
+            Blank/whitespace-only patterns are ignored. Unioned with `fp32_modules_auto_detect`. Only supported when
+            `fsdp_version` is set to `2`.
+        fp32_modules_auto_detect (`bool`, defaults to `True`):
+            Whether to also union in the modules implied by the model's `_keep_in_fp32_modules_strict` attribute
+            (the 🤗 Transformers signal for the same purpose on the bf16 load path). These are matched as an
+            unanchored substring against each module's fully-qualified name, not as class-name patterns. Set to
+            `False` to only use `fp32_modules`. Only supported when `fsdp_version` is set to `2`.
         state_dict_type (`Union[str, torch.distributed.fsdp.StateDictType]`, defaults to `'FULL_STATE_DICT'`):
             State dict type to use. If a string, it must be one of `full_state_dict`, `local_state_dict`, or
             `sharded_state_dict`.
@@ -1719,6 +1731,22 @@ class FullyShardedDataParallelPlugin:
     ignored_modules: Optional[Union[Iterable[torch.nn.Module], str]] = field(
         default=None,
         metadata={"help": "A list of modules to ignore when wrapping with FSDP."},
+    )
+    fp32_modules: Optional[list[str]] = field(
+        default=None,
+        metadata={
+            "help": "A list of class-name patterns for modules (e.g. norm layers) to keep in fp32 (storage and "
+            "compute) under FSDP2, pre-sharded with their own `MixedPrecisionPolicy` before the rest of the model "
+            "is wrapped. Only supported when `fsdp_version` is set to 2."
+        },
+    )
+    fp32_modules_auto_detect: Optional[bool] = field(
+        default=None,
+        metadata={
+            "help": "Whether to automatically union modules implied by the model's `_keep_in_fp32_modules_strict` "
+            "attribute into the fp32 module set used by `fp32_modules`. Defaults to `True`. Only supported when "
+            "`fsdp_version` is set to 2."
+        },
     )
 
     state_dict_type: Union[str, "torch.distributed.fsdp.StateDictType"] = field(
@@ -1954,6 +1982,25 @@ class FullyShardedDataParallelPlugin:
 
         if self.ignored_modules is None:
             self.ignored_modules = os.environ.get(env_prefix + "IGNORED_MODULES", None)
+
+        if self.fp32_modules is None:
+            fp32_modules_env = os.environ.get(env_prefix + "FP32_MODULES", None)
+            if fp32_modules_env is not None:
+                self.fp32_modules = fp32_modules_env.split(",")
+        elif isinstance(self.fp32_modules, str):
+            self.fp32_modules = self.fp32_modules.split(",")
+
+        if self.fp32_modules_auto_detect is None:
+            self.fp32_modules_auto_detect = (
+                str_to_bool(os.environ.get(env_prefix + "FP32_MODULES_AUTO_DETECT", "True")) == 1
+            )
+
+        if self.fp32_modules is not None and self.fsdp_version != 2:
+            _fsdp2_warnings.add(
+                "fp32_modules is only supported with `fsdp_version=2` (per-module `mp_policy` on `fully_shard`). "
+                "Setting fp32_modules to None."
+            )
+            self.fp32_modules = None
 
         if self.cpu_ram_efficient_loading is None:
             self.cpu_ram_efficient_loading = (

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -624,6 +624,82 @@ def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
     return model
 
 
+def _fp32_class_pattern_matches(module: torch.nn.Module, pattern: str) -> bool:
+    """Matches a `fp32_modules`-style class-name pattern against `module`'s class.
+
+    A pattern without a `.` is a suffix match on `type(module).__name__` (so `"RMSNorm"` catches
+    `LlamaRMSNorm`); a pattern with a `.` must exactly match `f"{module.__module__}.{ClassName}"`.
+    Blank/whitespace-only patterns never match.
+    """
+    if not isinstance(pattern, str):
+        return False
+    pattern = pattern.strip()
+    if not pattern:
+        return False
+    cls = type(module)
+    if "." in pattern:
+        return f"{cls.__module__}.{cls.__name__}" == pattern
+    return cls.__name__.endswith(pattern)
+
+
+def resolve_fp32_module_patterns(fsdp2_plugin, model: torch.nn.Module) -> tuple[list[str], list[str]]:
+    """Returns `(class_patterns, name_patterns)`, the effective fp32-module selection for `fsdp2_prepare_model`.
+
+    `class_patterns` come from `fsdp2_plugin.fp32_modules`, matched via `_fp32_class_pattern_matches`.
+    `name_patterns` come from `model._keep_in_fp32_modules_strict` (unless `fp32_modules_auto_detect`
+    is `False`), matched as an unanchored substring against each module's fully-qualified name -
+    mirroring how `transformers` matches these same patterns against parameter names. A module is
+    selected for fp32 if it matches either list.
+    """
+    class_patterns = [p for p in (fsdp2_plugin.fp32_modules or []) if isinstance(p, str) and p.strip()]
+
+    name_patterns = []
+    if getattr(fsdp2_plugin, "fp32_modules_auto_detect", True):
+        auto_patterns = getattr(model, "_keep_in_fp32_modules_strict", None)
+        if auto_patterns:
+            name_patterns = [p for p in auto_patterns if isinstance(p, str) and p.strip()]
+
+    return class_patterns, name_patterns
+
+
+def _module_selected_for_fp32(
+    name: str, module: torch.nn.Module, class_patterns: list[str], name_patterns: list[str]
+) -> bool:
+    if any(_fp32_class_pattern_matches(module, pattern) for pattern in class_patterns):
+        return True
+    return bool(name) and any(pattern in name for pattern in name_patterns)
+
+
+def _upcast_module_to_fp32(module: torch.nn.Module, cpu_ram_efficient_loading: bool) -> None:
+    """Upcasts `module`'s own (non-recursive) floating-point parameters and buffers to fp32 in place.
+
+    `mp_policy.param_dtype` only controls FSDP2's compute dtype; storage dtype is fixed to whatever the
+    parameter has when `fully_shard` is called, so it must already be fp32 going in.
+
+    If the module is still on `meta` (mid-`cpu_ram_efficient_loading` reload), only the meta tensor's
+    dtype is updated - `fsdp2_load_full_state_dict` infers the real target dtype from it afterwards.
+    Outside that reload path there's no way to recover real values for a meta parameter, so we raise
+    instead of silently producing an empty fp32 meta tensor.
+    """
+    params = list(module.parameters(recurse=False))
+    buffers = list(module.buffers(recurse=False))
+    has_meta_tensors = any(t.is_meta for t in params) or any(t.is_meta for t in buffers)
+    if has_meta_tensors and not cpu_ram_efficient_loading:
+        raise RuntimeError(
+            f"Cannot promote module `{type(module).__name__}` to fp32 precision under FSDP2: its parameters are "
+            "on the `meta` device and `cpu_ram_efficient_loading` is not enabled, so there is no way to recover "
+            "their real values. Either enable `FullyShardedDataParallelPlugin(cpu_ram_efficient_loading=True)` "
+            "(accelerate's supported meta-device reload path) or materialize the model before calling "
+            "`accelerator.prepare()`."
+        )
+    for param in params:
+        if param.is_floating_point() and param.dtype != torch.float32:
+            param.data = param.data.to(torch.float32)
+    for buffer in buffers:
+        if buffer.is_floating_point() and buffer.dtype != torch.float32:
+            buffer.data = buffer.data.to(torch.float32)
+
+
 def _find_final_norm(model: torch.nn.Module) -> torch.nn.Module | None:
     """Find the final normalization layer before the output head.
 
@@ -740,6 +816,24 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         # We assume `transformers` models have a `tie_weights` method if they support it
         if hasattr(model, "tie_weights"):
             model.tie_weights()
+
+    # Pre-shard fp32-selected modules (e.g. norms) with their own fp32 `MixedPrecisionPolicy` before the
+    # class-wrap loop below. Later wraps already skip `FSDPModule` instances, so this also carves a
+    # matching final norm out of the tail group further down.
+    fp32_class_patterns, fp32_name_patterns = resolve_fp32_module_patterns(fsdp2_plugin, model)
+    if fp32_class_patterns or fp32_name_patterns:
+        fp32_policy = MixedPrecisionPolicy(
+            param_dtype=torch.float32,
+            reduce_dtype=torch.float32,
+            output_dtype=fsdp2_kwargs["mp_policy"].param_dtype,
+        )
+        for name, module in get_module_children_bottom_up(model, return_fqns=True)[:-1]:
+            if isinstance(module, FSDPModule):
+                continue
+            if not _module_selected_for_fp32(name, module, fp32_class_patterns, fp32_name_patterns):
+                continue
+            _upcast_module_to_fp32(module, fsdp2_plugin.cpu_ram_efficient_loading)
+            fully_shard(module, **{**fsdp2_kwargs, "mp_policy": fp32_policy})
 
     auto_wrap_policy_func = fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model)
     if auto_wrap_policy_func is not None:

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -502,6 +502,8 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         mock_plugin.cpu_offload = None
         mock_plugin.cpu_ram_efficient_loading = False
         mock_plugin.ignored_modules = None
+        mock_plugin.fp32_modules = None
+        mock_plugin.fp32_modules_auto_detect = True
         mock_accelerator.state.fsdp_plugin = mock_plugin
 
         with (
@@ -544,6 +546,8 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         mock_plugin.cpu_offload = None
         mock_plugin.cpu_ram_efficient_loading = False
         mock_plugin.ignored_modules = None
+        mock_plugin.fp32_modules = None
+        mock_plugin.fp32_modules_auto_detect = True
         mock_accelerator.state.fsdp_plugin = mock_plugin
 
         with (
@@ -583,6 +587,8 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         mock_plugin.cpu_offload = None
         mock_plugin.cpu_ram_efficient_loading = False
         mock_plugin.ignored_modules = None
+        mock_plugin.fp32_modules = None
+        mock_plugin.fp32_modules_auto_detect = True
         mock_accelerator.state.fsdp_plugin = mock_plugin
 
         with (
@@ -629,6 +635,8 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         mock_plugin.cpu_offload = None
         mock_plugin.cpu_ram_efficient_loading = False
         mock_plugin.ignored_modules = None
+        mock_plugin.fp32_modules = None
+        mock_plugin.fp32_modules_auto_detect = True
         mock_accelerator.state.fsdp_plugin = mock_plugin
 
         try:
@@ -688,6 +696,340 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         # And each block + non-repeated leaf is compiled in-place
         assert all(getattr(b, "_compiled_call_impl", None) is not None for b in model.layers)
         assert getattr(model.head, "_compiled_call_impl", None) is not None
+
+
+class _FakeRMSNorm(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.ones(dim))
+
+    def forward(self, x):
+        return x
+
+
+class _FakeDecoderLayer(torch.nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.input_layernorm = _FakeRMSNorm(dim)
+        self.mlp = torch.nn.Linear(dim, dim)
+
+    def forward(self, x):
+        return self.mlp(self.input_layernorm(x))
+
+
+class _FakeBaseModel(torch.nn.Module):
+    def __init__(self, dim, n_layers, vocab):
+        super().__init__()
+        self.embed_tokens = torch.nn.Embedding(vocab, dim)
+        self.layers = torch.nn.ModuleList([_FakeDecoderLayer(dim) for _ in range(n_layers)])
+        self.norm = _FakeRMSNorm(dim)
+
+    def forward(self, x):
+        x = self.embed_tokens(x)
+        for layer in self.layers:
+            x = layer(x)
+        return self.norm(x)
+
+
+class _FakeCausalLM(torch.nn.Module):
+    """Minimal tied-embedding decoder-only LM shaped the way `fsdp2_prepare_model` expects it
+    (`base_model_prefix`, `get_input/output_embeddings`, a final norm as a direct child of the base
+    model), without needing a real HF checkpoint."""
+
+    base_model_prefix = "model"
+
+    def __init__(self, dim=8, n_layers=2, vocab=16):
+        super().__init__()
+        self.model = _FakeBaseModel(dim, n_layers, vocab)
+        self.lm_head = torch.nn.Linear(dim, vocab, bias=False)
+        self.tie_weights()
+
+    def forward(self, x):
+        return self.lm_head(self.model(x))
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def tie_weights(self):
+        self.lm_head.weight = self.model.embed_tokens.weight
+
+
+@require_fsdp2
+class FSDP2Fp32ModulesTest(AccelerateTestCase):
+    """CPU-only tests for `fp32_modules`/`fp32_modules_auto_detect` and the fp32 pre-sharding pre-loop
+    in `fsdp2_prepare_model`. `fully_shard` is faked with a stand-in that mimics its real class-swap
+    behavior (mixing in `FSDPModule`) so the `isinstance(module, FSDPModule)` skip-guards elsewhere in
+    `fsdp2_prepare_model` behave like they would in production, without needing a real process group.
+    """
+
+    def _mock_plugin(self, fp32_modules=None, fp32_modules_auto_detect=True, param_dtype=torch.bfloat16):
+        from unittest.mock import Mock
+
+        mock_mp_policy = Mock()
+        mock_mp_policy.param_dtype = param_dtype
+        mock_plugin = Mock()
+        mock_plugin.mixed_precision_policy = mock_mp_policy
+        mock_plugin.reshard_after_forward = True
+        mock_plugin.cpu_offload = None
+        mock_plugin.cpu_ram_efficient_loading = False
+        mock_plugin.ignored_modules = None
+        mock_plugin.fp32_modules = fp32_modules
+        mock_plugin.fp32_modules_auto_detect = fp32_modules_auto_detect
+        return mock_plugin
+
+    def _mock_accelerator(self, plugin):
+        from unittest.mock import Mock
+
+        mock_accelerator = Mock()
+        mock_accelerator.mixed_precision = "no"
+        mock_accelerator.torch_device_mesh = None
+        mock_accelerator.device = torch.device("cpu")
+        mock_accelerator.is_main_process = True
+        mock_accelerator.state.fsdp_plugin = plugin
+        return mock_accelerator
+
+    def _fake_fully_shard(self, calls):
+        from torch.distributed.fsdp import FSDPModule
+
+        def _mark_sharded(module):
+            cls = type(module)
+            if not issubclass(cls, FSDPModule):
+                module.__class__ = type(f"FSDP{cls.__name__}", (FSDPModule, cls), {})
+
+        def _fake(module_or_list, **kwargs):
+            calls.append((module_or_list, kwargs))
+            for m in module_or_list if isinstance(module_or_list, list) else [module_or_list]:
+                _mark_sharded(m)
+
+        return _fake
+
+    def test_class_pattern_matcher_suffix(self):
+        from accelerate.utils.fsdp_utils import _fp32_class_pattern_matches
+
+        class LlamaRMSNorm(torch.nn.Module):
+            pass
+
+        assert _fp32_class_pattern_matches(LlamaRMSNorm(), "RMSNorm")
+        assert _fp32_class_pattern_matches(torch.nn.LayerNorm(4), "LayerNorm")
+        assert not _fp32_class_pattern_matches(torch.nn.Linear(2, 2), "RMSNorm")
+
+    def test_class_pattern_matcher_fully_qualified(self):
+        from accelerate.utils.fsdp_utils import _fp32_class_pattern_matches
+
+        layer_norm = torch.nn.LayerNorm(4)
+        cls = type(layer_norm)
+        fq_name = f"{cls.__module__}.{cls.__name__}"
+
+        assert _fp32_class_pattern_matches(layer_norm, fq_name)
+        assert not _fp32_class_pattern_matches(layer_norm, "some.other.module." + cls.__name__)
+
+    def test_class_pattern_matcher_blank_patterns_never_match(self):
+        from accelerate.utils.fsdp_utils import _fp32_class_pattern_matches
+
+        linear = torch.nn.Linear(2, 2)
+        for pattern in ("", "   ", None):
+            assert not _fp32_class_pattern_matches(linear, pattern)
+
+    def test_resolve_fp32_module_patterns_explicit_only(self):
+        from accelerate.utils.fsdp_utils import resolve_fp32_module_patterns
+
+        model = torch.nn.Linear(2, 2)
+        plugin = self._mock_plugin(fp32_modules=["RMSNorm", " ", "LayerNorm"], fp32_modules_auto_detect=True)
+        class_patterns, name_patterns = resolve_fp32_module_patterns(plugin, model)
+
+        assert class_patterns == ["RMSNorm", "LayerNorm"]
+        assert name_patterns == []
+
+    def test_resolve_fp32_module_patterns_auto_detect_union(self):
+        from accelerate.utils.fsdp_utils import resolve_fp32_module_patterns
+
+        model = torch.nn.Linear(2, 2)
+        model._keep_in_fp32_modules_strict = ["input_layernorm", "  ", "norm"]
+        plugin = self._mock_plugin(fp32_modules=["RMSNorm"], fp32_modules_auto_detect=True)
+
+        class_patterns, name_patterns = resolve_fp32_module_patterns(plugin, model)
+        assert class_patterns == ["RMSNorm"]
+        assert name_patterns == ["input_layernorm", "norm"]
+
+    def test_resolve_fp32_module_patterns_auto_detect_disabled(self):
+        from accelerate.utils.fsdp_utils import resolve_fp32_module_patterns
+
+        model = torch.nn.Linear(2, 2)
+        model._keep_in_fp32_modules_strict = ["input_layernorm"]
+        plugin = self._mock_plugin(fp32_modules=None, fp32_modules_auto_detect=False)
+
+        class_patterns, name_patterns = resolve_fp32_module_patterns(plugin, model)
+        assert class_patterns == []
+        assert name_patterns == []
+
+    def test_module_selected_for_fp32(self):
+        from accelerate.utils.fsdp_utils import _module_selected_for_fp32
+
+        class RMSNorm(torch.nn.Module):
+            pass
+
+        norm = RMSNorm()
+        linear = torch.nn.Linear(2, 2)
+
+        assert _module_selected_for_fp32("model.norm", norm, ["RMSNorm"], [])
+        assert _module_selected_for_fp32("model.layers.0.input_layernorm", linear, [], ["input_layernorm"])
+        assert not _module_selected_for_fp32("model.layers.0.mlp", linear, ["RMSNorm"], ["input_layernorm"])
+
+    def test_upcast_module_to_fp32(self):
+        from accelerate.utils.fsdp_utils import _upcast_module_to_fp32
+
+        module = torch.nn.LayerNorm(4).to(torch.bfloat16)
+        module.register_buffer("running_stat", torch.ones(4, dtype=torch.bfloat16))
+
+        _upcast_module_to_fp32(module, cpu_ram_efficient_loading=False)
+
+        assert module.weight.dtype == torch.float32
+        assert module.bias.dtype == torch.float32
+        assert module.running_stat.dtype == torch.float32
+
+    def test_upcast_module_to_fp32_meta_with_cpu_ram_efficient_loading(self):
+        from accelerate.utils.fsdp_utils import _upcast_module_to_fp32
+
+        module = torch.nn.LayerNorm(4).to(torch.device("meta")).to(torch.bfloat16)
+
+        _upcast_module_to_fp32(module, cpu_ram_efficient_loading=True)
+
+        assert module.weight.is_meta
+        assert module.weight.dtype == torch.float32
+
+    def test_upcast_module_to_fp32_meta_without_cpu_ram_efficient_loading_raises(self):
+        from accelerate.utils.fsdp_utils import _upcast_module_to_fp32
+
+        module = torch.nn.LayerNorm(4).to(torch.device("meta"))
+
+        with self.assertRaises(RuntimeError) as cm:
+            _upcast_module_to_fp32(module, cpu_ram_efficient_loading=False)
+        assert "meta" in str(cm.exception)
+
+    def test_fsdp2_prepare_model_fp32_modules_noop_when_unset(self):
+        """Unset `fp32_modules` (and no `_keep_in_fp32_modules_strict`) must reproduce today's
+        `fully_shard` call structure exactly: one call per decoder layer, one tail call grouping
+        [final_norm, tied_embedding], one root call - all sharing the same global `mp_policy`."""
+        from unittest.mock import patch
+
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        model = _FakeCausalLM(n_layers=2)
+        plugin = self._mock_plugin(fp32_modules=None, fp32_modules_auto_detect=True)
+        mock_accelerator = self._mock_accelerator(plugin)
+
+        calls = []
+        with (
+            patch("torch.distributed.fsdp.fully_shard", side_effect=self._fake_fully_shard(calls)),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch(
+                "accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy",
+                return_value=lambda m: isinstance(m, _FakeDecoderLayer),
+            ),
+        ):
+            fsdp2_prepare_model(mock_accelerator, model)
+
+        assert len(calls) == 4  # 2 decoder layers + 1 tail + 1 root
+        for _, kwargs in calls:
+            assert kwargs["mp_policy"] is plugin.mixed_precision_policy
+
+        tail_calls = [c for c, _ in calls if isinstance(c, list)]
+        assert len(tail_calls) == 1
+        assert tail_calls[0] == [model.model.norm, model.model.embed_tokens]
+
+    def test_fsdp2_prepare_model_pre_shards_matching_norms_in_fp32(self):
+        """Norms matching `fp32_modules` get pre-sharded with their own fp32 `MixedPrecisionPolicy`
+        (output_dtype = the global compute dtype) before the class-wrap loop; everything else keeps
+        the global policy, and the tail carve-out excludes the already-sharded final norm."""
+        from unittest.mock import patch
+
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        model = _FakeCausalLM(n_layers=2)
+        plugin = self._mock_plugin(fp32_modules=["RMSNorm"], param_dtype=torch.bfloat16)
+        mock_accelerator = self._mock_accelerator(plugin)
+
+        calls = []
+        with (
+            patch("torch.distributed.fsdp.fully_shard", side_effect=self._fake_fully_shard(calls)),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch(
+                "accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy",
+                return_value=lambda m: isinstance(m, _FakeDecoderLayer),
+            ),
+        ):
+            fsdp2_prepare_model(mock_accelerator, model)
+
+        fp32_calls = [(m, kw) for m, kw in calls if not isinstance(m, list) and isinstance(m, _FakeRMSNorm)]
+        # 2 per-layer input_layernorms + 1 final norm.
+        assert len(fp32_calls) == 3
+        for _, kwargs in fp32_calls:
+            assert kwargs["mp_policy"].param_dtype == torch.float32
+            assert kwargs["mp_policy"].reduce_dtype == torch.float32
+            assert kwargs["mp_policy"].output_dtype == torch.bfloat16
+
+        other_calls = [c for c in calls if c not in fp32_calls]
+        for _, kwargs in other_calls:
+            assert kwargs["mp_policy"] is plugin.mixed_precision_policy
+
+        # Final norm already sharded -> excluded from the [final_norm, tied_embedding] tail group.
+        tail_calls = [c for c, _ in calls if isinstance(c, list)]
+        assert len(tail_calls) == 1
+        assert tail_calls[0] == [model.model.embed_tokens]
+
+    def test_fsdp2_prepare_model_auto_detects_keep_in_fp32_modules_strict(self):
+        """`model._keep_in_fp32_modules_strict` alone (no explicit `fp32_modules`) is enough to
+        trigger fp32 pre-sharding, matched as a substring against the module's fully-qualified name."""
+        from unittest.mock import patch
+
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        model = _FakeCausalLM(n_layers=2)
+        model._keep_in_fp32_modules_strict = ["model.norm"]
+        plugin = self._mock_plugin(fp32_modules=None, fp32_modules_auto_detect=True)
+        mock_accelerator = self._mock_accelerator(plugin)
+
+        calls = []
+        with (
+            patch("torch.distributed.fsdp.fully_shard", side_effect=self._fake_fully_shard(calls)),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch(
+                "accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy",
+                return_value=lambda m: isinstance(m, _FakeDecoderLayer),
+            ),
+        ):
+            fsdp2_prepare_model(mock_accelerator, model)
+
+        fp32_calls = [(m, kw) for m, kw in calls if not isinstance(m, list) and isinstance(m, _FakeRMSNorm)]
+        assert len(fp32_calls) == 1
+        assert fp32_calls[0][0] is model.model.norm
+        assert fp32_calls[0][1]["mp_policy"].param_dtype == torch.float32
+
+        tail_calls = [c for c, _ in calls if isinstance(c, list)]
+        assert tail_calls == [[model.model.embed_tokens]]
+
+    def test_fp32_modules_env_override(self):
+        with patch_environment(FSDP_FP32_MODULES="RMSNorm,LayerNorm"):
+            plugin = FullyShardedDataParallelPlugin(fsdp_version=2)
+        assert plugin.fp32_modules == ["RMSNorm", "LayerNorm"]
+
+    def test_fp32_modules_auto_detect_env_override(self):
+        with patch_environment(FSDP_FP32_MODULES_AUTO_DETECT="False"):
+            plugin = FullyShardedDataParallelPlugin(fsdp_version=2)
+        assert plugin.fp32_modules_auto_detect is False
+
+    def test_fp32_modules_string_is_split_on_comma(self):
+        plugin = FullyShardedDataParallelPlugin(fsdp_version=2, fp32_modules="RMSNorm,LayerNorm")
+        assert plugin.fp32_modules == ["RMSNorm", "LayerNorm"]
+
+    def test_fp32_modules_cleared_outside_fsdp2(self):
+        with self.assertLogs("accelerate.utils.dataclasses", level="WARNING") as cm:
+            plugin = FullyShardedDataParallelPlugin(fsdp_version=1, fp32_modules=["RMSNorm"])
+        assert plugin.fp32_modules is None
+        assert any("fp32_modules is only supported" in out for out in cm.output)
 
 
 @run_first


### PR DESCRIPTION
# What does this PR do?

We had a report that Arcee's AFMoE had poor convergence when fine-tuning using FSDP. This was triaged to the norms getting cast to bf16. 

Expose FullyShardedDataParallelPlugin.fp32_modules (+ env var override and fp32_modules_auto_detect) so callers can pre-shard selected modules (e.g. RMSNorm/LayerNorm) with their own fp32 MixedPrecisionPolicy before fsdp2_prepare_model's bottom-up class-wrap loop, instead of having them folded into the enclosing decoder layer's lower-precision flat-param group. Auto-detects the transformers `_keep_in_fp32_modules_strict` signal by default. Handles the final-norm/lm_head tail carve-out and raises a clear error instead of silently mis-casting meta-device params when cpu_ram_efficient_loading isn't enabled.

Fix 4 pre-existing FSDP2 unit tests broken by the new attribute access on bare Mock() plugin objects, and add CPU-only coverage for the pattern matcher, the auto-detect union, meta-device handling, and the fsdp2_prepare_model wrapping/tail-carve-out behavior.

@SunMarc 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc
- DeepSpeed: @SunMarc
- Command Line Interface: @SunMarc
- Documentation: @SunMarc
- Core parts of the library: @BenjaminBossan @SunMarc
- Maintained examples: @SunMarc

 -->