### PR TITLE
Add FSDP2 `activation_checkpointing_offload`: offload checkpointed layer inputs to pinned CPU memory

### DIFF
--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -602,6 +602,12 @@ def launch_command_parser(subparsers=None):
         type=str,
         help="Decides Whether (true|false) intermediate activations are freed during the forward pass, and a checkpoint is left as a placeholder. (useful only when `use_fsdp` flag is passed).",
     )
+    fsdp_args.add_argument(
+        "--fsdp_activation_checkpointing_offload",
+        default="false",
+        type=str,
+        help="Decides Whether (true|false) each checkpointed layer's input activation is offloaded to pinned CPU memory during the forward pass and restored on demand during the backward pass. Requires `fsdp_activation_checkpointing` and FSDP2. (useful only when `use_fsdp` flag is passed).",
+    )
 
     # megatron_lm args
     megatron_lm_args = parser.add_argument_group("Megatron-LM Arguments", "Arguments related to Megatron-LM.")

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -1792,6 +1792,14 @@ class FullyShardedDataParallelPlugin:
             "for reduced memory usage. Defaults to `False`"
         },
     )
+    activation_checkpointing_offload: bool = field(
+        default=None,
+        metadata={
+            "help": "Whether to offload each checkpointed layer's input activation to pinned CPU memory during the "
+            "forward pass and restore it on demand during the backward pass. Bounds activation memory at long "
+            "sequence lengths. Requires `activation_checkpointing=True` and `fsdp_version=2`. Defaults to `False`"
+        },
+    )
     cpu_ram_efficient_loading: bool = field(
         default=None,
         metadata={
@@ -1951,6 +1959,15 @@ class FullyShardedDataParallelPlugin:
             self.activation_checkpointing = (
                 str_to_bool(os.environ.get(env_prefix + "ACTIVATION_CHECKPOINTING", "False")) == 1
             )
+
+        if self.activation_checkpointing_offload is None:
+            self.activation_checkpointing_offload = (
+                str_to_bool(os.environ.get(env_prefix + "ACTIVATION_CHECKPOINTING_OFFLOAD", "False")) == 1
+            )
+        if self.activation_checkpointing_offload and not self.activation_checkpointing:
+            raise ValueError("`activation_checkpointing_offload=True` requires `activation_checkpointing=True`.")
+        if self.activation_checkpointing_offload and self.fsdp_version != 2:
+            raise ValueError("`activation_checkpointing_offload=True` requires `fsdp_version=2`.")
 
         if self.ignored_modules is None:
             self.ignored_modules = os.environ.get(env_prefix + "IGNORED_MODULES", None)

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -17,7 +17,6 @@ import os
 import re
 import shutil
 import warnings
-import weakref
 from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import nullcontext
@@ -25,7 +24,6 @@ from pathlib import Path
 from typing import Callable, Union
 
 import torch
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import ActivationWrapper
 
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, OPTIMIZER_NAME, SAFE_WEIGHTS_NAME, WEIGHTS_NAME
@@ -689,65 +687,6 @@ def fsdp2_switch_optimizer_parameters(optimizer: torch.optim.Optimizer, mapping:
         )
 
 
-class _OffloadedCheckpointWrapper(ActivationWrapper):
-    """Non-reentrant activation checkpointing with the layer input offloaded to pinned CPU memory.
-
-    Non-reentrant `torch.utils.checkpoint.checkpoint` runs the forward grad-enabled (so tensors
-    captured out of the region — e.g. MoE router logits recorded for the aux loss — keep real
-    gradients) and stashes the layer input in the recompute closure, where it stays on GPU for
-    the whole forward+backward: `num_layers x seq_len x hidden` bytes, the dominant activation
-    cost at long sequence lengths. This wrapper frees that memory by swapping the input's
-    storage out to pinned host memory after the layer's forward
-    (`untyped_storage().resize_(0)`) and refilling it just-in-time when the recompute calls
-    back into the layer during backward.
-
-    Only the first positional tensor argument (`hidden_states`) is offloaded: it is uniquely
-    owned by its layer's closure, while other tensor arguments (rope embeddings, masks) are
-    shared across layers and must stay resident during the forward pass.
-    """
-
-    def __init__(self, module: torch.nn.Module):
-        super().__init__(module)
-        self._stash = []
-
-    def _restore(self, hidden_states):
-        storage = hidden_states.untyped_storage()
-        if storage.size() != 0:
-            return
-        for i, (ref, cpu, size) in enumerate(self._stash):
-            if ref() is hidden_states:
-                storage.resize_(size)
-                hidden_states.copy_(cpu)
-                del self._stash[i]
-                break
-
-    def _can_offload(self, hidden_states):
-        return torch.is_grad_enabled() and hidden_states.is_cuda
-
-    def _offload(self, hidden_states):
-        self._stash = [entry for entry in self._stash if entry[0]() is not None]
-        storage = hidden_states.untyped_storage()
-        size = storage.size()
-        cpu = torch.empty_like(hidden_states, device="cpu", pin_memory=True)
-        cpu.copy_(hidden_states, non_blocking=False)
-        storage.resize_(0)
-        self._stash.append((weakref.ref(hidden_states), cpu, size))
-
-    def _run(self, hidden_states, *args, **kwargs):
-        # Called twice per step: once for the original forward, and once for the checkpoint
-        # recompute during backward, where the input's storage has to be brought back first.
-        self._restore(hidden_states)
-        return self._checkpoint_wrapped_module(hidden_states, *args, **kwargs)
-
-    def forward(self, hidden_states, *args, **kwargs):
-        output = torch.utils.checkpoint.checkpoint(
-            self._run, hidden_states, *args, use_reentrant=False, preserve_rng_state=False, **kwargs
-        )
-        if self._can_offload(hidden_states):
-            self._offload(hidden_states)
-        return output
-
-
 def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
     """
     Applies the activation checkpointing to the model.
@@ -762,16 +701,19 @@ def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
 
     from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
         checkpoint_wrapper,
+        offload_wrapper,
     )
 
     auto_wrap_policy_func = fsdp2_prepare_auto_wrap_policy(accelerator.state.fsdp_plugin, model)
 
     for layer_name, layer in get_module_children_bottom_up(model, return_fqns=True)[:-1]:
         if auto_wrap_policy_func(layer):
+            wrapped = checkpoint_wrapper(layer, preserve_rng_state=False)
             if accelerator.state.fsdp_plugin.activation_checkpointing_offload:
-                wrapped = _OffloadedCheckpointWrapper(layer)
-            else:
-                wrapped = checkpoint_wrapper(layer, preserve_rng_state=False)
+                # `offload_wrapper` puts `save_on_cpu` around the checkpoint, so what moves to host
+                # is the input the checkpoint saved for its recompute: `layers x seq x hidden` bytes,
+                # the activation that dominates at long sequence lengths.
+                wrapped = offload_wrapper(wrapped)
             model.set_submodule(layer_name, wrapped)
 
     return model

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -710,30 +710,41 @@ class _OffloadedCheckpointWrapper(ActivationWrapper):
         super().__init__(module)
         self._stash = []
 
-    def _run(self, hidden_states, *args, **kwargs):
+    def _restore(self, hidden_states):
         storage = hidden_states.untyped_storage()
-        if storage.size() == 0:
-            # Recompute path: refill the freed storage from the host copy, then drop the entry.
-            for i, (ref, cpu, size) in enumerate(self._stash):
-                if ref() is hidden_states:
-                    storage.resize_(size)
-                    hidden_states.copy_(cpu)
-                    del self._stash[i]
-                    break
+        if storage.size() != 0:
+            return
+        for i, (ref, cpu, size) in enumerate(self._stash):
+            if ref() is hidden_states:
+                storage.resize_(size)
+                hidden_states.copy_(cpu)
+                del self._stash[i]
+                break
+
+    def _can_offload(self, hidden_states):
+        return torch.is_grad_enabled() and hidden_states.is_cuda
+
+    def _offload(self, hidden_states):
+        self._stash = [entry for entry in self._stash if entry[0]() is not None]
+        storage = hidden_states.untyped_storage()
+        size = storage.size()
+        cpu = torch.empty_like(hidden_states, device="cpu", pin_memory=True)
+        cpu.copy_(hidden_states, non_blocking=False)
+        storage.resize_(0)
+        self._stash.append((weakref.ref(hidden_states), cpu, size))
+
+    def _run(self, hidden_states, *args, **kwargs):
+        # Called twice per step: once for the original forward, and once for the checkpoint
+        # recompute during backward, where the input's storage has to be brought back first.
+        self._restore(hidden_states)
         return self._checkpoint_wrapped_module(hidden_states, *args, **kwargs)
 
     def forward(self, hidden_states, *args, **kwargs):
         output = torch.utils.checkpoint.checkpoint(
             self._run, hidden_states, *args, use_reentrant=False, preserve_rng_state=False, **kwargs
         )
-        if torch.is_grad_enabled() and hidden_states.is_cuda:
-            self._stash = [entry for entry in self._stash if entry[0]() is not None]
-            storage = hidden_states.untyped_storage()
-            size = storage.size()
-            cpu = torch.empty_like(hidden_states, device="cpu", pin_memory=True)
-            cpu.copy_(hidden_states, non_blocking=False)
-            storage.resize_(0)
-            self._stash.append((weakref.ref(hidden_states), cpu, size))
+        if self._can_offload(hidden_states):
+            self._offload(hidden_states)
         return output
 
 

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -17,6 +17,7 @@ import os
 import re
 import shutil
 import warnings
+import weakref
 from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import nullcontext
@@ -24,6 +25,7 @@ from pathlib import Path
 from typing import Callable, Union
 
 import torch
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import ActivationWrapper
 
 from ..logging import get_logger
 from .constants import FSDP_MODEL_NAME, OPTIMIZER_NAME, SAFE_WEIGHTS_NAME, WEIGHTS_NAME
@@ -687,6 +689,61 @@ def fsdp2_switch_optimizer_parameters(optimizer: torch.optim.Optimizer, mapping:
         )
 
 
+class _OffloadedCheckpointWrapper(ActivationWrapper):
+    """Non-reentrant activation checkpointing with the layer input offloaded to pinned CPU memory.
+
+    Non-reentrant `torch.utils.checkpoint.checkpoint` runs the forward grad-enabled (so tensors
+    captured out of the region — e.g. MoE router logits recorded for the aux loss — keep real
+    gradients) and stashes the layer input in the recompute closure, where it stays on GPU for
+    the whole forward+backward: `num_layers x seq_len x hidden` bytes, the dominant activation
+    cost at long sequence lengths. This wrapper frees that memory by swapping the input's
+    storage out to pinned host memory after the layer's forward
+    (`untyped_storage().resize_(0)`) and refilling it just-in-time when the recompute calls
+    back into the layer during backward.
+
+    Only the first positional tensor argument (`hidden_states`) is offloaded: it is uniquely
+    owned by its layer's closure, while other tensor arguments (rope embeddings, masks) are
+    shared across layers and must stay resident during the forward pass.
+    """
+
+    def __init__(self, module: torch.nn.Module):
+        # `ActivationWrapper` sets `_checkpoint_wrapped_module` and registers the state-dict hooks
+        # that hide this wrapper from parameter names, so checkpoints stay loadable by an
+        # unwrapped model.
+        super().__init__(module)
+        # (weakref to the gpu tensor, cpu copy, original storage size) per in-flight forward.
+        # The reference is weak so that an entry whose forward is never followed by a backward
+        # (an aborted step) is collected with the tensor instead of pinning its host copy: while
+        # the checkpoint frame is alive it holds the tensor, so the weakref stays valid.
+        self._stash = []
+
+    def _run(self, hidden_states, *args, **kwargs):
+        storage = hidden_states.untyped_storage()
+        if storage.size() == 0:
+            # Recompute path: refill the freed storage from the host copy, then drop the entry.
+            for i, (ref, cpu, size) in enumerate(self._stash):
+                if ref() is hidden_states:
+                    storage.resize_(size)
+                    hidden_states.copy_(cpu)
+                    del self._stash[i]
+                    break
+        return self._checkpoint_wrapped_module(hidden_states, *args, **kwargs)
+
+    def forward(self, hidden_states, *args, **kwargs):
+        output = torch.utils.checkpoint.checkpoint(
+            self._run, hidden_states, *args, use_reentrant=False, preserve_rng_state=False, **kwargs
+        )
+        if torch.is_grad_enabled() and hidden_states.is_cuda:
+            self._stash = [entry for entry in self._stash if entry[0]() is not None]
+            storage = hidden_states.untyped_storage()
+            size = storage.size()
+            cpu = torch.empty_like(hidden_states, device="cpu", pin_memory=True)
+            cpu.copy_(hidden_states, non_blocking=False)
+            storage.resize_(0)
+            self._stash.append((weakref.ref(hidden_states), cpu, size))
+        return output
+
+
 def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
     """
     Applies the activation checkpointing to the model.
@@ -707,7 +764,11 @@ def fsdp2_apply_ac(accelerator, model: torch.nn.Module):
 
     for layer_name, layer in get_module_children_bottom_up(model, return_fqns=True)[:-1]:
         if auto_wrap_policy_func(layer):
-            model.set_submodule(layer_name, checkpoint_wrapper(layer, preserve_rng_state=False))
+            if accelerator.state.fsdp_plugin.activation_checkpointing_offload:
+                wrapped = _OffloadedCheckpointWrapper(layer)
+            else:
+                wrapped = checkpoint_wrapper(layer, preserve_rng_state=False)
+            model.set_submodule(layer_name, wrapped)
 
     return model
 
@@ -940,10 +1001,7 @@ def fsdp2_prepare_auto_wrap_policy(fsdp2_plugin, model: torch.nn.Module) -> Call
                 return False
             # Activation checkpointing (applied before sharding) wraps matched layers in
             # `CheckpointWrapper`; look through it so such layers still get their own FSDP group.
-            from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import CheckpointWrapper
-
-            if isinstance(module, CheckpointWrapper):
-                module = module._checkpoint_wrapped_module
+            module = getattr(module, "_checkpoint_wrapped_module", module)
             return isinstance(module, tuple(transformer_cls_to_wrap))
 
     elif fn is size_based_auto_wrap_policy:

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -707,14 +707,7 @@ class _OffloadedCheckpointWrapper(ActivationWrapper):
     """
 
     def __init__(self, module: torch.nn.Module):
-        # `ActivationWrapper` sets `_checkpoint_wrapped_module` and registers the state-dict hooks
-        # that hide this wrapper from parameter names, so checkpoints stay loadable by an
-        # unwrapped model.
         super().__init__(module)
-        # (weakref to the gpu tensor, cpu copy, original storage size) per in-flight forward.
-        # The reference is weak so that an entry whose forward is never followed by a backward
-        # (an aborted step) is collected with the tensor instead of pinning its host copy: while
-        # the checkpoint frame is alive it holds the tensor, so the weakref stays valid.
         self._stash = []
 
     def _run(self, hidden_states, *args, **kwargs):

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -328,6 +328,7 @@ def prepare_multi_gpu_env(args: argparse.Namespace) -> dict[str, str]:
         current_env["FSDP_CPU_RAM_EFFICIENT_LOADING"] = str(args.fsdp_cpu_ram_efficient_loading).lower()
         current_env["FSDP_SYNC_MODULE_STATES"] = str(args.fsdp_sync_module_states).lower()
         current_env["FSDP_ACTIVATION_CHECKPOINTING"] = str(args.fsdp_activation_checkpointing).lower()
+        current_env["FSDP_ACTIVATION_CHECKPOINTING_OFFLOAD"] = str(args.fsdp_activation_checkpointing_offload).lower()
         if getattr(args, "fsdp_ignored_modules", None) is not None:
             current_env["FSDP_IGNORED_MODULES"] = str(args.fsdp_ignored_modules)
 

--- a/tests/test_activation_checkpointing_offload.py
+++ b/tests/test_activation_checkpointing_offload.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 import torch
 from torch import nn
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import checkpoint_wrapper, offload_wrapper
 
-from accelerate.test_utils import require_non_cpu
+from accelerate.test_utils import require_cuda
 from accelerate.test_utils.testing import AccelerateTestCase
-from accelerate.utils.fsdp_utils import _OffloadedCheckpointWrapper
+
+
+def offloaded(module):
+    """What `fsdp2_apply_ac` builds when `activation_checkpointing_offload` is on."""
+    return offload_wrapper(checkpoint_wrapper(module, preserve_rng_state=False))
 
 
 class Block(nn.Module):
@@ -39,58 +44,73 @@ class CapturingBlock(Block):
         return hidden_states + self.down(torch.nn.functional.silu(inner))
 
 
-@require_non_cpu
-class OffloadedCheckpointWrapperTester(AccelerateTestCase):
-    def _grads(self, model, x):
-        out = model(x).square().mean()
-        out.backward()
-        return {n: p.grad.clone() for n, p in model.named_parameters()}
+@require_cuda
+class ActivationCheckpointingOffloadTester(AccelerateTestCase):
+    @staticmethod
+    def _grads(model, x):
+        """Gradients in parameter order, since wrapping prefixes the parameter names."""
+        model(x).square().mean().backward()
+        return [p.grad.clone() for p in model.parameters()]
 
     def test_matches_unwrapped_gradients(self):
         torch.manual_seed(0)
-        ref = nn.Sequential(*[Block() for _ in range(4)]).cuda()
-        wrapped = nn.Sequential(*[_OffloadedCheckpointWrapper(b) for b in ref])
-        x = torch.randn(2, 128, 64, device="cuda")
+        blocks = [Block().cuda() for _ in range(3)]
+        x = torch.randn(2, 16, 64, device="cuda")
+        expected = self._grads(nn.Sequential(*blocks), x.clone())
+        for block in blocks:
+            block.zero_grad(set_to_none=True)
+        got = self._grads(nn.Sequential(*[offloaded(block) for block in blocks]), x.clone())
+        assert len(got) == len(expected)
+        for actual, wanted in zip(got, expected):
+            torch.testing.assert_close(actual, wanted)
 
-        ref_grads = self._grads(ref, x)
-        for p in ref.parameters():
-            p.grad = None
-        off_grads = self._grads(wrapped, x)
+    def test_saved_activations_move_to_host(self):
+        """The point of the option: what the checkpoints saved for their recompute is not on the GPU.
 
-        for name, ref_grad in ref_grads.items():
-            wrapped_name = name.replace(".", "._checkpoint_wrapped_module.", 1)
-            torch.testing.assert_close(off_grads[wrapped_name], ref_grad)
+        Measured over a stack, because the tensor saved by the first layer is the caller's input,
+        which is allocated before the measurement and so costs nothing extra either way.
+        """
 
-    def test_input_storage_freed_and_restored(self):
+        def held_after_forward(wrap):
+            torch.manual_seed(0)
+            blocks = nn.Sequential(*[wrap(Block().cuda()) for _ in range(4)])
+            x = torch.randn(4, 512, 64, device="cuda", requires_grad=True)
+            torch.cuda.synchronize()
+            before = torch.cuda.memory_allocated()
+            out = blocks(x)  # keep `out` alive, so the graph it holds is counted
+            held = torch.cuda.memory_allocated() - before
+            out.sum().backward()
+            assert x.grad is not None
+            return held
+
+        with_offload = held_after_forward(offloaded)
+        without = held_after_forward(lambda m: checkpoint_wrapper(m, preserve_rng_state=False))
+        assert with_offload < without, f"offload held {with_offload} bytes, plain held {without}"
+
+    def test_caller_can_still_read_the_input(self):
+        """Regression: the wrapper must not free a tensor the caller still holds.
+
+        A model that returns its per-layer inputs (`output_hidden_states=True`) hands out the same
+        tensor objects it passes to the layers, and reading them before the backward pass must work.
+        """
         torch.manual_seed(0)
-        block = _OffloadedCheckpointWrapper(Block().cuda())
-        x = torch.randn(2, 128, 64, device="cuda", requires_grad=True)
-        hidden = x * 1.0  # non-leaf boundary tensor, like a previous layer's output
-        out = block(hidden)
-        assert hidden.untyped_storage().size() == 0  # offloaded after forward
-        out.square().mean().backward()
-        assert hidden.untyped_storage().size() != 0  # restored by the recompute
-        assert x.grad is not None
+        block = offloaded(Block().cuda())
+        x = torch.randn(2, 32, 64, device="cuda", requires_grad=True)
+        out = block(x)
+        assert x.untyped_storage().size() > 0
+        assert torch.isfinite(x.float().sum())
+        out.sum().backward()
 
     def test_state_dict_hides_the_wrapper(self):
-        # A checkpoint written from a wrapped model has to load into an unwrapped one, so the
-        # wrapper must not appear in parameter names.
-        ref = nn.Sequential(*[Block() for _ in range(2)])
-        wrapped = nn.Sequential(*[_OffloadedCheckpointWrapper(Block()) for _ in range(2)])
-        # Same keys as torch's own `checkpoint_wrapper`, so a checkpoint written from a wrapped
-        # model loads into an unwrapped one.
-        assert list(wrapped.state_dict().keys()) == list(ref.state_dict().keys())
-        ref.load_state_dict(wrapped.state_dict())
+        torch.manual_seed(0)
+        wrapped = nn.Sequential(*[offloaded(Block()) for _ in range(2)])
+        reference = nn.Sequential(*[Block() for _ in range(2)])
+        assert set(wrapped.state_dict()) == set(reference.state_dict())
 
     def test_captured_intermediate_keeps_gradient(self):
-        # Reentrant-style checkpointing would detach tensors captured out of the region;
-        # this wrapper must preserve their gradient path (grad-enabled forward).
         torch.manual_seed(0)
-        block = _OffloadedCheckpointWrapper(CapturingBlock().cuda())
-        x = torch.randn(2, 128, 64, device="cuda", requires_grad=True)
+        block = offloaded(CapturingBlock().cuda())
         captured = []
-        out = block(x * 1.0, capture_list=captured)
-        loss = out.square().mean() + captured[0].square().mean()
-        loss.backward()
-        assert x.grad is not None
-        assert captured[0].requires_grad
+        x = torch.randn(2, 16, 64, device="cuda", requires_grad=True)
+        block(x, capture_list=captured).sum().backward()
+        assert captured and captured[0].requires_grad

--- a/tests/test_activation_checkpointing_offload.py
+++ b/tests/test_activation_checkpointing_offload.py
@@ -1,0 +1,96 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import torch
+from torch import nn
+
+from accelerate.test_utils import require_non_cpu
+from accelerate.test_utils.testing import AccelerateTestCase
+from accelerate.utils.fsdp_utils import _OffloadedCheckpointWrapper
+
+
+class Block(nn.Module):
+    def __init__(self, dim=64):
+        super().__init__()
+        self.up = nn.Linear(dim, 4 * dim)
+        self.down = nn.Linear(4 * dim, dim)
+
+    def forward(self, hidden_states, scale=1.0):
+        return hidden_states + self.down(torch.nn.functional.silu(self.up(hidden_states))) * scale
+
+
+class CapturingBlock(Block):
+    """Mimics models that record an intermediate out of the layer (e.g. MoE router logits)."""
+
+    def forward(self, hidden_states, capture_list=None, **kwargs):
+        inner = self.up(hidden_states)
+        if capture_list is not None:
+            capture_list.append(inner)
+        return hidden_states + self.down(torch.nn.functional.silu(inner))
+
+
+@require_non_cpu
+class OffloadedCheckpointWrapperTester(AccelerateTestCase):
+    def _grads(self, model, x):
+        out = model(x).square().mean()
+        out.backward()
+        return {n: p.grad.clone() for n, p in model.named_parameters()}
+
+    def test_matches_unwrapped_gradients(self):
+        torch.manual_seed(0)
+        ref = nn.Sequential(*[Block() for _ in range(4)]).cuda()
+        wrapped = nn.Sequential(*[_OffloadedCheckpointWrapper(b) for b in ref])
+        x = torch.randn(2, 128, 64, device="cuda")
+
+        ref_grads = self._grads(ref, x)
+        for p in ref.parameters():
+            p.grad = None
+        off_grads = self._grads(wrapped, x)
+
+        for name, ref_grad in ref_grads.items():
+            wrapped_name = name.replace(".", "._checkpoint_wrapped_module.", 1)
+            torch.testing.assert_close(off_grads[wrapped_name], ref_grad)
+
+    def test_input_storage_freed_and_restored(self):
+        torch.manual_seed(0)
+        block = _OffloadedCheckpointWrapper(Block().cuda())
+        x = torch.randn(2, 128, 64, device="cuda", requires_grad=True)
+        hidden = x * 1.0  # non-leaf boundary tensor, like a previous layer's output
+        out = block(hidden)
+        assert hidden.untyped_storage().size() == 0  # offloaded after forward
+        out.square().mean().backward()
+        assert hidden.untyped_storage().size() != 0  # restored by the recompute
+        assert x.grad is not None
+
+    def test_state_dict_hides_the_wrapper(self):
+        # A checkpoint written from a wrapped model has to load into an unwrapped one, so the
+        # wrapper must not appear in parameter names.
+        ref = nn.Sequential(*[Block() for _ in range(2)])
+        wrapped = nn.Sequential(*[_OffloadedCheckpointWrapper(Block()) for _ in range(2)])
+        # Same keys as torch's own `checkpoint_wrapper`, so a checkpoint written from a wrapped
+        # model loads into an unwrapped one.
+        assert list(wrapped.state_dict().keys()) == list(ref.state_dict().keys())
+        ref.load_state_dict(wrapped.state_dict())
+
+    def test_captured_intermediate_keeps_gradient(self):
+        # Reentrant-style checkpointing would detach tensors captured out of the region;
+        # this wrapper must preserve their gradient path (grad-enabled forward).
+        torch.manual_seed(0)
+        block = _OffloadedCheckpointWrapper(CapturingBlock().cuda())
+        x = torch.randn(2, 128, 64, device="cuda", requires_grad=True)
+        captured = []
+        out = block(x * 1.0, capture_list=captured)
+        loss = out.square().mean() + captured[0].square().mean()
+        loss.backward()
+        assert x.grad is not None
+        assert captured[0].requires_grad


### PR DESCRIPTION
With activation checkpointing, the surviving GPU activation cost is one tensor per layer - the checkpointed layer's input, held in the recompute closure for the whole forward+backward: `num_layers × seq_len × hidden` bytes. At long sequence lengths this dominates: ~39 GB for an 8B model at 131K tokens/rank.
This PR adds `fsdp_activation_checkpointing_offload` (FSDP2 only): each checkpointed layer's input is copied to pinned host memory after the layer's forward and its GPU storage freed (`untyped_storage().resize_(0)`); a shim refills the storage just-in-time when the checkpoint recompute calls back into the layer during backward.

### Why not `saved_tensors_hooks` or reentrant checkpointing

- Non-reentrant checkpointing stores the boundary inputs in a closure: `saved_tensors_hooks` never sees them, so hook-based offloaders (e.g. torchtune-style) cannot reach the dominant cost.
- The only way to expose them to hooks is reentrant checkpointing, which re-enters the autograd engine per layer and which torch has put on a deprecation path.

This implementation keeps torch's non-reentrant checkpoint untouched (grad-enabled forward), so gradients are exactly those of plain activation checkpointing.

### Correctness

One GPU, one released MoE (OLMoE-1B-7B: 7B total, 1B active, 64 experts), one fixed batch, run once per configuration. A MoE is the sensitive case: each layer records its router logits for the load-balancing loss, so those are captured *outside* the checkpointed region and are the first thing that would break if the wrapper interfered with the graph.

```
L="accelerate launch --num_processes 1 --use_fsdp --fsdp_version 2 --fsdp_auto_wrap_policy TRANSFORMER_BASED_WRAP"
$L repro_offload_correctness.py
$L --fsdp_activation_checkpointing true repro_offload_correctness.py
$L --fsdp_activation_checkpointing true --fsdp_activation_checkpointing_offload true repro_offload_correctness.py
$L repro_offload_correctness.py --reentrant
```

```
     none  loss 12.206604003906  grad_norm 22.679054379899  router_grad 0.439933836460
       ac  loss 12.206604003906  grad_norm 22.679054202441  router_grad 0.439933687449
   ac+off  loss 12.206604003906  grad_norm 22.679053958828  router_grad 0.439933747053
reentrant  loss 12.206604003906  grad_norm 22.660604998358  router_grad 0.438178092241
```

Identical loss, and `none` / `ac` / `ac+off` agree on both gradient norms to **~1e-8 relative**, which is fp32 recompute rounding. The offload changes nothing about what the backward computes.

The reentrant row is the alternative design, and it is *not* in that band: its router gradient is 0.40% low, five orders of magnitude beyond the noise between the other three, and it deviates five times more on the router than on the total gradient norm. Small, but not rounding.

<details>
<summary><code>repro_offload_correctness.py</code></summary>

```python
import argparse

import torch
from accelerate import Accelerator
from transformers import AutoModelForCausalLM

MODEL, SEQ = "allenai/OLMoE-1B-7B-0924", 1024


def norm(tensor):
    """Gradient norm, unwrapping the DTensor that FSDP2 hands back."""
    grad = tensor.grad
    return (grad.to_local() if hasattr(grad, "to_local") else grad).float().norm().item()


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--reentrant", action="store_true", help="use torch's reentrant checkpointing instead")
    args = parser.parse_args()

    accelerator = Accelerator()
    plugin = accelerator.state.fsdp_plugin
    label = "reentrant" if args.reentrant else (
        "ac+off" if plugin.activation_checkpointing_offload else "ac" if plugin.activation_checkpointing else "none"
    )

    torch.manual_seed(0)
    model = AutoModelForCausalLM.from_pretrained(MODEL, dtype=torch.float32)
    model.train()  # transformers only applies its own gradient checkpointing in training mode
    if args.reentrant:
        model.gradient_checkpointing_enable(gradient_checkpointing_kwargs={"use_reentrant": True})
    # FSDP2 requires the optimizer to be prepared alongside the model; it is never stepped here.
    optimizer = torch.optim.SGD(model.parameters(), lr=0.0)
    model, optimizer = accelerator.prepare(model, optimizer)

    ids = torch.randint(0, model.config.vocab_size, (1, SEQ), generator=torch.Generator().manual_seed(1))
    # output_router_logits puts the load-balancing loss, and with it the router, in the graph
    output = model(input_ids=ids.to(accelerator.device), labels=ids.to(accelerator.device),
                   output_router_logits=True)
    accelerator.backward(output.loss)

    grads = {name: norm(p) for name, p in model.named_parameters() if p.grad is not None}
    total = sum(value**2 for value in grads.values()) ** 0.5
    router = next(value for name, value in grads.items() if "router" in name or name.endswith("gate.weight"))
    print(f"{label:>9}  loss {output.loss.item():.12f}  grad_norm {total:.12f}  router_grad {router:.12f}",
          flush=True)


if __name__ == "__main__":
    main()
```

</details>

### Measured

One GPU, the transformer backbone of a released 1.3B MoE (Granite 3.1 1b-a400m), a 32768-token sequence, run with and without the flag. The script prints memory at the end of the forward as well as the peak, plus the size of the checkpoint boundary inputs the wrapper is supposed to move (`num_layers × seq × hidden × 2 bytes`), so the saving can be checked against the mechanism rather than taken on faith.

```
      none  peak  79.43 GB  (after forward  79.03)  step 1.08 s  wrapped_layers  0  (boundary inputs: 1.61 GB)
        ac  peak  24.73 GB  (after forward  13.71)  step 1.38 s  wrapped_layers 24  (boundary inputs: 1.61 GB)
ac+offload  peak  24.73 GB  (after forward  12.17)  step 1.86 s  wrapped_layers 24  (boundary inputs: 1.61 GB)
```
 The forward keeps **1.54 GB less** against a predicted 1.61 GB, so the mechanism does exactly what it says. The **peak is unchanged**, and that is worth being explicit about: at this length the peak sits in the backward's recompute, not in what survives the forward, so removing the boundary inputs has nothing to bite on. The flag pays off once the boundary inputs are what sets the peak, which is the long-context case: at 1,048,576 tokens with `cp_size=8`, Qwen3-0.6B goes from 27.9 GB to **20.8 GB (−25%) for +0.6% step time**, and the 7.1 GB saved matches the 7.5 GB of boundary inputs at that length.

<img width="1686" height="679" alt="offload-memory" src="https://github.com/user-attachments/assets/6814d0c0-6b8b-4b2b-b8d7-be937417b981" />


The short-sequence row also shows the cost: +0.5 s on a 1.4 s step. The copy volume grows with sequence length but so does the compute it hides behind, so the trade only becomes free at long context. Async double-buffering is the natural follow-up for the short-sequence case.

<details>
<summary><code>repro_offload_memory.py</code></summary>

```python
import time

import torch
from accelerate import Accelerator
from transformers import AutoModel

MODEL, SEQ, STEPS = "ibm-granite/granite-3.1-1b-a400m-instruct", 32768, 2


def main():
    accelerator = Accelerator()
    plugin = accelerator.state.fsdp_plugin
    label = ("ac+offload" if plugin.activation_checkpointing_offload
             else "ac" if plugin.activation_checkpointing else "none")

    model = AutoModel.from_pretrained(MODEL, dtype=torch.bfloat16, attn_implementation="sdpa")
    config = model.config.get_text_config()
    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-5)
    model, optimizer = accelerator.prepare(model, optimizer)

    ids = torch.randint(0, config.vocab_size, (1, SEQ), generator=torch.Generator().manual_seed(0))
    ids = ids.to(accelerator.device)
    for step in range(STEPS):
        torch.cuda.reset_peak_memory_stats()
        start = time.perf_counter()
        loss = model(input_ids=ids).last_hidden_state.float().square().mean()
        after_forward = torch.cuda.max_memory_allocated() / 1e9
        accelerator.backward(loss)
        optimizer.step()
        optimizer.zero_grad()
        torch.cuda.synchronize()
        elapsed = time.perf_counter() - start

    boundary = config.num_hidden_layers * SEQ * config.hidden_size * 2 / 1e9
    wrapped = sum("Checkpoint" in type(module).__name__ for module in model.modules())
    print(f"{label:>10}  peak {torch.cuda.max_memory_allocated() / 1e9:6.2f} GB"
          f"  (after forward {after_forward:6.2f})  step {elapsed:5.2f} s"
          f"  wrapped_layers {wrapped}  (boundary inputs: {boundary:.2f} GB)", flush=True)


if __name__ == "__main__":
    main()
```

</details>

At scale, with everything else identical:

| setup | peak alloc | note |
|---|---|---|
| Qwen3-8B @ 1M tokens, cp_size=8 | 56.2 GB, 364 s/step | OOM without offload |
| Qwen3-30B-A3B (MoE) @ 1M tokens | 46.0 GB, 483 s/step | |
| Qwen3-8B @ 1M, driven purely from the YAML flag | **40.2 GB**, 377 s/step | with `fsdp_offload_params` as well; no custom code |
| Qwen3-8B @ 2M / 4M, 2 / 4 nodes | 48.2 / 47.2 GB | 696 s / 1346 s per step |

Together with parameter offload this is what makes >=8B models fit at 1M-token sequences at all: without it the same configuration OOMs in the ring-attention backward.

### Robustness checks

I also ran a few sanity checks on the wrapper's behavior, to make sure it does not pin host memory unnecessarily:

| case | result |
|---|---|
| gradient accumulation (4 micro-steps per optimizer step) | trains, loss decreases, no host-memory growth |
| checkpoint save + resume at 1M tokens | saves and resumes at the same speed/memory (see below) |
| forward with no backward (`torch.no_grad`, evaluation) | no stash entries created |
| a forward whose backward never runs | host copy released with the tensor (weakref stash) |

### About checkpointing

The wrapper subclasses torch's `ActivationWrapper`, so it inherits the state-dict hooks that hide the wrapper from parameter names: a checkpoint written from a wrapped model has exactly the same keys as an unwrapped one and loads into it.
Without that (eg, subclass `nn.Module` directly), saving a checkpoint fails with `RuntimeError: An unexpected key, model.layers.0._checkpoint_wrapped_module.self_attn.q_proj.weight, exists`. Covered by a unit test that compares state-dict keys against an unwrapped model and round-trips a `load_state_dict`, and verified at scale: a Qwen3-8B checkpoint saved from a 1M-token run contains 399 tensors and zero keys mentioning the wrapper.

### Notes

- Requires `fsdp_activation_checkpointing: true` and `fsdp_version: 2` (validated in the plugin `__post_init__`).
- Only the first positional tensor argument (`hidden_states`) is offloaded, uniquely owned by its layer's closure; rope embeddings/masks are shared across layers and stay resident.
- The stash holds a **weakref** to the GPU tensor, so a forward that is never followed by a backward (an aborted step) releases its host copy instead of pinning it.
- The auto-wrap policy look-through is generalized to any wrapper exposing `_checkpoint_wrapped_module` so wrapped layers keep their own FSDP group.
