### PR TITLE
Fix distributedType -> distributed_type typo in downcast_bf16 guard

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -532,7 +532,7 @@ class Accelerator:
         if (
             (mixed_precision != "bf16")
             and getattr(self.state, "downcast_bfloat", False)
-            and (self.state.distributedType != DistributedType.XLA)
+            and (self.state.distributed_type != DistributedType.XLA)
         ):
             raise ValueError("Can only use `downcast_bf16` when using `mixed_precision='bf16'` and on a TPU")
 


### PR DESCRIPTION
## Summary

The `downcast_bf16` validation in `Accelerator.__init__` references `self.state.distributedType`, which does not exist — the attribute is `distributed_type`:

```python
if (
    (mixed_precision != "bf16")
    and getattr(self.state, "downcast_bfloat", False)
    and (self.state.distributedType != DistributedType.XLA)   # <-- typo
):
    raise ValueError("Can only use `downcast_bf16` when using `mixed_precision='bf16'` and on a TPU")
```

`self.state` is an `AcceleratorState`, whose attribute is `distributed_type` (used one line above at ~520: `self.state.distributed_type == DistributedType.FSDP`, and throughout `state.py`). `distributedType` appears **only** on this line in the entire `src/` tree.

## Impact

Because of short-circuit evaluation, this line is reached when `mixed_precision != "bf16"` **and** `downcast_bfloat` is set. In that case — a user enabling `downcast_bf16` without `mixed_precision="bf16"` — the code raises:

```
AttributeError: 'AcceleratorState' object has no attribute 'distributedType'
```

instead of the intended, actionable `ValueError` that explains the misconfiguration.

## Fix

```diff
-            and (self.state.distributedType != DistributedType.XLA)
+            and (self.state.distributed_type != DistributedType.XLA)
```

One-token typo fix; the guard now raises the intended `ValueError`.

(Happy to add a regression test for the `downcast_bf16`-without-`bf16` path if you'd like — let me know the preferred fixture for constructing that state.)
