### PR TITLE
docs: clarify multi-process non-tensor batch limitation

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -719,7 +719,11 @@ def slice_tensors(data, tensor_slice, process_index=None, num_processes=None):
 def concatenate(data, dim=0):
     """
     Recursively concatenate the tensors in a nested list/tuple/dictionary of lists of tensors with the same shape.
-    If there is only a single batch of data, it is returned as-is.
+    Non-tensor leaves are returned as-is only when the top-level sequence has `len(data) == 1`. When
+    [`~data_loader.DataLoaderDispatcher`] concatenates batches with `dispatch_batches=True` and `split_batches=False`,
+    this normally corresponds to `num_processes == 1`. With multiple fetched batches, batch fields must be tensors or
+    nested structures whose leaves are tensors. Tensorize metadata in the collator before dispatching it: booleans and
+    numeric flags can be tensors, while strings require explicit encoding or must be excluded from the dispatched batch.
 
     Args:
         data (nested list/tuple/dictionary of lists of tensors `torch.Tensor`):


### PR DESCRIPTION
# What does this PR do?

Clarifies the `concatenate()` docstring to explain that non-tensor leaves are passed through only when the top-level input contains one batch. During dispatch without split batches, this normally corresponds to `num_processes == 1`; multiple fetched batches require nested structures with tensor leaves.

The updated documentation also recommends tensorizing metadata in the collator, explicitly encoding strings, or excluding unsupported metadata from the dispatched batch. This does not change concatenation behavior.

Fixes #4111

## Validation

- `python -m pytest tests/test_utils.py -k concatenate -q`
- `ruff check .`
- `ruff format --check .`
- `doc-builder build accelerate docs/source/ --build_dir <temporary-directory>`

## Before submitting

- [x] This PR improves the docs.
- [x] I read the contributor guidelines.
- [x] This was discussed in #4111.
- [x] The documentation was updated.
- [x] No new tests are necessary because this only clarifies existing behavior.