### PR TITLE
Fix stateful dataloader checkpointing across processes

### DIFF
--- a/docs/source/basic_tutorials/migration.md
+++ b/docs/source/basic_tutorials/migration.md
@@ -222,3 +222,4 @@ Any other stateful items to be stored should be registered with the [`~Accelerat
 
 > [!TIP]
 > If you have [`torchdata>=0.8.0`](https://github.com/pytorch/data/tree/main) installed, you can additionally pass `use_stateful_dataloader=True` into your [`~utils.DataLoaderConfiguration`]. This extends Accelerate's DataLoader classes with a `load_state_dict` and `state_dict` function, and makes it so `Accelerator.save_state` and `Accelerator.load_state` also track how far into the training dataset it has read when persisting the model.
+> During distributed training, each process's data loader state is saved and restored independently.

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -60,6 +60,12 @@ from .state import PartialState
 logger = get_logger(__name__)
 
 
+def _get_dataloader_state_dict_filename(index: int, process_index: Optional[int] = None) -> str:
+    dataloader_suffix = "" if index == 0 else f"_{index}"
+    process_suffix = "" if process_index is None else f"_rank{process_index}"
+    return f"dl_state_dict{dataloader_suffix}{process_suffix}.bin"
+
+
 def save_accelerator_state(
     output_dir: str,
     model_states: list[dict],
@@ -139,7 +145,9 @@ def save_accelerator_state(
             if isinstance(sampler, SeedableRandomSampler):
                 save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
         if getattr(dataloader, "use_stateful_dataloader", False):
-            dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
+            # Stateful dataloader state is process-specific during distributed training.
+            dataloader_process_index = process_index if PartialState().num_processes > 1 else None
+            dataloader_state_dict_name = _get_dataloader_state_dict_filename(i, dataloader_process_index)
             output_dataloader_state_dict_file = output_dir.joinpath(dataloader_state_dict_name)
             state_dict = dataloader.state_dict()
             torch.save(state_dict, output_dataloader_state_dict_file)
@@ -275,8 +283,14 @@ def load_accelerator_state(
             if isinstance(sampler, SeedableRandomSampler):
                 sampler = dataloader.set_sampler(load(input_sampler_file))
         if getattr(dataloader, "use_stateful_dataloader", False):
-            dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
+            dataloader_state_dict_name = _get_dataloader_state_dict_filename(i)
             input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)
+            if PartialState().num_processes > 1:
+                # Prefer process-specific state while supporting checkpoints created with the legacy shared filename.
+                dataloader_state_dict_name = _get_dataloader_state_dict_filename(i, process_index)
+                process_input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)
+                if process_input_dataloader_state_dict_file.exists():
+                    input_dataloader_state_dict_file = process_input_dataloader_state_dict_file
             if input_dataloader_state_dict_file.exists():
                 state_dict = load(input_dataloader_state_dict_file, **load_kwargs)
                 dataloader.load_state_dict(state_dict)

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pickle
 import tempfile
 import warnings
+from contextlib import nullcontext
 from unittest.mock import Mock
 
 import torch
@@ -31,6 +33,7 @@ from torch.utils.data import (
 )
 
 from accelerate.accelerator import Accelerator, DataLoaderConfiguration
+from accelerate.utils import broadcast_object_list
 from accelerate.utils.dataclasses import DistributedType
 
 
@@ -68,6 +71,24 @@ class DummyIterableDataset(IterableDataset):
 
     def __iter__(self):
         yield from self.data
+
+
+class RankStatefulDataset(Dataset):
+    def __init__(self, rank, size=32):
+        self.rank = rank
+        self.size = size
+
+    def __len__(self):
+        return self.size
+
+    def __getitem__(self, index):
+        return torch.tensor(self.rank * 10_000 + index)
+
+    def state_dict(self):
+        return {"rank": self.rank}
+
+    def load_state_dict(self, state_dict):
+        self.rank = state_dict["rank"]
 
 
 def create_accelerator(even_batches=True):
@@ -369,7 +390,48 @@ def test_stateful_dataloader_save_state(accelerator):
     _test_stateful_dataloader_save_state_resume(accelerator, iterable=False)
 
 
+def test_stateful_dataloader_save_state_per_process():
+    """Tests that distributed processes save and restore their own stateful dataloader state."""
+    accelerator = Accelerator(
+        dataloader_config=DataLoaderConfiguration(use_stateful_dataloader=True, dispatch_batches=False)
+    )
+    checkpoint_context = tempfile.TemporaryDirectory() if accelerator.is_main_process else nullcontext()
+
+    with checkpoint_context as checkpoint_dir:
+        checkpoint_dir = [checkpoint_dir]
+        broadcast_object_list(checkpoint_dir)
+        checkpoint_dir = checkpoint_dir[0]
+
+        dataset = RankStatefulDataset(accelerator.process_index)
+        dataloader = accelerator.prepare(DataLoader(dataset, batch_size=1, num_workers=0))
+        dataloader_iterator = iter(dataloader)
+        for _ in range(3):
+            next(dataloader_iterator)
+
+        accelerator.save_state(checkpoint_dir)
+        expected_batches = [next(dataloader_iterator) for _ in range(3)]
+        accelerator.load_state(checkpoint_dir)
+        resumed_iterator = iter(dataloader)
+        resumed_batches = [next(resumed_iterator) for _ in range(3)]
+
+        accelerator.wait_for_everyone()
+        checkpoint_files = set(os.listdir(checkpoint_dir))
+        expected_state_files = {f"dl_state_dict_rank{rank}.bin" for rank in range(accelerator.num_processes)}
+        files_are_per_process = (
+            expected_state_files.issubset(checkpoint_files) and "dl_state_dict.bin" not in checkpoint_files
+        )
+        accelerator.wait_for_everyone()
+
+    for expected, resumed in zip(expected_batches, resumed_batches):
+        assert torch.equal(expected, resumed), f"Expected batch {expected}, got {resumed}"
+    assert files_are_per_process, f"Expected {expected_state_files}, got {checkpoint_files}"
+
+
 def main():
+    if os.environ.get("ACCELERATE_TEST_STATEFUL_DATALOADER_CHECKPOINT_ONLY") == "1":
+        test_stateful_dataloader_save_state_per_process()
+        return
+
     accelerator = create_accelerator()
     torch.manual_seed(accelerator.process_index)
 
@@ -421,6 +483,7 @@ def main():
     test_data_loader(loader, accelerator)
     test_stateful_dataloader(accelerator)
     test_stateful_dataloader_save_state(accelerator)
+    test_stateful_dataloader_save_state_per_process()
 
     accelerator.end_training()
 

--- a/tests/test_multidevice.py
+++ b/tests/test_multidevice.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import inspect
+import sys
 import unittest
 from unittest import skip
 
@@ -103,6 +104,24 @@ class MultiDeviceTester(unittest.TestCase):
             env_kwargs.update(cuda_visible_devices="0,1")
 
         with patch_environment(**env_kwargs):
+            execute_subprocess_async(cmd)
+
+    @run_first
+    def test_stateful_dataloader_checkpoint_cpu(self):
+        cmd = [
+            sys.executable,
+            "-m",
+            "torch.distributed.run",
+            "--standalone",
+            "--nproc_per_node=2",
+            self.data_loop_file_path,
+        ]
+        with patch_environment(
+            accelerate_test_stateful_dataloader_checkpoint_only=1,
+            accelerate_use_cpu=True,
+            cuda_visible_devices="",
+            omp_num_threads=1,
+        ):
             execute_subprocess_async(cmd)
 
     @run_first

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -20,6 +20,7 @@ import shutil
 import tempfile
 import uuid
 from contextlib import contextmanager
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -28,6 +29,8 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
+from accelerate.checkpointing import load_accelerator_state, save_accelerator_state
+from accelerate.state import AcceleratorState
 from accelerate.test_utils import (
     DEFAULT_LAUNCH_COMMAND,
     execute_subprocess_async,
@@ -40,6 +43,57 @@ from accelerate.utils import DistributedType, ProjectConfiguration, patch_enviro
 
 
 logger = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def initialized_accelerator():
+    Accelerator()
+    yield
+    AcceleratorState._reset_state(True)
+
+
+def test_stateful_dataloader_checkpoint_save_names(tmp_path, initialized_accelerator):
+    dataloader = Mock(use_stateful_dataloader=True, dataset=None)
+    dataloader.state_dict.return_value = {"source": "single_process"}
+    with patch("accelerate.checkpointing.PartialState") as partial_state:
+        partial_state.return_value.num_processes = 1
+        save_accelerator_state(tmp_path, [], [], [], [dataloader], 0, 0)
+
+    assert (tmp_path / "dl_state_dict.bin").exists()
+    assert not (tmp_path / "dl_state_dict_rank0.bin").exists()
+
+    distributed_dir = tmp_path / "distributed"
+    distributed_dir.mkdir()
+    with patch("accelerate.checkpointing.PartialState") as partial_state:
+        partial_state.return_value.num_processes = 2
+        save_accelerator_state(distributed_dir, [], [], [], [dataloader, dataloader], 1, 0)
+    assert (distributed_dir / "dl_state_dict_rank1.bin").exists()
+    assert (distributed_dir / "dl_state_dict_1_rank1.bin").exists()
+
+
+def test_stateful_dataloader_checkpoint_load_prefers_process_state_and_falls_back(tmp_path, initialized_accelerator):
+    dataloaders = [Mock(use_stateful_dataloader=True, dataset=None) for _ in range(2)]
+    for index, source in enumerate(("legacy_0", "legacy_1")):
+        name = "dl_state_dict.bin" if index == 0 else f"dl_state_dict_{index}.bin"
+        torch.save({"source": source}, tmp_path / name)
+    torch.save({"source": "process_1_loader_0"}, tmp_path / "dl_state_dict_rank1.bin")
+    torch.save({"source": "process_1_loader_1"}, tmp_path / "dl_state_dict_1_rank1.bin")
+
+    with patch("accelerate.checkpointing.PartialState") as partial_state:
+        partial_state.return_value.num_processes = 2
+        load_accelerator_state(tmp_path, [], [], [], dataloaders, 1)
+    assert dataloaders[0].load_state_dict.call_args.args[0] == {"source": "process_1_loader_0"}
+    assert dataloaders[1].load_state_dict.call_args.args[0] == {"source": "process_1_loader_1"}
+
+    legacy_dir = tmp_path / "legacy"
+    legacy_dir.mkdir()
+    torch.save({"source": "legacy_0"}, legacy_dir / "dl_state_dict.bin")
+    torch.save({"source": "legacy_1"}, legacy_dir / "dl_state_dict_1.bin")
+    with patch("accelerate.checkpointing.PartialState") as partial_state:
+        partial_state.return_value.num_processes = 2
+        load_accelerator_state(legacy_dir, [], [], [], dataloaders, 1)
+    assert dataloaders[0].load_state_dict.call_args.args[0] == {"source": "legacy_0"}
+    assert dataloaders[1].load_state_dict.call_args.args[0] == {"source": "legacy_1"}
 
 
 def dummy_dataloaders(a=2, b=3, batch_size=16, n_train_batches: int = 10, n_valid_batches: int = 2):


### PR DESCRIPTION
## What does this PR do?

This saves stateful dataloader checkpoints per process during distributed training.

A stateful dataloader can hold process-specific cursor, dataset, worker, and RNG state. However, every process currently writes its state to the same `dl_state_dict.bin` filename in a shared checkpoint directory. The final file therefore contains whichever process wrote last, and other processes can restore the wrong data position.

Distributed checkpoints now use rank-qualified filenames such as `dl_state_dict_rank0.bin`. Loading prefers the current process's file and falls back to the legacy unqualified filename, preserving compatibility with existing checkpoints. Single-process checkpoint filenames remain unchanged.

## Tests

- Added a two-process regression using distinct per-rank dataset streams and a shared checkpoint directory. It verifies exact batch replay after restore and asserts that both rank-qualified state files exist.
- Added a CPU/Gloo entry point so the distributed regression runs in the normal pull-request test suite as well as the existing multi-device suite.
- Added unit coverage for single-process naming, multiple dataloaders, process-specific load precedence, and legacy fallback.
- Verified the regression failed before the implementation and passes afterward.
- `make quality`
- `pytest -q tests/test_state_checkpointing.py -k "not map_location"` — 18 passed
- `pytest -q tests/test_accelerator.py -k stateful_dataloader` — 17 passed
- CPU/Gloo two-process regression — passed
- Two-GPU distributed data-loop suite — passed
