### PR TITLE
Report MPS as the accelerator in `accelerate env`

### DIFF
--- a/src/accelerate/commands/env.py
+++ b/src/accelerate/commands/env.py
@@ -28,6 +28,7 @@ from accelerate.commands.config import default_config_file, load_config_from_fil
 
 from ..utils import (
     is_mlu_available,
+    is_mps_available,
     is_musa_available,
     is_neuron_available,
     is_npu_available,
@@ -60,6 +61,7 @@ def env_command(args):
     pt_musa_available = is_musa_available()
     pt_npu_available = is_npu_available()
     pt_neuron_available = is_neuron_available()
+    pt_mps_available = is_mps_available()
 
     accelerator = "N/A"
     if pt_cuda_available:
@@ -76,6 +78,8 @@ def env_command(args):
         accelerator = "NPU"
     elif pt_neuron_available:
         accelerator = "NEURON"
+    elif pt_mps_available:
+        accelerator = "MPS"
 
     accelerate_config = "Not found"
     # Get the default from the config file.
@@ -113,6 +117,12 @@ def env_command(args):
         info["MUSA type"] = torch.musa.get_device_name()
     elif pt_neuron_available:
         info["NEURON type"] = torch.neuron.get_device_name()
+    elif pt_mps_available:
+        try:
+            mps_type = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip()
+        except Exception:
+            mps_type = platform.processor() or "Apple Silicon"
+        info["MPS type"] = mps_type
     elif pt_npu_available:
         info["CANN version"] = torch.version.cann
 


### PR DESCRIPTION
# What does this PR do?

`accelerate env` reports `PyTorch accelerator: N/A` on Apple Silicon. The accelerator-detection chain in `env_command` checks CUDA, XPU, MLU, SDAA, MUSA, NPU and NEURON, but not MPS, so on a Mac with a working MPS backend it falls through to "N/A", and the diagnostic that your issue template asks users to paste under-reports their hardware.

This adds an MPS branch (using the existing `is_mps_available` helper) to both the accelerator-name chain and the device-type chain, so it now reports:

Before (M3 Pro, macOS, torch 2.13):
- PyTorch accelerator: N/A

After:
- PyTorch accelerator: MPS
- MPS type: Apple M3 Pro

The `MPS type` value is read at runtime via `sysctl machdep.cpu.brand_string` (macOS-only, which is fine since MPS is Apple-only), with a `platform.processor()` fallback if that call fails. Verified manually on Apple Silicon. Happy to gate the sysctl call on `platform.system() == "Darwin"` or change the `MPS type` source if you'd prefer.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the forum?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc — this touches the CLI (`accelerate env`).