### PR TITLE
Fix disk offload crash on FP8 tensors

### DIFF
--- a/src/accelerate/utils/offload.py
+++ b/src/accelerate/utils/offload.py
@@ -29,6 +29,10 @@ def offload_weight(weight, weight_name, offload_folder, index=None):
         # Need to reinterpret the underlined data as int16 since NumPy does not handle bfloat16s.
         weight = weight.view(torch.int16)
         dtype = "bfloat16"
+    elif str(weight.dtype).startswith("torch.float8_"):
+        # NumPy does not handle any FP8 dtype either, so reinterpret the 1-byte data as int8.
+        dtype = str(weight.dtype).split(".")[1]
+        weight = weight.view(torch.int8)
     array = weight.cpu().numpy()
     tensor_file = os.path.join(offload_folder, f"{weight_name}.dat")
     if index is not None:
@@ -53,6 +57,9 @@ def load_offloaded_weight(weight_file, weight_info):
     if dtype == "bfloat16":
         # NumPy does not support bfloat16 so this was saved as a int16
         dtype = "int16"
+    elif dtype.startswith("float8_"):
+        # NumPy does not support any FP8 dtype either, so this was saved as an int8
+        dtype = "int8"
 
     weight = np.memmap(weight_file, dtype=dtype, shape=shape, mode="r")
 
@@ -61,6 +68,8 @@ def load_offloaded_weight(weight_file, weight_info):
     weight = torch.tensor(weight)
     if weight_info["dtype"] == "bfloat16":
         weight = weight.view(torch.bfloat16)
+    elif weight_info["dtype"].startswith("float8_"):
+        weight = weight.view(getattr(torch, weight_info["dtype"]))
 
     return weight
 

--- a/tests/test_offload.py
+++ b/tests/test_offload.py
@@ -26,6 +26,7 @@ from accelerate.utils import (
     offload_state_dict,
     offload_weight,
 )
+from accelerate.utils.versions import is_torch_version
 
 
 class ModelForTest(nn.Module):
@@ -56,8 +57,18 @@ class OffloadTester(unittest.TestCase):
     def test_offload_weight(self):
         dtypes = [torch.float16, torch.float32, torch.bfloat16]
 
+        # NumPy has no FP8 dtypes either, so these go through the same int8-view path as
+        # bfloat16 goes through int16. torch.randn(..., dtype=float8_*) isn't implemented, so
+        # the tensors are produced the way they actually show up in practice: cast down from a
+        # higher-precision tensor.
+        if is_torch_version(">=", "2.1.0"):
+            for name in ("float8_e4m3fn", "float8_e5m2"):
+                if hasattr(torch, name):
+                    dtypes.append(getattr(torch, name))
+
         for dtype in dtypes:
-            weight = torch.randn(2, 3, dtype=dtype)
+            is_fp8 = str(dtype).startswith("torch.float8_")
+            weight = torch.randn(2, 3, dtype=torch.float32).to(dtype) if is_fp8 else torch.randn(2, 3, dtype=dtype)
             with TemporaryDirectory() as tmp_dir:
                 index = offload_weight(weight, "weight", tmp_dir, {})
                 weight_file = os.path.join(tmp_dir, "weight.dat")
@@ -65,7 +76,11 @@ class OffloadTester(unittest.TestCase):
                 assert index == {"weight": {"shape": [2, 3], "dtype": str(dtype).split(".")[1]}}
 
                 new_weight = load_offloaded_weight(weight_file, index["weight"])
-                assert torch.equal(weight, new_weight)
+                assert new_weight.dtype == weight.dtype
+                # Compare on raw bits: FP8/bfloat16 round-trip through an int view, and float
+                # equality can't be trusted to catch a byte-level corruption anyway.
+                int_dtype = {1: torch.int8, 2: torch.int16, 4: torch.int32}[weight.element_size()]
+                assert torch.equal(weight.view(int_dtype), new_weight.view(int_dtype))
 
     def test_offload_weights_loader(self):
         model = ModelForTest()


### PR DESCRIPTION
# What does this PR do?

Disk-offloading a model with FP8 weights crashes in `offload_weight`:

