### PR TITLE
Fix environment conversion docstring example

### DIFF
--- a/src/accelerate/utils/environment.py
+++ b/src/accelerate/utils/environment.py
@@ -38,10 +38,10 @@ def convert_dict_to_env_variables(current_env: dict):
 
     Example:
     ```python
-    >>> from accelerate.utils.environment import verify_env
+    >>> from accelerate.utils.environment import convert_dict_to_env_variables
 
     >>> env = {"ACCELERATE_DEBUG_MODE": "1", "BAD_ENV_NAME": "<mything", "OTHER_ENV": "2"}
-    >>> valid_env_items = verify_env(env)
+    >>> valid_env_items = convert_dict_to_env_variables(env)
     >>> print(valid_env_items)
     ["ACCELERATE_DEBUG_MODE=1\n", "OTHER_ENV=2\n"]
     ```


### PR DESCRIPTION
The `convert_dict_to_env_variables` example currently imports and calls `verify_env`, which is not defined in the module. Update the snippet to use the function it documents so it can be copied and run as written.

```console
$ pytest tests/test_utils.py -k convert_dict_to_env_variables -q
1 passed, 48 deselected
```

`make quality` passes with the project's pinned Ruff version.
