### PR TITLE
Fix IterableDatasetShard.__len__ to account for split_batches

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -332,10 +332,13 @@ class IterableDatasetShard(IterableDataset):
 
     def __len__(self):
         # We will just raise the downstream error if the underlying dataset is not sized
+        # Mirror the batch sizing used in `__iter__` so the length is correct in `split_batches` mode too.
+        real_batch_size = self.batch_size if self.split_batches else (self.batch_size * self.num_processes)
+        process_batch_size = (self.batch_size // self.num_processes) if self.split_batches else self.batch_size
         if self.drop_last:
-            return (len(self.dataset) // (self.batch_size * self.num_processes)) * self.batch_size
+            return (len(self.dataset) // real_batch_size) * process_batch_size
         else:
-            return math.ceil(len(self.dataset) / (self.batch_size * self.num_processes)) * self.batch_size
+            return math.ceil(len(self.dataset) / real_batch_size) * process_batch_size
 
     def __iter__(self):
         if (

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -517,6 +517,25 @@ class DataLoaderTester(AccelerateTestCase):
         self.check_iterable_dataset_shards(dataset, seed, batch_size=4, drop_last=False, split_batches=True)
         self.check_iterable_dataset_shards(dataset, seed, batch_size=4, drop_last=True, split_batches=True)
 
+    def test_iterable_dataset_shard_len_matches_iteration(self):
+        # `__len__` must agree with the number of items actually yielded by `__iter__`, including in
+        # `split_batches` mode (where the per-process batch size differs from the global batch size).
+        batch_size, num_processes = 4, 2
+        for num_samples in [20, 22, 12]:
+            dataset = SimpleIterableDataset(num_samples=num_samples)
+            for drop_last in [False, True]:
+                for split_batches in [False, True]:
+                    for process_index in range(num_processes):
+                        shard = IterableDatasetShard(
+                            dataset,
+                            batch_size=batch_size,
+                            drop_last=drop_last,
+                            num_processes=num_processes,
+                            process_index=process_index,
+                            split_batches=split_batches,
+                        )
+                        assert len(shard) == len(list(shard))
+
     def test_iterable_dataset_using_none_batch_size(self):
         dataset = SimpleIterableDataset(100)
         dataloader = DataLoader(dataset, batch_size=None)


### PR DESCRIPTION
## What does this PR do?

`IterableDatasetShard.__iter__` uses a per-process batch size of `batch_size // num_processes` when `split_batches=True`, but `__len__` always assumed the non-split sizing (`batch_size * num_processes` for the divisor, `batch_size` for the multiplier). As a result `len(shard)` — and therefore `len(prepared_dataloader)` for a sized iterable dataset prepared with `split_batches=True` — over-reports the length.

### Reproduction

```python
from accelerate.data_loader import IterableDatasetShard

shard = IterableDatasetShard(
    list(range(12)), batch_size=4, num_processes=2, process_index=0, split_batches=True
)
print(len(shard))        # 8  ← wrong
print(len(list(shard)))  # 6  ← what __iter__ actually yields
```

Each shard yields 6 items (`[0, 1, 4, 5, 8, 9]`), but `len()` returns 8. This affects anything relying on the reported length (e.g. progress-bar totals, per-epoch step math). The batch *contents* are already correct — only the reported length was off.

### Fix

Mirror the `real_batch_size` / `process_batch_size` computation from `__iter__` in `__len__`. For `split_batches=False` the formula reduces to exactly the previous expression, so existing behavior is unchanged; only the `split_batches=True` path is corrected.

### Why the existing tests didn't catch it

`check_iterable_dataset_shards` (the helper behind `test_iterable_dataset_shard`) only asserts iterated content and cross-shard length equality — it never asserts `shard.__len__()`. I added `test_iterable_dataset_shard_len_matches_iteration`, which asserts `len(shard) == len(list(shard))` across both `split_batches` modes, `drop_last` values, and process indices. It fails before this change and passes after. Full `tests/test_data_loader.py` passes (25 passed, 13 skipped — the skips are distributed/multi-device paths unrelated to this change).

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr)?
- [x] Did you make sure to update the documentation with your changes? (N/A — behavior fix, no public API change)
- [x] Did you write any new necessary tests?

## Who can review?

@muellerzr @SunMarc

---

*Disclosure: I used Claude Code (Anthropic) to help investigate and implement this. I verified the bug and fix myself — reproduced the length mismatch against actual iteration and confirmed the corrected formula matches `__iter__` across an exhaustive sweep of dataset sizes / batch sizes / process counts / `drop_last` / `split_batches` combinations, with no change to the `split_batches=False` path.*