### PR TITLE
Validate TPU accelerate versions consistently

### DIFF
--- a/src/accelerate/commands/tpu.py
+++ b/src/accelerate/commands/tpu.py
@@ -18,7 +18,7 @@ import argparse
 import os
 import subprocess
 
-from packaging.version import Version, parse
+from packaging.version import InvalidVersion, Version
 
 from accelerate.commands.config.config_args import default_config_file, load_config_from_file
 
@@ -105,7 +105,13 @@ def tpu_command_launcher(args):
         args.accelerate_version = "git+https://github.com/huggingface/accelerate.git"
     elif args.accelerate_version == "latest":
         args.accelerate_version = "accelerate -U"
-    elif isinstance(parse(args.accelerate_version), Version):
+    else:
+        try:
+            Version(args.accelerate_version)
+        except InvalidVersion as exc:
+            raise ValueError(
+                "--accelerate_version must be 'latest', 'dev', or a valid Python package version."
+            ) from exc
         args.accelerate_version = f"accelerate=={args.accelerate_version}"
 
     if not args.command_file and not args.command:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -430,6 +430,20 @@ class TpuConfigTester(unittest.TestCase):
             in output
         )
 
+    def test_accelerate_install_invalid_version(self):
+        args = self.parser.parse_args(
+            [
+                "--config_file",
+                "tests/test_configs/latest.yaml",
+                "--install_accelerate",
+                "--accelerate_version",
+                "not-a-version",
+                "--debug",
+            ]
+        )
+
+        with self.assertRaisesRegex(ValueError, "--accelerate_version must be"):
+            tpu_command_launcher(args)
 
 class ModelEstimatorTester(unittest.TestCase):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -444,6 +444,7 @@ class TpuConfigTester(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "--accelerate_version must be"):
             tpu_command_launcher(args)
+            
 
 class ModelEstimatorTester(unittest.TestCase):
     """


### PR DESCRIPTION
## What

Validate `--accelerate_version` with `packaging.version.Version` and convert invalid input into a clear, stable `ValueError`.

## Why

Accelerate supports `packaging>=20.0`, but `packaging.version.parse()` handles invalid versions differently across supported releases:

- Packaging 21.3 returns a legacy version object.
- Packaging 22.0 and later raise `InvalidVersion`.

As a result, `accelerate tpu-config` currently accepts or rejects the same invalid value depending on the installed Packaging version.

## Validation

- Existing `latest`, `dev`, and explicit-version behavior remains unchanged.
- Added a focused regression test for invalid versions.
- Verified the proposed behavior under Packaging 21.3 and 22.0.
- Breakcheck exercised 18/18 Packaging call sites with agent-authored fixtures, identified this changed call site, and verified that the repaired call behaves identically across both versions.

Discovered and reproduced with [Breakcheck](https://github.com/lovettsendit/breakcheck).
