### PR TITLE
Fix concatenate() for non-tensor batch fields across multiple batches

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -719,7 +719,15 @@ def slice_tensors(data, tensor_slice, process_index=None, num_processes=None):
 def concatenate(data, dim=0):
     """
     Recursively concatenate the tensors in a nested list/tuple/dictionary of lists of tensors with the same shape.
-    If there is only a single batch of data, it is returned as-is.
+
+    Non-tensor values are only supported along the first dimension (`dim` is ignored for them) and are handled as
+    follows:
+
+    - If there is only a single batch of data, it is returned as-is, even if it contains non-tensor values.
+    - Lists of non-tensor values (e.g. a list of strings, holding one value per sample in the batch) are chained
+      into a single list, mimicking a concatenation along the batch dimension.
+    - Any other non-tensor value (e.g. a string or a boolean shared by a whole batch) is collected into a list
+      holding the value of each batch.
 
     Args:
         data (nested list/tuple/dictionary of lists of tensors `torch.Tensor`):
@@ -731,6 +739,12 @@ def concatenate(data, dim=0):
         The same data structure as `data` with all the tensors concatenated.
     """
     if isinstance(data[0], (tuple, list)):
+        if isinstance(data[0], list) and not any(
+            isinstance(sample, (torch.Tensor, tuple, list, Mapping)) for sample in data[0]
+        ):
+            # Lists of non-tensor values hold one value per sample in the batch, so we chain them into a single
+            # list, mimicking a concatenation along the batch dimension.
+            return [sample for batch in data for sample in batch]
         return honor_type(data[0], (concatenate([d[i] for d in data], dim=dim) for i in range(len(data[0]))))
     elif isinstance(data[0], Mapping):
         return type(data[0])({k: concatenate([d[k] for d in data], dim=dim) for k in data[0].keys()})
@@ -738,6 +752,10 @@ def concatenate(data, dim=0):
         return torch.cat(data, dim=dim)
     elif isinstance(data, (tuple, list)) and len(data) == 1:
         return data[0]
+    elif isinstance(data, (tuple, list)):
+        # Multiple batches of non-tensor values (e.g. a string or a boolean shared by a whole batch) cannot be
+        # concatenated, so we collect the value of each batch into a list instead.
+        return list(data)
     else:
         raise TypeError(f"Can only concatenate tensors but got {type(data[0])}")
 

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -726,8 +726,9 @@ def concatenate(data, dim=0):
     - If there is only a single batch of data, it is returned as-is, even if it contains non-tensor values.
     - Lists of non-tensor values (e.g. a list of strings, holding one value per sample in the batch) are chained
       into a single list, mimicking a concatenation along the batch dimension.
-    - Any other non-tensor value (e.g. a string or a boolean shared by a whole batch) is collected into a list
-      holding the value of each batch.
+    - Any other scalar non-tensor value (e.g. a string or a boolean shared by a whole batch) is collected into a
+      list holding the value of each batch. Non-scalar, non-tensor values (e.g. numpy arrays) are not concatenated
+      and raise, as before.
 
     Args:
         data (nested list/tuple/dictionary of lists of tensors `torch.Tensor`):
@@ -752,12 +753,15 @@ def concatenate(data, dim=0):
         return torch.cat(data, dim=dim)
     elif isinstance(data, (tuple, list)) and len(data) == 1:
         return data[0]
-    elif isinstance(data, (tuple, list)):
-        # Multiple batches of non-tensor values (e.g. a string or a boolean shared by a whole batch) cannot be
-        # concatenated, so we collect the value of each batch into a list instead.
+    elif isinstance(data, (tuple, list)) and all(
+        isinstance(d, (str, int, float, bool, bytes, type(None))) for d in data
+    ):
+        # Multiple batches of a scalar non-tensor value (e.g. a string or a boolean shared by a whole batch)
+        # cannot be concatenated along the batch dim, so we collect the value of each batch into a list instead.
+        # Non-scalar non-tensor values (e.g. numpy arrays) fall through and raise, preserving prior behavior.
         return list(data)
     else:
-        raise TypeError(f"Can only concatenate a list or tuple of batches but got {type(data)}")
+        raise TypeError(f"Can only concatenate tensors but got {type(data[0])}")
 
 
 class CannotPadNestedTensorWarning(UserWarning):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -757,7 +757,7 @@ def concatenate(data, dim=0):
         # concatenated, so we collect the value of each batch into a list instead.
         return list(data)
     else:
-        raise TypeError(f"Can only concatenate tensors but got {type(data[0])}")
+        raise TypeError(f"Can only concatenate a list or tuple of batches but got {type(data)}")
 
 
 class CannotPadNestedTensorWarning(UserWarning):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -491,13 +491,55 @@ class UtilsTester(unittest.TestCase):
         assert result["a"].shape == torch.Size([4, 3])
         assert result["b"].shape == torch.Size([4, 4])
 
-        # NOTE: We can't merge multiple batches of non-tensor data
+        # NOTE: Multiple batches of scalar non-tensor data (e.g. one string per batch) are collected into a list
         data = [
             {"a": torch.randn(2, 3), "b": torch.randn(2, 4), "c": "test_string1"},
             {"a": torch.randn(2, 3), "b": torch.randn(2, 4), "c": "test_string2"},
         ]
