### PR TITLE
[FSDP] Validate activation checkpointing auto-wrap policy

### DIFF
--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1951,6 +1951,11 @@ class FullyShardedDataParallelPlugin:
             self.activation_checkpointing = (
                 str_to_bool(os.environ.get(env_prefix + "ACTIVATION_CHECKPOINTING", "False")) == 1
             )
+        if self.activation_checkpointing and self.auto_wrap_policy is None:
+            raise ValueError(
+                "`activation_checkpointing=True` requires an auto wrap policy. Please choose "
+                "`TRANSFORMER_BASED_WRAP` or `SIZE_BASED_WRAP` instead of `NO_WRAP`."
+            )
 
         if self.ignored_modules is None:
             self.ignored_modules = os.environ.get(env_prefix + "IGNORED_MODULES", None)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -288,6 +288,19 @@ class FSDPPluginIntegration(AccelerateTestCase):
         fsdp_plugin.set_auto_wrap_policy(model)
         assert fsdp_plugin.auto_wrap_policy is None
 
+    def test_activation_checkpointing_requires_auto_wrap_policy(self):
+        fsdp_version = self.current_fsdp_version
+        error_message = "`activation_checkpointing=True` requires an auto wrap policy"
+
+        env = self.fsdp_envs[fsdp_version].copy()
+        env["FSDP_AUTO_WRAP_POLICY"] = "NO_WRAP"
+        env["FSDP_ACTIVATION_CHECKPOINTING"] = "true"
+        with patch_environment(**env), self.assertRaisesRegex(ValueError, error_message):
+            FullyShardedDataParallelPlugin()
+
+        with patch_environment(**self.fsdp_envs[fsdp_version]), self.assertRaisesRegex(ValueError, error_message):
+            FullyShardedDataParallelPlugin(auto_wrap_policy="NO_WRAP", activation_checkpointing=True)
+
     def test_mixed_precision(self):
         fsdp_version = self.current_fsdp_version
         if fsdp_version == 2:


### PR DESCRIPTION
## What does this PR do?

Rejects FSDP activation checkpointing configurations that use `NO_WRAP` and raises an actionable `ValueError` during plugin initialization.

Activation checkpointing selects modules through the configured auto-wrap policy. `NO_WRAP` is normalized to `None`, so the previous code failed later in model preparation with an opaque `TypeError: 'NoneType' object is not callable`.

The regression coverage exercises both environment-variable configuration and direct `FullyShardedDataParallelPlugin` construction for FSDP1 and FSDP2.

Fixes #3822

## Validation

```text
python -m pytest -q \
  tests/fsdp/test_fsdp.py::FSDPPluginIntegration::test_activation_checkpointing_requires_auto_wrap_policy \
  tests/fsdp/test_fsdp.py::FSDP2PluginIntegration::test_activation_checkpointing_requires_auto_wrap_policy
# 2 passed

ruff check src/accelerate/utils/dataclasses.py tests/fsdp/test_fsdp.py
ruff format --check src/accelerate/utils/dataclasses.py tests/fsdp/test_fsdp.py
```
