### PR TITLE
Forward reduce_batch_size_fn in find_executable_batch_size decorator factory

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -152,7 +152,11 @@ def find_executable_batch_size(
     ```
     """
     if function is None:
-        return functools.partial(find_executable_batch_size, starting_batch_size=starting_batch_size)
+        return functools.partial(
+            find_executable_batch_size,
+            starting_batch_size=starting_batch_size,
+            reduce_batch_size_fn=reduce_batch_size_fn,
+        )
 
     batch_size = starting_batch_size
     if reduce_batch_size_fn is None:

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -126,6 +126,25 @@ class MemoryTest(unittest.TestCase):
         ]
         assert [bs, arg1] == [8, "hello"]
 
+    def test_custom_reduce_batch_size_fn(self):
+        # The parenthesized decorator form must forward `reduce_batch_size_fn`
+        # to the wrapped call: the custom reducer was silently dropped before,
+        # falling back to the default *0.9 behavior.
+        calls = []
+
+        def reduce_to_one():
+            calls.append("called")
+            return 1
+
+        @find_executable_batch_size(starting_batch_size=128, reduce_batch_size_fn=reduce_to_one)
+        def mock_training_loop_function(batch_size):
+            if batch_size > 1:
+                raise_fake_out_of_memory()
+            return batch_size
+
+        assert mock_training_loop_function() == 1
+        assert calls == ["called"]
+
     def test_start_zero(self):
         @find_executable_batch_size(starting_batch_size=0)
         def mock_training_loop_function(batch_size):


### PR DESCRIPTION
## Bug

`find_executable_batch_size`'s parenthesized decorator form drops `reduce_batch_size_fn` when building its `functools.partial`, so a custom batch-size reducer is silently ignored and the default multiply-by-0.9 behavior always runs:

```py
@find_executable_batch_size(starting_batch_size=128, reduce_batch_size_fn=my_reducer)
def train(batch_size):
    if batch_size > 10:
        raise RuntimeError("CUDA out of memory.")
    return batch_size

train()          # → 9, after iterating *0.9 twenty-odd times
# my_reducer was never called
```

Since the first positional parameter is the function itself, the factory form is the *only* way to pass a custom reducer — the parameter added in #3071 has been unusable, and it is documented in the docstring.

## Fix

The `functools.partial` now forwards `reduce_batch_size_fn` alongside `starting_batch_size`.

## Verification

- New `test_custom_reduce_batch_size_fn` asserts the custom reducer is called and its return value is used: fails on `main`, passes with the fix.
- `tests/test_memory_utils.py`: 8 passed.
