### PR TITLE
fix(data_loader): handle dataloaders missing batch_sampler attribute

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1009,7 +1009,8 @@ def get_sampler(dataloader):
     if sampler_is_batch_sampler:
         sampler = getattr(dataloader.sampler, "sampler", None)
     else:
-        sampler = getattr(dataloader.batch_sampler, "sampler", None)
+        batch_sampler = getattr(dataloader, "batch_sampler", None)
+        sampler = getattr(batch_sampler, "sampler", None) if batch_sampler is not None else None
     return sampler
 
 
@@ -1188,7 +1189,7 @@ def prepare_data_loader(
 
     new_dataset = dataloader.dataset
     # Iterable dataset doesn't like batch_sampler, but data_loader creates a default one for it
-    new_batch_sampler = dataloader.batch_sampler if not isinstance(new_dataset, IterableDataset) else None
+    new_batch_sampler = getattr(dataloader, "batch_sampler", None) if not isinstance(new_dataset, IterableDataset) else None
     sampler_is_batch_sampler = isinstance(dataloader.sampler, BatchSampler)
     synchronized_generator = None
 
@@ -1250,7 +1251,7 @@ def prepare_data_loader(
                     seed = int(torch.empty((), dtype=torch.int64).random_().item())
                     sampler.generator.manual_seed(seed)
                 synchronized_generator = sampler.generator
-            batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler
+            batch_sampler = dataloader.sampler if sampler_is_batch_sampler else getattr(dataloader, "batch_sampler", None)
             new_batch_sampler = BatchSamplerShard(
                 batch_sampler,
                 num_processes=num_processes,

--- a/tests/test_issue_882.py
+++ b/tests/test_issue_882.py
@@ -1,0 +1,37 @@
+import unittest
+import torch
+from torch.utils.data import DataLoader, Dataset
+from accelerate import Accelerator
+from accelerate.data_loader import DataLoaderShard
+
+class SimpleDataset(Dataset):
+    def __init__(self, size=100):
+        self.size = size
+    def __getitem__(self, index):
+        return torch.tensor([index])
+    def __len__(self):
+        self.size
+        return self.size
+
+class DataLoaderWithoutBatchSampler(DataLoader):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if hasattr(self, 'batch_sampler'):
+            delattr(self, 'batch_sampler')
+
+class AccelerateIssue882Tests(unittest.TestCase):
+    def test_prepare_dataloader_without_batch_sampler(self):
+        accelerator = Accelerator()
+        dataset = SimpleDataset()
+        dataloader = DataLoaderWithoutBatchSampler(dataset, batch_size=32)
+        
+        # This should not raise AttributeError
+        prepared_dl = accelerator.prepare(dataloader)
+        
+        self.assertIsInstance(prepared_dl, (DataLoader, DataLoaderShard))
+        # Verify it can still be iterated
+        batch = next(iter(prepared_dl))
+        self.assertEqual(batch.shape[0], 32)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?
This PR fixes issue #882 where `prepare_data_loader` (and consequently `Accelerator.prepare`) fails with an `AttributeError` when a `DataLoader` object does not have a `batch_sampler` attribute. While standard PyTorch `DataLoader` objects always have this attribute, some custom or wrapped dataloaders might not, causing crashes in `accelerate`.

## Changes
- Updated `get_sampler` helper to safely access `batch_sampler` using `getattr`.
- Updated `prepare_data_loader` to use `getattr(dataloader, "batch_sampler", None)` instead of direct access.
- Added a native regression test `tests/test_issue_882.py` that simulates a dataloader without a `batch_sampler` attribute.

## Validation
- Verified with a reproduction script that was previously failing.
- Native regression test passes locally.
- Confirmed that it still preserves custom sampler structures if present.

Fixes #882