### PR TITLE
Fix get_non_persistent_buffers mutating module._non_persistent_buffers_set

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -480,7 +480,7 @@ def get_non_persistent_buffers(module: nn.Module, recurse: bool = False, fqns: b
             Whether or not to return the fully-qualified names of the non persistent buffers.
     """
 
-    non_persistent_buffers_set = module._non_persistent_buffers_set
+    non_persistent_buffers_set = set(module._non_persistent_buffers_set)
     if recurse:
         for n, m in module.named_modules():
             if fqns:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -45,6 +45,7 @@ from accelerate.utils.modeling import (
     find_tied_parameters,
     get_balanced_memory,
     get_module_size_with_ties,
+    get_non_persistent_buffers,
     get_state_dict_offloaded_model,
     infer_auto_device_map,
     load_checkpoint_in_model,
@@ -93,6 +94,29 @@ class LinearWithNonPersistentBuffers(nn.Module):
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         return torch.nn.functional.linear(input, self.weight, self.bias)
+
+
+class SubmoduleWithNonPersistentBuffer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("np_buf", torch.rand(4), persistent=False)
+
+
+class RootWithNonPersistentSubmodule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("persistent_buf", torch.rand(4))
+        self.sub = SubmoduleWithNonPersistentBuffer()
+
+
+class RootWithCollidingBufferName(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # Persistent buffer on the root that shares its name with a
+        # non-persistent buffer deeper in the module tree.
+        self.register_buffer("mask", torch.rand(4))
+        self.sub = nn.Module()
+        self.sub.register_buffer("mask", torch.rand(4), persistent=False)
 
 
 class ModelSeveralDtypes(nn.Module):
@@ -272,6 +296,41 @@ class ModelingUtilsTester(unittest.TestCase):
 
         named_tensors = named_module_tensors(model, include_buffers=True, remove_non_persistent=True)
         assert [name for name, _ in named_tensors] == ["weight"]
+
+    def test_get_non_persistent_buffers_does_not_mutate_module(self):
+        model = RootWithNonPersistentSubmodule()
+        # The root module itself has no non-persistent buffer, so its private set starts empty.
+        assert model._non_persistent_buffers_set == set()
+
+        # recurse=True must collect the submodule's non-persistent buffer without mutating the module.
+        assert get_non_persistent_buffers(model, recurse=True) == {"np_buf"}
+        assert model._non_persistent_buffers_set == set()
+
+        # Same with fully-qualified names.
+        assert get_non_persistent_buffers(model, recurse=True, fqns=True) == {"sub.np_buf"}
+        assert model._non_persistent_buffers_set == set()
+
+        # Calling repeatedly must be idempotent (no dot-prefixed accumulation from the "" root name).
+        assert get_non_persistent_buffers(model, recurse=True) == {"np_buf"}
+        assert get_non_persistent_buffers(model, recurse=True, fqns=True) == {"sub.np_buf"}
+        assert model._non_persistent_buffers_set == set()
+
+        # The submodule's own private set must be returned as a copy, not aliased.
+        result = get_non_persistent_buffers(model.sub, recurse=False)
+        assert result == {"np_buf"}
+        assert result is not model.sub._non_persistent_buffers_set
+        assert model.sub._non_persistent_buffers_set == {"np_buf"}
+
+    def test_named_module_tensors_does_not_corrupt_state_dict(self):
+        model = RootWithCollidingBufferName()
+        assert "mask" in model.state_dict()
+
+        # This is exactly the call AlignDevicesHook makes when offloading a model.
+        list(named_module_tensors(model, recurse=True, remove_non_persistent=True))
+
+        # The root's private set must be untouched, so its persistent "mask" buffer must survive.
+        assert model._non_persistent_buffers_set == set()
+        assert "mask" in model.state_dict()
 
     def test_find_tied_parameters(self):
         model = sequential_model(4)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -302,23 +302,12 @@ class ModelingUtilsTester(unittest.TestCase):
         # The root module itself has no non-persistent buffer, so its private set starts empty.
         assert model._non_persistent_buffers_set == set()
 
-        # recurse=True must collect the submodule's non-persistent buffer without mutating the module.
-        assert get_non_persistent_buffers(model, recurse=True) == {"np_buf"}
-        assert model._non_persistent_buffers_set == set()
-
-        # Same with fully-qualified names.
-        assert get_non_persistent_buffers(model, recurse=True, fqns=True) == {"sub.np_buf"}
-        assert model._non_persistent_buffers_set == set()
-
-        # Calling repeatedly must be idempotent (no dot-prefixed accumulation from the "" root name).
-        assert get_non_persistent_buffers(model, recurse=True) == {"np_buf"}
-        assert get_non_persistent_buffers(model, recurse=True, fqns=True) == {"sub.np_buf"}
-        assert model._non_persistent_buffers_set == set()
-
-        # The submodule's own private set must be returned as a copy, not aliased.
-        result = get_non_persistent_buffers(model.sub, recurse=False)
+        # recurse=True must collect the submodule's non-persistent buffer without mutating the module,
+        # and must return a copy rather than aliasing a module's private set.
+        result = get_non_persistent_buffers(model, recurse=True)
         assert result == {"np_buf"}
         assert result is not model.sub._non_persistent_buffers_set
+        assert model._non_persistent_buffers_set == set()
         assert model.sub._non_persistent_buffers_set == {"np_buf"}
 
     def test_named_module_tensors_does_not_corrupt_state_dict(self):


### PR DESCRIPTION
# What does this PR do?

Fixes a bug in `get_non_persistent_buffers` where the function mutates the
module's private `_non_persistent_buffers_set` instead of returning a fresh set.
In the worst case this silently drops a persistent buffer from `state_dict()`.

## Problem

`get_non_persistent_buffers` (in `src/accelerate/utils/modeling.py`) binds its
accumulator directly to the module's live private set:

```python
non_persistent_buffers_set = module._non_persistent_buffers_set
if recurse:
    for n, m in module.named_modules():
        if fqns:
            non_persistent_buffers_set |= {n + "." + b for b in m._non_persistent_buffers_set}
        else:
            non_persistent_buffers_set |= m._non_persistent_buffers_set
```

`set.__ior__` (`|=`) is an **in-place** update, so when `recurse=True` this
mutates `module._non_persistent_buffers_set` rather than building a separate
result. The returned object *is* the module's internal set (verified with an
`is` identity check). Consequences:

- **Idempotence is broken.** `named_modules()` yields the module itself first
  with name `""`, so with `fqns=True` the call injects dot-prefixed names like
  `".sub.np_buf"` into the live set, and repeated calls keep accumulating.
- **Silent data loss.** PyTorch's `Module._save_to_state_dict` skips any buffer
  whose name is in `_non_persistent_buffers_set`. If a descendant leaf buffer
  shares its name with a persistent buffer on an ancestor, injecting that leaf
  name into the ancestor's set makes the ancestor's persistent buffer vanish
  from `state_dict()`.

This is reachable on a normal path, not just a synthetic one:
`named_module_tensors(recurse=True, remove_non_persistent=True)` calls it, which
is exactly what `AlignDevicesHook` does during `device_map` / CPU offload
(`hooks.py`), and `fsdp_utils.py` calls it with `fqns=True` on the live model.

Minimal reproduction:

```python
import torch
from torch import nn
from accelerate.utils.modeling import get_non_persistent_buffers

class Sub(nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer("np_buf", torch.rand(4), persistent=False)

class Root(nn.Module):
    def __init__(self):
        super().__init__()
        self.register_buffer("persistent_buf", torch.rand(4))
        self.sub = Sub()

m = Root()
assert m._non_persistent_buffers_set == set()
get_non_persistent_buffers(m, recurse=True)
print(m._non_persistent_buffers_set)  # {'np_buf'}  <-- module was mutated
```

## Fix

Copy the set instead of aliasing it:

```python
non_persistent_buffers_set = set(module._non_persistent_buffers_set)
```

The function now returns a fresh set, leaves the module's private state
untouched, and is idempotent. Every in-repo caller only reads the returned set
(`hooks.py` iterates it, `fsdp_utils.py` and `modeling.py` do membership tests),
so there is no other behavioural change. The docstring already promises to
"gather ... into a set", not to return a live view.

## Testing

Two CPU-only tests added to `tests/test_modeling_utils.py`
(`ModelingUtilsTester`):

- `test_get_non_persistent_buffers_does_not_mutate_module` — asserts the module
  set is left empty across `recurse`/`fqns` variants, that results are
  idempotent (no dot-prefixed accumulation), and that the returned set is a copy.
- `test_named_module_tensors_does_not_corrupt_state_dict` — runs the exact
  `named_module_tensors(recurse=True, remove_non_persistent=True)` call
  `AlignDevicesHook` makes and asserts a colliding persistent buffer survives in
  `state_dict()`.

Both fail on `main` and pass with the fix.

```
$ python -m pytest tests/test_modeling_utils.py -k "non_persistent or state_dict" -q
4 passed, 40 deselected

$ python -m pytest tests/test_modeling_utils.py -q
42 passed, 2 skipped, 12 subtests passed

$ python -m pytest tests/test_hooks.py -q
12 passed, 3 skipped

$ python -m pytest tests/test_big_modeling.py -q -k offload
6 passed, 4 skipped, 24 deselected

$ make quality
All checks passed!
```

(`tests/test_modeling_utils.py` runs under its own CI shard rather than
`make test_core`, so I've cited the direct pytest command above.)

## Note for reviewers

There is a pre-existing quirk this minimal fix intentionally leaves alone: with
`fqns=True` and a non-persistent buffer registered *directly on the root*,
`named_modules()` yields the root as `n=""`, so line 484 produces a spurious
`"." + b` entry alongside the correct one. It's harmless to the only `fqns`
caller (`fsdp_utils.py`, membership tests — the correct name is also present),
but I kept this PR to the one-line data-corruption fix. Happy to fold in the
trivial `n + "." + b if n else b` guard here or as a follow-up if you'd prefer.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr)?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc (big modeling / owns hooks and modeling utils)
