### PR TITLE
Fix typos in comments, docs, and examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Follow these steps to start contributing:
 
 3. Create a new branch to hold your development changes, and do this for every new PR you work on.
 
-   Start by synchronizing your `main` branch with the `upstream/main` branch (ore details in the [GitHub Docs](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork)):
+   Start by synchronizing your `main` branch with the `upstream/main` branch (more details in the [GitHub Docs](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/syncing-a-fork)):
 
    ```bash
    $ git checkout main

--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ If the description is too long to fit in one line (more than 119 characters in t
 before writing the description after the argument.
 
 Finally, to maintain uniformity if any *one* description is too long to fit on one line, the 
-rest of the parameters should follow suit and have an indention before their description.
+rest of the parameters should follow suit and have an indentation before their description.
 
 Here's an example showcasing everything so far:
 

--- a/examples/by_feature/automatic_gradient_accumulation.py
+++ b/examples/by_feature/automatic_gradient_accumulation.py
@@ -29,7 +29,7 @@ from accelerate.utils import find_executable_batch_size
 ########################################################################
 # This is a fully working simple example to use Accelerate,
 # specifically showcasing how to combine both the gradient accumulation
-# and automatic batch size finder utilities of Accelerate to perfrom
+# and automatic batch size finder utilities of Accelerate to perform
 # automatic gradient accumulation
 #
 # This example trains a Bert base model on GLUE MRPC
@@ -152,7 +152,7 @@ def training_function(config, args):
         # Next we need to free all of the stored model references in the Accelerator each time
         accelerator.free_memory()
 
-        # And set the seed so our results are reproducable each reset
+        # And set the seed so our results are reproducible each reset
         set_seed(seed)
 
         # Instantiate the model (we build the model here so that the seed also control new weights initialization)

--- a/examples/by_feature/gradient_accumulation_for_autoregressive_models.py
+++ b/examples/by_feature/gradient_accumulation_for_autoregressive_models.py
@@ -231,7 +231,7 @@ def training_function(config, args):
             num_items_in_batch = accelerator.gather(local_num_items_in_batch).sum().item()
             losses = []
             for i, batch in enumerate(batch_samples):
-                # if we perform gradient accumulation in a multi-devices set-up, we want to avoid unecessary communications when accumulating
+                # if we perform gradient accumulation in a multi-devices set-up, we want to avoid unnecessary communications when accumulating
                 # cf: https://muellerzr.github.io/blog/gradient_accumulation.html
                 ctx = (
                     model.no_sync

--- a/examples/by_feature/megatron_lm_gpt_pretraining.py
+++ b/examples/by_feature/megatron_lm_gpt_pretraining.py
@@ -605,7 +605,7 @@ def main():
         with open(latest_iter_file) as f:
             contents = f.read().strip()
         assert contents == "0", (
-            f"latest_checkpointed_iteration.txt in {checkpoint_dir} must contain only '0' (found '{contents}'), please mannually change it to '0' and rename the directory release to iter_0000000, also make sure megatron_lm_no_load_optim is set to true in the config file"
+            f"latest_checkpointed_iteration.txt in {checkpoint_dir} must contain only '0' (found '{contents}'), please manually change it to '0' and rename the directory release to iter_0000000, also make sure megatron_lm_no_load_optim is set to true in the config file"
         )
         # Also assert iter_0000000 directory exists
         iter0_dir = os.path.join(checkpoint_dir, "iter_0000000")
@@ -714,7 +714,7 @@ def main():
             accelerator.save_state(output_dir)
 
     # this is causing some issue with Megatron-LM when using `wandb` at the end of the main function.
-    # Everything works fine inspite of commenting this out. (wandb finishes/closes the run without error)
+    # Everything works fine in spite of commenting this out. (wandb finishes/closes the run without error)
     # if args.with_tracking:
     #     accelerator.end_training()
 

--- a/examples/by_feature/tracking.py
+++ b/examples/by_feature/tracking.py
@@ -260,7 +260,7 @@ def main():
         "--project_dir",
         type=str,
         default="logs",
-        help="Location on where to store experiment tracking logs` and relevent project information",
+        help="Location on where to store experiment tracking logs` and relevant project information",
     )
     args = parser.parse_args()
     config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}

--- a/examples/complete_cv_example.py
+++ b/examples/complete_cv_example.py
@@ -322,7 +322,7 @@ def main():
         "--project_dir",
         type=str,
         default="logs",
-        help="Location on where to store experiment tracking logs` and relevent project information",
+        help="Location on where to store experiment tracking logs` and relevant project information",
     )
     args = parser.parse_args()
     config = {"lr": 3e-2, "num_epochs": 3, "seed": 42, "batch_size": 64, "image_size": 224}

--- a/examples/complete_nlp_example.py
+++ b/examples/complete_nlp_example.py
@@ -313,7 +313,7 @@ def main():
         "--project_dir",
         type=str,
         default="logs",
