### PR TITLE
docs: fix documented parameter names that do not match the signature

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -842,13 +842,13 @@ class MLflowTracker(GeneralTracker):
         Logs an figure to the current run.
 
         Args:
-            figure (Any):
-            The figure to be logged.
+            figure (`Any`):
+                The figure to be logged.
             artifact_file (`str`, *optional*):
-            The run-relative artifact file path in posixpath format to which the image is saved.
-            If not provided, the image is saved to a default location.
-            **kwargs:
-            Additional keyword arguments passed to the underlying mlflow.log_image function.
+                The run-relative artifact file path in posixpath format to which the image is saved. If not
+                provided, the image is saved to a default location.
+            **save_kwargs:
+                Additional keyword arguments passed to the underlying `mlflow.log_figure` function.
         """
         import mlflow
 
@@ -1201,15 +1201,15 @@ class SwanLabTracker(GeneralTracker):
         Logs `values` to the current run.
 
         Args:
-        data : Dict[str, DataType]
-            Data must be a dict. The key must be a string with 0-9, a-z, A-Z, " ", "_", "-", "/". The value must be a
-            `float`, `float convertible object`, `int` or `swanlab.data.BaseType`.
-        step : int, optional
-            The step number of the current data, if not provided, it will be automatically incremented.
-        If step is duplicated, the data will be ignored.
+            values (`Dict[str, DataType]`):
+                Values to be logged as key-value pairs. The key must be a string with 0-9, a-z, A-Z, " ", "_", "-",
+                "/". The value must be a `float`, `float convertible object`, `int` or `swanlab.data.BaseType`.
+            step (`int`, *optional*):
+                The step number of the current data, if not provided, it will be automatically incremented. If step
+                is duplicated, the data will be ignored.
             kwargs:
                 Additional key word arguments passed along to the `swanlab.log` method. Likes:
-                    print_to_console : bool, optional
+                    print_to_console (`bool`, *optional*):
                         Whether to print the data to the console, the default is False.
         """
         self.run.log(values, step=step, **kwargs)

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -89,20 +89,20 @@ def recursively_apply(func, data, *args, test_type=is_torch_tensor, error_on_oth
     Args:
         func (`callable`):
             The function to recursively apply.
-        data (nested list/tuple/dictionary of `main_type`):
+        data (nested list/tuple/dictionary of objects accepted by `test_type`):
             The data on which to apply `func`
         *args:
             Positional arguments that will be passed to `func` when applied on the unpacked data.
-        main_type (`type`, *optional*, defaults to `torch.Tensor`):
-            The base type of the objects to which apply `func`.
+        test_type (`Callable[[Any], bool]`, *optional*, defaults to `is_torch_tensor`):
+            The predicate deciding whether `func` should be applied to a given leaf object.
         error_on_other_type (`bool`, *optional*, defaults to `False`):
-            Whether to return an error or not if after unpacking `data`, we get on an object that is not of type
-            `main_type`. If `False`, the function will leave objects of types different than `main_type` unchanged.
+            Whether to return an error or not if after unpacking `data`, we get on an object for which `test_type`
+            returns `False`. If `False`, the function will leave such objects unchanged.
         **kwargs (additional keyword arguments, *optional*):
             Keyword arguments that will be passed to `func` when applied on the unpacked data.
 
     Returns:
-        The same data structure as `data` with `func` applied to every object of type `main_type`.
+        The same data structure as `data` with `func` applied to every object for which `test_type` returns `True`.
     """
     if isinstance(data, (tuple, list)):
         return honor_type(


### PR DESCRIPTION
## What

Three docstrings document a parameter name that does not exist in the function signature:

| location | documented | actual |
|---|---|---|
| `utils/operations.py` `recursively_apply` | `main_type` | `test_type` |
| `tracking.py` `SwanLabTracker.log` | `data` | `values` |
| `tracking.py` `MLflowTracker.log_figure` | `**kwargs` | `**save_kwargs` |

## Why it's worth fixing

For the first two the mismatch is not only cosmetic. Both functions accept `**kwargs`, so a
keyword copied from the documentation is not rejected at the boundary — it is swallowed and
forwarded to the user's own callback:

```python
>>> recursively_apply(my_fn, data, main_type=torch.Tensor)   # as documented
TypeError: my_fn() got an unexpected keyword argument 'main_type'
```

The traceback names `my_fn`, not `recursively_apply`, so nothing points back to the docstring
that suggested the argument.

`recursively_apply`'s docstring also describes `main_type` as a *type* defaulting to
`torch.Tensor`, while `test_type` is a *predicate* defaulting to `is_torch_tensor`. The three
other references to `main_type` in the same docstring (including the `Returns:` line) are
updated to match.

For `MLflowTracker.log_figure` the `**` form absorbs any name, so there is no error — but the
docstring also pointed at `mlflow.log_image` rather than `mlflow.log_figure`. The surrounding
`Args:` block had its description lines un-indented, which breaks rendering, so those lines are
re-indented to the style used by the rest of the file. `SwanLabTracker.log` had the same issue
and now matches the other trackers' `log` methods in that module.

## How these were found

Mechanically: parsing each `Args:` block and diffing it against the `ast` signature, then
checking each hit by hand. Only these three came out as documented-but-absent across
`src/accelerate`.

## Checks

- docs only — no behaviour change, no public API touched
- `ruff format --check` clean on both files; `ruff check` reports only pre-existing findings in
  untouched lines
