### PR TITLE
Apply the bit-vs-byte suffix rule to the binary size units

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -128,11 +128,14 @@ def convert_file_size_to_int(size: Union[int, str]):
         if isinstance(size, int):
             mem_size = size
         elif size.upper().endswith("GIB"):
-            mem_size = int(float(size[:-3]) * (2**30))
+            int_size = int(float(size[:-3]) * (2**30))
+            mem_size = int_size // 8 if size.endswith("b") else int_size
         elif size.upper().endswith("MIB"):
-            mem_size = int(float(size[:-3]) * (2**20))
+            int_size = int(float(size[:-3]) * (2**20))
+            mem_size = int_size // 8 if size.endswith("b") else int_size
         elif size.upper().endswith("KIB"):
-            mem_size = int(float(size[:-3]) * (2**10))
+            int_size = int(float(size[:-3]) * (2**10))
+            mem_size = int_size // 8 if size.endswith("b") else int_size
         elif size.upper().endswith("GB"):
             int_size = int(float(size[:-2]) * (10**9))
             mem_size = int_size // 8 if size.endswith("b") else int_size

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -1084,6 +1084,19 @@ class ModelingUtilsTester(unittest.TestCase):
         result = convert_file_size_to_int(500)
         assert result == 500
 
+        # A lowercase trailing "b" is bits, so the byte count is an eighth of the same unit
+        # spelled with an uppercase "B". That holds for the binary units as well as the decimal
+        # ones: "1Gib" is a gibibit, "1GiB" a gibibyte.
+        for spelling, expected in [
+            ("100Kb", (100 * (10**3)) // 8),
+            ("100Mb", (100 * (10**6)) // 8),
+            ("2Gb", (2 * (10**9)) // 8),
+            ("512Kib", (512 * (2**10)) // 8),
+            ("100Mib", (100 * (2**20)) // 8),
+            ("2Gib", (2 * (2**30)) // 8),
+        ]:
+            assert convert_file_size_to_int(spelling) == expected, spelling
+
         with self.assertRaises(ValueError):
             convert_file_size_to_int("5MBB")
 


### PR DESCRIPTION
### Symptom

`convert_file_size_to_int()` treats a lowercase trailing `b` as bits and divides by 8, but only for the decimal units. The binary units ignore the suffix:

```python
>>> from accelerate.utils import convert_file_size_to_int
>>> convert_file_size_to_int("1Gb")    # gigabit, correct
125000000
>>> convert_file_size_to_int("1Gib")   # gibibit, should be 2**30 // 8
1073741824
>>> convert_file_size_to_int("1GiB")   # gibibyte
1073741824
```

`"1Gib"` and `"1GiB"` return the same number, so a size given in gibibits is read as gibibytes and comes out 8x too large. The same holds for `Kib` and `Mib`.

### Root cause

Six sibling branches in the same function, and only three of them apply the rule:

```python
elif size.upper().endswith("GIB"):
    mem_size = int(float(size[:-3]) * (2**30))     # no bit handling
...
elif size.upper().endswith("GB"):
    int_size = int(float(size[:-2]) * (10**9))
    mem_size = int_size // 8 if size.endswith("b") else int_size
```

This is not a question of whether bit units should be supported: the decimal branches already say they are, and give the exact two-line form. The `*iB` branches sit above them and were never updated.

### Fix

Apply the same two lines to the three binary branches so all six units agree on what a trailing `b` means. An uppercase `B` takes the identical path it took before, and the `float` parsing added in #1799 plus the `mem_size < 0` guard from #2507 are untouched.

### Why it matters

This is what `max_memory` entries are parsed with, in `get_max_memory`, `get_balanced_memory`, `infer_auto_device_map` and `load_checkpoint_in_model`. An 8x overshoot there is silent: it plans a device map against memory that is not there, rather than raising.

### Test

Extended the existing `ModelingUtilsTester::test_convert_file_size` with the six lowercase-`b` spellings:

```
# this branch
$ pytest tests/test_modeling_utils.py -k test_convert_file_size -q
1 passed, 43 deselected

# against main
$ pytest tests/test_modeling_utils.py -k test_convert_file_size -q
1 failed, 43 deselected
E   AssertionError: 512Kib
E   assert 524288 == 65536
E    +  where 524288 = convert_file_size_to_int('512Kib')
```

The three decimal cases in that loop (`100Kb`, `100Mb`, `2Gb`) pass on both sides, so they are controls rather than tests of the new code.

`ruff check` reports the same 41 findings on these two files before and after the change (my ruff is newer than the pinned one), and `ruff format --check` is clean. Three `test_infer_auto_device_map_*_buffer*` tests fail when the whole file is run, both with and without this change, and pass in isolation either way, so they are unrelated ordering flakes.
