### PR TITLE
Fix eval mode for wrapped optimizers

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -141,6 +141,13 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
         """
         if hasattr(self.optimizer, "eval") and callable(self.optimizer.eval):
             self.optimizer.eval()
+        elif (
+            hasattr(self.optimizer, "optimizer")
+            and hasattr(self.optimizer.optimizer, "eval")
+            and callable(self.optimizer.optimizer.eval)
+        ):
+            # the deepspeed optimizer further wraps the optimizer
+            self.optimizer.optimizer.eval()
 
     def step(self, closure=None):
         if is_lomo_available():

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -17,6 +17,7 @@ import pickle
 import torch
 
 from accelerate import Accelerator
+from accelerate.optimizer import AcceleratedOptimizer
 from accelerate.test_utils import require_cpu, require_fp16, require_non_cpu
 from accelerate.test_utils.testing import AccelerateTestCase
 
@@ -32,6 +33,36 @@ class CPUOptimizerTester(AccelerateTestCase):
             pickle.loads(pickle.dumps(optimizer))
         except Exception as e:
             self.fail(f"Accelerated optimizer pickling failed with {e}")
+
+
+class OptimizerModeTester(AccelerateTestCase):
+    def test_accelerated_optimizer_eval_reaches_deepspeed_wrapper(self):
+        class ScheduleFreeLikeOptimizer(torch.optim.SGD):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.mode = None
+
+            def eval(self):
+                self.mode = "eval"
+
+        class DeepSpeedLikeOptimizerWrapper:
+            def __init__(self, optimizer):
+                self.optimizer = optimizer
+
+            def state_dict(self):
+                return self.optimizer.state_dict()
+
+            def load_state_dict(self, state_dict):
+                self.optimizer.load_state_dict(state_dict)
+
+        Accelerator()
+        model = torch.nn.Linear(10, 10)
+        inner = ScheduleFreeLikeOptimizer(model.parameters(), lr=0.1)
+        optimizer = AcceleratedOptimizer(DeepSpeedLikeOptimizerWrapper(inner), device_placement=False)
+
+        optimizer.eval()
+
+        assert inner.mode == "eval"
 
 
 @require_fp16


### PR DESCRIPTION
## What does this PR do?

Fixes #4159.

`AcceleratedOptimizer.train()` already reaches through the extra optimizer wrapper used by DeepSpeed. `eval()` only checked the outer wrapper, so schedule-free optimizers could remain in training mode when an evaluation checkpoint was saved.

This adds the matching one-level fallback and a regression test using a small schedule-free-like optimizer wrapped in a DeepSpeed-like object.

## Testing

- `PYTHONPATH=src uv run --with torch --with pytest --with numpy --with packaging --with psutil --with pyyaml --with huggingface_hub --with safetensors --with '.[test_prod]' pytest tests/test_optimizer.py -q`
- `uv run --with ruff ruff format --check tests/test_optimizer.py src/accelerate/optimizer.py`
- `git diff --check`

## AI writing disclosure

- [x] AI-assisted: Codex helped investigate the issue, draft the focused patch and regression test, and run the checks. I reviewed the changed lines, reproduced the failure before the fix, and verified the passing test result.
- [ ] AI-generated
- [ ] No AI usage

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] I read the contributor guideline and searched existing issues and PRs before starting.
- [x] I linked the issue addressed by this change.
- [ ] Documentation needs updating.
- [x] I added a regression test for the changed behavior.
