### PR TITLE
Fix circular import between utils.bnb and big_modeling

### DIFF
--- a/src/accelerate/utils/bnb.py
+++ b/src/accelerate/utils/bnb.py
@@ -26,7 +26,6 @@ from accelerate.utils.imports import (
     is_8bit_bnb_available,
 )
 
-from ..big_modeling import dispatch_model, init_empty_weights
 from .dataclasses import BnbQuantizationConfig
 from .modeling import (
     find_tied_parameters,
@@ -84,6 +83,7 @@ def load_and_quantize_model(
     Returns:
         `torch.nn.Module`: The quantized model
     """
+    from ..big_modeling import dispatch_model, init_empty_weights
 
     load_in_4bit = bnb_quantization_config.load_in_4bit
     load_in_8bit = bnb_quantization_config.load_in_8bit
@@ -386,6 +386,8 @@ def get_keys_to_not_convert(model):
     model (`torch.nn.Module`):
         Input model
     """
+    from ..big_modeling import init_empty_weights
+
     # Create a copy of the model
     with init_empty_weights():
         tied_model = deepcopy(model)  # this has 0 cost since it is done inside `init_empty_weights` context manager`

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import subprocess
 import sys
+import unittest
 
 from accelerate.test_utils import require_transformer_engine
 from accelerate.test_utils.testing import TempDirTestCase, require_import_timer
@@ -98,3 +99,56 @@ class LazyImportTester(TempDirTestCase):
         output = run_import_time("import accelerate, accelerate.utils.transformer_engine")
 
         self.assertFalse(" transformer_engine" in output, "`transformer_engine` should not be imported on import")
+
+
+class ConcurrentImportTester(unittest.TestCase):
+    """Regression for huggingface/accelerate#4173.
+
+    `utils.bnb` imported `big_modeling` at module level, which closed a cycle
+    (`utils` -> `bnb` -> `big_modeling` -> `hooks` -> `utils`). Single-threaded
+    imports usually survived by accident; concurrent submodule imports failed
+    with a partial-initialization ImportError.
+    """
+
+    def test_concurrent_utils_and_big_modeling_imports(self):
+        # Fresh interpreter so accelerate is not already in sys.modules.
+        script = r"""
+import importlib
+import threading
+
+barrier = threading.Barrier(2)
+errors = []
+
+
+def do_import(name):
+    barrier.wait()
+    try:
+        importlib.import_module(name)
+    except BaseException as exc:
+        errors.append(f"{name} -> {type(exc).__name__}: {exc}")
+
+
+threads = [
+    threading.Thread(target=do_import, args=(name,))
+    for name in ("accelerate.utils", "accelerate.big_modeling")
+]
+for thread in threads:
+    thread.start()
+for thread in threads:
+    thread.join()
+
+if errors:
+    raise SystemExit("\n".join(errors))
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"concurrent imports failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )


### PR DESCRIPTION
Fixes #4173

## Summary

`accelerate.utils.bnb` imported `dispatch_model` and `init_empty_weights` at module level, which closed a cycle:

`utils` → `bnb` → `big_modeling` → `hooks` → `utils`

Single-threaded imports usually survived by accident. Concurrent imports of `accelerate.utils` and `accelerate.big_modeling` failed with a partial-initialization `ImportError`.

Those names are only used inside `load_and_quantize_model` and `get_keys_to_not_convert`, so they are imported there instead. Public exports are unchanged.

The diagnosis and this cut are from @adrihans on #4173.

## Tests

```
pytest tests/test_imports.py::ConcurrentImportTester -sv
```

Passed 4 times locally (Python 3.12, torch 2.13.0, macOS arm64). The same test fails on unpatched `main` with:

```
ImportError: cannot import name 'dispatch_model' from partially initialized module 'accelerate.big_modeling'
```

AI assistance was used to apply the change and write the regression test. I reviewed the diff.