### PR TITLE
Skip automatic DataLoader sharding when the loader is already rank-sharded

### DIFF
--- a/docs/source/concept_guides/internal_mechanism.md
+++ b/docs/source/concept_guides/internal_mechanism.md
@@ -35,6 +35,13 @@ because PyTorch does not let the user change the `batch_sampler` of a dataloader
 library handles the sharding of your data between processes by changing that `batch_sampler` to yield every other
 `num_processes` batches (if enabled).
 
+If you already shard the dataloader yourself (for example with a rank-aware `DistributedSampler`, a pre-sliced
+iterable, or `datasets.IterableDataset.shard()`), set `already_sharded=True` on [`~utils.DataLoaderConfiguration`].
+Accelerate then keeps your sharding and still wraps the loader in [`~data_loader.DataLoaderShard`] for device
+placement, `set_epoch`, and state tracking. It does not apply `BatchSamplerShard`, `IterableDatasetShard`, or a second
+Hugging Face `shard()`. This is incompatible with `dispatch_batches` and `split_batches`. `even_batches` does not apply
+in this mode; each process must iterate the same number of steps.
+
 The [`~data_loader.DataLoaderShard`] subclasses `DataLoader` to add the following functionality:
 
 - it synchronizes the appropriate random number generator of all processes at each new iteration, to ensure any

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1355,8 +1355,12 @@ class Accelerator:
                     if isinstance(dl, DataLoaderDispatcher):
                         iterable_dl_seen = True
                         continue
-                    dl_even_batches_values.append((dl_idx, dl.batch_sampler.even_batches))
-                    dl.batch_sampler.even_batches = even_batches
+                    batch_sampler = getattr(dl, "batch_sampler", None)
+                    if not hasattr(batch_sampler, "even_batches"):
+                        # Already-sharded (or otherwise unwrapped) samplers have no padding to toggle.
+                        continue
+                    dl_even_batches_values.append((dl_idx, batch_sampler.even_batches))
+                    batch_sampler.even_batches = even_batches
 
                 if iterable_dl_seen:
                     warnings.warn(

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -718,6 +718,10 @@ class Accelerator:
         return False
 
     @property
+    def already_sharded(self):
+        return getattr(self.dataloader_config, "already_sharded", False)
+
+    @property
     def project_dir(self):
         return self.project_configuration.project_dir
 
@@ -2728,6 +2732,7 @@ class Accelerator:
             non_blocking=self.non_blocking,
             use_stateful_dataloader=self.use_stateful_dataloader,
             torch_device_mesh=device_mesh,
+            already_sharded=self.already_sharded,
         )
         self._dataloaders.append(prepared_data_loader)
         return prepared_data_loader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -552,6 +552,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         use_stateful_dataloader=False,
         _drop_last: bool = False,
         _non_blocking: bool = False,
+        _total_num_processes: int = 1,
         torch_device_mesh=None,
         iteration=0,
         **kwargs,
@@ -564,6 +565,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.gradient_state = GradientState()
         self._drop_last = _drop_last
         self._non_blocking = _non_blocking
+        self._total_num_processes = _total_num_processes
         self.iteration = iteration
 
     def adjust_state_dict_for_prefetch(self):
@@ -641,11 +643,12 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
     @property
     def total_batch_size(self):
         batch_sampler = self.sampler if isinstance(self.sampler, BatchSampler) else self.batch_sampler
-        return (
-            batch_sampler.batch_size
-            if getattr(batch_sampler, "split_batches", False)
-            else (batch_sampler.batch_size * getattr(batch_sampler, "num_processes", 1))
-        )
+        if getattr(batch_sampler, "split_batches", False):
+            return batch_sampler.batch_size
+        # A `BatchSamplerShard` carries `num_processes`; an already-sharded dataloader keeps the user's
+        # batch sampler, so fall back to the process count captured at prepare time.
+        num_processes = getattr(batch_sampler, "num_processes", None) or getattr(self, "_total_num_processes", 1)
+        return batch_sampler.batch_size * num_processes
 
     @property
     def total_dataset_length(self):
