### PR TITLE
fix(modeling): reject sharded weight_map paths that escape checkpoint folder

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1802,6 +1802,50 @@ def get_state_dict_from_offload(
     return state_dict
 
 
+def _resolve_sharded_checkpoint_file(checkpoint_folder: Union[str, os.PathLike], shard_file: str) -> str:
+    """
+    Resolve a sharded-checkpoint `weight_map` entry under `checkpoint_folder`.
+
+    Untrusted index JSON may list absolute paths or `..` segments that escape the
+    checkpoint directory. Reject those before any shard is opened.
+    """
+    if not isinstance(shard_file, str) or not shard_file:
+        raise ValueError(
+            f"Invalid sharded checkpoint index: weight map entry {shard_file!r} is not a non-empty relative path."
+        )
+    if os.path.isabs(shard_file):
+        raise ValueError(
+            f"Invalid sharded checkpoint index: weight map entry {shard_file!r} is an absolute path. "
+            "Refusing to load a potentially malicious checkpoint."
+        )
+    # Normalize separators so Windows-style `..\\` segments are also rejected.
+    normalized = shard_file.replace("\\", "/")
+    parts = [p for p in normalized.split("/") if p not in ("", ".")]
+    if any(p == ".." for p in parts):
+        raise ValueError(
+            f"Invalid sharded checkpoint index: weight map entry {shard_file!r} escapes the checkpoint folder. "
+            "Refusing to load a potentially malicious checkpoint."
+        )
+
+    checkpoint_folder_abs = os.path.abspath(checkpoint_folder)
+    resolved = os.path.abspath(os.path.join(checkpoint_folder_abs, *parts))
+    try:
+        if os.path.commonpath([checkpoint_folder_abs, resolved]) != checkpoint_folder_abs:
+            raise ValueError(
+                f"Invalid sharded checkpoint index: weight map entry {shard_file!r} resolves outside "
+                f"the checkpoint folder. Refusing to load a potentially malicious checkpoint."
+            )
+    except ValueError as exc:
+        # commonpath raises when paths are on different drives (Windows).
+        if "outside" in str(exc):
+            raise
+        raise ValueError(
+            f"Invalid sharded checkpoint index: weight map entry {shard_file!r} resolves outside "
+            f"the checkpoint folder. Refusing to load a potentially malicious checkpoint."
+        ) from exc
+    return resolved
+
+
 def load_checkpoint_in_model(
     model: nn.Module,
     checkpoint: Union[str, os.PathLike],
@@ -1929,7 +1973,7 @@ def load_checkpoint_in_model(
         if "weight_map" in index:
             index = index["weight_map"]
         checkpoint_files = sorted(list(set(index.values())))
-        checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
+        checkpoint_files = [_resolve_sharded_checkpoint_file(checkpoint_folder, f) for f in checkpoint_files]
 
     # Logic for missing/unexpected keys goes here.
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -430,6 +430,50 @@ class ModelingUtilsTester(unittest.TestCase):
             self.shard_test_model(model, tmp_dir)
             load_checkpoint_in_model(model, tmp_dir)
 
+    def test_load_checkpoint_in_model_rejects_path_traversal(self):
+        # A malicious/corrupted sharded-checkpoint index must not open shards outside
+        # the checkpoint folder (relative `..` escapes or absolute paths).
+        model = ModelForTest()
+        malicious_targets = (
+            "../escaped_shard.bin",
+            f"..{os.sep}escaped_shard.bin",
+            os.path.join(os.sep, "tmp", "escaped_shard.bin"),
+            "",
+        )
+        for malicious_target in malicious_targets:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                index = {name: malicious_target for name in model.state_dict()}
+                index_file = os.path.join(tmp_dir, "weight_map.index.json")
+                with open(index_file, "w") as f:
+                    json.dump(index, f)
+                with self.assertRaises(ValueError) as cm:
+                    load_checkpoint_in_model(model, index_file)
+                msg = str(cm.exception).lower()
+                self.assertTrue(
+                    any(token in msg for token in ("outside", "absolute", "escape", "non-empty", "relative")),
+                    msg=str(cm.exception),
+                )
+
+    def test_load_checkpoint_in_model_allows_nested_relative_shards(self):
+        # Nested relative shard paths under the checkpoint folder remain valid.
+        model = ModelForTest()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            shard_dir = os.path.join(tmp_dir, "shards")
+            os.makedirs(shard_dir)
+            index = {}
+            module_index = {}
+            for i, name in enumerate(model.state_dict()):
+                module = name.split(".")[0]
+                if module not in module_index:
+                    module_index[module] = os.path.join("shards", f"part_{len(module_index)}.bin")
+                index[name] = module_index[module]
+            with open(os.path.join(tmp_dir, "weight_map.index.json"), "w") as f:
+                json.dump(index, f)
+            for module, rel_fname in module_index.items():
+                state_dict = {k: v for k, v in model.state_dict().items() if k.startswith(module)}
+                torch.save(state_dict, os.path.join(tmp_dir, rel_fname))
+            load_checkpoint_in_model(model, tmp_dir)
+
     @require_non_cpu
     def test_load_checkpoint_in_model_one_gpu(self):
         device_map = {"linear1": 0, "batchnorm": "cpu", "linear2": "cpu"}


### PR DESCRIPTION
# What does this PR do?

Fixes #4067

`load_checkpoint_in_model` builds shard paths from the untrusted `weight_map` in a sharded-checkpoint `*.index.json`:

```python
checkpoint_files = sorted(list(set(index.values())))
checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
```

Absolute values and `..` segments can escape the checkpoint folder and be opened by `load_state_dict`. Maintainer invited a fix on the issue; a previous attempt (#4070) was closed without merge, and main still has the join path.

## Change

- Add `_resolve_sharded_checkpoint_file()`:
  - reject empty / non-string entries
  - reject absolute paths
  - reject `..` path segments (including Windows-style separators)
  - resolve under `checkpoint_folder` and enforce containment via `os.path.commonpath`
- Use it when expanding sharded `weight_map` entries
- Keep legitimate nested relative shards (e.g. `shards/part_0.bin`)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Test plan

- [x] `pytest tests/test_modeling_utils.py::ModelingUtilsTester::test_load_checkpoint_in_model_rejects_path_traversal`
- [x] `pytest tests/test_modeling_utils.py::ModelingUtilsTester::test_load_checkpoint_in_model_allows_nested_relative_shards`
- [x] `pytest tests/test_modeling_utils.py::ModelingUtilsTester::test_load_checkpoint_in_model`
- Result: **3 passed**

## Who can review?

@SunMarc (big modeling / core)
