### PR TITLE
[Umbrella] FSDP2 × expert-parallelism fixes (do not merge)

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1872,9 +1872,7 @@ class Accelerator:
                     "If you want train the 8-bit or 4-bit model in CPU, please install bitsandbytes with multi-backend, see https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend"
                 )
         elif device_placement and not self.verify_device_map(model) and not model_has_dtensor(model):
-            # A DTensor-sharded model (e.g. sharded at load by transformers' DistributedConfig)
-            # manages its own placement; `.to()` on FSDP2-managed or CPU-offloaded parameters
-            # raises `_apply(): Couldn't swap ...`.
+            # DTensor-sharded models manage their own placement; `.to()` on FSDP2-managed or CPU-offloaded params raises `_apply(): Couldn't swap ...`
             model = model.to(self.device)
         if not evaluation_mode:
             if self.multi_device and not (self.parallelism_config and self.parallelism_config.tp_enabled):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1871,7 +1871,10 @@ class Accelerator:
                     "You can't train a model that has been loaded in 8-bit or 4-bit precision with CPU or disk offload. "
                     "If you want train the 8-bit or 4-bit model in CPU, please install bitsandbytes with multi-backend, see https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend"
                 )
-        elif device_placement and not self.verify_device_map(model):
+        elif device_placement and not self.verify_device_map(model) and not model_has_dtensor(model):
+            # A DTensor-sharded model (e.g. sharded at load by transformers' DistributedConfig)
+            # manages its own placement; `.to()` on FSDP2-managed or CPU-offloaded parameters
+            # raises `_apply(): Couldn't swap ...`.
             model = model.to(self.device)
         if not evaluation_mode:
             if self.multi_device and not (self.parallelism_config and self.parallelism_config.tp_enabled):

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -761,6 +761,19 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     fsdp2_plugin.set_auto_wrap_policy(model)
 
     mesh = getattr(accelerator, "torch_device_mesh", None)
+    pc = accelerator.parallelism_config
+
+    # `fsdp_dim_names` always asks for `dp_shard_cp`, but that joint dimension is only flattened into the mesh when
+    # `dp_shard` or `cp` is enabled. Without either, slicing the mesh below raises a `KeyError` from `device_mesh`.
+    if mesh is not None and not pc.dp_shard_enabled and not pc.cp_enabled:
+        raise ValueError(
+            f"FSDP is enabled but the device mesh is {tuple(mesh.mesh_dim_names)}, which has no dimension for FSDP "
+            "to shard across (both `dp_shard_size` and `cp_size` are 1). This usually means a model that is already "
+            "parallelized another way -- e.g. loaded with `DistributedConfig(tp_size=N)` or "
+            "`enable_expert_parallel=True`, which makes the whole world size tensor/expert parallel -- was launched "
+            "under an FSDP config. Either launch it without the FSDP config, or leave ranks for FSDP to use by "
+            "lowering `tp_size`."
+        )
 
     fsdp2_kwargs = {
         "reshard_after_forward": fsdp2_plugin.reshard_after_forward,

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import shutil
+import sys
 import tempfile
 import warnings
 from collections import OrderedDict, defaultdict
@@ -73,10 +74,15 @@ logger = logging.getLogger(__name__)
 def is_peft_model(model):
     from .other import extract_model_from_parallel
 
-    if is_peft_available():
-        from peft import PeftModel
-
-    return is_peft_available() and isinstance(extract_model_from_parallel(model), PeftModel)
+    # `is_peft_available()` checks distribution metadata, which misses a peft provided only through
+    # `PYTHONPATH` / `sys.path` (no dist-info). If peft is already imported, trust the import: a
+    # `PeftModel` instance can only exist if its module does.
+    peft = sys.modules.get("peft")
+    if peft is None and is_peft_available():
+        import peft
+    if peft is None:
+        return False
+    return isinstance(extract_model_from_parallel(model), peft.PeftModel)
 
 
 def check_device_same(first_device, second_device):

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -20,7 +20,6 @@ import logging
 import os
 import re
 import shutil
-import sys
 import tempfile
 import warnings
 from collections import OrderedDict, defaultdict
@@ -74,15 +73,10 @@ logger = logging.getLogger(__name__)
 def is_peft_model(model):
     from .other import extract_model_from_parallel
 
-    # `is_peft_available()` checks distribution metadata, which misses a peft provided only through
-    # `PYTHONPATH` / `sys.path` (no dist-info). If peft is already imported, trust the import: a
-    # `PeftModel` instance can only exist if its module does.
-    peft = sys.modules.get("peft")
-    if peft is None and is_peft_available():
-        import peft
-    if peft is None:
-        return False
-    return isinstance(extract_model_from_parallel(model), peft.PeftModel)
+    if is_peft_available():
+        from peft import PeftModel
+
+    return is_peft_available() and isinstance(extract_model_from_parallel(model), PeftModel)
 
 
 def check_device_same(first_device, second_device):


### PR DESCRIPTION
Install-only umbrella for FSDP2 × expert parallelism (huggingface/transformers#48204): merges

- #4180 (clear error for the FSDP2 mesh mismatch)
- #4181 (skip `model.to(device)` in `prepare_model` for DTensor-sharded models)

so colleagues can install one branch. Not meant to merge.

Used by the runnable 100B–753B MoE training examples in huggingface/trl#6869.