-        help="Location on where to store experiment tracking logs` and relevent project information",
+        help="Location on where to store experiment tracking logs` and relevant project information",
     )
     args = parser.parse_args()
     config = {"lr": 2e-5, "num_epochs": 3, "seed": 42, "batch_size": 16}

--- a/examples/config_yaml_templates/README.md
+++ b/examples/config_yaml_templates/README.md
@@ -3,7 +3,7 @@
 This folder contains a variety of minimal configurations for `Accelerate` achieving certain goals. You can use these 
 direct config YAML's, or build off of them for your own YAML's.
 
-These are highly annoted versions, aiming to teach you what each section does.
+These are highly annotated versions, aiming to teach you what each section does.
 
 Each config can be run via `accelerate launch --config_file {file} run_me.py`
 

--- a/examples/inference/pippy/README.md
+++ b/examples/inference/pippy/README.md
@@ -36,7 +36,7 @@ torchrun --nproc-per-node {NUM_GPUS} bert.py
 
 ## General speedups
 
-One can expect that PiPPy will outperform native model parallism by a multiplicative factor since all GPUs are running at all times with inputs, rather than one input being passed through a GPU at a time waiting for the prior to finish. 
+One can expect that PiPPy will outperform native model parallelism by a multiplicative factor since all GPUs are running at all times with inputs, rather than one input being passed through a GPU at a time waiting for the prior to finish. 
 
 Below are some benchmarks we have found when using the accelerate-pippy integration for a few models when running on 2x4090's:
 

--- a/examples/inference/pippy/bert.py
+++ b/examples/inference/pippy/bert.py
@@ -23,7 +23,7 @@ from accelerate.utils import set_seed
 
 synchronize_func = getattr(torch, torch_device, torch.cuda).synchronize
 
-# Set the random seed to have reproducable outputs
+# Set the random seed to have reproducible outputs
 set_seed(42)
 
 # Create an example model

--- a/examples/inference/pippy/gpt2.py
+++ b/examples/inference/pippy/gpt2.py
@@ -23,7 +23,7 @@ from accelerate.utils import set_seed
 
 synchronize_func = getattr(torch, torch_device, torch.cuda).synchronize
 
-# Set the random seed to have reproducable outputs
+# Set the random seed to have reproducible outputs
 set_seed(42)
 
 # Create an example model

--- a/examples/inference/pippy/t5.py
+++ b/examples/inference/pippy/t5.py
@@ -32,7 +32,7 @@ if version.parse(accelerate_version) > version.parse("0.33.0"):
     )
 
 
-# Set the random seed to have reproducable outputs
+# Set the random seed to have reproducible outputs
 set_seed(42)
 
 # Create an example model

--- a/examples/torch_native_parallelism/nd_parallel.py
+++ b/examples/torch_native_parallelism/nd_parallel.py
@@ -57,7 +57,7 @@ def parse_args():
 def forward(model, batch, optimizer, accelerator: Accelerator):
     batch["position_ids"] = torch.arange(0, batch["input_ids"].size(1), device=batch["input_ids"].device).unsqueeze(0)
     # We need both labels and shift_labels, as the loss computation in the model is hidden behind `if labels is not None`, but the loss computation
-    # itself prioritzes shift_labels (if provided) which are the correct ones (due to labels being wrong if cp enabled)
+    # itself prioritizes shift_labels (if provided) which are the correct ones (due to labels being wrong if cp enabled)
     buffers = [batch["input_ids"], batch["shift_labels"], batch["labels"], batch["position_ids"]]
     with accelerator.maybe_context_parallel(
         buffers=buffers, buffer_seq_dims=[1, 1, 1, 1], no_restore_buffers=set(buffers)

--- a/manim_animations/dataloaders/stage_2.py
+++ b/manim_animations/dataloaders/stage_2.py
@@ -165,7 +165,7 @@ class Stage2(Scene):
 
         self.remove(step_1)
         step_2 = MarkupText(
-            f"This behavior is undesireable, because we want\neach GPU to see different data for efficient training.",
+            f"This behavior is undesirable, because we want\neach GPU to see different data for efficient training.",
             font_size=18
         )
         step_2.move_to([0, -2.5, 0])


### PR DESCRIPTION
Fix several spelling mistakes found across comments, documentation, and example files:

- `ore` -> `more` in CONTRIBUTING.md
- `indention` -> `indentation` in docs/README.md
- `relevent` -> `relevant` in three example files
- `perfrom` -> `perform` in automatic_gradient_accumulation.py
- `reproducable` -> `reproducible` in automatic_gradient_accumulation.py and three pippy inference examples
- `unecessary` -> `unnecessary` in gradient_accumulation_for_autoregressive_models.py
- `mannually` -> `manually` in megatron_lm_gpt_pretraining.py
- `inspite` -> `in spite` in megatron_lm_gpt_pretraining.py
- `annoted` -> `annotated` in examples/config_yaml_templates/README.md
- `parallism` -> `parallelism` in examples/inference/pippy/README.md
- `prioritzes` -> `prioritizes` in nd_parallel.py
- `undesireable` -> `undesirable` in manim_animations/dataloaders/stage_2.py

Found with `codespell`.