### PR TITLE
Fix FSDP2 tied-embedding models on torch >= 2.13: put the output embedding in the same fully_shard group

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -856,10 +856,15 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
         fully_shard(input_embed, **fsdp2_kwargs)
 
     final_norm = _find_final_norm(model)
-    # Tied case uses `input_embed` so the pre-forward hook fires at forward-start
+    # Tied case puts `input_embed` first so the pre-forward hook fires at forward-start
     # (embed's use of the shared tensor), not at forward-end with `output_embed`.
-    tail_embed = input_embed if is_weights_tied else output_embed
-    tail = [m for m in (final_norm, tail_embed) if m is not None and not isinstance(m, FSDPModule)]
+    # `output_embed` must still be in the same group: torch >= 2.13 raises if a shared
+    # parameter is visible to two FSDP groups (here: the tail group and the root).
+    if is_weights_tied:
+        tail_modules = (final_norm, input_embed, output_embed)
+    else:
+        tail_modules = (final_norm, output_embed)
+    tail = [m for m in tail_modules if m is not None and not isinstance(m, FSDPModule)]
     if tail:
         fully_shard(tail, **{**fsdp2_kwargs, "reshard_after_forward": False})
 


### PR DESCRIPTION
On torch >= 2.13, preparing any tied-embedding model (Qwen3-0.6B/1.7B/4B, Gemma, Llama-3.2-1B/3B, ...) with FSDP2 fails at the first forward:

```
ValueError: Parameter 'model.embed_tokens.weight' is shared with a parameter already managed
by another FSDP group. For shared/tied parameters, use fully_shard([module_a, module_b]) to
place them in the same FSDP group.
```

`fsdp2_prepare_model` carves a tail group `fully_shard([final_norm, input_embed])` and, in the tied case, leaves `lm_head` (the same parameter) to the root group. torch >= 2.13 added a strict check that a shared parameter may not be visible to two FSDP groups.

### Fix

What the torch error message prescribes: in the tied case, put the output embedding module in the same group (`fully_shard([final_norm, input_embed, output_embed])`). `input_embed` stays first so the group still unshards at forward-start (unchanged hook timing). Untied models take the exact same path as before.

### Repro

`fsdp2.yaml`:

```yaml
compute_environment: LOCAL_MACHINE
distributed_type: FSDP
fsdp_config:
  fsdp_activation_checkpointing: true
  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
  fsdp_cpu_ram_efficient_loading: true
  fsdp_offload_params: false
  fsdp_reshard_after_forward: true
  fsdp_state_dict_type: FULL_STATE_DICT
  fsdp_version: 2
mixed_precision: bf16
num_machines: 1
num_processes: 1
use_cpu: false
```

`repro.py`:

```python
import torch
from accelerate import Accelerator
from transformers import AutoModelForCausalLM

accelerator = Accelerator()
model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3-0.6B", dtype=torch.bfloat16)
optimizer = torch.optim.AdamW(model.parameters())
model, optimizer = accelerator.prepare(model, optimizer)
input_ids = torch.randint(0, 1000, (1, 16), device=accelerator.device)
out = model(input_ids=input_ids, labels=input_ids)
print("forward OK, loss =", out.loss.item())
```

```bash
accelerate launch --config_file fsdp2.yaml repro.py
```

Before (main @ 7fccde2, torch 2.13.0): `ValueError` above at the first forward.
After (this branch, same command): `forward OK, loss = 12.6`.

(Note: the model and optimizer must be prepared together, which is the required FSDP2 usage anyway; `prepare(model)` alone is rejected with a different error before reaching this bug.)

Also exercised heavily downstream: Qwen3-0.6B trained at 128K-4M token sequences with `parallelism_config_cp_size=8` on top of this fix.
