### PR TITLE
feat: span-marker library support added to the estimator tool

### DIFF
--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -24,6 +24,7 @@ from accelerate.commands.utils import CustomArgumentParser
 from accelerate.utils import (
     calculate_maximum_sizes,
     convert_bytes,
+    is_span_marker_available,
     is_timm_available,
     is_transformers_available,
 )
@@ -35,6 +36,9 @@ if is_transformers_available():
 
 if is_timm_available():
     import timm
+
+if is_span_marker_available():
+    from span_marker import SpanMarkerModel
 
 
 def verify_on_hub(repo: str, token: Optional[str] = None):
@@ -59,6 +63,12 @@ def check_has_model(error):
         and "does not appear to have a file named" in error.args[0]
     ):
         return "transformers"
+    elif (
+        is_span_marker_available()
+        and isinstance(error, OSError)
+        and "does not appear to have a file named" in error.args[0]
+    ):
+        return "span-marker"
     else:
         return "unknown"
 
@@ -136,6 +146,16 @@ def create_empty_model(
         print(f"Loading pretrained config for `{model_name}` from `timm`...")
         with init_empty_weights():
             model = timm.create_model(model_name, pretrained=False)
+
+    elif library_name == "span-marker":
+        if not is_span_marker_available():
+            raise ImportError(
+                f"To check `{model_name}`, `span-marker` must be installed. Please install it via `pip install span-marker`"
+            )
+        print(f"Loading pretrained config for `{model_name}` from `span-marker`...")
+        with init_empty_weights():
+            model = SpanMarkerModel.from_pretrained(model_name)
+
     else:
         raise ValueError(
             f"Library `{library_name}` is not supported yet, please open an issue on GitHub for us to add support."
@@ -197,7 +217,7 @@ def estimate_command_parser(subparsers=None):
         "--library_name",
         type=str,
         help="The library the model has an integration with, such as `transformers`, needed only if this information is not stored on the Hub.",
-        choices=["timm", "transformers"],
+        choices=["timm", "transformers", "span-marker"],
     )
     parser.add_argument(
         "--dtypes",

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -62,6 +62,7 @@ from ..utils import (
     is_pytest_available,
     is_schedulefree_available,
     is_sdaa_available,
+    is_span_marker_available,
     is_swanlab_available,
     is_tensorboard_available,
     is_timm_available,
@@ -331,6 +332,13 @@ def require_timm(test_case):
     Decorator marking a test that requires timm. These tests are skipped when they are not.
     """
     return unittest.skipUnless(is_timm_available(), "test requires the timm library")(test_case)
+
+
+def require_span_marker(test_case):
+    """
+    Decorator marking a test that requires span-marker. These tests are skipped when they are not.
+    """
+    return unittest.skipUnless(is_span_marker_available(), "test requires the span-marker library")(test_case)
 
 
 def require_torchvision(test_case):

--- a/src/accelerate/utils/__init__.py
+++ b/src/accelerate/utils/__init__.py
@@ -126,6 +126,7 @@ from .imports import (
     is_sagemaker_available,
     is_schedulefree_available,
     is_sdaa_available,
+    is_span_marker_available,
     is_swanlab_available,
     is_tensorboard_available,
     is_timm_available,

--- a/src/accelerate/utils/imports.py
+++ b/src/accelerate/utils/imports.py
@@ -254,6 +254,10 @@ def is_timm_available():
     return _is_package_available("timm")
 
 
+def is_span_marker_available():
+    return _is_package_available("span_marker", "span-marker")
+
+
 def is_triton_available():
     if is_xpu_available():
         return _is_package_available("triton", "triton-xpu")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ from accelerate.test_utils.testing import (
     path_in_accelerate_package,
     require_multi_device,
     require_non_hpu,
+    require_span_marker,
     require_timm,
     require_transformers,
     run_command,
@@ -457,6 +458,13 @@ class ModelEstimatorTester(unittest.TestCase):
         with self.assertRaises(RuntimeError, msg="Tried to load `muellerzr/dummy` with `transformers` but"):
             args = self.parser.parse_args(["muellerzr/dummy", "--library_name", "transformers"])
             estimate_command(args)
+
+    @require_span_marker
+    def test_span_marker(self):
+        args = self.parser.parse_args(
+            ["tomaarsen/span-marker-bert-base-fewnerd-fine-super", "--library_name", "span-marker"]
+        )
+        estimate_command(args)
 
     def test_no_metadata(self):
         with self.assertRaises(


### PR DESCRIPTION
# What does this PR do?

Fixes #2401

Added span-marker library support to the estimator tool.

SpanMarker is a framework for training powerful Named Entity Recognition models using familiar encoders such as BERT, RoBERTa and ELECTRA. 

# Test coverage

added test for span_marker , test passes locally.

<img width="1095" height="209" alt="image" src="https://github.com/user-attachments/assets/6e467f81-dfff-4a28-b304-6c7c77722d0b" />

@BenjaminBossan @SunMarc @muellerzr 

In the process, i observed the tests fails on the function "test_invalid_model_name_transformers" in the test_cli, confirmed it fails even before i started writing support for span-marker.

Let me know the changes required. 

Thankyou.