### PR TITLE
Handle missing accelerate executable in env command

### DIFF
--- a/src/accelerate/commands/env.py
+++ b/src/accelerate/commands/env.py
@@ -17,7 +17,7 @@
 import argparse
 import os
 import platform
-import subprocess
+from shutil import which
 
 import numpy as np
 import psutil
@@ -82,15 +82,7 @@ def env_command(args):
     if args.config_file is not None or os.path.isfile(default_config_file):
         accelerate_config = load_config_from_file(args.config_file).to_dict()
 
-    # if we can run which, get it
-    command = None
-    bash_location = "Not found"
-    if os.name == "nt":
-        command = ["where", "accelerate"]
-    elif os.name == "posix":
-        command = ["which", "accelerate"]
-    if command is not None:
-        bash_location = subprocess.check_output(command, text=True, stderr=subprocess.STDOUT).strip()
+    bash_location = which("accelerate") or "Not found"
     info = {
         "`Accelerate` version": version,
         "Platform": platform.platform(),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 import torch
 from huggingface_hub.utils import GatedRepoError
 
+import accelerate.commands.env as accelerate_env_cmd
 import accelerate.commands.test as accelerate_test_cmd
 from accelerate.commands.config.config_args import BaseConfig, ClusterConfig, SageMakerConfig, load_config_from_file
 from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
@@ -41,6 +42,16 @@ from accelerate.test_utils.testing import (
 )
 from accelerate.utils import patch_environment
 from accelerate.utils.launch import prepare_simple_launcher_cmd_env
+
+
+class EnvCommandTester(unittest.TestCase):
+    @patch("accelerate.commands.env.which", return_value=None)
+    def test_executable_not_found(self, _):
+        args = accelerate_env_cmd.env_command_parser().parse_args([])
+
+        info = accelerate_env_cmd.env_command(args)
+
+        self.assertEqual(info["`accelerate` bash location"], "Not found")
 
 
 class AccelerateLauncherTester(unittest.TestCase):


### PR DESCRIPTION
## Summary

- replace the platform-specific `which`/`where` subprocess with `shutil.which`
- preserve the existing `Not found` diagnostic when the console script is not on `PATH`
- add regression coverage for invoking the environment command without an `accelerate` executable on `PATH`

## Why

`accelerate env` initializes the reported executable location to `Not found`, but then unconditionally runs an external lookup command. When Accelerate is invoked through an explicit path without activating its environment, that lookup exits non-zero and `subprocess.check_output()` raises `CalledProcessError`. As a result, the diagnostic command crashes instead of reporting the already-intended fallback.

Using `shutil.which()` provides the same lookup on POSIX and Windows while allowing a missing executable to be handled normally.

## Validation

- `PATH=/usr/bin:/bin accelerate env` (reports `` `accelerate` bash location: Not found ``)
- `pytest -q tests/test_cli.py -k 'EnvCommandTester or test_hyphen or test_underscore'` (3 passed)
- `pytest -q tests/test_memory_utils.py` (7 passed)
- `pytest -q tests/test_cli.py -k 'not test_invalid_model_name_transformers'` (38 passed, 1 skipped, 5 subtests passed)
- `make style`
- `make quality`
