### PR TITLE
Fix write_basic_config clobbering MLU config to CPU

### DIFF
--- a/src/accelerate/commands/config/default.py
+++ b/src/accelerate/commands/config/default.py
@@ -71,7 +71,7 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
             config["distributed_type"] = "MULTI_MLU"
         else:
             config["distributed_type"] = "NO"
-    if is_sdaa_available():
+    elif is_sdaa_available():
         num_sdaas = torch.sdaa.device_count()
         config["num_processes"] = num_sdaas
         config["use_cpu"] = False


### PR DESCRIPTION
## Problem

`write_basic_config` (`src/accelerate/commands/config/default.py`) detects the available accelerator with what is meant to be a single mutually-exclusive chain, so exactly one device type is selected:

```python
if is_mlu_available():
    ...
if is_sdaa_available():        # <-- bare `if` starts a SECOND, independent chain
    ...
elif is_musa_available():
    ...
elif torch.cuda.is_available():
    ...
elif is_xpu_available():
    ...
elif is_npu_available():
    ...
elif is_neuron_available():
    ...
else:                          # clobbers the config back to CPU
    num_xpus = 0
    config["use_cpu"] = True
    config["num_processes"] = 1
    config["distributed_type"] = "NO"
```

Every device branch (`musa`, `hpu`, `cuda`, `xpu`, `npu`, `neuron`) is an `elif` of the SDAA `if`, forming one chain — but the SDAA check itself is a **bare `if`**, so it opens a *second* chain that does not include the MLU check above it.

Consequence: on an **MLU-only** machine, the MLU block correctly sets `distributed_type=MULTI_MLU`, `use_cpu=False`, then the second chain runs, matches nothing, falls into its `else`, and **overwrites the config with `use_cpu=True, num_processes=1, distributed_type=NO`**. `accelerate config default` on an MLU box silently produces a CPU config.

## Fix

Make the SDAA check an `elif` so it folds into the MLU-led chain and exactly one device is selected:

```python
elif is_sdaa_available():
```

## Reproduction

Simulating an MLU-only machine (all other `is_*_available()` false) through the branch logic:

| | result |
|---|---|
| before (`if is_sdaa`) | `{use_cpu: True, num_processes: 1, distributed_type: NO}` ❌ |
| after (`elif is_sdaa`) | `{use_cpu: False, num_processes: 4, distributed_type: MULTI_MLU}` ✅ |
