### PR TITLE
Fix send_to_device crashing on defaultdict batches

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -17,6 +17,7 @@ A set of basic tensor ops compatible with tpu, gpu, and multigpu
 
 import pickle
 import warnings
+from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from functools import update_wrapper, wraps
@@ -181,12 +182,17 @@ def send_to_device(tensor, device, non_blocking=False, skip_keys=None):
             skip_keys = [skip_keys]
         elif skip_keys is None:
             skip_keys = []
-        return type(tensor)(
-            {
-                k: t if k in skip_keys else send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys)
-                for k, t in tensor.items()
-            }
-        )
+        new_data = {
+            k: t if k in skip_keys else send_to_device(t, device, non_blocking=non_blocking, skip_keys=skip_keys)
+            for k, t in tensor.items()
+        }
+        if isinstance(tensor, defaultdict):
+            # `defaultdict`'s constructor takes the `default_factory` as its first positional argument, so
+            # `type(tensor)(new_data)` would incorrectly use `new_data` as the `default_factory`.
+            new_tensor = type(tensor)(tensor.default_factory)
+            new_tensor.update(new_data)
+            return new_tensor
+        return type(tensor)(new_data)
     else:
         return tensor
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ import pickle
 import tempfile
 import unittest
 import warnings
-from collections import UserDict, namedtuple
+from collections import UserDict, defaultdict, namedtuple
 from typing import NamedTuple, Optional
 from unittest.mock import Mock, patch
 
@@ -113,6 +113,22 @@ class UtilsTester(unittest.TestCase):
         assert torch.equal(result4["b"][0].cpu(), tensor)
         assert torch.equal(result4["b"][1].cpu(), tensor)
         assert result4["c"] == 1
+
+    def test_send_to_device_defaultdict(self):
+        # Regression test: `defaultdict`'s constructor takes `default_factory` as its first positional
+        # argument, so naively doing `type(tensor)(new_mapping)` raises `TypeError: first argument must be
+        # callable or None`. See https://github.com/huggingface/accelerate/issues/4154
+        tensor = torch.randn(5, 2)
+        device = torch.device(f"{torch_device}:0")
+
+        data = defaultdict(list, {"a": tensor})
+        result = send_to_device(data, device)
+
+        assert isinstance(result, defaultdict)
+        assert result.default_factory is list
+        assert torch.equal(result["a"].cpu(), tensor)
+        # missing keys should still fall back to the default factory
+        assert result["missing"] == []
 
     def test_honor_type(self):
         with self.assertRaises(TypeError) as cm:


### PR DESCRIPTION
## Summary

`send_to_device` reconstructs `Mapping` batches via `type(tensor)(new_mapping)`. For `collections.defaultdict`, the constructor's first positional argument is the `default_factory`, not initial data, so this raises `TypeError: first argument must be callable or None` whenever a `DataLoader` collate function returns a `defaultdict` batch.

Fixes #4154.

## Change

In `src/accelerate/utils/operations.py::send_to_device`, when the mapping being converted is a `defaultdict`, construct the new instance with `type(tensor)(tensor.default_factory)` and populate it via `.update(new_data)` instead of passing the data dict as the constructor's first argument. Other `Mapping` subclasses keep the previous behavior.

## Test plan

- Added `tests/test_utils.py::UtilsTester::test_send_to_device_defaultdict`, a regression test that reproduces the issue (fails before the fix with the exact `TypeError` from the report, passes after) and checks that the `default_factory` and existing values are preserved.
- Ran `python -m pytest tests/test_utils.py -k send_to_device -v` -- all 3 tests pass.
- Ran the full `tests/test_utils.py` suite -- same pass/fail results as before the change (one pre-existing, unrelated failure: `test_convert_to_fp32`, a `torch._inductor`/`torch.compile` issue in this local Windows/CPU environment, not touched by this PR).

AI disclosure: AI assistance was used to help investigate the issue and draft this fix and test. I reviewed the change and test results myself.
