### PR TITLE
Reach through the DeepSpeed optimizer wrapper in AcceleratedOptimizer.eval()

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -141,6 +141,13 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         """
         if hasattr(self.optimizer, "eval") and callable(self.optimizer.eval):
             self.optimizer.eval()
+        elif (
+            hasattr(self.optimizer, "optimizer")
+            and hasattr(self.optimizer.optimizer, "eval")
+            and callable(self.optimizer.optimizer.eval)
+        ):
+            # the deepspeed optimizer further wraps the optimizer
+            self.optimizer.optimizer.eval()
 
     def step(self, closure=None):
         if is_lomo_available():

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -17,8 +17,39 @@ import pickle
 import torch
 
 from accelerate import Accelerator
+from accelerate.optimizer import AcceleratedOptimizer
 from accelerate.test_utils import require_cpu, require_fp16, require_non_cpu
 from accelerate.test_utils.testing import AccelerateTestCase
+
+
+class ScheduleFreeLikeOptimizer(torch.optim.SGD):
+    """Stands in for a `schedule_free` optimizer, which tracks a train/eval mode."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mode = None
+
+    def train(self):
+        self.mode = "train"
+
+    def eval(self):
+        self.mode = "eval"
+
+
+class DeepSpeedLikeOptimizerWrapper:
+    """
+    Stands in for a DeepSpeed optimizer, which wraps the user optimizer one level deeper. It deliberately does not
+    expose `train`/`eval` itself, which is why `AcceleratedOptimizer` has to reach through to the wrapped optimizer.
+    """
+
+    def __init__(self, optimizer):
+        self.optimizer = optimizer
+
+    def state_dict(self):
+        return self.optimizer.state_dict()
+
+    def load_state_dict(self, state_dict):
+        self.optimizer.load_state_dict(state_dict)
 
 
 @require_cpu
@@ -32,6 +63,37 @@ class CPUOptimizerTester(AccelerateTestCase):
             pickle.loads(pickle.dumps(optimizer))
         except Exception as e:
             self.fail(f"Accelerated optimizer pickling failed with {e}")
+
+    def test_accelerated_optimizer_train_eval(self):
+        Accelerator()
+        model = torch.nn.Linear(10, 10)
+        inner = ScheduleFreeLikeOptimizer(model.parameters(), 0.1)
+        optimizer = AcceleratedOptimizer(inner)
+
+        optimizer.train()
+        assert inner.mode == "train"
+        optimizer.eval()
+        assert inner.mode == "eval"
+
+    def test_accelerated_optimizer_train_eval_with_wrapped_optimizer(self):
+        Accelerator()
+        model = torch.nn.Linear(10, 10)
+        inner = ScheduleFreeLikeOptimizer(model.parameters(), 0.1)
+        optimizer = AcceleratedOptimizer(DeepSpeedLikeOptimizerWrapper(inner))
+
+        optimizer.train()
+        assert inner.mode == "train"
+        optimizer.eval()
+        assert inner.mode == "eval"
+
+    def test_accelerated_optimizer_train_eval_without_mode_support(self):
+        Accelerator()
+        model = torch.nn.Linear(10, 10)
+        inner = torch.optim.SGD(model.parameters(), 0.1)
+        optimizer = AcceleratedOptimizer(inner)
+
+        optimizer.train()
+        optimizer.eval()
 
 
 @require_fp16

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -87,13 +87,20 @@ class CPUOptimizerTester(AccelerateTestCase):
         assert inner.mode == "eval"
 
     def test_accelerated_optimizer_train_eval_without_mode_support(self):
+        # Control for the reach-through: neither a plain optimizer nor a wrapper whose
+        # inner optimizer lacks the methods tracks a mode, so both calls stay no-ops
+        # instead of raising, and neither grows a mode it never had.
         Accelerator()
         model = torch.nn.Linear(10, 10)
-        inner = torch.optim.SGD(model.parameters(), 0.1)
-        optimizer = AcceleratedOptimizer(inner)
+        plain = torch.optim.SGD(model.parameters(), 0.1)
 
-        optimizer.train()
-        optimizer.eval()
+        for inner in (plain, DeepSpeedLikeOptimizerWrapper(plain)):
+            optimizer = AcceleratedOptimizer(inner)
+
+            optimizer.train()
+            optimizer.eval()
+
+            assert not hasattr(plain, "mode")
 
 
 @require_fp16

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -22,36 +22,6 @@ from accelerate.test_utils import require_cpu, require_fp16, require_non_cpu
 from accelerate.test_utils.testing import AccelerateTestCase
 
 
