### PR TITLE
Fix mixed precision argument typo in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -52,7 +52,7 @@ To run it in each of these various modes, use the following commands:
     python ./nlp_example.py  # from a server with a GPU
     ```
 - with fp16 (mixed-precision)
-    * from any server by passing `mixed_precison=fp16` to the `Accelerator`.
+    * from any server by passing `mixed_precision=fp16` to the `Accelerator`.
         ```bash
         python ./nlp_example.py --mixed_precision fp16
         ```
@@ -150,13 +150,13 @@ To run it in each of these various modes, use the following commands:
     python ./cv_example.py  # from a server with a GPU
     ```
 - with fp16 (mixed-precision)
-    * from any server by passing `mixed_precison=fp16` to the `Accelerator`.
+    * from any server by passing `mixed_precision=fp16` to the `Accelerator`.
         ```bash
-        python ./cv_example.py --data_dir path_to_data --mixed_precison fp16
+        python ./cv_example.py --data_dir path_to_data --mixed_precision fp16
         ```
     * from any server with Accelerate launcher
         ```bash
-        accelerate launch --mixed_precison fp16 ./cv_example.py --data_dir path_to_data
+        accelerate launch --mixed_precision fp16 ./cv_example.py --data_dir path_to_data
 - multi CPUs (requires Open MPI, Intel MPI, or MVAPICH)
     * With Accelerate config and launcher, run the following from node 0:
         ```bash


### PR DESCRIPTION
# What does this PR do?

Fixes `mixed_precison` typos in `examples/README.md`.

The CV examples currently use `--mixed_precison`, while the actual argument is `--mixed_precision`, causing the documented commands to fail when copied directly.

This also updates the surrounding text to use the correct `mixed_precision` spelling.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.