### PR TITLE
Add module: nn.Module type hints to ModelHook lifecycle methods

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -67,7 +67,7 @@ class ModelHook:
 
     no_grad = False
 
-    def init_hook(self, module):
+    def init_hook(self, module: nn.Module):
         """
         To be executed when the hook is attached to the module.
 
@@ -76,7 +76,7 @@ class ModelHook:
         """
         return module
 
-    def pre_forward(self, module, *args, **kwargs):
+    def pre_forward(self, module: nn.Module, *args, **kwargs):
         """
         To be executed just before the forward method of the model.
 
@@ -90,7 +90,7 @@ class ModelHook:
         """
         return args, kwargs
 
-    def post_forward(self, module, output):
+    def post_forward(self, module: nn.Module, output):
         """
         To be executed just after the forward method of the model.
 
@@ -103,7 +103,7 @@ class ModelHook:
         """
         return output
 
-    def detach_hook(self, module):
+    def detach_hook(self, module: nn.Module):
         """
         To be executed when the hook is detached from a module.
 


### PR DESCRIPTION
## What this PR does

Adds `module: nn.Module` type hints to the four lifecycle methods on the
base `ModelHook` class in `src/accelerate/hooks.py`:

- `init_hook`
- `pre_forward`
- `post_forward`
- `detach_hook`

Each of these methods already documents `module` as `torch.nn.Module` in its
docstring (`module (`torch.nn.Module`): ...`), and `nn` is already imported
at the top of the file (`import torch.nn as nn`) and used elsewhere for
signatures such as `add_hook_to_module(module: nn.Module, ...)`. This PR
just makes the base class's own method signatures match the documentation
and the convention already established in the same file.

This is a self-identified typing-consistency follow-up (no linked issue) —
a small companion to my other open PR (#4123, type hints in
`utils/imports.py`), which touches a different file in the same repo.

## Scope note

Only the base `ModelHook` class methods were annotated. Subclasses
(`SequentialHook`, `AlignDevicesHook`, etc.) override these same method
names with their own signatures; some are already partially typed and
others are not, so touching them was left out of scope here to keep this
PR small and focused on the base class contract that all hooks inherit.

## No behaviour change

Type-hint-only change. No logic was modified.

## Testing

- `ruff check src/accelerate/hooks.py` — 4 pre-existing findings, none on
  changed lines, none introduced by this change (verified against upstream
  `main` before/after via `git stash`).
- `ruff format --diff src/accelerate/hooks.py` — no diff, file already
  formatted.
- Verified `module` is used as `torch.nn.Module` at every call site of
  these methods before annotating.

> **Note:** Claude Code was used to assist in drafting this change. All
> changes were reviewed by the submitter.
