### PR TITLE
Preserve defaultdict batches during device placement

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -17,6 +17,7 @@ A set of basic tensor ops compatible with tpu, gpu, and multigpu
 
 import pickle
 import warnings
+from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from functools import update_wrapper, wraps
@@ -181,12 +182,13 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             skip_keys = [skip_keys]
         elif skip_keys is None:
             skip_keys = []
-        return type(tensor)(
-            {
-                k: t if k in skip_keys else send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys)
-                for k, t in tensor.items()
-            }
-        )
+        new_mapping = {
+            k: t if k in skip_keys else send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys)
+            for k, t in tensor.items()
+        }
+        if isinstance(tensor, defaultdict):
+            return type(tensor)(tensor.default_factory, new_mapping)
+        return type(tensor)(new_mapping)
     else:
         return tensor
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ import pickle
 import tempfile
 import unittest
 import warnings
-from collections import UserDict, namedtuple
+from collections import UserDict, defaultdict, namedtuple
 from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
 
@@ -113,6 +113,12 @@ class UtilsTester(unittest.TestCase):
         assert torch.equal(result4["b"][0].cpu(), tensor)
         assert torch.equal(result4["b"][1].cpu(), tensor)
         assert result4["c"] == 1
+
+        result5 = send_to_device(defaultdict(list, {"a": tensor}), device)
+        assert isinstance(result5, defaultdict)
+        assert result5.default_factory is list
+        assert torch.equal(result5["a"].cpu(), tensor)
+        assert result5["missing"] == []
 
     def test_honor_type(self):
         with self.assertRaises(TypeError) as cm:


### PR DESCRIPTION
## What does this PR do?

Preserves standard-library `defaultdict` batches while `send_to_device` recursively moves their values.

`send_to_device` currently reconstructs every mapping as `type(mapping)(items)`. For `defaultdict`, that positional argument is interpreted as the default factory, so prepared dataloaders crash before yielding a batch. This change rebuilds a `defaultdict` with both its original `default_factory` and the moved values, while leaving the existing path unchanged for other mapping types.

Fixes #4154

## Validation

- `pytest tests/test_utils.py::UtilsTester::test_send_to_device -q` - 1 passed
- `pytest tests/test_utils.py -q -k 'not test_convert_to_fp32'` - 43 passed, 5 skipped
- Full repository `ruff check .` - passed
- Full repository `ruff format --check .` - 184 files already formatted
- Public `Accelerator.prepare(DataLoader(...))` reproduction - fixed on CPU

The one excluded test invokes `torch.compile` and fails on this Windows host because the MSVC `cl` compiler is unavailable; it is unrelated to this mapping change.

## Before submitting

- [x] I read the contributor guideline.
- [x] The bug is documented in #4154.
- [x] No documentation update is needed; this restores nested mapping behavior.
- [x] I added a focused regression test.

AI disclosure: I used Codex to help identify and reproduce the bug, search for duplicates, implement the focused patch, run validation, and draft this PR. I reviewed and understand the change and will personally handle review feedback.

