### PR TITLE
Fix moved nd_parallel.py example path in context-parallelism guide

### DIFF
--- a/docs/source/concept_guides/context_parallelism.md
+++ b/docs/source/concept_guides/context_parallelism.md
@@ -93,9 +93,9 @@ This can scale your context size to 1M+ sequence length potentially. Below, we s
 </p>
 
 > [!Tip]
-> These examples were created with a script you can find [in the examples folder](https://github.com/huggingface/accelerate/blob/main/examples/fsdp2/nd_parallel.py). To run the example on 8 H100 GPUs (128k sequence length), you can use the following command:
+> These examples were created with a script you can find [in the examples folder](https://github.com/huggingface/accelerate/blob/main/examples/torch_native_parallelism/nd_parallel.py). To run the example on 8 H100 GPUs (128k sequence length), you can use the following command:
 > ```bash
-> accelerate launch --use-fsdp --fsdp-activation-checkpointing=TRUE examples/fsdp2/nd_parallel.py --cp-size=8 --sequence-length=128000
+> accelerate launch --use-fsdp --fsdp-activation-checkpointing=TRUE examples/torch_native_parallelism/nd_parallel.py --cp-size=8 --sequence-length=128000
 > ```
 
 
@@ -129,7 +129,7 @@ Accelerate provides only a single option to configure context parallelism (excep
 Context parallel size is rather self-explanatory, it's the number of ranks across which the inputs are to be-sharded.
 Context parallel shard rotation defines how the shards of the inputs are rotated across ranks. We'll cover the 2 options in more detail in the next section.
 
-You can see an end-to-end example in the [ND parallel example](https://github.com/huggingface/accelerate/blob/main/examples/fsdp2/nd_parallel.py) file, where you can train an 8B model with up-to 128k context length on a single 8xH100 node. Using multi-node training, you can scale this to 1M+ sequence length on multiple GPUs. You can also seamlessly combine it with other parallelism strategies to fit your needs.
+You can see an end-to-end example in the [ND parallel example](https://github.com/huggingface/accelerate/blob/main/examples/torch_native_parallelism/nd_parallel.py) file, where you can train an 8B model with up-to 128k context length on a single 8xH100 node. Using multi-node training, you can scale this to 1M+ sequence length on multiple GPUs. You can also seamlessly combine it with other parallelism strategies to fit your needs.
 
 ## Technical details
 


### PR DESCRIPTION
# What does this PR do?

The ND-parallel example script moved from `examples/fsdp2/` to `examples/torch_native_parallelism/` (confirmed by `examples/torch_native_parallelism/README.md`), but `docs/source/concept_guides/context_parallelism.md` still references the old path:

- the runnable command `accelerate launch ... examples/fsdp2/nd_parallel.py` fails with `No such file or directory`
- two source links (`.../blob/main/examples/fsdp2/nd_parallel.py`) 404

This updates the three `nd_parallel.py` references to `examples/torch_native_parallelism/nd_parallel.py`. The image-asset URLs under `examples/fsdp2/` (`cp_perf.png`, etc.) point at the `documentation-images` dataset, not this repo, and are intentionally left unchanged.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).