### PR TITLE
Reject sharded-checkpoint shard paths that escape the checkpoint folder

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1802,6 +1802,40 @@ def get_state_dict_from_offload(
     return state_dict
 
 
+def _resolve_shard_file(checkpoint_folder: str, shard_file: str) -> str:
+    """Join a shard name from a checkpoint index onto its folder, refusing to escape that folder.
+
+    The shard names come from the checkpoint's own `*.index.json`, which is attacker-controlled for
+    an untrusted checkpoint. `os.path.join` follows `..` segments and drops the folder entirely when
+    given an absolute path, so the name has to be checked before it is joined.
+
+    Args:
+        checkpoint_folder: The folder the index file was found in.
+        shard_file: A shard name taken from the index's `weight_map`.
+
+    Returns:
+        The path to the shard, guaranteed to sit inside `checkpoint_folder`.
+
+    Raises:
+        ValueError: If `shard_file` is absolute or points outside `checkpoint_folder`.
+    """
+    if os.path.isabs(shard_file):
+        raise ValueError(
+            f"Checkpoint index contains an absolute shard path ({shard_file}). Shard paths must be relative to the "
+            "checkpoint folder."
+        )
+
+    folder = os.path.normpath(checkpoint_folder) if checkpoint_folder else "."
+    resolved = os.path.normpath(os.path.join(folder, shard_file))
+    # Compare the normalized strings rather than `realpath`, so that legitimately symlinked
+    # checkpoints (as laid out by the Hugging Face hub cache) keep working.
+    if resolved != folder and not resolved.startswith(folder.rstrip(os.sep) + os.sep):
+        raise ValueError(
+            f"Checkpoint index contains a shard path that points outside the checkpoint folder ({shard_file})."
+        )
+    return resolved
+
+
 def load_checkpoint_in_model(
     model: nn.Module,
     checkpoint: Union[str, os.PathLike],
@@ -1929,7 +1963,7 @@ def load_checkpoint_in_model(
         if "weight_map" in index:
             index = index["weight_map"]
         checkpoint_files = sorted(list(set(index.values())))
-        checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
+        checkpoint_files = [_resolve_shard_file(checkpoint_folder, f) for f in checkpoint_files]
 
     # Logic for missing/unexpected keys goes here.
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -478,6 +478,48 @@ class ModelingUtilsTester(unittest.TestCase):
             self.shard_test_model(model, tmp_dir)
             load_checkpoint_in_model(model, tmp_dir)
 
+    def test_load_checkpoint_in_model_rejects_shard_paths_outside_folder(self):
+        # The `weight_map` of a sharded checkpoint is attacker-controlled for an untrusted
+        # checkpoint. Shard names that escape the checkpoint folder must be refused rather
+        # than opened.
+        model = ModelForTest()
+        for escaping_name in ["../outside.bin", "sub/../../outside.bin", os.path.join(os.sep, "tmp", "outside.bin")]:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                index = dict.fromkeys(model.state_dict(), escaping_name)
+                with open(os.path.join(tmp_dir, "weight_map.index.json"), "w") as f:
+                    json.dump(index, f)
+
+                with self.assertRaises(ValueError):
+                    load_checkpoint_in_model(model, tmp_dir)
+
+    def test_load_checkpoint_in_model_allows_shard_paths_inside_folder(self):
+        # Nested shard names and symlinked shards (as laid out by the Hugging Face hub cache)
+        # stay inside the checkpoint folder and must keep loading.
+        model = ModelForTest()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.makedirs(os.path.join(tmp_dir, "shards"))
+            shard_name = os.path.join("shards", "checkpoint.bin")
+            torch.save(model.state_dict(), os.path.join(tmp_dir, shard_name))
+            index = dict.fromkeys(model.state_dict(), shard_name)
+            with open(os.path.join(tmp_dir, "weight_map.index.json"), "w") as f:
+                json.dump(index, f)
+
+            load_checkpoint_in_model(model, tmp_dir)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            blob_dir = os.path.join(tmp_dir, "blobs")
+            snapshot_dir = os.path.join(tmp_dir, "snapshot")
+            os.makedirs(blob_dir)
+            os.makedirs(snapshot_dir)
+            blob = os.path.join(blob_dir, "deadbeef")
+            torch.save(model.state_dict(), blob)
+            os.symlink(os.path.relpath(blob, snapshot_dir), os.path.join(snapshot_dir, "checkpoint.bin"))
+            index = dict.fromkeys(model.state_dict(), "checkpoint.bin")
+            with open(os.path.join(snapshot_dir, "weight_map.index.json"), "w") as f:
+                json.dump(index, f)
+
+            load_checkpoint_in_model(model, snapshot_dir)
+
     @require_non_cpu
     def test_load_checkpoint_in_model_one_gpu(self):
         device_map = {"linear1": 0, "batchnorm": "cpu", "linear2": "cpu"}


### PR DESCRIPTION
Closes #4067 (the path-traversal half of the report)

### The problem

`load_checkpoint_in_model` builds its list of shard files from the `weight_map` of a sharded checkpoint's `*.index.json`:

```python
checkpoint_files = sorted(list(set(index.values())))
checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
```

Those values come from whoever authored the checkpoint. `os.path.join` follows `..` segments, and discards the folder entirely when the second argument is absolute, so a crafted index makes the loader open files outside the checkpoint directory. It is reachable through plain `load_checkpoint_in_model(model, "<dir>")` and `load_checkpoint_and_dispatch(...)` — no `trust_remote_code`, no opt-in flag.

Reproduced on `main` with a checkpoint whose `weight_map` points at `../outside/payload.safetensors`, and again with an absolute path: both loaded the outside file successfully.

This is not remote code execution — safetensors goes through `safe_open` and the torch branch already passes `weights_only=True`. The impact is an out-of-directory file open, which doubles as an existence and parse oracle for paths on the host.

### The change

Shard names are validated before they are joined: absolute paths are rejected, and the normalized result must stay inside the checkpoint folder.

The containment check deliberately compares **normalized path strings rather than `realpath`**. That distinction matters: the Hugging Face hub cache stores `snapshots/<rev>/model.safetensors` as a symlink into `../../blobs/<sha>`, so a `realpath`-based check would resolve outside the snapshot directory and reject perfectly legitimate cached checkpoints. Normalizing the string blocks `..` traversal without following symlinks.

### Verification

Both attack vectors are now refused with a clear `ValueError`. I also checked the layouts that must keep working, since a fix here can easily be too strict:

| layout | before | after |
| --- | --- | --- |
| `../outside/payload.safetensors` | loads outside file | rejected |
| absolute path outside the folder | loads outside file | rejected |
| plain `model-00001.safetensors` | loads | loads |
| nested `shards/model-00001.safetensors` | loads | loads |
| hub-cache style symlink to `../../blobs/<sha>` | loads | loads |
| `./model-00001.safetensors` | loads | loads |

Tests added to `tests/test_modeling_utils.py`: one covering the escaping names (relative, nested-relative, absolute), one covering the nested-subdirectory and symlinked-shard layouts so the guard cannot be tightened into breaking the hub cache. The first fails on `main`.

`pytest tests/test_modeling_utils.py` → 43 passed, 3 skipped. `ruff` (0.13.1, as pinned in `setup.py`) format and check are clean.

### Not covered here

The report also describes a DoS where a shard pointed at a FIFO makes `torch.load` block forever. That needs a separate decision about rejecting non-regular files, which has its own compatibility surface, so I left it out rather than bundling it. Happy to follow up if you'd like it handled the same way.

A previous attempt at this (#4070) was closed by the stale bot rather than on review, and the vulnerability is still present on `main`.
