### PR TITLE
Fix memory accounting for integrated CUDA devices

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -762,6 +762,7 @@ def get_max_memory(max_memory: Optional[dict[Union[int, str], Union[int, str]]] 
 
     if max_memory is None:
         max_memory = {}
+        is_integrated_cuda = False
         # Make sure device is initialized on each device to have the right memory info.
         if is_npu_available():
             for i in range(torch.npu.device_count()):
@@ -816,13 +817,15 @@ def get_max_memory(max_memory: Optional[dict[Union[int, str], Union[int, str]]] 
                 try:
                     _ = torch.tensor([0], device=i)
                     max_memory[i] = torch.cuda.mem_get_info(i)[0]
+                    device_properties = torch.cuda.get_device_properties(i)
+                    is_integrated_cuda = is_integrated_cuda or getattr(device_properties, "is_integrated", False)
                 except Exception:
                     logger.info(f"Device {i} seems unavailable, Proceeding to check subsequent devices.")
                     continue
-        # allocate everything in the mps device as the RAM is shared
+        # MPS and integrated CUDA devices share host RAM, so exposing a separate CPU budget would double-count it.
         if is_mps_available():
             max_memory["mps"] = psutil.virtual_memory().available
-        else:
+        elif not is_integrated_cuda:
             max_memory["cpu"] = psutil.virtual_memory().available
         return max_memory
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -18,7 +18,9 @@ import tempfile
 import unittest
 import warnings
 from collections import OrderedDict
+from types import SimpleNamespace
 from typing import Optional
+from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -34,6 +36,7 @@ from accelerate.test_utils import (
     require_non_hpu,
     torch_device,
 )
+from accelerate.utils import modeling
 from accelerate.utils.modeling import (
     align_module_device,
     check_device_map,
@@ -44,6 +47,7 @@ from accelerate.utils.modeling import (
     dtype_byte_size,
     find_tied_parameters,
     get_balanced_memory,
+    get_max_memory,
     get_module_size_with_ties,
     get_non_persistent_buffers,
     get_state_dict_offloaded_model,
@@ -135,6 +139,34 @@ def sequential_model(num_layers):
 
 
 class ModelingUtilsTester(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (True, {0: 1234}),
+            (False, {0: 1234, "cpu": 4321}),
+            (None, {0: 1234, "cpu": 4321}),
+        ]
+    )
+    def test_get_max_memory_integrated_cuda(self, is_integrated, expected):
+        properties = SimpleNamespace()
+        if is_integrated is not None:
+            properties.is_integrated = is_integrated
+
+        with (
+            patch.object(modeling, "is_npu_available", return_value=False),
+            patch.object(modeling, "is_mlu_available", return_value=False),
+            patch.object(modeling, "is_sdaa_available", return_value=False),
+            patch.object(modeling, "is_musa_available", return_value=False),
+            patch.object(modeling, "is_xpu_available", return_value=False),
+            patch.object(modeling, "is_hpu_available", return_value=False),
+            patch.object(modeling, "is_mps_available", return_value=False),
+            patch.object(torch.cuda, "device_count", return_value=1),
+            patch.object(torch.cuda, "mem_get_info", return_value=(1234, 5678)),
+            patch.object(torch.cuda, "get_device_properties", return_value=properties),
+            patch.object(torch, "tensor"),
+            patch("psutil.virtual_memory", return_value=SimpleNamespace(available=4321)),
+        ):
+            self.assertEqual(get_max_memory(), expected)
+
     def test_dtype_byte_size(self):
         self.assertEqual(dtype_byte_size(torch.bool), 1 / 8)
         self.assertEqual(dtype_byte_size(torch.float16), 2)

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -18,9 +18,7 @@ import tempfile
 import unittest
 import warnings
 from collections import OrderedDict
-from types import SimpleNamespace
 from typing import Optional
-from unittest.mock import patch
 
 import torch
 import torch.nn as nn
@@ -36,7 +34,6 @@ from accelerate.test_utils import (
     require_non_hpu,
     torch_device,
 )
-from accelerate.utils import modeling
 from accelerate.utils.modeling import (
     align_module_device,
     check_device_map,
@@ -47,7 +44,6 @@ from accelerate.utils.modeling import (
     dtype_byte_size,
     find_tied_parameters,
     get_balanced_memory,
-    get_max_memory,
     get_module_size_with_ties,
     get_non_persistent_buffers,
     get_state_dict_offloaded_model,

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -139,34 +139,6 @@ def sequential_model(num_layers):
 
 
 class ModelingUtilsTester(unittest.TestCase):
-    @parameterized.expand(
-        [
-            (True, {0: 1234}),
-            (False, {0: 1234, "cpu": 4321}),
-            (None, {0: 1234, "cpu": 4321}),
-        ]
-    )
-    def test_get_max_memory_integrated_cuda(self, is_integrated, expected):
-        properties = SimpleNamespace()
-        if is_integrated is not None:
-            properties.is_integrated = is_integrated
-
-        with (
-            patch.object(modeling, "is_npu_available", return_value=False),
-            patch.object(modeling, "is_mlu_available", return_value=False),
-            patch.object(modeling, "is_sdaa_available", return_value=False),
-            patch.object(modeling, "is_musa_available", return_value=False),
-            patch.object(modeling, "is_xpu_available", return_value=False),
-            patch.object(modeling, "is_hpu_available", return_value=False),
-            patch.object(modeling, "is_mps_available", return_value=False),
-            patch.object(torch.cuda, "device_count", return_value=1),
-            patch.object(torch.cuda, "mem_get_info", return_value=(1234, 5678)),
-            patch.object(torch.cuda, "get_device_properties", return_value=properties),
-            patch.object(torch, "tensor"),
-            patch("psutil.virtual_memory", return_value=SimpleNamespace(available=4321)),
-        ):
-            self.assertEqual(get_max_memory(), expected)
-
     def test_dtype_byte_size(self):
         self.assertEqual(dtype_byte_size(torch.bool), 1 / 8)
         self.assertEqual(dtype_byte_size(torch.float16), 2)


### PR DESCRIPTION
# What does this PR do?

`get_max_memory()` currently reports CUDA memory and available CPU RAM as separate memory budgets. This is incorrect for integrated CUDA devices because both values refer to the same shared physical memory.

As a result, downstream code such as `infer_auto_device_map()` can treat the two values as independent capacities and plan a model placement that exceeds the machine's actual available memory.

This PR:

- Checks `torch.cuda.get_device_properties(i).is_integrated` while discovering CUDA devices.
- Omits the separate `"cpu"` memory budget when an integrated CUDA device is detected.
- Uses `getattr(..., False)` so devices and older PyTorch versions without the `is_integrated` attribute retain the existing behavior.
- Preserves the existing behavior for discrete CUDA devices.
- Adds tests covering integrated devices, discrete devices, and device properties without the `is_integrated` attribute.

This follows the existing MPS behavior, where shared host and accelerator memory is exposed as a single allocation pool.

Fixes #4183

## Testing

Added a parameterized unit test for `get_max_memory()` that runs without requiring CUDA hardware.

The test mocks CUDA device discovery, available device memory, device properties, CPU memory, and CUDA initialization. It covers:

- An integrated CUDA device (`is_integrated=True`), verifying that no separate `"cpu"` memory budget is returned.
- A discrete CUDA device (`is_integrated=False`), verifying that the existing CUDA and CPU budgets are preserved.
- A device-properties object without `is_integrated`, verifying compatibility with older PyTorch versions through the `getattr(..., False)` fallback.

Results:

```text
pytest tests/test_modeling_utils.py -k get_max_memory_integrated_cuda -q
3 passed, 44 deselected

pytest tests/test_modeling_utils.py -q
38 passed, 9 skipped, 4 subtests passed

The issue reproducer now returns:
{0: 1234}
instead of returning an additional independent "cpu" entry.
The reporter has also offered to validate the change on GB10/DGX Spark hardware, including the downstream device_map="auto" path.
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.

- Big modeling: @SunMarc
- Fully-Sharded Data Parallism: @SunMarc
- DeepSpeed: @SunMarc
- Command Line Interface: @SunMarc
- Documentation: @SunMarc
- Core parts of the library: @BenjaminBossan @SunMarc
- Maintained examples: @SunMarc

 -->