### PR TITLE
FSDP2 activation checkpointing: wrap the matched transformer layer itself, not each of its children

### DIFF
--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -713,7 +713,11 @@ def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
             child_name = layer_name
 
         parent_module = model.get_submodule(parent_name) if parent_name else model
-        if auto_wrap_policy_func(parent_module):
+        # Wrap the matched module itself (e.g. the whole decoder layer). Wrapping each of its
+        # children separately keeps every inter-child activation (norm outputs, attention
+        # output, residuals) saved for backward — ~4 sequence-length tensors per layer
+        # instead of 1, which at long sequence lengths multiplies activation memory by ~4x.
+        if auto_wrap_policy_func(layer):
             layer = checkpoint_wrapper(layer, preserve_rng_state=False)
             parent_module.register_module(child_name, layer)
 
@@ -946,6 +950,12 @@ def fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model: torch.nn.Module) -> Call
         def policy(module: torch.nn.Module) -> bool:
             if not transformer_cls_to_wrap:
                 return False
+            # Activation checkpointing (applied before sharding) wraps matched layers in
+            # `CheckpointWrapper`; look through it so such layers still get their own FSDP group.
+            from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointWrapper
+
+            if isinstance(module, CheckpointWrapper):
+                module = module._checkpoint_wrapped_module
             return isinstance(module, tuple(transformer_cls_to_wrap))
 
     elif fn is size_based_auto_wrap_policy:

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -713,10 +713,6 @@ def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
             child_name = layer_name
 
         parent_module = model.get_submodule(parent_name) if parent_name else model
-        # Wrap the matched module itself (e.g. the whole decoder layer). Wrapping each of its
-        # children separately keeps every inter-child activation (norm outputs, attention
-        # output, residuals) saved for backward — ~4 sequence-length tensors per layer
-        # instead of 1, which at long sequence lengths multiplies activation memory by ~4x.
         if auto_wrap_policy_func(layer):
             layer = checkpoint_wrapper(layer, preserve_rng_state=False)
             parent_module.register_module(child_name, layer)

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -706,16 +706,8 @@ def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
     auto_wrap_policy_func = fsdp2_prepare_auto_wrap_policy(accelerator.state.fsdp_plugin, model)
 
     for layer_name, layer in get_module_children_bottom_up(model, return_fqns=True)[:-1]:
-        if len(layer_name.split(".")) > 1:
-            parent_name, child_name = layer_name.rsplit(".", 1)
-        else:
-            parent_name = None
-            child_name = layer_name
-
-        parent_module = model.get_submodule(parent_name) if parent_name else model
         if auto_wrap_policy_func(layer):
-            layer = checkpoint_wrapper(layer, preserve_rng_state=False)
-            parent_module.register_module(child_name, layer)
+            model.set_submodule(layer_name, checkpoint_wrapper(layer, preserve_rng_state=False))
 
     return model
 


### PR DESCRIPTION
`fsdp2_apply_ac` iterates over all modules and checkpoint-wraps every module whose **parent** matches the auto-wrap policy:

```python
if auto_wrap_policy_func(parent_module):
    layer = checkpoint_wrapper(layer, ...)
```

With `TRANSFORMER_BASED_WRAP`, the policy matches the decoder layer -- so its *children* (`self_attn`, `mlp`, `input_layernorm`, `post_attention_layernorm`) each get their own checkpoint wrapper instead of the layer itself. Every inter-child activation (norm outputs, attention output, residual stream) then stays saved for backward: ~4 sequence-length tensors per layer instead of 1. FSDP1's `apply_activation_checkpointing(check_fn=...)` wraps the layer itself; FSDP2 should too.

This is the dominant activation cost at long sequence lengths, memory-snapshot replay on Qwen3-0.6B at 131K tokens shows 29 GB of the 40.8 GB peak are these inter-child saves.

### Fix

1. `fsdp2_apply_ac`: wrap the module the policy matches (`auto_wrap_policy_func(layer)`).
2. `fsdp2_prepare_auto_wrap_policy`: look through `CheckpointWrapper` (`module._checkpoint_wrapped_module`) so the subsequent `fully_shard` pass still recognizes wrapped decoder layers and gives each its own FSDP group. (Previously this worked only *because* the layer class stayed unwrapped.)

### Repro

`fsdp2.yaml`: same as in #4171 (FSDP2, `TRANSFORMER_BASED_WRAP`, `fsdp_activation_checkpointing: true`, bf16, 1 process).

`repro.py`:

```python
import torch
from accelerate import Accelerator
from transformers import AutoModelForCausalLM

accelerator = Accelerator()
model = AutoModelForCausalLM.from_pretrained("TinyLlama/TinyLlama-1.1B-Chat-v1.0", dtype=torch.bfloat16)
optimizer = torch.optim.AdamW(model.parameters())
model, optimizer = accelerator.prepare(model, optimizer)

input_ids = torch.randint(0, 1000, (1, 65536), device=accelerator.device)
# logits_to_keep=1: skip the [seq, vocab] logits so activation memory dominates the peak
out = model(input_ids=input_ids, logits_to_keep=1, use_cache=False)
out.logits.float().sum().backward()
print(f"peak allocated: {torch.cuda.max_memory_allocated()/1e9:.1f} GB")
```

```bash
accelerate launch --config_file fsdp2.yaml repro.py
```

| model | main @ 7fccde2 | this branch |
|---|---|---|
| TinyLlama-1.1B, 65K tokens | 33.3 GB | **18.4 GB** (−45%) |
| pythia-410m, 65K tokens | 13.5 GB | **8.2 GB** (−39%) |

Step time is unchanged (36.5 s → 36.8 s, Qwen3-0.6B @ 131K on one H100).

<img width="1379" height="620" alt="image" src="https://github.com/user-attachments/assets/53b0a4e5-f76b-4526-a4a9-7ba921224491" />


Note: measure with `use_cache=False` (what every Trainer sets); with a KV cache being built, cache tensors dominate the saved set and mask the effect!

### Downstream effect

This unlocked long-context training in TRL: Qwen3-0.6B @ 1M tokens with `cp_size=8` went from 49.1 → 28.1 GB/GPU peak, and Qwen3-8B @ 1M / 0.6B @ 2M+ went from OOM to training on one 8×H100 node. It's also the likely reason TRL's published CP benchmark capped at ~300K tokens for an 8B model.
