### PR TITLE
Add level and msg type hints to MultiProcessAdapter.log

### DIFF
--- a/src/accelerate/logging.py
+++ b/src/accelerate/logging.py
@@ -46,7 +46,7 @@ class MultiProcessAdapter(logging.LoggerAdapter):
         msg = f"[RANK {state.process_index}] {msg}"
         return msg, kwargs
 
-    def log(self, level, msg, *args, **kwargs):
+    def log(self, level: int, msg: object, *args, **kwargs):
         """
         Delegates logger call after checking if we should log.
 


### PR DESCRIPTION
## What this PR does

Adds type hints to the `level` and `msg` parameters of
`MultiProcessAdapter.log()` in `src/accelerate/logging.py`:

```python
def log(self, level: int, msg: object, *args, **kwargs):
```

`MultiProcessAdapter` subclasses `logging.LoggerAdapter`, and this matches
the standard library's own typeshed signature for
`LoggerAdapter.log(self, level: int, msg: object, ...)` — `level` is always
an integer logging level (e.g. `logging.INFO`), and `msg` is typed as
`object` rather than `str` because Python's logging module accepts any
object with a `__str__` (including lazy-formatting helper objects), and
that's exactly how this method is exercised elsewhere via
`self.isEnabledFor(level)` and `self.process(msg, kwargs)`.

This is a self-identified typing-consistency follow-up (no linked issue) —
a small companion to my other open PR (#4123, type hints in
`utils/imports.py`), which touches a different file in the same repo.

## No behaviour change

Type-hint-only change. No logic was modified. The file already has
`from __future__ import annotations` at the top, so this adds no runtime
overhead.

## Testing

- `ruff check src/accelerate/logging.py` — 1 pre-existing finding
  (unrelated `functools.lru_cache` on `warning_once`), not on the changed
  line, not introduced by this change (verified against upstream `main`
  before/after via `git stash`).
- `ruff format --diff src/accelerate/logging.py` — no diff, file already
  formatted.

> **Note:** Claude Code was used to assist in drafting this change. All
> changes were reviewed by the submitter.
