### PR TITLE
Document bnb_quantization_config in replace_with_bnb_layers

### DIFF
--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -285,6 +285,8 @@ def replace_with_bnb_layers(model, bnb_quantization_config, modules_to_not_conve
     Parameters:
         model (`torch.nn.Module`):
             Input model or `torch.nn.Module` as the function is run recursively.
+        bnb_quantization_config (`BnbQuantizationConfig`):
+            The bitsandbytes quantization parameters
         modules_to_not_convert (`List[str]`):
             Names of the modules to not quantize convert. In practice we keep the `lm_head` in full precision for
             numerical stability reasons.


### PR DESCRIPTION
`replace_with_bnb_layers` documents `model`, `modules_to_not_convert` and `current_key_name`, but not `bnb_quantization_config` — even though it's the required argument that drives the quantization.

Added an entry for it, reusing the same wording the sibling `load_and_quantize_model` already uses for the same parameter in this file. Docs only.