### PR TITLE
feat(utils): support arbitrary object gathering on XLA devices (#2858)

### DIFF
--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -364,8 +364,6 @@ class DistributedOperationException(Exception):
     tensors.
     """
 
-    pass
-
 
 def verify_operation(function):
     """
@@ -502,6 +500,40 @@ def _gpu_gather_object(object: Any):
     return [x for y in output_objects for x in y]
 
 
+def _xla_gather_object(object: Any):
+    """Gather picklable objects from all XLA devices using padded byte tensors.
+
+    XLA does not provide ``all_gather_object``. Serializing to bytes first lets us
+    use the regular tensor collective while keeping the gathered tensor shape
+    identical on every rank.
+    """
+    state = PartialState()
+    serialized = pickle.dumps(object)
+    payload = torch.frombuffer(serialized, dtype=torch.uint8).clone().to(state.device)
+    payload_size = torch.tensor([payload.numel()], dtype=torch.int64, device=state.device)
+
+    sizes = xm.all_gather(payload_size, dim=0)
+    sizes = sizes.reshape(-1).cpu().tolist()
+    max_size = max(sizes, default=0)
+
+    padded_payload = torch.zeros(max_size, dtype=torch.uint8, device=state.device)
+    if payload.numel() > 0:
+        padded_payload[: payload.numel()] = payload
+    gathered = xm.all_gather(padded_payload, dim=0)
+    gathered = (
+        gathered.reshape(state.num_processes, max_size) if max_size else gathered.reshape(state.num_processes, 0)
+    )
+
+    result = []
+    for rank, size in enumerate(sizes):
+        value = pickle.loads(gathered[rank, :size].cpu().numpy().tobytes())
+        if isinstance(value, list):
+            result.extend(value)
+        else:
+            result.append(value)
+    return result
+
+
 def gather_object(object: Any):
     """
     Recursively gather object in a nested list/tuple/dictionary of objects from all devices.
@@ -514,7 +546,7 @@ def gather_object(object: Any):
         The same data structure as `object` with all the objects sent to every device.
     """
     if PartialState().distributed_type == DistributedType.XLA:
-        raise NotImplementedError("gather objects in TPU is not supported")
+        return _xla_gather_object(object)
     elif PartialState().distributed_type in TORCH_DISTRIBUTED_OPERATION_TYPES:
         if PartialState().device.type == "neuron":
             return _neuron_gather_object(object)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -1,0 +1,71 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pickle
+
+import pytest
+import torch
+
+from accelerate.utils import operations
+from accelerate.utils.dataclasses import DistributedType
+
+
+class _VirtualXlaCollective:
+    def __init__(self, values):
+        self.values = values
+        self.sizes = [len(pickle.dumps(value)) for value in values]
+        self.max_size = max(self.sizes, default=0)
+
+    def all_gather(self, tensor, dim=0):
+        if tensor.numel() == 1:
+            return torch.tensor(self.sizes, dtype=tensor.dtype, device=tensor.device)
+
+        padded = []
+        for value, size in zip(self.values, self.sizes):
+            payload = torch.frombuffer(pickle.dumps(value), dtype=torch.uint8).clone()
+            padded.append(torch.nn.functional.pad(payload, (0, self.max_size - size)))
+        return torch.cat(padded).to(tensor.device)
+
+
+class _VirtualXlaState:
+    distributed_type = DistributedType.XLA
+    device = torch.device("cpu")
+    num_processes = 3
+
+
+@pytest.mark.parametrize(
+    "values, expected",
+    [
+        ([[], ["rank-1", "extra"], []], ["rank-1", "extra"]),
+        (
+            [
+                {"rank": 0, "metadata": {"tokens": [1, 2]}},
+                None,
+                {"rank": 2, "metadata": {"text": "a much longer string"}},
+            ],
+            [
+                {"rank": 0, "metadata": {"tokens": [1, 2]}},
+                None,
+                {"rank": 2, "metadata": {"text": "a much longer string"}},
+            ],
+        ),
+        (["short", "a much longer string", ""], ["short", "a much longer string", ""]),
+    ],
+)
+def test_xla_gather_object_preserves_rank_order(monkeypatch, values, expected):
+    collective = _VirtualXlaCollective(values)
+    monkeypatch.setattr(operations, "PartialState", lambda: _VirtualXlaState)
+    monkeypatch.setattr(operations, "xm", collective, raising=False)
+
+    assert operations.gather_object(values[0]) == expected


### PR DESCRIPTION
Fixes #2858\n\nAdds XLA-compatible arbitrary Python object gathering by serializing payloads to uint8 tensors, exchanging lengths, gathering padded payloads, and restoring objects in rank order. Includes CPU-only virtual collective regression tests for empty lists, nested dictionaries, None values, and variable-length strings.