### PR TITLE
Avoid double-counting CPU RAM for integrated CUDA

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -762,6 +762,7 @@ def get_max_memory(max_memory: Optional[dict[Union[int, str], Union[int, str]]] 
 
     if max_memory is None:
         max_memory = {}
+        shared_ram_cuda = False
         # Make sure device is initialized on each device to have the right memory info.
         if is_npu_available():
             for i in range(torch.npu.device_count()):
@@ -816,13 +817,16 @@ def get_max_memory(max_memory: Optional[dict[Union[int, str], Union[int, str]]] 
                 try:
                     _ = torch.tensor([0], device=i)
                     max_memory[i] = torch.cuda.mem_get_info(i)[0]
+                    shared_ram_cuda = shared_ram_cuda or getattr(
+                        torch.cuda.get_device_properties(i), "is_integrated", False
+                    )
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
-        # allocate everything in the mps device as the RAM is shared
+        # allocate everything in the mps device as the RAM is shared; integrated CUDA devices do the same
         if is_mps_available():
             max_memory["mps"] = psutil.virtual_memory().available
-        else:
+        elif not shared_ram_cuda:
             max_memory["cpu"] = psutil.virtual_memory().available
         return max_memory
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -18,7 +18,9 @@ import tempfile
 import unittest
 import warnings
 from collections import OrderedDict
+from types import SimpleNamespace
 from typing import Optional
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -34,6 +36,7 @@ from accelerate.test_utils import (
     require_non_hpu,
     torch_device,
 )
+from accelerate.utils import modeling
 from accelerate.utils.modeling import (
     align_module_device,
     check_device_map,
@@ -44,6 +47,7 @@ from accelerate.utils.modeling import (
     dtype_byte_size,
     find_tied_parameters,
     get_balanced_memory,
+    get_max_memory,
     get_module_size_with_ties,
     get_non_persistent_buffers,
     get_state_dict_offloaded_model,
@@ -1092,6 +1096,24 @@ class ModelingUtilsTester(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             convert_file_size_to_int("-1GB")
+
+    def test_get_max_memory_integrated_cuda_does_not_add_cpu(self):
+        with (
+            patch.object(modeling, "is_npu_available", return_value=False),
+            patch.object(modeling, "is_mlu_available", return_value=False),
+            patch.object(modeling, "is_sdaa_available", return_value=False),
+            patch.object(modeling, "is_musa_available", return_value=False),
+            patch.object(modeling, "is_xpu_available", return_value=False),
+            patch.object(modeling, "is_hpu_available", return_value=False),
+            patch.object(modeling, "is_mps_available", return_value=False),
+            patch.object(torch.cuda, "device_count", return_value=1),
+            patch.object(torch.cuda, "mem_get_info", return_value=(1234, 5678)),
+            patch.object(torch.cuda, "get_device_properties", return_value=SimpleNamespace(is_integrated=True)),
+            patch.object(torch, "tensor"),
+        ):
+            max_memory = get_max_memory()
+
+        assert max_memory == {0: 1234}
 
     def test_get_state_dict_offloaded_model(self):
         for model_cls in (ModelForTest, NestedModelForTest):


### PR DESCRIPTION
﻿### Problem
`get_max_memory()` adds a separate `"cpu"` memory entry even when CUDA reports an integrated GPU. Integrated CUDA devices share host RAM, so downstream device-map planning can treat one physical memory pool as independent CUDA and CPU capacities. Closes #4183.

### Reproducer
```python
from types import SimpleNamespace
from unittest.mock import patch
import torch
from accelerate.utils import modeling
from accelerate.utils.modeling import get_max_memory

with patch.object(modeling, "is_mps_available", return_value=False), \
     patch.object(torch.cuda, "device_count", return_value=1), \
     patch.object(torch.cuda, "mem_get_info", return_value=(1234, 5678)), \
     patch.object(torch.cuda, "get_device_properties", return_value=SimpleNamespace(is_integrated=True)), \
     patch.object(torch, "tensor"):
    print(get_max_memory())
# before: {0: 1234, "cpu": ...}
# after:  {0: 1234}
```

### Fix
Track whether any available CUDA device reports `is_integrated` and skip adding a separate CPU memory budget in that case. The attribute is read with `getattr(..., False)` so older PyTorch/device properties keep the existing behavior.

### Testing
Added `tests/test_modeling_utils.py::ModelingUtilsTester::test_get_max_memory_integrated_cuda_does_not_add_cpu`.

Before the fix:
```text
FAILED tests/test_modeling_utils.py::ModelingUtilsTester::test_get_max_memory_integrated_cuda_does_not_add_cpu
1 failed in 7.37s
```

After the fix:
```text
2 passed, 1 skipped in 6.56s
7 passed, 6 skipped in 69.63s (0:01:09)
```

Quality:
```text
ruff check ... --fix: All checks passed!
ruff format ...: 2 files left unchanged
ruff check ...: All checks passed!
ruff format --check ...: 2 files already formatted
```
