### PR TITLE
[launch] Report one actionable diagnostic when distributed ranks fail (and make --quiet work for multi-GPU)

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -20,6 +20,7 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 import torch
@@ -314,6 +315,27 @@ def launch_command_parser(subparsers=None):
         help=(
             "Base directory to use for log files when using torchrun/torch.distributed.run as launcher. "
             "Use with --tee to redirect std streams info log files."
+        ),
+    )
+    distributed_args.add_argument(
+        "-r",
+        "--redirects",
+        type=str,
+        default="0",
+        help=(
+            "Redirect std streams into per-rank log files under --log_dir (e.g. `3` for stdout+stderr on all "
+            "ranks, `0:1,1:2` for per-rank control). Passed through to torch.distributed.run."
+        ),
+    )
+    distributed_args.add_argument(
+        "--local_ranks_filter",
+        "--local-ranks-filter",
+        type=str,
+        default="",
+        help=(
+            "Only echo logs from these local ranks to the console (e.g. `0`). Passed through to "
+            "torch.distributed.run. Per-rank log files are still written in full; if --tee/--log_dir are unset "
+            "they are enabled automatically so that muted output is never lost."
         ),
     )
     distributed_args.add_argument(
@@ -983,11 +1005,68 @@ def launch_command_parser(subparsers=None):
     return parser
 
 
+def _guard_console_filter(args):
+    """Never mute a rank whose output is not being written to disk.
+
+    torchrun routes a filtered rank's console stream to os.devnull when no redirect is
+    configured, which would destroy the muted output instead of demoting it to a file.
+    """
+    if not getattr(args, "local_ranks_filter", None):
+        return args
+    if args.log_dir is None:
+        args.log_dir = os.path.join(tempfile.gettempdir(), f"accelerate_logs_{os.getpid()}")
+        logger.warning(
+            f"--local_ranks_filter was set without --log_dir; per-rank logs will be written to "
+            f"{args.log_dir} so that muted output is preserved."
+        )
+    if args.tee in (None, "", "0") and args.redirects in (None, "", "0"):
+        args.tee = "3"
+        logger.warning("--local_ranks_filter was set without --tee/--redirects; enabling --tee 3.")
+    return args
+
+
+def _report_child_failure(error, entrypoint, quiet=False, log_dir=None, tee=None):
+    """Print one aggregated diagnostic for a multi-rank failure, then exit or re-raise.
+
+    Additive by default: the original ``ChildFailedError`` is re-raised unchanged (same
+    exception type, same exit semantics). With ``--quiet``, exits with the first failure's
+    code mapped to the shell convention (signal ``-N`` -> ``128 + N``). If the formatter
+    returns ``None`` (disabled, no per-rank data, or an internal formatting error), the
+    original exception propagates exactly as before.
+
+    Accelerate-side values (``quiet``/``log_dir``/``tee``) must be captured by the caller
+    BEFORE ``_filter_args`` replaces the namespace with torchrun-recognized args only.
+    """
+    from accelerate.utils.error_reporting import classify_rank_failures, summarize_child_failure
+
+    summary = summarize_child_failure(error, entrypoint=entrypoint, log_dir=log_dir, tee=tee)
+    if summary is None:
+        raise error
+    print(summary, file=sys.stderr, flush=True)
+    if quiet:
+        sys.exit(classify_rank_failures(error.failures)["exitcode"])
+    raise error
+
+
 def simple_launcher(args):
     cmd, current_env = prepare_simple_launcher_cmd_env(args)
 
     process = subprocess.Popen(cmd, env=current_env)
-    process.wait()
+    try:
+        process.wait()
+    except KeyboardInterrupt:
+        # The child already received SIGINT from the terminal's process group. Wait briefly,
+        # escalate once, and exit with the conventional 128 + SIGINT code instead of dumping
+        # accelerate's own traceback (see https://github.com/huggingface/accelerate/issues/1089).
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.terminate()
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        sys.exit(130)
     if process.returncode != 0:
         if not args.quiet:
             raise subprocess.CalledProcessError(returncode=process.returncode, cmd=cmd)
@@ -997,6 +1076,7 @@ def simple_launcher(args):
 
 def multi_gpu_launcher(args):
     import torch.distributed.run as distrib_run
+    from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
     current_env = prepare_multi_gpu_env(args)
     if not check_cuda_p2p_ib_support():
@@ -1012,6 +1092,9 @@ def multi_gpu_launcher(args):
             logger.warning(message)
 
     debug = getattr(args, "debug", False)
+    entrypoint = args.training_script
+    args = _guard_console_filter(args)
+    quiet, log_dir, tee = args.quiet, args.log_dir, args.tee
     args = _filter_args(
         args,
         distrib_run.get_args_parser(),
@@ -1021,6 +1104,8 @@ def multi_gpu_launcher(args):
     with patch_environment(**current_env):
         try:
             distrib_run.run(args)
+        except ChildFailedError as e:
+            _report_child_failure(e, entrypoint, quiet=quiet, log_dir=log_dir, tee=tee)
         except Exception:
             if is_rich_available() and debug:
                 console = get_console()
@@ -1032,6 +1117,7 @@ def multi_gpu_launcher(args):
 
 def deepspeed_launcher(args):
     import torch.distributed.run as distrib_run
+    from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
 
     if not is_deepspeed_available():
         raise ImportError("DeepSpeed is not installed => run `pip3 install deepspeed` or build it from source.")
@@ -1066,6 +1152,9 @@ def deepspeed_launcher(args):
                 sys.exit(1)
     else:
         debug = getattr(args, "debug", False)
+        entrypoint = args.training_script
+        args = _guard_console_filter(args)
+        quiet, log_dir, tee = args.quiet, args.log_dir, args.tee
         args = _filter_args(
             args,
             distrib_run.get_args_parser(),
@@ -1074,6 +1163,8 @@ def deepspeed_launcher(args):
         with patch_environment(**current_env):
             try:
                 distrib_run.run(args)
+            except ChildFailedError as e:
+                _report_child_failure(e, entrypoint, quiet=quiet, log_dir=log_dir, tee=tee)
             except Exception:
                 if is_rich_available() and debug:
                     console = get_console()

--- a/src/accelerate/utils/error_reporting.py
+++ b/src/accelerate/utils/error_reporting.py
@@ -1,0 +1,217 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pure helpers that turn ``torch.distributed.elastic`` per-rank failure data into a
+single actionable console diagnostic.
+
+Deliberately narrow by design:
+
+* Nothing in this module issues a collective, touches a process group, or blocks.
+* Nothing in this module imports ``torch`` — it reads already-materialized
+  ``ProcessFailure`` metadata duck-typed via ``getattr``, so it is unit-testable
+  on a CPU-only runner with plain fakes.
+* Formatting failures must never mask the original crash: the public entrypoint
+  ``summarize_child_failure`` returns ``None`` on any internal error, and callers
+  are expected to fall back to re-raising the original exception unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+__all__ = [
+    "SUMMARY_ENV_VAR",
+    "classify_rank_failures",
+    "format_failure_summary",
+    "summarize_child_failure",
+]
+
+# Setting ACCELERATE_DISTRIBUTED_ERROR_SUMMARY=0 disables the diagnostic block
+# entirely, restoring byte-identical previous behavior.
+SUMMARY_ENV_VAR = "ACCELERATE_DISTRIBUTED_ERROR_SUMMARY"
+
+# SIGABRT is the signature of PyTorch's NCCL watchdog / heartbeat monitor taking
+# the process down (std::terminate on the watchdog thread). The other entries are
+# hard faults that likewise never surface as Python exceptions.
+_ABORT_SIGNALS = frozenset({"SIGABRT", "SIGSEGV", "SIGBUS", "SIGFPE", "SIGILL"})
+# Ranks killed by the elastic agent after another rank failed. Their tracebacks
+# are collateral of the group teardown, not evidence about the root cause.
+_TEARDOWN_SIGNALS = frozenset({"SIGTERM", "SIGINT", "SIGKILL"})
+
+_WATCHDOG_EXPLANATION = (
+    "A rank exiting on SIGABRT is the signature of PyTorch's NCCL watchdog or heartbeat "
+    "monitor tearing the process down after a collective exceeded its timeout. This is by "
+    "design and is not catchable in Python: the abort is raised on a C++ watchdog thread, "
+    "not on the thread that issued the collective."
+)
+_VICTIM_WARNING = (
+    "The rank that reports a timeout is frequently a VICTIM waiting on a peer. The "
+    "root-cause rank is often the one that produced no output at all (it hung), so treat "
+    "'first observed failure' as a heuristic, not a verdict."
+)
+
+
+def _signal_name(failure: Any) -> str | None:
+    """``ProcessFailure.signal_name`` is a method upstream; tolerate shape drift."""
+    name = getattr(failure, "signal_name", None)
+    try:
+        name = name() if callable(name) else name
+    except Exception:
+        return None
+    # Upstream uses "<N/A>" for non-signal exits; normalize anything non-signal-like to None.
+    if not name or not str(name).startswith("SIG"):
+        return None
+    return str(name)
+
+
+def classify_rank_failures(failures: dict[int, Any]) -> dict[str, Any]:
+    """
+    Partition ``ChildFailedError.failures`` into diagnostic buckets.
+
+    Returns a dict with ``first_rank``, ``first`` (the ``ProcessFailure`` with the
+    earliest timestamp — torchelastic's own, explicitly heuristic, root-cause rule),
+    ``aborted`` / ``torn_down`` / ``raised`` rank lists, and ``exitcode`` mapped to
+    the shell convention (a signal death of ``-N`` becomes ``128 + N``).
+    """
+    if not failures:
+        return {
+            "first_rank": None,
+            "first": None,
+            "aborted": [],
+            "torn_down": [],
+            "raised": [],
+            "exitcode": 1,
+        }
+
+    first_rank = min(failures, key=lambda rank: getattr(failures[rank], "timestamp", 0))
+    aborted, torn_down, raised = [], [], []
+    for rank in sorted(failures):
+        name = _signal_name(failures[rank])
+        if name in _ABORT_SIGNALS:
+            aborted.append(rank)
+        elif name in _TEARDOWN_SIGNALS:
+            torn_down.append(rank)
+        else:
+            raised.append(rank)
+
+    exitcode = getattr(failures[first_rank], "exitcode", 1) or 1
+    return {
+        "first_rank": first_rank,
+        "first": failures[first_rank],
+        "aborted": aborted,
+        "torn_down": torn_down,
+        "raised": raised,
+        # Shell exit codes are unsigned: map a signal death (-N) to 128 + N.
+        "exitcode": (128 - exitcode) if exitcode < 0 else exitcode,
+    }
+
+
+def format_failure_summary(
+    failures: dict[int, Any],
+    *,
+    entrypoint: str = "training script",
+    log_dir: str | None = None,
+    tee: str | None = None,
+    width: int = 78,
+) -> str:
+    """Render one bordered, self-contained diagnostic block. Pure; never raises by contract of its caller."""
+    info = classify_rank_failures(failures)
+    first, first_rank = info["first"], info["first_rank"]
+    border, rule = "=" * width, "-" * width
+    out = [border, f"accelerate launch: `{entrypoint}` failed on {len(failures)} rank(s)", rule]
+    if first is None:
+        return "\n".join(out + ["No per-rank failure detail was reported by the launcher.", border])
+
+    sig = _signal_name(first)
+    error_file = getattr(first, "error_file", None)
+    out += [
+        "First observed failure (earliest timestamp -- HEURISTIC, not a verdict):",
+        f"  rank      : {first_rank} (local_rank {getattr(first, 'local_rank', '?')})",
+        f"  exitcode  : {getattr(first, 'exitcode', '?')}"
+        + (f" ({sig})" if sig else "")
+        + f", pid {getattr(first, 'pid', '?')}",
+        f"  error_file: {error_file if error_file and error_file != '<N/A>' else '<none written -- see @record note below>'}",
+        "",
+    ]
+    if sig in _ABORT_SIGNALS:
+        out += [f"  {_WATCHDOG_EXPLANATION}", ""]
+    out += [f"  {_VICTIM_WARNING}", "", "Rank breakdown:"]
+    for label, ranks in (
+        ("aborted (watchdog / hard fault)", info["aborted"]),
+        ("torn down by the launcher", info["torn_down"]),
+        ("raised a Python exception / exited", info["raised"]),
+    ):
+        out.append(f"  {label:<36}: {len(ranks)}" + (f"  -> ranks {ranks}" if ranks else ""))
+    if info["torn_down"]:
+        out += [
+            "",
+            "  Ranks torn down by SIGTERM/SIGKILL were killed by the elastic agent AFTER",
+            "  the first failure. Their tracebacks are collateral, not causes.",
+        ]
+
+    out += ["", "Preserved per-rank detail:"]
+    wrote_any = False
+    for rank in sorted(failures):
+        path = getattr(failures[rank], "error_file", None)
+        if path and path != "<N/A>" and os.path.exists(path):
+            out.append(f"  rank {rank}: {path}")
+            wrote_any = True
+    if not wrote_any:
+        out += [
+            "  none -- worker entrypoints were not decorated with",
+            "  `torch.distributed.elastic.multiprocessing.errors.record`, so no error",
+            "  files were written (exit codes and signals only).",
+        ]
+    if not log_dir or tee in (None, "", "0"):
+        out += [
+            "  Per-rank stdout/stderr was NOT captured to disk for this run.",
+            "  Re-run with:  accelerate launch --tee 3 --log_dir ./accelerate_logs ...",
+        ]
+    else:
+        out.append(f"  Per-rank stdout/stderr: {log_dir}")
+
+    out += [
+        "",
+        "Suggested next steps:",
+        "  1. Re-run with per-rank capture and a quiet console:",
+        "       accelerate launch --tee 3 --log_dir ./accelerate_logs \\",
+        "                         --local_ranks_filter 0 ...",
+        "  2. Enable Flight Recorder to see which collective each rank was in:",
+        "       TORCH_NCCL_TRACE_BUFFER_SIZE=2000 TORCH_NCCL_DUMP_ON_TIMEOUT=1",
+        "  3. Look first at the rank that produced NO output.",
+        border,
+    ]
+    return "\n".join(out)
+
+
+def summarize_child_failure(error: Any, **kwargs: Any) -> str | None:
+    """
+    Best-effort wrapper: ``ChildFailedError`` -> one diagnostic string.
+
+    Returns ``None`` (meaning: caller re-raises exactly as before) when the summary
+    is disabled via the environment, when the error carries no per-rank failures, or
+    when formatting itself fails for any reason. A bug in the diagnostics must never
+    hide the actual crash.
+    """
+    if os.environ.get(SUMMARY_ENV_VAR, "1").lower() in ("0", "false", "no", "off"):
+        return None
+    failures = getattr(error, "failures", None)
+    if not failures:
+        return None
+    try:
+        return format_failure_summary(failures, **kwargs)
+    except Exception:
+        return None

--- a/tests/test_error_reporting.py
+++ b/tests/test_error_reporting.py
@@ -1,0 +1,214 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from dataclasses import dataclass, field
+
+import pytest
+
+from accelerate.utils.error_reporting import (
+    SUMMARY_ENV_VAR,
+    classify_rank_failures,
+    format_failure_summary,
+    summarize_child_failure,
+)
+
+
+@dataclass
+class FakeFailure:
+    """Duck-typed stand-in for torch.distributed.elastic's ProcessFailure."""
+
+    local_rank: int
+    pid: int
+    exitcode: int
+    timestamp: int
+    error_file: str = "<N/A>"
+    message: str = ""  # required by ChildFailedError.format_msg() in the Tier-2a tests
+    _signal: str | None = field(default=None)
+
+    def signal_name(self):
+        return self._signal or "<N/A>"
+
+    def timestamp_isoformat(self):
+        # Also required by ChildFailedError.format_msg(); a fixed stamp keeps tests deterministic.
+        return "2026-07-28_00:00:00"
+
+
+def _sigabrt(rank, ts=100):
+    return FakeFailure(local_rank=rank, pid=1000 + rank, exitcode=-6, timestamp=ts, _signal="SIGABRT")
+
+
+def _sigterm(rank, ts=105):
+    return FakeFailure(local_rank=rank, pid=1000 + rank, exitcode=-15, timestamp=ts, _signal="SIGTERM")
+
+
+def _pyexit(rank, code=1, ts=100):
+    return FakeFailure(local_rank=rank, pid=1000 + rank, exitcode=code, timestamp=ts)
+
+
+class ClassifyRankFailuresTester(unittest.TestCase):
+    def test_watchdog_style_abort_is_bucketed_and_mapped(self):
+        info = classify_rank_failures({1: _sigabrt(1, ts=100), 0: _sigterm(0, ts=105), 2: _sigterm(2, ts=106)})
+        assert info["first_rank"] == 1  # earliest timestamp, not lowest rank
+        assert info["aborted"] == [1]
+        assert info["torn_down"] == [0, 2]
+        assert info["raised"] == []
+        assert info["exitcode"] == 134  # 128 + SIGABRT(6)
+
+    def test_ordinary_python_exit_is_not_mislabelled_as_watchdog(self):
+        info = classify_rank_failures({0: _pyexit(0)})
+        assert info["aborted"] == []
+        assert info["raised"] == [0]
+        assert info["exitcode"] == 1
+
+    def test_empty_failures_never_raise(self):
+        info = classify_rank_failures({})
+        assert info["first"] is None
+        assert info["exitcode"] == 1
+
+    def test_signal_name_shape_drift_is_tolerated(self):
+        class WeirdFailure:
+            local_rank, pid, exitcode, timestamp, error_file = 0, 1, -9, 100, "<N/A>"
+            signal_name = "SIGKILL"  # attribute instead of method
+
+        info = classify_rank_failures({0: WeirdFailure()})
+        assert info["torn_down"] == [0]
+        assert info["exitcode"] == 137
+
+
+class FormatFailureSummaryTester(unittest.TestCase):
+    def test_watchdog_abort_report_content(self):
+        out = format_failure_summary(
+            {1: _sigabrt(1, ts=100), 0: _sigterm(0, ts=105), 2: _sigterm(2, ts=106)}, entrypoint="train.py"
+        )
+        assert out.count("First observed failure") == 1
+        assert "HEURISTIC" in out  # honesty caveat is load-bearing, not decoration
+        assert "NCCL watchdog" in out
+        assert "collateral, not causes" in out
+        assert "--local_ranks_filter 0" in out  # re-run recipe present
+        assert "`train.py` failed on 3 rank(s)" in out
+
+    def test_python_failure_report_has_no_watchdog_claim(self):
+        out = format_failure_summary({0: _pyexit(0)}, entrypoint="train.py")
+        assert "NCCL watchdog" not in out
+        assert "record" in out  # points at @record for tracebacks
+
+    def test_missing_error_files_are_reported_honestly(self):
+        out = format_failure_summary({1: _sigabrt(1)}, entrypoint="train.py")
+        assert "none -- worker entrypoints were not decorated" in out
+
+
+class SummarizeChildFailureTester(unittest.TestCase):
+    class FakeChildFailedError(Exception):
+        def __init__(self, failures):
+            self.failures = failures
+
+    def test_env_kill_switch_disables_summary(self):
+        error = self.FakeChildFailedError({1: _sigabrt(1)})
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv(SUMMARY_ENV_VAR, "0")
+            assert summarize_child_failure(error) is None
+
+    def test_error_without_failures_returns_none(self):
+        assert summarize_child_failure(RuntimeError("not a child failure")) is None
+
+    def test_formatter_bug_degrades_to_none_never_raises(self):
+        class Poison:
+            def __getattr__(self, name):
+                raise ValueError("poisoned attribute access")
+
+        error = self.FakeChildFailedError({0: Poison()})
+        assert summarize_child_failure(error) is None  # zero-blast-radius gate
+
+
+class LauncherClauseTester(unittest.TestCase):
+    """Tier 2a: exercise the real `except ChildFailedError` clause in multi_gpu_launcher
+    by monkeypatching `distrib_run.run` — reachable on a zero-GPU runner. (A `--cpu`
+    subprocess test would dispatch to `simple_launcher` and never reach this clause.)
+    """
+
+    def _launch_args(self, extra=None):
+        from accelerate.commands.launch import launch_command_parser
+
+        argv = [
+            "--multi_gpu",
+            "--num_processes",
+            "2",
+            "--num_machines",
+            "1",
+            "--mixed_precision",
+            "no",
+            "--dynamo_backend",
+            "no",
+            "train.py",
+        ]
+        if extra:
+            argv = extra + argv
+        args = launch_command_parser().parse_args(argv)
+        args.debug = False
+        return args
+
+    def _synthesized_error(self):
+        from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
+
+        return ChildFailedError("train.py", {1: _sigabrt(1, ts=100), 0: _sigterm(0, ts=105)})
+
+    def test_clause_prints_one_summary_and_reraises_by_default(self):
+        import torch.distributed.run as distrib_run
+        from torch.distributed.elastic.multiprocessing.errors import ChildFailedError
+
+        from accelerate.commands import launch as launch_module
+
+        args = self._launch_args()
+        error = self._synthesized_error()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(distrib_run, "run", lambda a: (_ for _ in ()).throw(error))
+            with pytest.raises(ChildFailedError), _capture_stderr() as captured:
+                launch_module.multi_gpu_launcher(args)
+        assert captured["value"].count("First observed failure") == 1
+
+    def test_quiet_exits_with_signal_mapped_code(self):
+        import torch.distributed.run as distrib_run
+
+        from accelerate.commands import launch as launch_module
+
+        args = self._launch_args(extra=["--quiet"])
+        error = self._synthesized_error()
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(distrib_run, "run", lambda a: (_ for _ in ()).throw(error))
+            with pytest.raises(SystemExit) as exc_info, _capture_stderr() as captured:
+                launch_module.multi_gpu_launcher(args)
+        assert exc_info.value.code == 134
+        assert captured["value"].count("First observed failure") == 1
+
+
+class _capture_stderr:
+    def __init__(self):
+        self._buf = None
+
+    def __enter__(self):
+        import io
+        import sys
+
+        self._old = sys.stderr
+        self._buf = io.StringIO()
+        sys.stderr = self._buf
+        self.result = {"value": ""}
+        return self.result
+
+    def __exit__(self, *exc):
+        import sys
+
+        self.result["value"] = self._buf.getvalue()
+        sys.stderr = self._old
+        return False


### PR DESCRIPTION
## What does this PR do?

When a rank dies during `accelerate launch --multi_gpu` (or FSDP / single-node DeepSpeed), `torch.distributed.elastic` hands accelerate a fully structured `ChildFailedError` — one `ProcessFailure` per rank with exitcode, signal, pid, timestamp and error-file path. Today the launchers catch it with a generic `except Exception` and re-raise unchanged, so that structure reaches the user as raw traceback text underneath the per-rank log flood — and torchelastic's own "Root Cause (first observed failure)" heuristic can name a *victim* rank (one that timed out waiting) while the true culprit is the rank that logged nothing.

This PR reads that object and prints **one bordered diagnostic block**: the first observed failure (rank, pid, exitcode, signal) explicitly labelled as torchelastic's earliest-timestamp *heuristic*, a signal-class breakdown separating watchdog-style aborts from ranks the elastic agent tore down afterwards ("collateral, not causes"), pointers to every preserved per-rank artifact, and the exact re-run command for per-rank capture and Flight Recorder. It also:

* forwards torchrun's existing `--local_ranks_filter` / `--redirects` (accelerate already forwards `--tee` / `--log_dir` through the same `_filter_args` path) — and refuses the lossy configuration: filtering without file capture auto-enables `--tee 3 --log_dir` with a warning, so muted console output is demoted to files, never destroyed;
* makes `--quiet` apply to the multi-GPU path (its help text currently disclaims it, which is part of what #1089 reports); in quiet mode the exit code becomes `128 + signum` (a watchdog SIGABRT yields 134 instead of a lossy 1);
* catches `KeyboardInterrupt` in `simple_launcher`, so Ctrl-C exits 130 instead of dumping accelerate's own traceback — the direct ask in #1089;
* keeps the classifier/formatter in a new pure-function module (`accelerate.utils.error_reporting`) with no `torch` import, unit-testable without GPUs.

The three modes, stated precisely: the default **interprets** the failure (strictly additive — nothing is removed); `--quiet` **silences** the Python-side launcher traceback; `--local_ranks_filter` **mutes the C++-side console flood with preservation** (torchrun's OS-level redirection; per-rank files always written). No mode deletes diagnostic data.

## Verification (real hardware)

* **Hardware validation:** tested end-to-end on a 2x NVIDIA L40 instance (PyTorch 2.12.1+cu130, NCCL 2.27.7) with a genuine NCCL watchdog timeout provoked by freezing one rank while its peer entered an all-reduce.
* **Default mode:** the watchdog killed **rank 0 — the victim waiting on frozen rank 1** — and the diagnostic block classified the SIGABRT as a watchdog abort, displayed the victim caveat over exactly the case it exists for, then re-raised `ChildFailedError` unchanged (no logs masked).
* **`--quiet`:** exit code 134 (128+SIGABRT), zero launcher tracebacks, single diagnostic report.
* **`--local_ranks_filter`:** eliminated the C++ console flood (169 -> 81 lines, zero watchdog lines on console) while the guard auto-enabled `--tee`/`--log_dir`; the full C++ stack traces were verified preserved in per-rank `stderr.log` files.
* **Regression safety:** healthy runs byte-identical (exit 0, zero new output); ordinary Python exceptions keep their full traceback; `tests/test_cli.py` and `tests/test_utils.py` pass.

<details>
<summary><b>Before</b> — raw waterfall on the L40s (excerpt of 169 lines)</summary>

```
[rank0]:[E728 18:15:39.660703688 ProcessGroupNCCL.cpp:2197] [PG ID 0 PG GUID 0(default_pg) Rank 0] Process group watchdog thread terminated with exception: NCCL error in: /pytorch/torch/csrc/distributed/c10d/NCCLUtils.cpp:461, Unknown, NCCL version 2.27.7
ncclInternalError: Internal check failed.
Last error:
Unknown
... (~50 more lines of C++ watchdog / NCCL / teardown output) ...
terminate called after throwing an instance of 'c10::DistBackendError'
  what():  [PG ID 0 PG GUID 0(default_pg) Rank 0] Process group watchdog thread terminated with exception: NCCL error in: /pytorch/torch/csrc/distributed/c10d/NCCLUtils.cpp:461, Unknown, NCCL version 2.27.7
ncclInternalError: Internal check failed.
terminate called recursively
W0728 18:15:41.375000 528 torch/distributed/elastic/multiprocessing/api.py:1014] Sending process 676 closing signal SIGTERM
```
</details>

<details>
<summary><b>After</b> — the diagnostic block this PR adds (default mode, printed before the unchanged re-raise)</summary>

```
accelerate launch: `repro_gpu_crash.py` failed on 2 rank(s)
------------------------------------------------------------------------------
First observed failure (earliest timestamp -- HEURISTIC, not a verdict):
  rank      : 0 (local_rank 0)
  exitcode  : -6 (SIGABRT), pid 675
  error_file: <none written -- see @record note below>

  A rank exiting on SIGABRT is the signature of PyTorch's NCCL watchdog or heartbeat monitor tearing the process down after a collective exceeded its timeout. This is by design and is not catchable in Python: the abort is raised on a C++ watchdog thread, not on the thread that issued the collective.

  The rank that reports a timeout is frequently a VICTIM waiting on a peer. The root-cause rank is often the one that produced no output at all (it hung), so treat 'first observed failure' as a heuristic, not a verdict.

Rank breakdown:
  aborted (watchdog / hard fault)     : 1  -> ranks [0]
  torn down by the launcher           : 1  -> ranks [1]
  raised a Python exception / exited  : 0

  Ranks torn down by SIGTERM/SIGKILL were killed by the elastic agent AFTER
  the first failure. Their tracebacks are collateral, not causes.

Preserved per-rank detail:
  none -- worker entrypoints were not decorated with
  `torch.distributed.elastic.multiprocessing.errors.record`, so no error
  files were written (exit codes and signals only).
  Per-rank stdout/stderr was NOT captured to disk for this run.
  Re-run with:  accelerate launch --tee 3 --log_dir ./accelerate_logs ...

Suggested next steps:
  1. Re-run with per-rank capture and a quiet console:
       accelerate launch --tee 3 --log_dir ./accelerate_logs \
                         --local_ranks_filter 0 ...
  2. Enable Flight Recorder to see which collective each rank was in:
       TORCH_NCCL_TRACE_BUFFER_SIZE=2000 TORCH_NCCL_DUMP_ON_TIMEOUT=1
  3. Look first at the rank that produced NO output.
==============================================================================
Traceback (most recent call last):
  File "/home/ubuntu/.local/bin/accelerate", line 6, in <module>
    sys.exit(main())
```
</details>

## What this deliberately does NOT do

* **No recovery, no retry.** PyTorch core's position (pytorch/pytorch#163546) is that `ProcessGroupNCCL` is not built for recovery. This PR improves *presentation* of a crash the launcher already handles.
* **No claim to catch NCCL watchdog timeouts in Python.** The watchdog aborts from a C++ thread via `std::terminate` (RFC pytorch/pytorch#46874, by design); this PR classifies the resulting SIGABRT at the launcher, where it is observable.
* **No exception swallowing, no data deletion.** The default is strictly additive: print one block, then re-raise the original `ChildFailedError` (same type, same exit semantics). `ACCELERATE_DISTRIBUTED_ERROR_SUMMARY=0` disables the block entirely. If the formatter itself fails for any reason it returns `None` and the original exception propagates exactly as before — a bug in the diagnostics can never hide the real crash.
* **No collectives, barriers or state rescue in the crash path.** (Lightning shipped the opposite once — Lightning-AI/pytorch-lightning#6842 — and removed it after it deadlocked.) The handler runs in the launcher process, formats, and exits or re-raises.

## Scope limitation: DeepSpeed multi-node

DeepSpeed's PDSH/OpenMPI multi-node launchers run through `subprocess.Popen` and expose only the child's return code, so there is no `ChildFailedError` on that path (unless elastic training is enabled); behavior there is unchanged.

## Tests

`tests/test_error_reporting.py` — classifier/formatter units (signal bucketing, minimum-timestamp selection, `-6 -> 134` mapping, empty-input safety, the heuristic caveat, the `None`-fallback guard), plus an in-process harness that reaches the real `except ChildFailedError` clause on zero-GPU CI by monkeypatching `torch.distributed.run.run` — chosen deliberately because a `--cpu` subprocess test dispatches to `simple_launcher` and never reaches the clause. A real watchdog firing is not CI-inducible on hosted runners; the hardware validation above covers it.

## Backwards compatibility

New code executes only on the crash path or when a new flag is passed. Exit codes and exception types are unchanged by default.

Refs #1089. Related reports of this failure mode: #3861, #2183, #314, #223. Precedent for launcher-layer mitigation of a distributed footgun: #2195.

## Who can review?

@muellerzr @SunMarc @BenjaminBossan