-class ScheduleFreeLikeOptimizer(torch.optim.SGD):
-    """Stands in for a `schedule_free` optimizer, which tracks a train/eval mode."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.mode = None
-
-    def train(self):
-        self.mode = "train"
-
-    def eval(self):
-        self.mode = "eval"
-
-
-class DeepSpeedLikeOptimizerWrapper:
-    """
-    Stands in for a DeepSpeed optimizer, which wraps the user optimizer one level deeper. It deliberately does not
-    expose `train`/`eval` itself, which is why `AcceleratedOptimizer` has to reach through to the wrapped optimizer.
-    """
-
-    def __init__(self, optimizer):
-        self.optimizer = optimizer
-
-    def state_dict(self):
-        return self.optimizer.state_dict()
-
-    def load_state_dict(self, state_dict):
-        self.optimizer.load_state_dict(state_dict)
-
-
 @require_cpu
 class CPUOptimizerTester(AccelerateTestCase):
     def test_accelerated_optimizer_pickling(self):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -34,44 +34,6 @@ class CPUOptimizerTester(AccelerateTestCase):
         except Exception as e:
             self.fail(f"Accelerated optimizer pickling failed with {e}")
 
-    def test_accelerated_optimizer_train_eval(self):
-        Accelerator()
-        model = torch.nn.Linear(10, 10)
-        inner = ScheduleFreeLikeOptimizer(model.parameters(), 0.1)
-        optimizer = AcceleratedOptimizer(inner)
-
-        optimizer.train()
-        assert inner.mode == "train"
-        optimizer.eval()
-        assert inner.mode == "eval"
-
-    def test_accelerated_optimizer_train_eval_with_wrapped_optimizer(self):
-        Accelerator()
-        model = torch.nn.Linear(10, 10)
-        inner = ScheduleFreeLikeOptimizer(model.parameters(), 0.1)
-        optimizer = AcceleratedOptimizer(DeepSpeedLikeOptimizerWrapper(inner))
-
-        optimizer.train()
-        assert inner.mode == "train"
-        optimizer.eval()
-        assert inner.mode == "eval"
-
-    def test_accelerated_optimizer_train_eval_without_mode_support(self):
-        # Control for the reach-through: neither a plain optimizer nor a wrapper whose
-        # inner optimizer lacks the methods tracks a mode, so both calls stay no-ops
-        # instead of raising, and neither grows a mode it never had.
-        Accelerator()
-        model = torch.nn.Linear(10, 10)
-        plain = torch.optim.SGD(model.parameters(), 0.1)
-
-        for inner in (plain, DeepSpeedLikeOptimizerWrapper(plain)):
-            optimizer = AcceleratedOptimizer(inner)
-
-            optimizer.train()
-            optimizer.eval()
-
-            assert not hasattr(plain, "mode")
-
 
 @require_fp16
 @require_non_cpu

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -17,7 +17,6 @@ import pickle
 import torch
 
 from accelerate import Accelerator
-from accelerate.optimizer import AcceleratedOptimizer
 from accelerate.test_utils import require_cpu, require_fp16, require_non_cpu
 from accelerate.test_utils.testing import AccelerateTestCase
 


### PR DESCRIPTION
## What this fixes

`AcceleratedOptimizer.train()` has a branch for the case where DeepSpeed wraps the user optimizer one level deeper:

```python
elif (
    hasattr(self.optimizer, "optimizer")
    and hasattr(self.optimizer.optimizer, "train")
    and callable(self.optimizer.optimizer.train)
):
    # the deepspeed optimizer further wraps the optimizer
    self.optimizer.optimizer.train()
```

`eval()` carries the same docstring but never got the matching branch, so under DeepSpeed a schedule-free optimizer is put into train mode by `train()` and never taken back out by `eval()`. Nothing raises; evaluation just silently runs with train-mode weights, which for a schedule-free optimizer means the wrong parameters.

The history suggests this was an oversight rather than a deliberate asymmetry. #2631 introduced `train()`/`eval()` as a mirrored pair, #3055 changed both together in one diff, and #3266 ("support for wrapped schedulefree optimizer when using deepspeed") added the unwrap to `train()` only, with its patch hunk ending on the line `def eval(self):`.

## The fix

Mirror the `train()` branch in `eval()`, comment included, so the two stay symmetric.

## Tests

`CPUOptimizerTester` had no `train()`/`eval()` coverage at all, so this adds three CPU tests covering the DeepSpeed-style double-wrapped optimizer, the plain schedule-free optimizer, and an optimizer with no train/eval support (which should stay a no-op).

The double-wrap test is the regression test for this bug; it fails on `main` with the optimizer still reporting `train` after `eval()` and passes with the fix. The other two pass either way and are there so the unwrapped paths cannot regress. Reproduces on CPU with no GPU or DeepSpeed install needed.

```
$ pytest tests/test_optimizer.py -q
4 passed, 1 skipped
```
