### PR TITLE
Raise a clear error when FSDP is enabled on a mesh with no shard dimension

### DIFF
--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -376,6 +376,17 @@ class ParallelismConfig:
                 f"dp_shard_size/tp_size/cp_size/sp_size."
             )
 
+        # FSDP shards across the joint `dp_shard_cp` mesh dimension, which only exists when `dp_shard` or `cp` is
+        # enabled; with neither, preparation fails later with an opaque `KeyError` from `device_mesh`.
+        if accelerator.is_fsdp2 and not self.dp_shard_enabled and not self.cp_enabled:
+            raise ValueError(
+                "FSDP is enabled but the parallelism config has no dimension for FSDP to shard across (both "
+                "`dp_shard_size` and `cp_size` are 1). This usually means a model that is already parallelized "
+                "another way -- e.g. loaded with `DistributedConfig(tp_size=N)` or `enable_expert_parallel=True`, "
+                "which makes the whole world size tensor/expert parallel -- was launched under an FSDP config. "
+                "Either launch it without the FSDP config, or leave ranks for FSDP to use by lowering `tp_size`."
+            )
+
         if self.total_size > 1 and not (
             accelerator.is_fsdp2
             or accelerator.multi_device

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -760,19 +760,6 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     fsdp2_plugin.set_auto_wrap_policy(model)
 
     mesh = getattr(accelerator, "torch_device_mesh", None)
-    pc = accelerator.parallelism_config
-
-    # `fsdp_dim_names` always asks for `dp_shard_cp`, but that joint dimension is only flattened into the mesh when
-    # `dp_shard` or `cp` is enabled. Without either, slicing the mesh below raises a `KeyError` from `device_mesh`.
-    if mesh is not None and not pc.dp_shard_enabled and not pc.cp_enabled:
-        raise ValueError(
-            f"FSDP is enabled but the device mesh is {tuple(mesh.mesh_dim_names)}, which has no dimension for FSDP "
-            "to shard across (both `dp_shard_size` and `cp_size` are 1). This usually means a model that is already "
-            "parallelized another way -- e.g. loaded with `DistributedConfig(tp_size=N)` or "
-            "`enable_expert_parallel=True`, which makes the whole world size tensor/expert parallel -- was launched "
-            "under an FSDP config. Either launch it without the FSDP config, or leave ranks for FSDP to use by "
-            "lowering `tp_size`."
-        )
 
     fsdp2_kwargs = {
         "reshard_after_forward": fsdp2_plugin.reshard_after_forward,

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -753,6 +753,19 @@ def fsdp2_prepare_model(accelerator, model: torch.nn.Module) -> torch.nn.Module:
     fsdp2_plugin.set_auto_wrap_policy(model)
 
     mesh = getattr(accelerator, "torch_device_mesh", None)
+    pc = accelerator.parallelism_config
+
+    # `fsdp_dim_names` always asks for `dp_shard_cp`, but that joint dimension is only flattened into the mesh when
+    # `dp_shard` or `cp` is enabled. Without either, slicing the mesh below raises a `KeyError` from `device_mesh`.
+    if mesh is not None and not pc.dp_shard_enabled and not pc.cp_enabled:
+        raise ValueError(
+            f"FSDP is enabled but the device mesh is {tuple(mesh.mesh_dim_names)}, which has no dimension for FSDP "
+            "to shard across (both `dp_shard_size` and `cp_size` are 1). This usually means a model that is already "
+            "parallelized another way -- e.g. loaded with `DistributedConfig(tp_size=N)` or "
+            "`enable_expert_parallel=True`, which makes the whole world size tensor/expert parallel -- was launched "
+            "under an FSDP config. Either launch it without the FSDP config, or leave ranks for FSDP to use by "
+            "lowering `tp_size`."
+        )
 
     fsdp2_kwargs = {
         "reshard_after_forward": fsdp2_plugin.reshard_after_forward,


### PR DESCRIPTION
When FSDP2 is enabled together with a `ParallelismConfig` whose ranks are fully consumed by other dimensions (for example `tp_size == world_size`, which is also what transformers' expert parallelism produces), `fsdp2_prepare_model` slices the mesh with `fsdp_dim_names` and fails with a confusing error:

```
KeyError: "Invalid mesh_dim_names ('dp_shard_cp',) specified. Valid mesh_dim_names are ['tp']."
```

This PR raises an explicit error instead:

```
ValueError: FSDP is enabled but the device mesh is ('tp',), which has no dimension for FSDP to shard across (both `dp_shard_size` and `cp_size` are 1). This usually means a model that is already parallelized another way -- e.g. loaded with `DistributedConfig(tp_size=N)` or `enable_expert_parallel=True`, which makes the whole world size tensor/expert parallel -- was launched under an FSDP config. Either launch it without the FSDP config, or leave ranks for FSDP to use by lowering `tp_size`.
```

Reproduction (2 GPUs):

```python
# torchrun --nproc_per_node 2 repro.py
import torch
import torch.nn as nn
from accelerate import Accelerator
from accelerate.parallelism_config import ParallelismConfig
from accelerate.utils import FullyShardedDataParallelPlugin

accelerator = Accelerator(
    parallelism_config=ParallelismConfig(tp_size=2),
    fsdp_plugin=FullyShardedDataParallelPlugin(fsdp_version=2),
)
model = nn.Linear(8, 8)
optimizer = torch.optim.AdamW(model.parameters())
model, optimizer = accelerator.prepare(model, optimizer)
```
