### PR TITLE
Add missing type hints in utils/memory.py

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -37,7 +37,7 @@ from .imports import (
 )
 
 
-def clear_device_cache(garbage_collection=False):
+def clear_device_cache(garbage_collection: bool = False) -> None:
     """
     Clears the device cache by calling `torch.{backend}.empty_cache`. Can also run `gc.collect()`, but do note that
     this is a *considerable* slowdown and should be used sparingly.
@@ -67,7 +67,7 @@ def clear_device_cache(garbage_collection=False):
         torch.neuron.empty_cache()
 
 
-def release_memory(*objects):
+def release_memory(*objects) -> list:
     """
     Releases memory from `objects` by setting them to `None` and calls `gc.collect()` and `torch.cuda.empty_cache()`.
     Returned objects should be reassigned to the same variables.


### PR DESCRIPTION
## What this PR does

Adds missing type hints to two functions in `src/accelerate/utils/memory.py`:

- `clear_device_cache(garbage_collection: bool = False) -> None`
- `release_memory(*objects) -> list`

This follows the same self-identified typing-consistency pattern as my prior
PRs in this repo (#4123, #4124, #4125) — no linked issue, just filling in
type hints that were missing while the rest of the module (and the file's
other two functions, `should_reduce_batch_size` and
`find_executable_batch_size`) already had them.

## Functions updated

- `clear_device_cache`: `garbage_collection` is only ever called with `bool`
  values (`True`/`False`) at every call site in the codebase, and the
  function has no `return` statement, so `-> None` is accurate.
- `release_memory`: builds a `list` from `*objects`, sets every element to
  `None`, and returns that list — verified by reading the full function
  body, so `-> list` is accurate. The variadic `*objects` parameter itself
  is intentionally left unannotated (it accepts arbitrary object types to
  release from memory), consistent with how `*args`/`**kwargs` were left
  unannotated in my earlier `hooks.py` (#4124) and `logging.py` (#4125) PRs.

## Functions intentionally left unchanged

- `should_reduce_batch_size` and `find_executable_batch_size` already have
  complete type hints on every parameter in this file — no changes needed.

## No behaviour change

Type-hint-only change. No logic was modified.

## Testing

- `ruff check src/accelerate/utils/memory.py` — all checks pass.
- `ruff format --check src/accelerate/utils/memory.py` — passes, file
  already formatted.
- `python3 -c "import ast; ast.parse(...)"` on the modified file — passes.

> **Note:** Claude Code was used to assist in drafting this change. All
> changes were reviewed by the submitter.
