### PR TITLE
Address non-persistent buffers by fully-qualified name when recursing

### DIFF
--- a/src/accelerate/hooks.py
+++ b/src/accelerate/hooks.py
@@ -335,7 +335,7 @@ class AlignDevicesHook(ModelHook):
                         module, name, self.execution_device, tied_params_map=self.tied_params_map
                     )
             elif self.offload_buffers and self.execution_device is not None:
-                for name in get_non_persistent_buffers(module, recurse=self.place_submodules):
+                for name in get_non_persistent_buffers(module, recurse=self.place_submodules, fqns=True):
                     set_module_tensor_to_device(
                         module, name, self.execution_device, tied_params_map=self.tied_params_map
                     )

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -460,7 +460,7 @@ def named_module_tensors(
     if include_buffers:
         non_persistent_buffers = set()
         if remove_non_persistent:
-            non_persistent_buffers = get_non_persistent_buffers(module, recurse=recurse)
+            non_persistent_buffers = get_non_persistent_buffers(module, recurse=recurse, fqns=True)
         for named_buffer in module.named_buffers(recurse=recurse):
             name, _ = named_buffer
             if name not in non_persistent_buffers:
@@ -484,7 +484,9 @@ def get_non_persistent_buffers(module: nn.Module, recurse: bool = False, fqns: b
     if recurse:
         for n, m in module.named_modules():
             if fqns:
-                non_persistent_buffers_set |= {n + "." + b for b in m._non_persistent_buffers_set}
+                # `named_modules` yields the root as "", which must not become a leading dot.
+                prefix = f"{n}." if n else ""
+                non_persistent_buffers_set |= {prefix + b for b in m._non_persistent_buffers_set}
             else:
                 non_persistent_buffers_set |= m._non_persistent_buffers_set
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -52,6 +52,34 @@ class ModelForTest(nn.Module):
         return self.linear2(self.batchnorm(self.linear1(x)))
 
 
+class SubWithNonPersistentBuffer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(3, 4)
+        self.register_buffer("np_buf", torch.rand(4), persistent=False)
+
+    def forward(self, x):
+        return self.linear(x) + self.np_buf
+
+
+class PreloadedBlock(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.sub = SubWithNonPersistentBuffer()
+
+    def forward(self, x):
+        return self.sub(x)
+
+
+class ModelWithNonPersistentBufferInSubmodule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block = PreloadedBlock()
+
+    def forward(self, x):
+        return self.block(x)
+
+
 class PreForwardHook(ModelHook):
     def pre_forward(self, module, *args, **kwargs):
         return (args[0] + 1,) + args[1:], kwargs
@@ -330,6 +358,27 @@ class HooksModelTester(unittest.TestCase):
         assert model.linear1.weight.device == torch.device("cpu")
         assert model.batchnorm.weight.device == torch.device("cpu")
         assert model.linear2.weight.device == torch.device("cpu")
+
+    def test_attach_align_device_hook_offload_buffers_with_preloaded_submodules(self):
+        # `preload_module_classes` is the only path that combines offload with place_submodules,
+        # so the non-persistent buffers of submodules must be addressed by fully-qualified name.
+        model = ModelWithNonPersistentBufferInSubmodule()
+
+        attach_align_device_hook(
+            model,
+            execution_device=torch_device,
+            offload=True,
+            offload_buffers=True,
+            preload_module_classes=["PreloadedBlock"],
+        )
+
+        # Non-persistent buffers are not offloaded, so they stay on the execution device.
+        assert model.block.sub.np_buf.device == torch.device(torch_device)
+
+        output = model(torch.randn(2, 3))
+        assert output.device == torch.device(torch_device)
+
+        remove_hook_from_submodules(model)
 
     def test_attach_align_device_hook_as_cpu_offload_with_weight_map(self):
         model = ModelForTest()

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -109,6 +109,13 @@ class RootWithNonPersistentSubmodule(nn.Module):
         self.sub = SubmoduleWithNonPersistentBuffer()
 
 
+class RootAndSubWithNonPersistentBuffers(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.register_buffer("root_np_buf", torch.rand(4), persistent=False)
+        self.sub = SubmoduleWithNonPersistentBuffer()
+
+
 class RootWithCollidingBufferName(nn.Module):
     def __init__(self):
         super().__init__()
@@ -309,6 +316,19 @@ class ModelingUtilsTester(unittest.TestCase):
         assert result is not model.sub._non_persistent_buffers_set
         assert model._non_persistent_buffers_set == set()
         assert model.sub._non_persistent_buffers_set == {"np_buf"}
+
+    def test_get_non_persistent_buffers_fqns_are_fully_qualified(self):
+        model = RootAndSubWithNonPersistentBuffers()
+
+        # Every name must be usable against `named_buffers()`, so the root's own buffer
+        # keeps its bare name rather than picking up the empty root prefix.
+        assert get_non_persistent_buffers(model, recurse=True, fqns=True) == {"root_np_buf", "sub.np_buf"}
+
+    def test_named_module_tensors_removes_non_persistent_buffers_when_recursing(self):
+        model = RootAndSubWithNonPersistentBuffers()
+
+        names = [name for name, _ in named_module_tensors(model, recurse=True, remove_non_persistent=True)]
+        assert names == []
 
     def test_named_module_tensors_does_not_corrupt_state_dict(self):
         model = RootWithCollidingBufferName()


### PR DESCRIPTION
# What does this PR do?

`get_non_persistent_buffers` gained an `fqns` argument and `fsdp_utils.py` uses it, but the two older recursive call sites still compare **bare** buffer names against **fully-qualified** ones. Three related defects fall out of that, all fixed here (per the guidance to fix one small issue everywhere rather than in separate PRs).

**1. `remove_non_persistent` is a no-op under recursion.** `named_module_tensors` filters `module.named_buffers(recurse=True)` — whose names are fully qualified — against a set of bare names, so every non-persistent buffer living in a submodule survives the filter:

```python
names = [n for n, _ in named_module_tensors(model, recurse=True, remove_non_persistent=True)]
# ['sub.np_buf']  -- expected []
```

**2. `AlignDevicesHook.init_hook` raises.** It passes those same bare names to `set_module_tensor_to_device`, which resolves names relative to the module. `offload` together with `place_submodules` is reachable from `attach_align_device_hook`, which sets `place_submodules=full_offload` while passing `offload=offload` — so a model offloaded with `offload_buffers=True` and a `preload_module_classes` entry whose submodule holds a non-persistent buffer fails outright:

```
ValueError: PreloadedBlock(
  (sub): SubWithNonPersistentBuffer(...)
) does not have a parameter or a buffer named np_buf.
```

**3. Root buffers were qualified to a leading dot.** Passing `fqns=True` at those sites surfaced this: `named_modules()` yields the root as `""`, so `n + "." + b` produced `".buf"` — not a name any lookup accepts. Now prefixed only when the module name is non-empty.

Existing tests miss all three because `ModelForTest` and `LinearWithNonPersistentBuffers` have no non-persistent buffer below the root, and the one `remove_non_persistent=True` assertion runs without `recurse=True`, where a bare name and an FQN happen to coincide.

Fixes # (no issue filed; found while reading the recent `get_non_persistent_buffers` fix in #4116)

## Tests

Three tests added, each failing before the change and passing after:

- `tests/test_modeling_utils.py::test_get_non_persistent_buffers_fqns_are_fully_qualified` — before: `{'root_np_buf', '.root_np_buf', 'sub.np_buf'}`
- `tests/test_modeling_utils.py::test_named_module_tensors_removes_non_persistent_buffers_when_recursing` — before: `['sub.np_buf']`
- `tests/test_hooks.py::test_attach_align_device_hook_offload_buffers_with_preloaded_submodules` — before: the `ValueError` above

Run locally on CPU (torch 2.10, Python 3.12):

```
pytest tests/test_modeling_utils.py tests/test_hooks.py   ->  56 passed, 6 skipped
pytest tests/test_offload.py                              ->   4 passed
ruff check / ruff format --check (0.13.1, as pinned in setup.py)  ->  clean
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc @muellerzr