```
File "src/accelerate/utils/offload.py", line 32, in offload_weight
    array = weight.cpu().numpy()
TypeError: Got unsupported ScalarType Float8_e4m3fn
```

Same error for `float8_e5m2`. NumPy has no FP8 representation, so `weight.cpu().numpy()`
fails outright.

This is the identical problem `bfloat16` already has, and `offload_weight` already has a
branch for it: view the tensor as `int16`, write that, and record the real dtype in the
index so `load_offloaded_weight` can view it back. FP8 hits the same NumPy gap but has no
equivalent branch.

The reason this is easy to miss: `dtype_byte_size` (`src/accelerate/utils/modeling.py`)
*already* understands FP8 (correctly returns 1 byte for `float8_e4m3fn`, `float8_e5m2`,
`float8_e4m3fnuz`, `float8_e5m2fnuz`, `float8_e8m0fnu` — the last three added in #4063). So
device-map planning happily sizes an FP8 model, decides some layers go to disk, and then
the write itself blows up. The planning path knows about FP8; the write path doesn't.

## Fix

Mirror the bfloat16 idiom on both sides of `offload.py`:

- `offload_weight`: if the dtype string starts with `torch.float8_`, view the tensor as
  `int8` before handing it to NumPy, and record the real dtype name in the index (matching
  what's already done for bfloat16 -> int16).
- `load_offloaded_weight`: if the recorded dtype starts with `float8_`, load the memmap as
  `int8` and view it back to the original FP8 dtype via `getattr(torch, dtype)`.

**Judgment call worth flagging:** I matched on the `float8_` *prefix* rather than listing
the five variants explicitly. `dtype_byte_size` already tracks five FP8 dtypes (two of them
added by #4063 after the original three), and a hardcoded pair/list here would just be
another place for that list to drift out of sync as new FP8 variants land. Happy to switch
this to an explicit list (mirroring the `dtype_byte_size` set) if maintainers would rather
be conservative about it.

## Precedent

The int-view-and-restore trick is the established pattern for this exact class of bug —
it's what closed issue #454 ("Disk offload fails with bfloat16 weights") produced for
bfloat16. This PR applies the same fix to FP8.

## Test plan

Extended the existing dtype loop in `test_offload_weight` (`tests/test_offload.py`) to
include `float8_e4m3fn` / `float8_e5m2`, guarded with `is_torch_version(">=", "2.1.0")` +
`hasattr(torch, name)` — the same guard style used by #4063. `torch.randn(..., dtype=float8_*)`
raises `NotImplementedError`, so the FP8 tensors are produced the way they actually show up
in practice: cast down from a float32 tensor via `.to(dtype)`.

Round-trip correctness is checked on raw bits (`.view(int8/int16/int32)`), not float
equality, since float equality can't be trusted to catch a byte-level corruption for these
dtypes anyway.

Manually verified (beyond what's in the test) with NaN/inf-adjacent bit patterns injected
directly, including a full sweep of all 256 possible FP8 byte values:

| dtype | byte_exact | dtype_preserved |
|---|---|---|
| float8_e4m3fn (all 256 bit patterns incl. NaN) | True | True |
| float8_e5m2 (all 256 bit patterns incl. inf/NaN) | True | True |
| bfloat16 (inf/nan/zero bit patterns) | True | True |
| float16 (inf/nan/zero bit patterns) | True | True |
| float32 (inf/nan/zero bit patterns) | True | True |

Confirmed the test actually discriminates: reverted only the source change (kept the new
test), and it fails with the original crash:

```
weight = tensor([[-1.0000,  0.4688,  1.0000],
        [-1.2500,  0.2500, -0.1719]], dtype=torch.float8_e4m3fn)
...
>       array = weight.cpu().numpy()
E       TypeError: Got unsupported ScalarType Float8_e4m3fn
src/accelerate/utils/offload.py:32: TypeError
```

Full suite results on this branch:
- `tests/test_offload.py`: 4 passed
- `tests/test_modeling_utils.py`: 42 passed, 2 skipped (GPU-only)
- `ruff check` / `ruff format --check` (pinned 0.13.1): clean

## Who can review?

@SunMarc @muellerzr
