### PR TITLE
Fix BatchSamplerShard.__len__ overcounting when split_batches=True and even_batches=False

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -169,8 +169,15 @@ class BatchSamplerShard(BatchSampler):
 
     def __len__(self):
         if self.split_batches:
-            # Split batches does not change the length of the batch sampler
-            return len(self.batch_sampler)
+            if self.drop_last or self.even_batches:
+                # Split batches does not change the length of the batch sampler
+                return len(self.batch_sampler)
+            # Otherwise the last batch may be smaller and is only yielded on the processes whose part of it is not
+            # empty, so the length depends on the process index.
+            remainder = len(self.batch_sampler.sampler) % self.batch_size
+            if remainder == 0 or remainder > self.batch_size // self.num_processes * self.process_index:
+                return len(self.batch_sampler)
+            return len(self.batch_sampler) - 1
         if len(self.batch_sampler) % self.num_processes == 0:
             # If the length is a round multiple of the number of processes, it's easy.
             return len(self.batch_sampler) // self.num_processes

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -103,8 +103,7 @@ class DataLoaderTester(AccelerateTestCase):
             for i in range(2)
         ]
         batch_sampler_lists = [list(batch_sampler_shard) for batch_sampler_shard in batch_sampler_shards]
-        if not split_batches:
-            assert [len(shard) for shard in batch_sampler_shards] == [len(e) for e in expected]
+        assert [len(shard) for shard in batch_sampler_shards] == [len(e) for e in expected]
         assert batch_sampler_lists == expected
 
     def test_batch_sampler_shards_with_no_splits(self):
@@ -348,6 +347,23 @@ class DataLoaderTester(AccelerateTestCase):
         batch_sampler = BatchSampler(range(2), batch_size=4, drop_last=True)
         expected = [[], []]
         self.check_batch_sampler_shards(batch_sampler, expected, split_batches=True, even_batches=False)
+
+    @parameterized.expand([(2, 2), (4, 2), (6, 2), (6, 3)])
+    def test_batch_sampler_shards_with_splits_no_even_len_matches_iteration(self, batch_size, num_processes):
+        # Regression test for #4122: with `split_batches=True` and `even_batches=False`, `len(shard)` must match the
+        # number of batches actually yielded for every process index. Only combinations where `batch_size` is a round
+        # multiple of `num_processes` are tested, since the others raise a `ValueError` at init.
+        for dataset_size in range(1, 20):
+            for drop_last in [False, True]:
+                batch_sampler = BatchSampler(range(dataset_size), batch_size=batch_size, drop_last=drop_last)
+                for process_index in range(num_processes):
+                    shard = BatchSamplerShard(
+                        batch_sampler, num_processes, process_index, split_batches=True, even_batches=False
+                    )
+                    assert len(shard) == len(list(shard)), (
+                        f"len mismatch for dataset_size={dataset_size}, batch_size={batch_size}, "
+                        f"num_processes={num_processes}, process_index={process_index}, drop_last={drop_last}"
+                    )
 
     def test_batch_sampler_with_varying_batch_size(self):
         batch_sampler = [[0, 1, 2], [3, 4], [5, 6, 7, 8], [9, 10, 11], [12, 13]]


### PR DESCRIPTION
# What does this PR do?

Fixes #4122

When `split_batches=True`, `BatchSamplerShard.__len__` unconditionally returns `len(self.batch_sampler)` for every process. However `_iter_with_split` only yields the final smaller batch (present when the sampler length is not a round multiple of the batch size and `drop_last=False`) to the processes whose slice of it is non-empty (`len(batch) > batch_length * process_index`). With `even_batches=False`, the ranks whose slice is empty were therefore overcounted by one, breaking the `len(shard) == len(list(shard))` invariant.

**Before** (issue repro, sampler of length 3, batch_size=2, 2 processes):
```
process_index=0: len(shard)=2, actual batches=[[0], [2]]
process_index=1: len(shard)=2, actual batches=[[1]]
```
**After**:
```
process_index=0: len(shard)=2, actual batches=[[0], [2]]
process_index=1: len(shard)=1, actual batches=[[1]]
```

The fix mirrors the per-process logic the `split_batches=False` branch already uses (`process_index < len(self.batch_sampler) % self.num_processes`): compute the size of the last batch as `len(self.batch_sampler.sampler) % self.batch_size` and report one fewer batch for the processes whose slice of it would be empty — the exact same condition `_iter_with_split` uses to decide whether to yield it.

**Sweep statistics** (dataset sizes 1–19 × batch_size {2, 4, 6} × num_processes {2, 3}, `split_batches=True, even_batches=False, drop_last=False`): 38 of the 114 (size, batch_size, num_processes) combinations raise `ValueError` at init (batch size not divisible by process count), leaving 76 valid combinations. Before this fix, 43/76 combinations have at least one rank where `len(shard) != len(list(shard))`; counted per (combination, rank) shard instance that is 50 of 171 instances — matching the numbers in the issue, whose 171 corresponds to per-rank instances over the valid combinations. After the fix: 0/76 and 0/171.

**Tests**: adds a parametrized regression sweep (`test_batch_sampler_shards_with_splits_no_even_len_matches_iteration`) covering that grid for every rank, with both `drop_last` values, and removes the `if not split_batches:` guard in `check_batch_sampler_shards` so the existing expected fixtures now also assert shard lengths on the `split_batches=True` paths (all pre-existing fixtures pass unchanged). `pytest tests/test_data_loader.py`: 24 passed / 13 skipped before the change, the new tests fail without the fix, 28 passed / 13 skipped with it. `ruff check` / `ruff format --check` (ruff 0.13.1) pass.

Two design notes to pre-empt review questions:
- *Reading `self.batch_sampler.sampler`*: the class documents that it "Wraps a PyTorch `BatchSampler`", already reads the wrapped sampler's `batch_size` and `drop_last` in `__init__`, and `split_batches` mode requires a real `batch_size` (raises `ValueError` otherwise). `torch.utils.data.BatchSampler.__len__` is itself computed from `len(self.sampler)`, so any sized batch sampler this branch already works with (it calls `len(self.batch_sampler)`) has a sized `.sampler`. A custom batch-sampler-like object exposing `batch_size` but no `.sampler` attribute would only hit the new code on the previously-broken path (`split_batches=True, even_batches=False, drop_last=False`), where the old answer was wrong anyway — happy to switch to a `getattr` fallback if preferred.
- *Why fix this narrow path*: the `split_batches=False` branch already guarantees `len(shard) == len(list(shard))` per rank (its `even_batches=False` case returns a process-index-dependent length a few lines below); there is no reason the `split_batches=True` branch should uphold a weaker invariant. The mismatch is rank-dependent, so `len(dataloader)`-driven loops (progress bars, scheduler total-step computation, loops that iterate `len(dataloader)` times with synchronized collectives) can desync across ranks.

Related: #4118 fixes the analogous overcount in `IterableDatasetShard.__len__` and does not touch `BatchSamplerShard`; the two changes are independent and non-conflicting.

Prepared with AI assistance (Claude Code); all changes and test results were verified locally.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. → #4122
- [ ] Did you make sure to update the documentation with your changes? (No user-facing docs describe the buggy length; docstring behavior is unchanged.)
- [x] Did you write any new necessary tests?

## Who can review?

@BenjaminBossan @SunMarc
