### PR TITLE
Fix split batch sampler lengths

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -158,7 +158,7 @@ If the description is too long to fit in one line (more than 119 characters in t
 before writing the description after the argument.
 
 Finally, to maintain uniformity if any *one* description is too long to fit on one line, the 
-rest of the parameters should follow suit and have an indention before their description.
+rest of the parameters should follow suit and have an indentation before their description.
 
 Here's an example showcasing everything so far:
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -169,8 +169,17 @@ class BatchSamplerShard(BatchSampler):
 
     def __len__(self):
         if self.split_batches:
-            # Split batches does not change the length of the batch sampler
-            return len(self.batch_sampler)
+            length = len(self.batch_sampler)
+            if self.even_batches or self.drop_last:
+                return length
+            sampler = getattr(self.batch_sampler, "sampler", None)
+            if sampler is None or self.batch_size is None:
+                return length
+            remainder = len(sampler) % self.batch_size
+            if remainder == 0:
+                return length
+            batch_length = self.batch_size // self.num_processes
+            return length - 1 + (remainder > batch_length * self.process_index)
         if len(self.batch_sampler) % self.num_processes == 0:
             # If the length is a round multiple of the number of processes, it's easy.
             return len(self.batch_sampler) // self.num_processes

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -97,6 +97,15 @@ class SimpleBatchSampler(BatchSampler):
 
 
 class DataLoaderTester(AccelerateTestCase):
+    def test_split_batches_length_tracks_partial_batch(self):
+        batch_sampler = BatchSampler(range(3), batch_size=2, drop_last=False)
+        shards = [
+            BatchSamplerShard(batch_sampler, 2, i, split_batches=True, even_batches=False)
+            for i in range(2)
+        ]
+        assert [len(shard) for shard in shards] == [2, 1]
+        assert [len(list(shard)) for shard in shards] == [2, 1]
+
     def check_batch_sampler_shards(self, batch_sampler, expected, split_batches=False, even_batches=True):
         batch_sampler_shards = [
             BatchSamplerShard(batch_sampler, 2, i, split_batches=split_batches, even_batches=even_batches)


### PR DESCRIPTION
Match BatchSamplerShard.__len__ with the batches yielded to each process when split_batches is enabled without even_batches.

Test: python3 -m py_compile src/accelerate/data_loader.py tests/test_data_loader.py

AI assistance was used.