### PR TITLE
Add end-to-end distributed test suite (Phase 0: DDP smoke + env parity)

### DIFF
--- a/tests/distributed/__init__.py
+++ b/tests/distributed/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/distributed/accelerate_configs/ddp.yaml
+++ b/tests/distributed/accelerate_configs/ddp.yaml
@@ -1,0 +1,4 @@
+compute_environment: LOCAL_MACHINE
+distributed_type: MULTI_GPU
+num_machines: 1
+num_processes: 2

--- a/tests/distributed/accelerate_configs/fsdp2.yaml
+++ b/tests/distributed/accelerate_configs/fsdp2.yaml
@@ -1,0 +1,6 @@
+compute_environment: LOCAL_MACHINE
+distributed_type: FSDP
+num_machines: 1
+num_processes: 2
+fsdp_config:
+  fsdp_version: 2

--- a/tests/distributed/scripts/env_check.py
+++ b/tests/distributed/scripts/env_check.py
@@ -1,0 +1,72 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dump the per-rank distributed environment seen by an ``Accelerator`` to JSON.
+
+Each rank instantiates an ``Accelerator``, builds a small record of what it perceives
+(distributed_type, rank/local_rank, device, mixed_precision, plus a few raw env vars),
+and the main process writes all records sorted by ``process_index`` to ``--output_file``.
+
+Every value is coerced to a JSON-serializable scalar; enum values are ``str()``-ified
+(e.g., ``"DistributedType.MULTI_GPU"``).
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from accelerate import Accelerator
+from accelerate.utils import gather_object
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--output_file", type=Path, required=True)
+    return p.parse_args()
+
+
+def build_env_record(accelerator: Accelerator) -> dict:
+    return {
+        "distributed_type": str(accelerator.distributed_type),
+        "num_processes": accelerator.num_processes,
+        "process_index": accelerator.process_index,
+        "local_process_index": accelerator.local_process_index,
+        "device": str(accelerator.device),
+        "mixed_precision": str(accelerator.mixed_precision),
+        # Raw env-vars set by the launcher, for cross-launcher parity comparison.
+        "env_WORLD_SIZE": int(os.environ.get("WORLD_SIZE", "1")),
+        "env_RANK": int(os.environ.get("RANK", "0")),
+        # local_rank can legitimately be -1 before the framework consumes it.
+        "env_LOCAL_RANK": int(os.environ.get("LOCAL_RANK", "0")),
+        "env_MASTER_ADDR": os.environ.get("MASTER_ADDR", ""),
+    }
+
+
+def main():
+    args = parse_args()
+    accelerator = Accelerator()
+
+    record = build_env_record(accelerator)
+    all_records = gather_object([record])
+
+    accelerator.wait_for_everyone()
+
+    if accelerator.is_main_process:
+        all_records.sort(key=lambda r: r["process_index"])
+        args.output_file.parent.mkdir(parents=True, exist_ok=True)
+        args.output_file.write_text(json.dumps(all_records, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/distributed/scripts/train.py
+++ b/tests/distributed/scripts/train.py
@@ -1,0 +1,172 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Raw Accelerator training loop over a tiny causal LM and hermetic synthetic tokens.
+
+Backend (DDP, FSDP, DeepSpeed) is selected by the launcher config passed to
+``accelerate launch --config_file``; this script itself is backend-agnostic.
+
+The main process writes a JSON summary (loss history, step count, distributed_type,
+mixed_precision) to ``--output_file`` for the caller to assert on.
+"""
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+from accelerate import Accelerator, DataLoaderConfiguration
+from accelerate.utils import set_seed
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--output_file", type=Path, required=True)
+    p.add_argument("--max_steps", type=int, default=20)
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--batch_size", type=int, default=4)
+    p.add_argument("--lr", type=float, default=5e-4)
+    p.add_argument("--mixed_precision", choices=["no", "fp16", "bf16"], default="no")
+    p.add_argument("--gradient_accumulation_steps", type=int, default=1)
+    p.add_argument(
+        "--checkpoint_dir",
+        type=Path,
+        default=None,
+        help="Directory for save_state()/load_state(). Required when --save_at_step or --resume_from is set.",
+    )
+    p.add_argument(
+        "--save_at_step",
+        type=int,
+        default=None,
+        help="After this many steps, call save_state() into --checkpoint_dir and exit.",
+    )
+    p.add_argument(
+        "--resume_from",
+        type=Path,
+        default=None,
+        help="Call load_state() from this path before training begins.",
+    )
+    p.add_argument("--num_sequences", type=int, default=32, help="Size of the memorizable synthetic corpus.")
+    p.add_argument("--sequence_length", type=int, default=32)
+    p.add_argument("--vocab_size", type=int, default=256)
+    p.add_argument("--hidden_size", type=int, default=64)
+    p.add_argument("--num_hidden_layers", type=int, default=2)
+    p.add_argument("--num_attention_heads", type=int, default=2)
+    return p.parse_args()
+
+
+def build_model(args):
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    config = LlamaConfig(
+        vocab_size=args.vocab_size,
+        hidden_size=args.hidden_size,
+        intermediate_size=args.hidden_size * 2,
+        num_hidden_layers=args.num_hidden_layers,
+        num_attention_heads=args.num_attention_heads,
+        num_key_value_heads=args.num_attention_heads,
+        max_position_embeddings=args.sequence_length,
+        rms_norm_eps=1e-5,
+        tie_word_embeddings=False,
+    )
+    return LlamaForCausalLM(config)
+
+
+def build_dataset(args):
+    # REASON: a small fixed corpus repeated across epochs is intentionally memorizable,
+    # so downstream convergence assertions have a reliable signal.
+    gen = torch.Generator().manual_seed(args.seed)
+    tokens = torch.randint(0, args.vocab_size, (args.num_sequences, args.sequence_length), generator=gen)
+    return TensorDataset(tokens, tokens.clone())
+
+
+def main():
+    args = parse_args()
+
+    set_seed(args.seed, deterministic=True)
+
+    accelerator = Accelerator(
+        mixed_precision=args.mixed_precision,
+        gradient_accumulation_steps=args.gradient_accumulation_steps,
+        dataloader_config=DataLoaderConfiguration(use_seedable_sampler=True),
+    )
+
+    model = build_model(args)
+    dataset = build_dataset(args)
+    dataloader = DataLoader(
+        dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=0,
+    )
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+
+    model, optimizer, dataloader = accelerator.prepare(model, optimizer, dataloader)
+
+    if args.resume_from is not None:
+        accelerator.load_state(str(args.resume_from))
+
+    loss_history = []
+    step = 0
+    saved_and_exiting = False
+
+    while step < args.max_steps and not saved_and_exiting:
+        for input_ids, labels in dataloader:
+            if step >= args.max_steps:
+                break
+            with accelerator.accumulate(model):
+                outputs = model(input_ids=input_ids, labels=labels)
+                loss = outputs.loss
+                accelerator.backward(loss)
+                if accelerator.sync_gradients:
+                    accelerator.clip_grad_norm_(model.parameters(), max_norm=1.0)
+                optimizer.step()
+                optimizer.zero_grad()
+
+            gathered = accelerator.gather_for_metrics(loss.detach().unsqueeze(0))
+            loss_history.append(gathered.mean().item())
+            step += 1
+
+            if args.save_at_step is not None and step == args.save_at_step:
+                if args.checkpoint_dir is None:
+                    raise ValueError("--save_at_step requires --checkpoint_dir")
+                accelerator.wait_for_everyone()
+                accelerator.save_state(str(args.checkpoint_dir))
+                accelerator.wait_for_everyone()
+                saved_and_exiting = True
+                break
+
+    accelerator.wait_for_everyone()
+
+    if accelerator.is_main_process:
+        payload = {
+            "loss_history": loss_history,
+            "initial_loss": loss_history[0] if loss_history else None,
+            "final_loss": loss_history[-1] if loss_history else None,
+            "num_steps": step,
+            "distributed_type": str(accelerator.distributed_type),
+            "num_processes": accelerator.num_processes,
+            "mixed_precision": str(accelerator.mixed_precision),
+            "saved_and_exiting": saved_and_exiting,
+            "resumed_from": str(args.resume_from) if args.resume_from is not None else None,
+            "world_size_env": int(os.environ.get("WORLD_SIZE", "1")),
+        }
+        args.output_file.parent.mkdir(parents=True, exist_ok=True)
+        args.output_file.write_text(json.dumps(payload, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/distributed/test_e2e_distributed.py
+++ b/tests/distributed/test_e2e_distributed.py
@@ -1,0 +1,130 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end distributed tests for ``accelerate``.
+
+Structure per backend (three pieces):
+
+    * ``{Backend}CommandsMixin`` — builds the ``accelerate launch`` and ``torchrun`` commands.
+    * ``TestDistributed{Backend}`` — backend-specific, non-slow tests (env parity).
+    * ``TestDistributed{Backend}Common`` — shared ``check_*`` scenarios, ``@slow``.
+"""
+
+import json
+import math
+from pathlib import Path
+
+from accelerate.test_utils.testing import (
+    TempDirTestCase,
+    execute_subprocess_async,
+    get_launch_command,
+    get_torch_dist_unique_port,
+    require_multi_device,
+    require_non_torch_xla,
+    require_transformers,
+    slow,
+)
+
+
+HERE = Path(__file__).parent
+CONFIGS_DIR = HERE / "accelerate_configs"
+SCRIPTS_DIR = HERE / "scripts"
+TRAIN_SCRIPT = SCRIPTS_DIR / "train.py"
+ENV_CHECK_SCRIPT = SCRIPTS_DIR / "env_check.py"
+
+
+class DDPCommandsMixin:
+    config_file = CONFIGS_DIR / "ddp.yaml"
+    num_processes = 2
+
+    def get_accelerate_cmd(self, script, *args):
+        cmd = get_launch_command(config_file=str(self.config_file))
+        cmd.extend([str(script), *args])
+        return cmd
+
+    def get_torchrun_cmd(self, script, *args):
+        return [
+            "torchrun",
+            f"--nproc_per_node={self.num_processes}",
+            "--nnodes=1",
+            f"--master_port={get_torch_dist_unique_port()}",
+            str(script),
+            *args,
+        ]
+
+
+class DistributedCommon:
+    """Shared scenarios. Subclasses provide ``get_accelerate_cmd`` via a Mixin."""
+
+    def check_smoke(self):
+        output = self.tmpdir / "smoke.json"
+        cmd = self.get_accelerate_cmd(
+            TRAIN_SCRIPT,
+            f"--output_file={output}",
+            "--max_steps=4",
+        )
+        execute_subprocess_async(cmd, timeout=180)
+
+        assert output.exists(), f"train.py did not write {output}"
+        payload = json.loads(output.read_text())
+        assert payload["num_steps"] == 4, payload
+        assert payload["num_processes"] == self.num_processes, payload
+        assert len(payload["loss_history"]) == 4, payload
+        assert math.isfinite(payload["final_loss"]), payload
+        assert all(math.isfinite(x) for x in payload["loss_history"]), payload
+
+
+@require_non_torch_xla
+@require_multi_device
+@require_transformers
+class TestDistributedDDP(DDPCommandsMixin, TempDirTestCase):
+    """Non-slow DDP tests: env parity between ``accelerate launch`` and ``torchrun``."""
+
+    def test_env_parity_accelerate_vs_torchrun(self):
+        acc_out = self.tmpdir / "env_accelerate.json"
+        tr_out = self.tmpdir / "env_torchrun.json"
+
+        acc_cmd = self.get_accelerate_cmd(ENV_CHECK_SCRIPT, f"--output_file={acc_out}")
+        execute_subprocess_async(acc_cmd, timeout=60)
+
+        tr_cmd = self.get_torchrun_cmd(ENV_CHECK_SCRIPT, f"--output_file={tr_out}")
+        execute_subprocess_async(tr_cmd, timeout=60)
+
+        acc = json.loads(acc_out.read_text())
+        tr = json.loads(tr_out.read_text())
+
+        assert len(acc) == self.num_processes, acc
+        assert len(tr) == self.num_processes, tr
+
+        for a, t in zip(acc, tr):
+            assert a["num_processes"] == t["num_processes"] == self.num_processes
+            assert a["process_index"] == t["process_index"]
+            assert a["local_process_index"] == t["local_process_index"]
+            assert a["distributed_type"] == t["distributed_type"]
+            assert a["device"] == t["device"]
+            assert a["mixed_precision"] == t["mixed_precision"]
+            assert a["env_WORLD_SIZE"] == t["env_WORLD_SIZE"]
+            assert a["env_RANK"] == t["env_RANK"]
+            # LOCAL_RANK may be -1 until the framework consumes it — accept either.
+            assert a["env_LOCAL_RANK"] in (t["env_LOCAL_RANK"], -1)
+
+
+@require_non_torch_xla
+@require_multi_device
+@require_transformers
+@slow
+class TestDistributedDDPCommon(DDPCommandsMixin, DistributedCommon, TempDirTestCase):
+    """Slow DDP scenarios that launch ``train.py`` via ``accelerate launch`` and assert on its JSON output."""
+
+    def test_smoke(self):
+        self.check_smoke()


### PR DESCRIPTION
## Summary

Adds `tests/distributed/`, a unified end-to-end layer for distributed training tests.
Backend selection is driven by per-backend YAML launch configs, and one training script
is exercised through every backend's `Accelerator.prepare()` dispatch branch. Mirrors
the pattern introduced in [`huggingface/transformers#44338`](https://github.com/huggingface/transformers/pull/44338)
and [`huggingface/trl#4784`](https://github.com/huggingface/trl/pull/4784), adapted for
the fact that `accelerate` has no `Trainer` — the raw `Accelerator` loop is itself the
system under test.

## Motivation

Accelerate's existing distributed tests are either unit-level (config/plugin dataclass
assertions) or backend-siloed (`tests/fsdp/`, `tests/deepspeed/`, `tests/tp/` with
different conventions and dataset-downloading legacy scripts). There is no unified
end-to-end layer asserting on user-facing correctness properties: run-to-completion,
convergence on memorizable data, save/resume equivalence, and eventual cross-backend
parity.

## What lands in this PR (Phase 0)

Foundation only. Two tests, DDP.

- `scripts/train.py` — raw `Accelerator` loop over a config-constructed tiny
  `LlamaForCausalLM` and hermetic seeded synthetic tokens. Emits a JSON summary
  (loss history, distributed type, num processes, mixed precision) for the harness to
  assert on. Exercises `Accelerator.prepare`, `accelerator.accumulate`,
  `accelerator.backward`, `accelerator.clip_grad_norm_`, `accelerator.save_state` /
  `load_state`, `accelerator.gather_for_metrics`, `accelerator.wait_for_everyone`, and
  `accelerator.is_main_process`.
- `scripts/env_check.py` — per-rank distributed environment dumper for launcher-parity
  checks.
- `accelerate_configs/ddp.yaml` — 2-process DDP config.
- `accelerate_configs/fsdp2.yaml` — 2-process FSDP2 config (included for the follow-up
  phase; not exercised by any test in this PR).
- `test_e2e_distributed.py` — three-piece structure per backend:
  - `DDPCommandsMixin` — builds `accelerate launch --config_file=ddp.yaml` and
    `torchrun` command lines.
  - `TestDistributedDDP` (non-`@slow`) — asserts env-parity between the two launchers
    using `env_check.py` (`distributed_type`, `device`, `mixed_precision`,
    `env_WORLD_SIZE`, `env_RANK`, `process_index`, `local_process_index`).
  - `TestDistributedDDPCommon` (`@slow`) — smoke: launches `train.py` for 4 steps,
    asserts on JSON output shape and `math.isfinite` loss values.

## Not in this PR (follow-ups)

Each will land in its own PR under the same three-piece pattern:

- **Phase 1** — L1 convergence assertion (`final_loss < initial_loss * margin`) and
  L2 resume-equivalence (save mid-training, load in a fresh process, assert trajectory
  match). Adds FSDP1 and FSDP2 test classes.
- **Phase 2** — DeepSpeed z2/z3 at smoke+convergence level, mixed-precision (bf16),
  and gradient-accumulation scenarios.
- **Phase 3** — L3 cross-backend parity vs DDP (loose tolerance for FSDP,
  best-effort for DeepSpeed), eval via `gather_for_metrics`, testing guide.

## Testing

```
pytest -v tests/distributed/test_e2e_distributed.py                # non-slow only
RUN_SLOW=1 pytest -v tests/distributed/test_e2e_distributed.py     # full
```

- Both tests pass on a 2×GPU host (~20s total).
- Single-GPU host cleanly SKIPs both tests via `@require_multi_device`.
- Three consecutive full-file runs are consistent (no flake).
- `ruff check` and `ruff format --check` clean.
- Integrates automatically into `make test_core` — no Makefile changes needed.

## Notes for reviewers

- **Pytest collection**: `pytest` picks up `test_e2e_distributed.py` only.
  `scripts/train.py` and `scripts/env_check.py` don't match the collection pattern and
  are only invoked as subprocesses by the harness.
- **Model instantiation is Hub-free**: `LlamaForCausalLM` is built from a `LlamaConfig`
  with tiny dims (`vocab=256`, `hidden=64`, 2 layers, 2 heads). No `from_pretrained`,
  no cached weights, no network dependency.
- **Structural question**: `scripts/` currently lives under `tests/distributed/`
  (matching the `transformers` PR). The legacy convention in accelerate places test
  scripts under `src/accelerate/test_utils/scripts/external_deps/`. Happy to move if
  maintainers prefer the legacy location.