@@ -1029,6 +1032,7 @@ def prepare_data_loader(
     non_blocking: bool = False,
     use_stateful_dataloader: bool = False,
     torch_device_mesh=None,
+    already_sharded: bool = False,
 ) -> DataLoader:
     """
     Wraps a PyTorch `DataLoader` to generate batches for one of the processes only.
@@ -1098,6 +1102,13 @@ def prepare_data_loader(
             This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed."
         torch_device_mesh (`torch.distributed.DeviceMesh`, *optional*, defaults to `None`):
             PyTorch device mesh.
+        already_sharded (`bool`, *optional*, defaults to `False`):
+            If set to `True`, Accelerate assumes the `dataloader` is already sharded across processes (for example via
+            a rank-aware `DistributedSampler`, a pre-sliced iterable, or `datasets.IterableDataset.shard()`) and skips
+            its own sharding (`BatchSamplerShard`, `IterableDatasetShard`, and a second Hugging Face `shard()` call).
+            The `DataLoaderShard` wrapper is still applied for device placement, `set_epoch` forwarding, and state
+            tracking. `even_batches` does not apply in this mode, so the user is responsible for equal step counts
+            across ranks. Incompatible with `dispatch_batches=True` and `split_batches=True`.
 
 
     Returns:
@@ -1110,6 +1121,22 @@ def prepare_data_loader(
 
     </Tip>
     """
+    if already_sharded:
+        # Validate against the user-provided values before `dispatch_batches` is auto-resolved below.
+        if dispatch_batches:
+            raise ValueError(
+                "`already_sharded=True` is incompatible with `dispatch_batches=True`: dispatch mode iterates the "
+                "dataloader on the main process and redistributes batches, which conflicts with a dataloader that is "
+                "already sharded per process."
+            )
+        if split_batches:
+            raise ValueError(
+                "`already_sharded=True` is incompatible with `split_batches=True`: split mode would split each "
+                "process's local batch again."
+            )
+        # An already-sharded dataloader is iterated independently on each process, never dispatched.
+        dispatch_batches = False
+
     if dispatch_batches is None:
         if not put_on_device:
             dispatch_batches = False
