### PR TITLE
prepare_model: don't move DTensor-sharded models to the device

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1794,7 +1794,10 @@ class Accelerator:
         ```
         """
         if device_placement is None:
-            device_placement = self.device_placement and self.distributed_type != DistributedType.FSDP
+            # DTensor-sharded models manage their own placement; `.to()` on FSDP2-managed or CPU-offloaded params raises `_apply(): Couldn't swap ...`
+            device_placement = (
+                self.device_placement and self.distributed_type != DistributedType.FSDP and not model_has_dtensor(model)
+            )
 
         # Ensure we can't double wrap a model
         if getattr(model, "_is_accelerate_prepared", False):
@@ -1871,8 +1874,7 @@ class Accelerator:
                     "You can't train a model that has been loaded in 8-bit or 4-bit precision with CPU or disk offload. "
                     "If you want train the 8-bit or 4-bit model in CPU, please install bitsandbytes with multi-backend, see https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend"
                 )
-        elif device_placement and not self.verify_device_map(model) and not model_has_dtensor(model):
-            # DTensor-sharded models manage their own placement; `.to()` on FSDP2-managed or CPU-offloaded params raises `_apply(): Couldn't swap ...`
+        elif device_placement and not self.verify_device_map(model):
             model = model.to(self.device)
         if not evaluation_mode:
             if self.multi_device and not (self.parallelism_config and self.parallelism_config.tp_enabled):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1796,7 +1796,9 @@ class Accelerator:
         if device_placement is None:
             # DTensor-sharded models manage their own placement; `.to()` on FSDP2-managed or CPU-offloaded params raises `_apply(): Couldn't swap ...`
             device_placement = (
-                self.device_placement and self.distributed_type != DistributedType.FSDP and not model_has_dtensor(model)
+                self.device_placement
+                and self.distributed_type != DistributedType.FSDP
+                and not model_has_dtensor(model)
             )
 
         # Ensure we can't double wrap a model

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1872,9 +1872,7 @@ class Accelerator:
                     "If you want train the 8-bit or 4-bit model in CPU, please install bitsandbytes with multi-backend, see https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend"
                 )
         elif device_placement and not self.verify_device_map(model) and not model_has_dtensor(model):
-            # A DTensor-sharded model (e.g. sharded at load by transformers' DistributedConfig)
-            # manages its own placement; `.to()` on FSDP2-managed or CPU-offloaded parameters
-            # raises `_apply(): Couldn't swap ...`.
+            # DTensor-sharded models manage their own placement; `.to()` on FSDP2-managed or CPU-offloaded params raises `_apply(): Couldn't swap ...`
             model = model.to(self.device)
         if not evaluation_mode:
             if self.multi_device and not (self.parallelism_config and self.parallelism_config.tp_enabled):

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1871,7 +1871,10 @@ class Accelerator:
                     "You can't train a model that has been loaded in 8-bit or 4-bit precision with CPU or disk offload. "
                     "If you want train the 8-bit or 4-bit model in CPU, please install bitsandbytes with multi-backend, see https://huggingface.co/docs/bitsandbytes/main/en/installation#multi-backend"
                 )
-        elif device_placement and not self.verify_device_map(model):
+        elif device_placement and not self.verify_device_map(model) and not model_has_dtensor(model):
+            # A DTensor-sharded model (e.g. sharded at load by transformers' DistributedConfig)
+            # manages its own placement; `.to()` on FSDP2-managed or CPU-offloaded parameters
+            # raises `_apply(): Couldn't swap ...`.
             model = model.to(self.device)
         if not evaluation_mode:
             if self.multi_device and not (self.parallelism_config and self.parallelism_config.tp_enabled):


### PR DESCRIPTION
A model sharded at load time (e.g. transformers' `DistributedConfig` with FSDP2, optionally CPU-offloaded) manages its own parameter placement, but `prepare_model` unconditionally calls `model = model.to(self.device)` when `device_placement` is set. `.to()` recurses `_apply` through FSDP2-managed parameters and raises:

```
RuntimeError: Attempted to set the storage of a tensor on device "cpu" to a storage on different device "cuda:0".
RuntimeError: _apply(): Couldn't swap FSDPLinear.weight
```

`model_has_dtensor` already exists and is consulted a few lines below for the DDP case; use it to skip the device move too. Hit while fine-tuning GLM-5.2 (753B) with `fsdp_cpu_offload=True` through `Trainer` (huggingface/transformers#48204); on-device sharded models are unaffected because the move was a same-device no-op for them.

## Reproduction

/!\ A standalone toy does not trigger this: plain FSDP2 (fresh or lazy-initialized, with or without CPU offload) tolerates the `.to()`.

The failing `_apply` swap needs the parameter arrangement that transformers' sharded loading produces (DTensor expert weights on a tp mesh combined with FSDP2-managed dense parameters, CPU-offloaded). With the transformers side installed (huggingface/transformers#48204):

```python
# torchrun --nproc_per_node 4 repro.py
import torch
from transformers import AutoModelForCausalLM, Trainer, TrainingArguments
from transformers.distributed import DistributedConfig

model = AutoModelForCausalLM.from_pretrained(
    "Qwen/Qwen3-30B-A3B", dtype=torch.bfloat16,
    distributed_config=DistributedConfig(tp_size=2, fsdp_size=2, enable_expert_parallel=True, fsdp_cpu_offload=True),
)
Trainer(model=model, args=TrainingArguments(output_dir="/tmp/x")).accelerator.prepare(model)
# RuntimeError: Attempted to set the storage of a tensor on device "cpu" to a storage on
# different device "cuda:0"  /  _apply(): Couldn't swap FSDPLinear.weight
```

The guard is correct independently of the trigger's rarity: a model holding DTensor parameters manages its own placement, and `model_has_dtensor` is already the codebase's test for exactly that condition a few lines below.