-        with self.assertRaises(TypeError):
-            result = concatenate(data)
+        result = concatenate(data)
+        assert result["a"].shape == torch.Size([4, 3])
+        assert result["b"].shape == torch.Size([4, 4])
+        assert result["c"] == ["test_string1", "test_string2"]
+
+        # Reproduction from https://github.com/huggingface/accelerate/issues/4111
+        data = [
+            {"input_ids": torch.tensor([[1, 2]]), "label": True},
+            {"input_ids": torch.tensor([[3, 4]]), "label": False},
+        ]
+        result = concatenate(data)
+        assert torch.equal(result["input_ids"], torch.tensor([[1, 2], [3, 4]]))
+        assert result["label"] == [True, False]
+
+        # NOTE: Lists of non-tensor values are chained along the batch dimension
+        data = [{"key1": ["str1", "str2"]}, {"key1": ["str3", "str4"]}]
+        result = concatenate(data)
+        assert result["key1"] == ["str1", "str2", "str3", "str4"]
+
+        # Lists of non-tensor values with different batch sizes (e.g. the remainder with `drop_last=False`)
+        data = [
+            {"labels": [True, False, True], "input_ids": torch.randn(3, 2)},
+            {"labels": [False, False], "input_ids": torch.randn(2, 2)},
+        ]
+        result = concatenate(data)
+        assert result["labels"] == [True, False, True, False, False]
+        assert result["input_ids"].shape == torch.Size([5, 2])
+
+        # Non-tensor values in nested dictionaries
+        data = [
+            {"meta": {"ids": ["a", "b"], "flag": True}, "x": torch.randn(2, 2)},
+            {"meta": {"ids": ["c", "d"], "flag": False}, "x": torch.randn(2, 2)},
+        ]
+        result = concatenate(data)
+        assert result["meta"]["ids"] == ["a", "b", "c", "d"]
+        assert result["meta"]["flag"] == [True, False]
+        assert result["x"].shape == torch.Size([4, 2])
+
+        # NOTE: Tuples are still treated as a data structure (not as batch data), only their leaves are merged
+        data = [(torch.randn(2, 3), "s1"), (torch.randn(2, 3), "s2")]
+        result = concatenate(data)
+        assert isinstance(result, tuple)
+        assert result[0].shape == torch.Size([4, 3])
+        assert result[1] == ["s1", "s2"]
 
         batch1 = torch.randn(5, 10)
         batch2 = torch.randn(5, 10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -532,6 +532,15 @@ class UtilsTester(unittest.TestCase):
         result = concatenate(data)
         assert result["meta"]["ids"] == ["a", "b", "c", "d"]
         assert result["meta"]["flag"] == [True, False]
+
+        # NOTE: Non-scalar, non-tensor values (e.g. numpy arrays) are not silently collected; they still raise,
+        # since collecting them into a list would hide a case where concatenation was almost certainly intended.
+        data = [
+            {"x": np.array([1, 2])},
+            {"x": np.array([3, 4])},
+        ]
+        with pytest.raises(TypeError):
+            concatenate(data)
         assert result["x"].shape == torch.Size([4, 2])
 
         # NOTE: Tuples are still treated as a data structure (not as batch data), only their leaves are merged


### PR DESCRIPTION
Fixes #4111.

## What
`accelerate.utils.operations.concatenate` raised `TypeError: Can only concatenate tensors` whenever a batch field wasn't a tensor (e.g. `bool`, `str`, `list`) and more than one batch was concatenated — the path hit by `DataLoaderDispatcher._fetch_batches` when `num_processes > 1`.

#3850 fixed only the single-batch case (`len(data) == 1` returns `data[0]`); as discussed there by @SunMarc and @tomaarsen, multi-process non-tensor support was left as a known gap ("it'll always fail in multi-process settings"). This PR closes that gap and expands the docstring @SunMarc asked for.

## How
- **List-valued non-tensor fields** (one entry per sample) are chained along the batch dimension into a single list — the natural analogue of `torch.cat` for per-sample metadata (this is what collate_fns emit; cf. huggingface/trl#6325).
- **Scalar non-tensor fields shared by a whole batch** are collected into a list with one value per batch.
- Tensor, nested list/tuple/dict, and single-batch behavior are unchanged.
- Docstring now documents the non-tensor semantics explicitly.

## Repro (before)
```python
from accelerate.utils.operations import concatenate
import torch
concatenate([{"input_ids": torch.tensor([[1,2]]), "label": True},
             {"input_ids": torch.tensor([[3,4]]), "label": False}])
# TypeError: Can only concatenate tensors but got <class 'bool'>
```
After: `{'input_ids': tensor([[1,2],[3,4]]), 'label': [True, False]}`.

## Tests
Extended `tests/test_utils.py::test_concatenate` (where #3850 added its tests) with multi-batch non-tensor cases: scalar bool/str, the #4111 repro, list-of-strings chaining, uneven batch sizes, nested dicts, and tuple-structure preservation. New tests fail on `main` and pass with this change; the rest of `test_utils.py` is unaffected.

---
This change was drafted with the help of an AI coding assistant and verified locally on a CPU-only setup (torch 2.13.0+cpu): the repro and the full `test_utils.py::test_concatenate` suite pass, and `ruff format --check` is clean on the changed files.