@@ -1219,8 +1246,12 @@ def prepare_data_loader(
         generator.manual_seed(seed)
         dataloader.generator = generator
         dataloader.sampler.generator = generator
-    # No change if no multiprocess
-    if (num_processes != 1 or state.distributed_type == DistributedType.MEGATRON_LM) and not dispatch_batches:
+    # No change if no multiprocess, or if the dataloader is already sharded by the user
+    if (
+        (num_processes != 1 or state.distributed_type == DistributedType.MEGATRON_LM)
+        and not dispatch_batches
+        and not already_sharded
+    ):
         if is_datasets_available():
             from datasets import IterableDataset as DatasetsIterableDataset
         if (
@@ -1305,6 +1336,7 @@ def prepare_data_loader(
             rng_types=rng_types,
             _drop_last=dataloader.drop_last,
             _non_blocking=non_blocking,
+            _total_num_processes=num_processes if already_sharded else 1,
             synchronized_generator=synchronized_generator,
             use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
@@ -1318,6 +1350,7 @@ def prepare_data_loader(
             synchronized_generator=synchronized_generator,
             _drop_last=dataloader.drop_last,
             _non_blocking=non_blocking,
+            _total_num_processes=num_processes if already_sharded else 1,
             use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
         )
@@ -1458,6 +1491,7 @@ def skip_first_batches(dataloader, num_batches=0):
             rng_types=dataloader.rng_types,
             synchronized_generator=dataloader.synchronized_generator,
             iteration=dataloader.iteration,
+            _total_num_processes=getattr(dataloader, "_total_num_processes", 1),
             **kwargs,
         )
     else:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -402,10 +402,17 @@ class DataLoaderStateMixin:
     def begin(self):
         "Prepares the gradient state for the current dataloader"
         self.reset()
-        with suppress(Exception):
-            if not self._drop_last:
-                length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
-                self.remainder = length % self.total_batch_size
+        if getattr(self, "_already_sharded", False):
+            # No Accelerate padding on this path, so `gather_for_metrics` must not
+            # treat `len(dataset) % (batch_size * num_processes)` as leftover samples.
+            # That formula assumes a global dataset length; a per-rank subset would
+            # invent a remainder and drop real eval rows.
+            self.remainder = 0
+        else:
+            with suppress(Exception):
+                if not self._drop_last:
+                    length = getattr(self.dataset, "total_dataset_length", len(self.dataset))
+                    self.remainder = length % self.total_batch_size
         self.gradient_state._add_dataloader(self)
 
     def end(self):
@@ -553,6 +560,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         _drop_last: bool = False,
         _non_blocking: bool = False,
         _total_num_processes: int = 1,
+        _already_sharded: bool = False,
         torch_device_mesh=None,
         iteration=0,
         **kwargs,
@@ -566,6 +574,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self._drop_last = _drop_last
         self._non_blocking = _non_blocking
         self._total_num_processes = _total_num_processes
+        self._already_sharded = _already_sharded
         self.iteration = iteration
 
     def adjust_state_dict_for_prefetch(self):
@@ -1337,6 +1346,7 @@ def prepare_data_loader(
             _drop_last=dataloader.drop_last,
             _non_blocking=non_blocking,
             _total_num_processes=num_processes if already_sharded else 1,
+            _already_sharded=already_sharded,
             synchronized_generator=synchronized_generator,
             use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
@@ -1351,6 +1361,7 @@ def prepare_data_loader(
             _drop_last=dataloader.drop_last,
             _non_blocking=non_blocking,
             _total_num_processes=num_processes if already_sharded else 1,
+            _already_sharded=already_sharded,
             use_stateful_dataloader=use_stateful_dataloader,
             **kwargs,
         )
@@ -1492,6 +1503,7 @@ def skip_first_batches(dataloader, num_batches=0):
             synchronized_generator=dataloader.synchronized_generator,
             iteration=dataloader.iteration,
             _total_num_processes=getattr(dataloader, "_total_num_processes", 1),
+            _already_sharded=getattr(dataloader, "_already_sharded", False),
             **kwargs,
         )
     else:

--- a/src/accelerate/utils/dataclasses.py
+++ b/src/accelerate/utils/dataclasses.py
@@ -854,6 +854,12 @@ class DataLoaderConfiguration:
             If set to `True`, the dataloader prepared by the Accelerator will be backed by
             [torchdata.StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader).
             This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed.
+        already_sharded (`bool`, defaults to `False`):
+            If set to `True`, Accelerate assumes each process's `DataLoader` is already sharded (for example via a
+            rank-aware `DistributedSampler`, a pre-sliced iterable, or `datasets.IterableDataset.shard()`) and skips
+            its own sharding so the data is not split twice. The wrapper features (device placement, `set_epoch`
+            forwarding, state tracking) are preserved. `even_batches` does not apply in this mode, so the user is
+            responsible for equal step counts across ranks. Incompatible with `dispatch_batches` and `split_batches`.
     """
 
     split_batches: bool = field(
@@ -910,6 +916,16 @@ class DataLoaderConfiguration:
         metadata={
             "help": "If set to `True`, the dataloader prepared by the Accelerator will be backed by "
             "[torchdata.StatefulDataLoader](https://github.com/pytorch/data/tree/main/torchdata/stateful_dataloader). This requires `torchdata` version 0.8.0 or higher that supports StatefulDataLoader to be installed."
+        },
+    )
+    already_sharded: bool = field(
+        default=False,
+        metadata={
+            "help": "If set to `True`, Accelerate assumes each process's `DataLoader` is already sharded (e.g. via a"
+            " rank-aware `DistributedSampler`, a pre-sliced iterable, or `datasets.IterableDataset.shard()`) and skips"
+            " its own sharding so the data is not split twice, while preserving device placement, `set_epoch`"
+            " forwarding, and state tracking. `even_batches` does not apply; the user is responsible for equal step"
+            " counts across ranks. Incompatible with `dispatch_batches` and `split_batches`."
         },
     )
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -858,6 +858,44 @@ class DataLoaderTester(AccelerateTestCase):
         assert hasattr(result, "set_epoch")
         assert hasattr(result, "gradient_state")
 
+    def test_already_sharded_local_subset_does_not_invent_remainder(self):
+        """A per-rank subset must not report a remainder against the global batch size."""
+        loader = prepare_data_loader(
+            DataLoader(list(range(8)), batch_size=4),
+            num_processes=4,
+            process_index=0,
+            already_sharded=True,
+        )
+        loader.begin()
+        try:
+            assert loader.remainder == 0
+        finally:
+            loader.end()
+
+    def test_already_sharded_join_uneven_inputs_skips_missing_even_batches(self):
+        """`join_uneven_inputs(..., even_batches=False)` must not read a missing attribute."""
+        from unittest.mock import MagicMock, patch
+
+        accelerator = Accelerator()
+        loader = prepare_data_loader(
+            DataLoader(list(range(8)), batch_size=4),
+            num_processes=4,
+            process_index=0,
+            already_sharded=True,
+        )
+        accelerator._dataloaders = [loader]
+        assert not hasattr(loader.batch_sampler, "even_batches")
+
+        join_cm = MagicMock()
+        join_cm.__enter__.return_value = None
+        join_cm.__exit__.return_value = None
+        with (
+            patch.object(type(accelerator), "multi_device", new=True),
+            patch("accelerate.accelerator.Join", return_value=join_cm),
+        ):
+            with accelerator.join_uneven_inputs([object()], even_batches=False):
+                pass
+
     def test_ensure_dataloader_gets_cleaned_up(self):
         # Ensure that the dataloader gets cleaned up properly
         class Dummy:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -18,7 +18,7 @@ import weakref
 import pytest
 import torch
 from parameterized import parameterized
-from torch.utils.data import BatchSampler, DataLoader, IterableDataset
+from torch.utils.data import BatchSampler, DataLoader, IterableDataset, Sampler
 
 from accelerate import Accelerator, PartialState
 from accelerate.data_loader import (
@@ -79,6 +79,46 @@ class SimpleIterableDataset(IterableDataset):
 
     def set_epoch(self, epoch):
         self.epoch = epoch
+
+
+class RankShardSampler(Sampler):
+    """Map-style sampler that already yields only this rank's indices (`i % num_processes == process_index`)."""
+
+    def __init__(self, num_samples, num_processes, process_index):
+        self.indices = [i for i in range(num_samples) if i % num_processes == process_index]
+
+    def __iter__(self):
+        return iter(self.indices)
+
+    def __len__(self):
+        return len(self.indices)
+
+
+class RankIterableDataset(IterableDataset):
+    """Iterable that already yields only this rank's local range."""
+
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __iter__(self):
+        yield from range(self.start, self.end)
+
+
+def _samples_from_loader(loader):
+    samples = []
+    for batch in loader:
+        if isinstance(batch, dict):
+            values = batch["x"] if "x" in batch else next(iter(batch.values()))
+            if isinstance(values, torch.Tensor):
+                samples.extend(values.detach().cpu().reshape(-1).tolist())
+            else:
+                samples.extend(list(values))
+        elif isinstance(batch, torch.Tensor):
+            samples.extend(batch.detach().cpu().reshape(-1).tolist())
+        else:
+            samples.extend(list(batch))
+    return samples
 
 
 class SimpleBatchSampler(BatchSampler):
@@ -696,6 +736,127 @@ class DataLoaderTester(AccelerateTestCase):
 
         # n_shards (2) == num_processes (2): should use native sharding, not IterableDatasetShard
         assert not isinstance(result.dataset, IterableDatasetShard)
+
+    def test_already_sharded_map_style_skips_second_shard(self):
+        """A rank-local map-style sampler must not be cut again (issues #3520/#4062/#4075)."""
+        num_samples = 32
+        num_processes = 4
+        dataset = list(range(num_samples))
+
+        for process_index in (0, 1):
+            local_indices = [i for i in range(num_samples) if i % num_processes == process_index]
+            sampler = RankShardSampler(num_samples, num_processes, process_index)
+            dataloader = DataLoader(dataset, batch_size=1, sampler=sampler)
+
+            double_sharded = prepare_data_loader(dataloader, num_processes=num_processes, process_index=process_index)
+            double_sharded_samples = _samples_from_loader(double_sharded)
+            assert len(set(double_sharded_samples)) < len(local_indices)
+
+            kept = prepare_data_loader(
+                DataLoader(dataset, batch_size=1, sampler=RankShardSampler(num_samples, num_processes, process_index)),
+                num_processes=num_processes,
+                process_index=process_index,
+                already_sharded=True,
+            )
+            kept_samples = _samples_from_loader(kept)
+            assert set(kept_samples) == set(local_indices)
+            assert len(kept_samples) == len(local_indices)
+
+    def test_already_sharded_iterable_skips_second_shard(self):
+        """A rank-local iterable must not be wrapped in IterableDatasetShard again."""
+        num_processes = 4
+        shard_size = 8
+
+        for process_index in (0, 1):
+            start = process_index * shard_size
+            end = start + shard_size
+            local = list(range(start, end))
+
+            double_sharded = prepare_data_loader(
+                DataLoader(RankIterableDataset(start, end), batch_size=1),
+                num_processes=num_processes,
+                process_index=process_index,
+                dispatch_batches=False,
+            )
+            assert isinstance(double_sharded.dataset, IterableDatasetShard)
+            double_sharded_samples = _samples_from_loader(double_sharded)
+            assert len(set(double_sharded_samples)) < len(local)
+
+            kept = prepare_data_loader(
+                DataLoader(RankIterableDataset(start, end), batch_size=1),
+                num_processes=num_processes,
+                process_index=process_index,
+                dispatch_batches=False,
+                already_sharded=True,
+            )
+            assert not isinstance(kept.dataset, IterableDatasetShard)
+            kept_samples = _samples_from_loader(kept)
+            assert kept_samples == local
+
+    @require_datasets
+    def test_already_sharded_skips_hf_iterable_native_shard(self):
+        """A user-sharded HF IterableDataset must not be sharded again."""
+        from datasets import Dataset
+
+        num_processes = 4
+        values = list(range(32))
+
+        def make_user_sharded(index):
+            return (
+                Dataset.from_dict({"x": values})
+                .to_iterable_dataset(num_shards=num_processes)
+                .shard(num_shards=num_processes, index=index)
+            )
+
+        expected = _samples_from_loader(DataLoader(make_user_sharded(0), batch_size=2))
+        assert len(expected) > 0
+
+        # After the user already called `.shard()`, n_shards < num_processes, so the default path
+        # falls through to IterableDatasetShard and silently drops most of the local data.
+        double_sharded = prepare_data_loader(
+            DataLoader(make_user_sharded(0), batch_size=2),
+            num_processes=num_processes,
+            process_index=0,
+            dispatch_batches=False,
+        )
+        assert isinstance(double_sharded.dataset, IterableDatasetShard)
+        double_sharded_samples = _samples_from_loader(double_sharded)
+        assert len(set(double_sharded_samples)) < len(set(expected))
+
+        kept = prepare_data_loader(
+            DataLoader(make_user_sharded(0), batch_size=2),
+            num_processes=num_processes,
+            process_index=0,
+            dispatch_batches=False,
+            already_sharded=True,
+        )
+        assert not isinstance(kept.dataset, IterableDatasetShard)
+        kept_samples = _samples_from_loader(kept)
+        assert set(kept_samples) == set(expected)
+
+    def test_already_sharded_rejects_incompatible_flags(self):
+        dataset = list(range(16))
+        with pytest.raises(ValueError, match="dispatch_batches"):
+            prepare_data_loader(
+                DataLoader(dataset, batch_size=4), already_sharded=True, dispatch_batches=True, put_on_device=True
+            )
+        with pytest.raises(ValueError, match="split_batches"):
+            prepare_data_loader(DataLoader(dataset, batch_size=4), already_sharded=True, split_batches=True)
+
+    def test_already_sharded_still_wraps_with_dataloader_shard(self):
+        dataset = list(range(16))
+        sampler = RankShardSampler(len(dataset), num_processes=2, process_index=0)
+        result = prepare_data_loader(
+            DataLoader(dataset, batch_size=4, sampler=sampler),
+            num_processes=2,
+            process_index=0,
+            already_sharded=True,
+        )
+        assert isinstance(result, DataLoaderShard)
+        assert not isinstance(result, DataLoaderDispatcher)
+        # Wrapper features used by training loops must still be present.
+        assert hasattr(result, "set_epoch")
+        assert hasattr(result, "gradient_state")
 
     def test_ensure_dataloader_gets_cleaned_up(self):
         # Ensure that the dataloader gets cleaned up properly


### PR DESCRIPTION
## What does this PR do?

`Accelerator.prepare(dataloader)` assumes the incoming loader is a global view of the dataset. In a distributed run it then wraps the sampler or dataset again. If the user already partitioned by rank, that second cut is silent data loss: each process keeps `1 / num_processes` of the shard it was given, the loss curve still looks normal, and there is no warning.

This adds `DataLoaderConfiguration(already_sharded=True)` (also accepted by `prepare_data_loader`). When set, Accelerate:

- does not wrap with `BatchSamplerShard` / `IterableDatasetShard`
- does not call `datasets.IterableDataset.shard(...)`
- still returns `DataLoaderShard`, so device placement, `set_epoch`, and state tracking keep working

Incompatible with `dispatch_batches=True` and `split_batches=True`. `even_batches` does not apply; the user is responsible for equal step counts. Default is `False`, so existing scripts are unchanged.

```python
accelerator = Accelerator(
    dataloader_config=DataLoaderConfiguration(already_sharded=True)
)
loader = accelerator.prepare(loader)
```

Fixes #4199. Same request as the stale #4075 / #4087.

## Tests

- Map-style rank-local sampler: default path drops samples; `already_sharded=True` keeps the local shard
- Iterable rank-local dataset: default wraps `IterableDatasetShard`; flag does not
- User-sharded HF `datasets.IterableDataset`: default falls through to `IterableDatasetShard`; flag does not
- Incompatible flags raise `ValueError`
- Wrapper is still `DataLoaderShard` (`set_epoch`, `gradient_state`)

## Who can review?

@SunMarc