### PR TITLE
[FSDP2] Add additional_modules_to_shard for sharding custom modules

### DIFF
--- a/docs/source/usage_guides/fsdp.md
+++ b/docs/source/usage_guides/fsdp.md
@@ -114,6 +114,54 @@ fsdp_plugin = FullyShardedDataParallelPlugin(
 accelerator = Accelerator(fsdp_plugin=fsdp_plugin)
 ```
 
+### Sharding additional modules (FSDP2)
+
+For FSDP2, on top of the modules selected by `auto_wrap_policy`, Accelerate automatically carves the input/output
+embeddings and the final norm into their own FSDP2 units. This relies on the standard 🤗 Transformers interface
+(`get_input_embeddings`/`get_output_embeddings` and a conventional final norm). Any large module that is neither
+matched by the `auto_wrap_policy` nor discovered by this heuristic ends up in the root FSDP2 unit, which is not
+resharded after the forward pass, so its full parameters stay resident and increase peak memory.
+
+`additional_modules_to_shard` lets you explicitly shard such modules — useful for non-standard/custom architectures,
+and for modules that need different sharding behavior than the rest of the model. It is **FSDP2 only** and **Python
+only** (it cannot be set through the CLI/YAML config, because its values may hold objects such as a
+`MixedPrecisionPolicy`).
+
+It is a mapping of `selector -> overrides`:
+
+- The **selector** (key) is either a single module identifier or a `tuple` of them. Each identifier is either an
+  exact fully-qualified module name matched against `model.named_modules()` (e.g. `"model.norm"`), or an `fnmatch`-style
+  glob matched against every module name (e.g. `"model.layers.*.mlp"`). `.` is a literal separator, not a regex
+  wildcard, and names are canonicalized before matching so selectors written against the original module names still
+  match after `torch.compile` / activation checkpointing. A `str` key shards every matched module as its **own** FSDP2
+  unit; a `tuple` key groups the referenced modules into a **single** FSDP2 unit (mirroring how the final norm and
+  output embedding are grouped for standard transformers). Grouped modules must all run in the same forward pass,
+  otherwise the group is never resharded.
+- The **overrides** (value) is a `dict` overriding the sharding kwargs for the matched module(s). Supported keys are
+  `"reshard_after_forward"` (`bool`) and `"mp_policy"` (`torch.distributed.fsdp.MixedPrecisionPolicy`); unset keys
+  inherit the model-wide values. Use an empty `dict` (`{}`) to shard with the model-wide defaults. Per-module CPU
+  offloading (`offload_policy`) is not supported.
+
+```py
+import torch
+from torch.distributed.fsdp import MixedPrecisionPolicy
+from accelerate import FullyShardedDataParallelPlugin
+
+fsdp_plugin = FullyShardedDataParallelPlugin(
+    fsdp_version=2,
+    additional_modules_to_shard={
+        # keep the tied final norm + lm_head in one unit and skip resharding after forward
+        ("model.norm", "lm_head"): {"reshard_after_forward": False},
+        # keep a precision-sensitive module in fp32
+        "vision_tower": {"mp_policy": MixedPrecisionPolicy(param_dtype=torch.float32)},
+        # shard every per-layer custom mlp with the model-wide defaults
+        "model.layers.*.custom_mlp": {},
+    },
+)
+
+accelerator = Accelerator(fsdp_plugin=fsdp_plugin)
+```
+
 ## Saving and loading
 
 The new recommended way of checkpointing when using FSDP models is to use `SHARDED_STATE_DICT` as `StateDictType` when setting up the accelerate config.

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1618,6 +1618,24 @@ class FullyShardedDataParallelPlugin:
         ignored_modules (`Optional[Union[Iterable[torch.nn.Module], str]]`, defaults to `None`):
             A list of modules to ignore when wrapping with FSDP. When passing a string, will match the modules by name
             using regex fullmatch. If `fsdp_version` is set to 2, the modules are converted to parameters and used.
+        additional_modules_to_shard (`Optional[dict[Union[str, tuple[str, ...]], dict]]`, defaults to `None`):
+            Explicitly shard extra modules into their own FSDP2 units on top of the ones selected by `auto_wrap_policy`,
+            with optional per-module overrides of the sharding keyword arguments. This is useful for modules that need
+            different sharding behavior than the rest of the model.
+
+            The mapping is `selector -> overrides`:
+
+            - `selector` (the key): either a single module identifier or a `tuple` of them. Each identifier is either
+              an exact fully-qualified module name matched against `model.named_modules()` (e.g. `"model.norm"`), or a
+              `fnmatch`-style glob matched against every module name (e.g. `"model.layers.*.mlp"`). Note that `.` is a
+              literal separator here (not a regex wildcard), and names are canonicalized before matching so selectors
+              written against the original module names still match after `torch.compile` / activation checkpointing.
+              A `str` key shards every matched module as its **own** FSDP2 unit; a `tuple` key groups the referenced
+              modules into a **single** FSDP2 unit.
+            - `overrides` (the value): a `dict` overriding the sharding kwargs for the matched module(s). Supported
+              keys are `"reshard_after_forward"` (`bool`) and `"mp_policy"`
+              (`torch.distributed.fsdp.MixedPrecisionPolicy`); unset keys inherit the model-wide values. Pass an empty
+              `dict` (`{}`) to shard with the model-wide defaults. `offload_policy` overrides are not supported.
         state_dict_type (`Union[str, torch.distributed.fsdp.StateDictType]`, defaults to `'FULL_STATE_DICT'`):
             State dict type to use. If a string, it must be one of `full_state_dict`, `local_state_dict`, or
             `sharded_state_dict`.
@@ -1719,6 +1737,14 @@ class FullyShardedDataParallelPlugin:
     ignored_modules: Optional[Union[Iterable[torch.nn.Module], str]] = field(
         default=None,
         metadata={"help": "A list of modules to ignore when wrapping with FSDP."},
+    )
+
+    additional_modules_to_shard: Optional[dict] = field(
+        default=None,
+        metadata={
+            "help": "FSDP2 only. Explicitly shard extra modules into their own FSDP2 units with optional per-module "
+            "overrides of the sharding kwargs."
+        },
     )
 
     state_dict_type: Union[str, "torch.distributed.fsdp.StateDictType"] = field(
@@ -2006,6 +2032,16 @@ class FullyShardedDataParallelPlugin:
                 "Setting ignored_modules to None."
             )
             self.ignored_modules = None
+
+        if self.additional_modules_to_shard is not None:
+            if self.fsdp_version == 1:
+                _fsdp2_warnings.add(
+                    "additional_modules_to_shard is only supported in FSDP2. "
+                    "Setting additional_modules_to_shard to None."
+                )
+                self.additional_modules_to_shard = None
+            else:
+                self.validate_additional_modules_to_shard()
         #  Single warning for all deprecation warnings due to FSDP2 conversion
         if _fsdp2_warnings:
             logger.warning("Multiple deprecation warnings due to FSDP2 conversion:\n".join(_fsdp2_warnings))
@@ -2157,6 +2193,79 @@ class FullyShardedDataParallelPlugin:
                 else "`torch.distributed.fsdp.MixedPrecision`"
             )
             raise ValueError(f"mixed_precision_policy must be an instance of {required_type}.")
+
+    def set_additional_modules_to_shard(self, additional_modules_to_shard):
+        """
+        Set `additional_modules_to_shard` after initialization and validate it.
+
+        `additional_modules_to_shard` is Python-only (it cannot be expressed through the CLI/YAML config), so this
+        setter is useful to add it to a plugin that was otherwise created from the CLI/YAML config. Validates the value
+        exactly like `__post_init__`: it is FSDP2 only, so under FSDP1 it is reset to `None` with a warning.
+
+        Args:
+            additional_modules_to_shard (`Optional[dict]`):
+                The `selector -> overrides` mapping as documented on `FullyShardedDataParallelPlugin`. Passing `None`
+                clears it.
+        """
+        self.additional_modules_to_shard = additional_modules_to_shard
+        if self.additional_modules_to_shard is None:
+            return
+        if self.fsdp_version == 1:
+            warnings.warn(
+                "additional_modules_to_shard is only supported in FSDP2. Setting additional_modules_to_shard to None."
+            )
+            self.additional_modules_to_shard = None
+        else:
+            self.validate_additional_modules_to_shard()
+
+    # Only these `fully_shard` kwargs may be overridden per module. `offload_policy` is intentionally excluded:
+    # partial CPU offloading is not supported yet, as `fsdp2_load_full_state_dict` uses a single model-wide flag to
+    # decide the device of all sharded tensors, so mixing offloaded and non-offloaded units would place parameters on
+    # the wrong device.
+    _ALLOWED_MODULE_SHARD_OVERRIDES = ("reshard_after_forward", "mp_policy")
+
+    def validate_additional_modules_to_shard(self):
+        """
+        Validates the structure of `additional_modules_to_shard`: the container type, the `selector` keys and the
+        per-module `overrides` values.
+        """
+        from torch.distributed.fsdp import MixedPrecisionPolicy
+
+        if not isinstance(self.additional_modules_to_shard, dict):
+            raise ValueError(
+                "`additional_modules_to_shard` must be a `dict` mapping a module selector (an exact FQN / glob "
+                f"`str`, or a `tuple` of them) to an overrides `dict`, got {type(self.additional_modules_to_shard)}."
+            )
+
+        for selector, overrides in self.additional_modules_to_shard.items():
+            identifiers = selector if isinstance(selector, tuple) else (selector,)
+            if not identifiers or not all(isinstance(identifier, str) for identifier in identifiers):
+                raise ValueError(
+                    "Each `additional_modules_to_shard` key must be a non-empty module identifier `str` or a `tuple` "
+                    f"of identifier `str`s, got {selector!r}."
+                )
+            if not isinstance(overrides, dict):
+                raise ValueError(
+                    f"The `additional_modules_to_shard` overrides for {selector!r} must be a `dict`, got "
+                    f"{type(overrides)}."
+                )
+            invalid_keys = set(overrides) - set(self._ALLOWED_MODULE_SHARD_OVERRIDES)
+            if invalid_keys:
+                raise ValueError(
+                    f"Unsupported override(s) {sorted(invalid_keys)} for {selector!r} in "
+                    f"`additional_modules_to_shard`. Supported overrides are "
+                    f"{list(self._ALLOWED_MODULE_SHARD_OVERRIDES)}."
+                )
+            if "reshard_after_forward" in overrides and not isinstance(overrides["reshard_after_forward"], bool):
+                raise ValueError(
+                    f"`reshard_after_forward` override for {selector!r} must be a `bool`, got "
+                    f"{type(overrides['reshard_after_forward'])}."
+                )
+            if "mp_policy" in overrides and not isinstance(overrides["mp_policy"], MixedPrecisionPolicy):
+                raise ValueError(
+                    f"`mp_policy` override for {selector!r} must be an instance of "
+                    f"`torch.distributed.fsdp.MixedPrecisionPolicy`, got {type(overrides['mp_policy'])}."
+                )
 
     def set_cpu_offload(self):
         if self.fsdp_version == 2:

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -738,6 +738,92 @@ def _find_final_norm(model: torch.nn.Module) -> torch.nn.Module | None:
     return final_norm
 
 
+def _canonicalize_fqn(fqn: str) -> str:
+    """Strips the module-name modifiers that `torch.compile` and activation checkpointing inject into FQNs.
+
+    This mirrors `fsdp2_canonicalize_names` so that user-provided selectors (written against the original, undecorated
+    module names) still match after the model has been wrapped by `torch.compile` (`_orig_mod`) or activation
+    checkpointing (`_checkpoint_wrapped_module`).
+    """
+    fqn = fqn.replace("._checkpoint_wrapped_module", "")
+    if fqn.startswith("_orig_mod."):
+        fqn = fqn.replace("_orig_mod.", "")
+    fqn = fqn.replace("._orig_mod", "")
+    return fqn
+
+
+def _params_already_sharded(module: torch.nn.Module) -> bool:
+    """Returns whether `module`'s own (non-recursive) parameters are already sharded (`DTensor`).
+
+    A module whose direct parameters are already `DTensor`s has been claimed by another FSDP2 unit (e.g. it sits
+    inside an already auto-wrapped layer), so it cannot be sharded again.
+    """
+    from torch.distributed.tensor import DTensor
+
+    return any(isinstance(param, DTensor) for param in module.parameters(recurse=False))
+
+
+def _resolve_modules_to_shard(
+    additional_modules_to_shard: dict, model: torch.nn.Module
+) -> tuple[dict[torch.nn.Module, dict], list[tuple[list[torch.nn.Module], dict]]]:
+    """Resolves the `additional_modules_to_shard` mapping into concrete module objects.
+
+    Args:
+        additional_modules_to_shard (`dict`):
+            Mapping of `selector -> overrides` as documented on `FullyShardedDataParallelPlugin`. A `selector` is a
+            module identifier (an exact fully-qualified module name, or an `fnmatch`-style glob) or a `tuple` of such
+            identifiers, and `overrides` is a `dict` of per-module `fully_shard` kwargs.
+        model (`torch.nn.Module`): The model whose submodules are being resolved.
+
+    Returns:
+        `tuple[dict[torch.nn.Module, dict], list[tuple[list[torch.nn.Module], dict]]]`:
+            - `single_targets`: maps a module (matched by a `str` selector) to its overrides. Each becomes its own
+              FSDP2 unit, sharded in the bottom-up traversal so children are always sharded before their parents.
+            - `group_targets`: a list of `(modules, overrides)` for `tuple` selectors, each grouped into one FSDP2 unit.
+
+    Raises:
+        ValueError: If any identifier does not match a module in the model.
+    """
+    import fnmatch
+
+    # Canonical name -> module. `named_modules` yields parents before children, so on a canonical-name collision
+    # (e.g. an activation-checkpointing wrapper and its inner module map to the same canonical name) we keep the
+    # outermost module, which is the one that should become the FSDP2 unit.
+    canonical_modules: list[tuple[str, torch.nn.Module]] = []
+    seen_names: set[str] = set()
+    for fqn, module in model.named_modules():
+        canonical_fqn = _canonicalize_fqn(fqn)
+        if canonical_fqn in seen_names:
+            continue
+        seen_names.add(canonical_fqn)
+        canonical_modules.append((canonical_fqn, module))
+
+    def _match(identifier: str) -> list[torch.nn.Module]:
+        # `.` is a literal separator (not a regex wildcard); exact match or `fnmatch` glob against canonical names.
+        matched = [m for name, m in canonical_modules if name == identifier or fnmatch.fnmatchcase(name, identifier)]
+        if not matched:
+            raise ValueError(
+                f"`additional_modules_to_shard` identifier {identifier!r} did not match any module in the model."
+            )
+        return matched
+
+    single_targets: dict[torch.nn.Module, dict] = {}
+    group_targets: list[tuple[list[torch.nn.Module], dict]] = []
+    for selector, overrides in additional_modules_to_shard.items():
+        if isinstance(selector, tuple):
+            modules: list[torch.nn.Module] = []
+            for identifier in selector:
+                for module in _match(identifier):
+                    if module not in modules:
+                        modules.append(module)
+            group_targets.append((modules, overrides))
+        else:
+            for module in _match(selector):
+                single_targets.setdefault(module, overrides)
+
+    return single_targets, group_targets
+
+
 def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     """Prepares the model for FSDP2 in-place. Also returns the model to avoid misuse of the original model.
 
@@ -838,10 +924,26 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
             model.tie_weights()
 
     auto_wrap_policy_func = fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model)
-    if auto_wrap_policy_func is not None:
-        # We skip the model itself, as that one is always wrapped
+
+    # Resolve user-specified extra modules to shard (FSDP2 only). Single-module selectors are folded into the
+    # bottom-up traversal below (so they are always sharded child-before-parent); grouped (`tuple`) selectors are
+    # handled after the embed/norm heuristic. This lets non-standard models replicate the embed/norm/tail treatment
+    # and lets users carve out modules that need different sharding kwargs (e.g. `mp_policy`, `reshard_after_forward`).
+    single_targets: dict[torch.nn.Module, dict] = {}
+    group_targets: list[tuple[list[torch.nn.Module], dict]] = []
+    if fsdp2_plugin.additional_modules_to_shard:
+        single_targets, group_targets = _resolve_modules_to_shard(fsdp2_plugin.additional_modules_to_shard, model)
+
+    if auto_wrap_policy_func is not None or single_targets:
+        # We skip the model itself, as that one is always wrapped. Bottom-up order guarantees that children are
+        # sharded before their parents, which is required for correct nested `fully_shard` composition.
         for module in get_module_children_bottom_up(model)[:-1]:
-            if auto_wrap_policy_func(module) and not isinstance(module, FSDPModule):
+            if isinstance(module, FSDPModule):
+                continue
+            if module in single_targets:
+                # Explicit `additional_modules_to_shard` selectors take precedence over the auto wrap policy.
+                fully_shard(module, **{**fsdp2_kwargs, **single_targets[module]})
+            elif auto_wrap_policy_func is not None and auto_wrap_policy_func(module):
                 fully_shard(module, **fsdp2_kwargs)
 
     # Carve embed + tail=[final_norm, lm_head] into their own units. Tail gets `False`
@@ -862,6 +964,24 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     tail = [m for m in (final_norm, tail_embed) if m is not None and not isinstance(m, FSDPModule)]
     if tail:
         fully_shard(tail, **{**fsdp2_kwargs, "reshard_after_forward": False})
+
+    # Grouped `additional_modules_to_shard` selectors: shard several modules into a single FSDP2 unit (e.g. a custom
+    # final norm + lm_head). Done after the auto wrap + embed/norm passes so that already-sharded descendants are
+    # skipped by `fully_shard` (nested composition). Members already owned by another unit (their own params are
+    # already sharded, e.g. they sit inside an auto-wrapped layer) cannot be re-sharded, so they are dropped.
+    for modules, overrides in group_targets:
+        members = []
+        for module in modules:
+            if module is model or isinstance(module, FSDPModule) or _params_already_sharded(module):
+                if accelerator.is_main_process:
+                    warnings.warn(
+                        "Skipping a module in a grouped `additional_modules_to_shard` entry because it is already "
+                        "sharded (its own FSDP2 unit, the root, or owned by an ancestor unit)."
+                    )
+                continue
+            members.append(module)
+        if members:
+            fully_shard(members, **{**fsdp2_kwargs, **overrides})
 
     if not isinstance(model, FSDPModule):
         # Defer to PyTorch's `reshard_after_forward=None` heuristic, which resolves to `False`

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -689,6 +689,205 @@ class FSDP2PluginIntegration(FSDPPluginIntegration):
         assert all(getattr(b, "_compiled_call_impl", None) is not None for b in model.layers)
         assert getattr(model.head, "_compiled_call_impl", None) is not None
 
+    @staticmethod
+    def _additional_modules_toy_model():
+        # No `get_input_embeddings`/`get_output_embeddings` and no `*Norm` child, so the embed/norm heuristic in
+        # `fsdp2_prepare_model` is a no-op and we can assert purely on `additional_modules_to_shard` behavior.
+        class _Block(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mlp = torch.nn.Linear(4, 4)
+
+        class _Model(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.layers = torch.nn.ModuleList([_Block(), _Block()])
+                self.head = torch.nn.Linear(4, 8)
+                self.extra = torch.nn.Linear(4, 4)
+
+        return _Model()
+
+    def _additional_modules_shard_calls(self, model, additional_modules_to_shard, auto_wrap_policy_func=None):
+        """Run `fsdp2_prepare_model` with `fully_shard` replaced by a spy.
+
+        Returns the list of `(module_or_modules, kwargs)` recorded for each `fully_shard` call, so we can assert which
+        modules get sharded (and with which kwargs) without a real distributed backend, mirroring the dtype tests.
+        """
+        from unittest.mock import Mock, patch
+
+        from accelerate.utils.fsdp_utils import fsdp2_prepare_model
+
+        mock_plugin = Mock()
+        mock_plugin.mixed_precision_policy = None
+        mock_plugin.reshard_after_forward = True
+        mock_plugin.cpu_offload = None
+        mock_plugin.cpu_ram_efficient_loading = False
+        mock_plugin.ignored_modules = None
+        mock_plugin.additional_modules_to_shard = additional_modules_to_shard
+
+        mock_accelerator = Mock()
+        mock_accelerator.mixed_precision = "no"
+        mock_accelerator.torch_device_mesh = None
+        mock_accelerator.device = torch.device("cpu")
+        mock_accelerator.is_main_process = True
+        mock_accelerator.state.fsdp_plugin = mock_plugin
+
+        calls = []
+
+        def _record(module, **kwargs):
+            calls.append((module, kwargs))
+
+        with (
+            patch("torch.distributed.fsdp.fully_shard", side_effect=_record),
+            patch("accelerate.utils.fsdp_utils.is_compiled_module", return_value=False),
+            patch("accelerate.utils.fsdp_utils.fsdp2_prepare_auto_wrap_policy", return_value=auto_wrap_policy_func),
+            patch("accelerate.utils.fsdp_utils.logger"),
+        ):
+            fsdp2_prepare_model(mock_accelerator, model)
+        return calls
+
+    def test_additional_modules_to_shard_single(self):
+        """A single-module selector shards exactly that module, and the root is still sharded last."""
+        model = self._additional_modules_toy_model()
+        calls = self._additional_modules_shard_calls(model, {"head": {}})
+        assert any(module is model.head for module, _ in calls)
+        assert calls[-1][0] is model
+
+    def test_additional_modules_to_shard_glob(self):
+        """A glob selector shards each matched module as its own unit."""
+        model = self._additional_modules_toy_model()
+        calls = self._additional_modules_shard_calls(model, {"layers.*.mlp": {}})
+        sharded = [module for module, _ in calls]
+        assert any(module is model.layers[0].mlp for module in sharded)
+        assert any(module is model.layers[1].mlp for module in sharded)
+
+    def test_additional_modules_to_shard_kwarg_overrides(self):
+        """Per-module overrides are merged on top of the model-wide `fully_shard` kwargs."""
+        from torch.distributed.fsdp import MixedPrecisionPolicy
+
+        model = self._additional_modules_toy_model()
+        mp_policy = MixedPrecisionPolicy(param_dtype=torch.float32)
+        calls = self._additional_modules_shard_calls(
+            model, {"head": {"reshard_after_forward": False, "mp_policy": mp_policy}}
+        )
+        head_kwargs = next(kwargs for module, kwargs in calls if module is model.head)
+        assert head_kwargs["reshard_after_forward"] is False
+        assert head_kwargs["mp_policy"] is mp_policy
+
+    def test_additional_modules_to_shard_group(self):
+        """A tuple selector groups the referenced modules into a single `fully_shard` call, applied after the traversal.
+
+        Grouped units are sharded right before the root (after the bottom-up single-module/auto-wrap pass) so that a
+        member's already-sharded descendants are skipped by `fully_shard` (nested composition). We assert that ordering
+        here: a single-module selector targeting a descendant of a grouped member is sharded *before* the group, which
+        is exactly why the group pass must run after the traversal rather than earlier.
+        """
+        model = self._additional_modules_toy_model()
+        calls = self._additional_modules_shard_calls(
+            model,
+            {("layers.0", "head"): {"reshard_after_forward": False}, "layers.0.mlp": {}},
+        )
+        # The group is a single `fully_shard` call over both members.
+        grouped = [(i, module, kwargs) for i, (module, kwargs) in enumerate(calls) if isinstance(module, list)]
+        assert len(grouped) == 1
+        group_index, modules, kwargs = grouped[0]
+        assert modules == [model.layers[0], model.head]
+        assert kwargs["reshard_after_forward"] is False
+        # `layers.0.mlp` (a descendant of the grouped `layers.0`) must be sharded *before* the group, preserving the
+        # bottom-up (child-before-parent) order that keeps nested `fully_shard` composition correct.
+        mlp_index = next(i for i, (module, _) in enumerate(calls) if module is model.layers[0].mlp)
+        assert mlp_index < group_index
+        # The root is still sharded last.
+        assert calls[-1][0] is model
+
+    def test_additional_modules_to_shard_precedence_over_auto_wrap(self):
+        """An explicit selector takes precedence over the auto wrap policy for the same module."""
+        model = self._additional_modules_toy_model()
+        calls = self._additional_modules_shard_calls(
+            model,
+            {"head": {"reshard_after_forward": False}},
+            auto_wrap_policy_func=lambda module: isinstance(module, torch.nn.Linear),
+        )
+        head_kwargs = next(kwargs for module, kwargs in calls if module is model.head)
+        extra_kwargs = next(kwargs for module, kwargs in calls if module is model.extra)
+        # `head` uses the explicit override; `extra` falls back to the auto-wrap (model-wide) kwargs.
+        assert head_kwargs["reshard_after_forward"] is False
+        assert extra_kwargs["reshard_after_forward"] is True
+
+    def test_additional_modules_to_shard_canonicalizes_names(self):
+        """A selector written against original names still matches after activation-checkpointing decoration."""
+        model = self._additional_modules_toy_model()
+
+        class _CheckpointWrapper(torch.nn.Module):
+            def __init__(self, inner):
+                super().__init__()
+                self._checkpoint_wrapped_module = inner
+
+        inner = model.layers[0]
+        model.layers[0] = _CheckpointWrapper(inner)
+        # Actual FQN is `layers.0._checkpoint_wrapped_module.mlp`; the user still refers to it as `layers.0.mlp`.
+        calls = self._additional_modules_shard_calls(model, {"layers.0.mlp": {}})
+        assert any(module is inner.mlp for module, _ in calls)
+
+    def test_additional_modules_to_shard_validation(self):
+        env = self.fsdp_envs[2].copy()
+        with patch_environment(**env):
+            # Must be a dict of `selector -> overrides`.
+            with self.assertRaises(ValueError):
+                FullyShardedDataParallelPlugin(fsdp_version=2, additional_modules_to_shard=["head"])
+            # Only `reshard_after_forward` / `mp_policy` overrides are allowed.
+            with self.assertRaises(ValueError):
+                FullyShardedDataParallelPlugin(
+                    fsdp_version=2, additional_modules_to_shard={"head": {"offload_policy": True}}
+                )
+            # `reshard_after_forward` must be a bool.
+            with self.assertRaises(ValueError):
+                FullyShardedDataParallelPlugin(
+                    fsdp_version=2, additional_modules_to_shard={"head": {"reshard_after_forward": "yes"}}
+                )
+            # A valid spec is preserved as-is.
+            plugin = FullyShardedDataParallelPlugin(
+                fsdp_version=2,
+                additional_modules_to_shard={("norm", "head"): {"reshard_after_forward": False}, "extra": {}},
+            )
+            assert plugin.additional_modules_to_shard == {
+                ("norm", "head"): {"reshard_after_forward": False},
+                "extra": {},
+            }
+
+    def test_additional_modules_to_shard_ignored_in_fsdp1(self):
+        # `additional_modules_to_shard` is FSDP2 only; under FSDP1 it is reset to None (with a warning).
+        env = self.fsdp_envs[1].copy()
+        with patch_environment(**env):
+            plugin = FullyShardedDataParallelPlugin(fsdp_version=1, additional_modules_to_shard={"head": {}})
+        assert plugin.additional_modules_to_shard is None
+
+    def test_set_additional_modules_to_shard(self):
+        # Simulates a plugin created from the CLI/YAML config (which cannot express `additional_modules_to_shard`)
+        # and then post-modified in Python via the setter.
+        env = self.fsdp_envs[2].copy()
+        with patch_environment(**env):
+            plugin = FullyShardedDataParallelPlugin(fsdp_version=2)
+            assert plugin.additional_modules_to_shard is None
+
+            plugin.set_additional_modules_to_shard({("norm", "head"): {"reshard_after_forward": False}})
+            assert plugin.additional_modules_to_shard == {("norm", "head"): {"reshard_after_forward": False}}
+
+            # The setter validates just like `__post_init__`.
+            with self.assertRaises(ValueError):
+                plugin.set_additional_modules_to_shard({"head": {"offload_policy": True}})
+
+            # Passing `None` clears it.
+            plugin.set_additional_modules_to_shard(None)
+            assert plugin.additional_modules_to_shard is None
+
+        # Under FSDP1 the setter resets the value to None (FSDP2 only).
+        env = self.fsdp_envs[1].copy()
+        with patch_environment(**env):
+            plugin = FullyShardedDataParallelPlugin(fsdp_version=1)
+            plugin.set_additional_modules_to_shard({"head": {}})
+        assert plugin.additional_modules_to_shard is None
+
 
 @run_first
 # Skip this test when TorchXLA is available because accelerate.launch does not support TorchXLA FSDP.


### PR DESCRIPTION
# What does this PR do?

Adds an opt-in `additional_modules_to_shard` option to `FullyShardedDataParallelPlugin` (FSDP2) that lets users explicitly shard extra modules into their own FSDP2 units, on top of what `auto_wrap_policy` selects.

## Motivation

FSDP2 preparation shards the modules matched by `auto_wrap_policy`, then uses a transformers-specific heuristic to carve the input/output embeddings and the final norm into their own units. Any module that is **neither** matched by the policy **nor** discovered by that heuristic falls into the root FSDP2 unit, which is not resharded after forward.

This is common for composite / multimodal / omni models that stitch together several transformer stacks. Take a Qwen3-TTS-style model as a concrete example: it contains a **speaker encoder**, a standard **LM decoder**, and a **code predictor** (another transformer). The top-level composite also doesn't expose a single `get_input_embeddings`/`get_output_embeddings`/final-norm through the standard `transformers` interface, so the built-in heuristic can't carve those out.

`additional_modules_to_shard` lets users close that gap explicitly — shard the non-standard modules into their own units, and optionally give specific submodules different sharding behavior (e.g. keep a precision-sensitive module in fp32, or skip resharding a custom tail)

## API

`additional_modules_to_shard` is a `selector -> overrides` mapping:

- **selector** (key): an exact fully-qualified module name or an `fnmatch` glob (e.g. `"model.norm"`, `"model.layers.*.mlp"`), or a `tuple` of them. A `str` shards each matched module as its **own** unit; a `tuple` groups the referenced modules into a **single** unit (like the built-in norm+lm_head tail). Names are canonicalized before matching, so selectors written against the original module names still match after `torch.compile` / activation checkpointing.
- **overrides** (value): a `dict` overriding the per-module sharding kwargs — `reshard_after_forward` and/or `mp_policy`; unset keys inherit the model-wide values (`offload_policy` is intentionally not supported).

```python
import torch
from torch.distributed.fsdp import MixedPrecisionPolicy
from accelerate import Accelerator, FullyShardedDataParallelPlugin

plugin = FullyShardedDataParallelPlugin(
    fsdp_version=2,
    additional_modules_to_shard={
        # keep the tied final norm + lm_head in one unit and skip resharding after forward
        ("model.norm", "lm_head"): {"reshard_after_forward": False},
        # keep a precision-sensitive module in fp32
        "vision_tower": {"mp_policy": MixedPrecisionPolicy(param_dtype=torch.float32)},
        # shard every per-layer custom mlp with the model-wide defaults
        "model.layers.*.custom_mlp": {},
    },
)
accelerator = Accelerator(fsdp_plugin=plugin)
```

## Tests

Adds CPU unit tests mirroring the existing mocked `fsdp2_prepare_model` tests (`fully_shard` spied), covering: single/glob/grouped selection, per-module kwarg overrides, precedence over the auto wrap policy, name canonicalization for `torch.compile`/activation checkpointing, group-vs-traversal ordering, config validation, the FSDP1 no-op, and the setter.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. @SunMarc

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc
- DeepSpeed: @SunMarc
- Command Line Interface: @SunMarc
- Documentation: @SunMarc
- Core parts of the library: @BenjaminBossan @SunMarc
- Maintained examples: @SunMarc

 -->