### PR TITLE
Add ep_size to ParallelismConfig so FSDP2 can compose with expert parallelism

### DIFF
--- a/docs/source/concept_guides/fsdp1_vs_fsdp2.md
+++ b/docs/source/concept_guides/fsdp1_vs_fsdp2.md
@@ -103,3 +103,13 @@ accelerate to-fsdp2 --config_file config.yaml --output_file new_config.yaml
 ```
 
 This will automatically convert all FSDP1 settings to their FSDP2 equivalents. Use `--overwrite` to update the existing file instead of creating a new one.
+
+## FSDP2 and expert parallelism
+
+`ParallelismConfig` accepts `ep_size` to add an `ep` dimension to the `DeviceMesh`. Expert parallelism is **not** an FSDP shard dimension:
+
+- `dp_shard` (and optionally `cp`) is used by FSDP2 to shard non-expert parameters.
+- `ep` is the expert mesh. The model is responsible for placing expert weights on this submesh.
+- Accelerate does not route tokens or implement all-to-all expert communication; it only builds the `ep` `DeviceMesh` dimension.
+
+Because every expert-parallel rank sees the same batch (like tensor or context parallelism), `ep_size` is a non-data-parallel dimension. The product of all parallelism sizes, including `ep_size`, must equal `num_processes`.

--- a/src/accelerate/commands/config/cluster.py
+++ b/src/accelerate/commands/config/cluster.py
@@ -547,6 +547,12 @@ def get_cluster_input():
                 default=1,
                 error_message="Please enter an integer.",
             )
+            parallelism_config[prefix + "ep_size"] = _ask_field(
+                "What is the expert parallelism size? [1]: ",
+                int,
+                default=1,
+                error_message="Please enter an integer.",
+            )
             if parallelism_config[prefix + "cp_size"] > 1:
                 parallelism_config[prefix + "cp_comm_strategy"] = _ask_options(
                     "What is the compute parallelism communication strategy?",

--- a/src/accelerate/commands/launch.py
+++ b/src/accelerate/commands/launch.py
@@ -981,6 +981,13 @@ def launch_command_parser(subparsers=None):
         help="Attention implementation to use. Can be one of 'flash_attention_2', 'flash_attention_3', 'sdpa', or a hub-hosted kernel (e.g. 'kernels-community/flash-attn2'). Defaults to `sdpa`.",
     )
 
+    parallelism_config_args.add_argument(
+        "--parallelism_config_ep_size",
+        type=int,
+        default=1,
+        help="The number of processes for expert parallel training. Defaults to 1 (no expert parallelism).",
+    )
+
     # Other arguments of the training scripts
     parser.add_argument("training_script_args", nargs=argparse.REMAINDER, help="Arguments of the training script.")
 

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -1148,20 +1148,23 @@ def prepare_data_loader(
             # ranks would range from 0...11
             # from data angle ranks should look like 0 0 0 1 1 1 2 2 2 3 3 3
             # processes with same ranks/ids would receive the same batch
-            # for CP the same as TP applies
+            # for CP and EP the same as TP applies
             submesh_fsdp_size = 1
             submesh_dp_size = 1
             submesh_tp_size = 1
             submesh_cp_size = 1
+            submesh_ep_size = 1
             if "tp" in torch_device_mesh.mesh_dim_names:
                 submesh_tp_size = torch_device_mesh["tp"].size()
             if "cp" in torch_device_mesh.mesh_dim_names:
                 submesh_cp_size = torch_device_mesh["cp"].size()
+            if "ep" in torch_device_mesh.mesh_dim_names:
+                submesh_ep_size = torch_device_mesh["ep"].size()
             if "dp_replicate" in torch_device_mesh.mesh_dim_names:
                 submesh_dp_size = torch_device_mesh["dp_replicate"].size()
             if "dp_shard" in torch_device_mesh.mesh_dim_names:
                 submesh_fsdp_size = torch_device_mesh["dp_shard"].size()
-            process_index = process_index // (submesh_tp_size * submesh_cp_size)
+            process_index = process_index // (submesh_tp_size * submesh_cp_size * submesh_ep_size)
             num_processes = submesh_fsdp_size * submesh_dp_size
 
     # Sanity check

--- a/src/accelerate/parallelism_config.py
+++ b/src/accelerate/parallelism_config.py
@@ -57,6 +57,12 @@ class ParallelismConfig:
             The size of the sequence parallel group.
         sp_backend (`str`, defaults to `deepspeed`):
             Which SP backend to use:`deepspeed` (ALST/Ulysses)
+        ep_size (`int`, defaults to `1`):
+            The size of the expert parallel group. If `ep_size` is set to `1`, the expert parallel group will not be
+            used. Expert parallelism is a non-data-parallel dimension (every EP rank sees the same batch) and is **not**
+            an FSDP shard dimension. With FSDP2 + EP, `dp_shard` shards non-expert parameters while `ep` is the expert
+            mesh; the model is responsible for placing expert weights on that submesh. Accelerate only builds the `ep`
+            `DeviceMesh` dimension and does not implement expert routing or all-to-all token dispatch.
 
     You may obtain different distributed data parallel paradigms by configuring `dp_replicate_size` and `dp_shard_size`
     together:
@@ -64,6 +70,9 @@ class ParallelismConfig:
         - `dp_replicate_size > 1` and `dp_shard_size > 1`, we obtain Hybrid Sharded Data Parallel (HSDP).
         - `dp_replicate_size > 1` and `dp_shard_size == 1` is an invalid configuration, to use pure DP, use
           `DistributedDataParallelKwargs` instead.
+
+    The product of all parallelism sizes (`dp_replicate_size * dp_shard_size * tp_size * cp_size * sp_size * ep_size`)
+    must equal `num_processes`.
 
     """
 
@@ -74,6 +83,7 @@ class ParallelismConfig:
     cp_backend: Literal["torch"] = None
     sp_size: Optional[int] = None
     sp_backend: Literal["deepspeed"] = None
+    ep_size: Optional[int] = None
 
     # we use Union because we might support other x parallel plugins (i.e. deepspeed, etc)
     tp_handler: Union[None, TorchTensorParallelConfig] = None
@@ -92,6 +102,7 @@ class ParallelismConfig:
             f"\tcp_backend={self.cp_backend},\n"
             f"\tsp_size={self.sp_size},\n"
             f"\tsp_backend={self.sp_backend},\n"
+            f"\tep_size={self.ep_size},\n"
             f"\ttotal_size={self.total_size}\n"
             f"\ttp_handler={self.tp_handler},\n"
             f"\tcp_handler={self.cp_handler})\n"
@@ -130,6 +141,8 @@ class ParallelismConfig:
             dims += ["cp"]
         if self.sp_enabled:
             dims += ["sp"]
+        if self.ep_enabled:
+            dims += ["ep"]
         return dims
 
     @property
@@ -166,12 +179,12 @@ class ParallelismConfig:
     @property
     def total_size(self):
         """The total size of the parallelism configuration, which is the product of all sizes."""
-        return self.dp_replicate_size * self.dp_shard_size * self.tp_size * self.cp_size * self.sp_size
+        return self.dp_replicate_size * self.dp_shard_size * self.tp_size * self.cp_size * self.sp_size * self.ep_size
 
     @property
     def non_data_parallel_size(self):
-        """The size of the non-data parallel dimensions, which is the product of tensor and context parallel sizes."""
-        return self.tp_size * self.cp_size * self.sp_size
+        """The size of the non-data parallel dimensions, which is the product of tensor, context, sequence, and expert parallel sizes."""
+        return self.tp_size * self.cp_size * self.sp_size * self.ep_size
 
     @property
     def data_parallel_size(self):
@@ -202,6 +215,11 @@ class ParallelismConfig:
     def sp_enabled(self):
         """True if context parallelism is enabled, i.e. `sp_size > 1`."""
         return self.sp_size > 1
+
+    @property
+    def ep_enabled(self):
+        """True if expert parallelism is enabled, i.e. `ep_size > 1`."""
+        return self.ep_size > 1
 
     @property
     def active_mesh_dims(self):
@@ -264,7 +282,7 @@ class ParallelismConfig:
         mesh_dims = {parallelism: self._sizes[parallelism] for parallelism in self.active_mesh_dims}
 
         # Apply canonical ordering
-        mesh_order = ["dp_replicate", "dp_shard", "cp", "sp", "tp"]
+        mesh_order = ["dp_replicate", "dp_shard", "cp", "sp", "ep", "tp"]
         sorted_items = sorted(
             mesh_dims.items(),
             key=lambda x: (mesh_order.index(x[0])),
@@ -287,6 +305,8 @@ class ParallelismConfig:
             self.sp_size = int(os.environ.get("PARALLELISM_CONFIG_SP_SIZE", "1"))
         if self.sp_backend is None:
             self.sp_backend = os.environ.get("PARALLELISM_CONFIG_SP_BACKEND", "deepspeed")
+        if self.ep_size is None:
+            self.ep_size = int(os.environ.get("PARALLELISM_CONFIG_EP_SIZE", "1"))
 
         if self.tp_size > 1:
             if self.tp_handler is None:
@@ -321,6 +341,8 @@ class ParallelismConfig:
 
         if self.sp_size < 1:
             raise ValueError(f"sp_size must be at least 1, but got {self.sp_size}")
+        if self.ep_size < 1:
+            raise ValueError(f"ep_size must be at least 1, but got {self.ep_size}")
         valid_sp_backends = ["deepspeed"]
         if self.sp_backend not in valid_sp_backends:
             raise ValueError(f"sp_backend must be one of {valid_sp_backends}, but got {self.sp_backend}")
@@ -345,6 +367,7 @@ class ParallelismConfig:
             "tp": self.tp_size,
             "cp": self.cp_size,
             "sp": self.sp_size,
+            "ep": self.ep_size,
         }
 
     def _set_size(self, parallelism: str, size: int):
@@ -373,7 +396,7 @@ class ParallelismConfig:
             raise ValueError(
                 f"ParallelismConfig total_size ({self.total_size}) does not match "
                 f"num_processes ({accelerator.num_processes}). Please adjust dp_replicate_size/ "
-                f"dp_shard_size/tp_size/cp_size/sp_size."
+                f"dp_shard_size/tp_size/cp_size/sp_size/ep_size."
             )
 
         if self.total_size > 1 and not (

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -417,6 +417,7 @@ def prepare_extend_env_parallelism_config(
     current_env[prefix + "CP_BACKEND"] = str(args.parallelism_config_cp_backend)
     current_env[prefix + "SP_SIZE"] = str(args.parallelism_config_sp_size)
     current_env[prefix + "SP_BACKEND"] = str(args.parallelism_config_sp_backend)
+    current_env[prefix + "EP_SIZE"] = str(args.parallelism_config_ep_size)
     if args.parallelism_config_cp_size > 1:
         current_env[prefix + "CP_COMM_STRATEGY"] = str(args.parallelism_config_cp_comm_strategy)
     if args.parallelism_config_sp_size > 1:

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -697,6 +697,44 @@ class DataLoaderTester(AccelerateTestCase):
         # n_shards (2) == num_processes (2): should use native sharding, not IterableDatasetShard
         assert not isinstance(result.dataset, IterableDatasetShard)
 
+    def test_device_mesh_ep_shares_batch_across_ep_ranks(self):
+        """EP is a same-batch dim: ranks in one EP group map to the same process_index."""
+
+        class _FakeDeviceMesh:
+            def __init__(self, sizes):
+                self.mesh_dim_names = list(sizes)
+                self._sizes = sizes
+
+            def __getitem__(self, key):
+                class _Submesh:
+                    def __init__(self, size):
+                        self._size = size
+
+                    def size(self):
+                        return self._size
+
+                return _Submesh(self._sizes[key])
+
+        dataset = list(range(16))
+        mesh = _FakeDeviceMesh({"dp_shard": 2, "ep": 4})
+        prepared = [
+            prepare_data_loader(
+                DataLoader(dataset, batch_size=4),
+                num_processes=8,
+                process_index=rank,
+                torch_device_mesh=mesh,
+            )
+            for rank in range(8)
+        ]
+
+        # EP ranks 0-3 share dp_shard=0; ranks 4-7 share dp_shard=1
+        for rank in range(4):
+            assert prepared[rank].batch_sampler.process_index == 0
+            assert prepared[rank].batch_sampler.num_processes == 2
+        for rank in range(4, 8):
+            assert prepared[rank].batch_sampler.process_index == 1
+            assert prepared[rank].batch_sampler.num_processes == 2
+
     def test_ensure_dataloader_gets_cleaned_up(self):
         # Ensure that the dataloader gets cleaned up properly
         class Dummy:

--- a/tests/test_dataclasses.py
+++ b/tests/test_dataclasses.py
@@ -215,6 +215,7 @@ class TestParallelismConfig:
             "PARALLELISM_CONFIG_DP_SHARD_SIZE": dp_shard_size,
             "PARALLELISM_CONFIG_TP_SIZE": tp_size,
             "PARALLELISM_CONFIG_CP_SIZE": cp_size,
+            "PARALLELISM_CONFIG_EP_SIZE": 1,
         }
 
         with patch_environment(**new_env):
@@ -275,3 +276,145 @@ class TestParallelismConfig:
 
     def test_tp_handler(self):
         assert True, "Tensor parallelism handler doesn't hold any logic yet"
+
+    @pytest.mark.parametrize(
+        "dp_replicate_size, dp_shard_size, tp_size, ep_size, expected_shape, expected_dim_names",
+        [
+            (1, 1, 1, 4, (4,), ("ep",)),  # EP only
+            (1, 2, 1, 4, (2, 4), ("dp_shard", "ep")),  # FSDP + EP
+            (1, 2, 2, 2, (2, 2, 2), ("dp_shard", "ep", "tp")),  # FSDP + EP + TP
+            (2, 2, 1, 2, (2, 2, 2), ("dp_replicate", "dp_shard", "ep")),  # HSDP + EP
+        ],
+    )
+    def test_get_mesh_with_ep(
+        self,
+        dp_replicate_size,
+        dp_shard_size,
+        tp_size,
+        ep_size,
+        expected_shape,
+        expected_dim_names,
+    ):
+        # Dummy handler avoids TorchTensorParallelConfig version checks; we only assert mesh layout.
+        config = ParallelismConfig(
+            dp_replicate_size=dp_replicate_size,
+            dp_shard_size=dp_shard_size,
+            tp_size=tp_size,
+            ep_size=ep_size,
+            tp_handler=Mock() if tp_size > 1 else None,
+        )
+        mesh_dim_names, mesh_shape = config._get_mesh()
+        assert mesh_shape == expected_shape
+        assert mesh_dim_names == expected_dim_names
+
+    @pytest.mark.parametrize(
+        "dp_replicate_size, dp_shard_size, tp_size, ep_size, expected_shape, expected_dim_names",
+        [
+            (1, 1, 1, 4, (4,), ("ep",)),
+            (1, 2, 1, 4, (2, 4), ("dp_shard", "ep")),
+            (1, 2, 2, 2, (2, 2, 2), ("dp_shard", "ep", "tp")),
+            (2, 2, 1, 2, (2, 2, 2), ("dp_replicate", "dp_shard", "ep")),
+        ],
+    )
+    def test_build_device_mesh_with_ep(
+        self,
+        dp_replicate_size,
+        dp_shard_size,
+        tp_size,
+        ep_size,
+        expected_shape,
+        expected_dim_names,
+    ):
+        """EP must appear on the mesh but must not be flattened into FSDP dims."""
+        config = ParallelismConfig(
+            dp_replicate_size=dp_replicate_size,
+            dp_shard_size=dp_shard_size,
+            tp_size=tp_size,
+            ep_size=ep_size,
+            tp_handler=Mock() if tp_size > 1 else None,
+        )
+        device_mesh = config.build_device_mesh("cpu")
+
+        assert device_mesh.shape == expected_shape
+        assert device_mesh.mesh_dim_names == expected_dim_names
+
+        expected_flattened = []
+        if config.dp_dim_names:
+            expected_flattened.append((config.dp_dim_names, "dp"))
+        if config.dp_shard_cp_dim_names:
+            expected_flattened.append((config.dp_shard_cp_dim_names, "dp_shard_cp"))
+        if config.dp_cp_dim_names:
+            expected_flattened.append((config.dp_cp_dim_names, "dp_cp"))
+
+        assert device_mesh.flattened_dims == expected_flattened
+        for flattened_keys, flattened_name in device_mesh.flattened_dims:
+            assert "ep" not in flattened_keys
+            assert flattened_name != "ep"
+        assert "ep" not in config.fsdp_dim_names
+        assert "ep" not in config.dp_shard_cp_dim_names
+        assert "ep" not in config.dp_cp_dim_names
+        assert "ep" not in config.dp_dim_names
+
+    def test_from_env_ep_size(self):
+        with patch_environment(PARALLELISM_CONFIG_EP_SIZE=4):
+            config = ParallelismConfig()
+            assert config.ep_size == 4
+            assert config.ep_enabled
+
+    def test_ep_size_zero_raises(self):
+        with pytest.raises(ValueError, match="ep_size must be at least 1"):
+            ParallelismConfig(ep_size=0)
+
+    def test_ep_dim_names_and_sizes(self):
+        config = ParallelismConfig(dp_shard_size=2, ep_size=4)
+
+        assert config.ep_enabled
+        assert "ep" in config.non_dp_dim_names
+        assert "ep" not in config.dp_dim_names
+        assert "ep" not in config.fsdp_dim_names
+        assert "ep" not in config.dp_shard_cp_dim_names
+        assert "ep" not in config.dp_cp_dim_names
+        assert config.total_size == 8
+        assert config.non_data_parallel_size == 4
+        assert config.data_parallel_size == 2
+
+    def test_default_ep_size_does_not_change_existing_mesh(self):
+        if _should_skip_cp_test(2):
+            pytest.skip(f"tests with `cp_size>1` require torch >= {BETA_CP_AVAILABLE_PYTORCH_VERSION}")
+        config = ParallelismConfig(dp_shard_size=2, cp_size=2)
+        mesh_dim_names, mesh_shape = config._get_mesh()
+        assert config.ep_size == 1
+        assert not config.ep_enabled
+        assert "ep" not in mesh_dim_names
+        assert mesh_shape == (2, 2)
+        assert mesh_dim_names == ("dp_shard", "cp")
+        assert config.total_size == 4
+        assert config.non_data_parallel_size == 2
+
+    def test_ep_with_dp_replicate_is_allowed(self):
+        """Replicating an expert-parallel model is a valid layout; the TP/CP DDP restriction does not apply to EP."""
+        config = ParallelismConfig(dp_replicate_size=2, ep_size=2)
+        mesh_dim_names, mesh_shape = config._get_mesh()
+        assert mesh_shape == (2, 2)
+        assert mesh_dim_names == ("dp_replicate", "ep")
+        assert config.total_size == 4
+
+    def test_ep_same_batch_rank_mapping(self):
+        """EP ranks receive the same batch, like TP/CP: process_index // (tp * cp * ep)."""
+        config = ParallelismConfig(dp_shard_size=2, ep_size=4)
+        mesh_dim_names, mesh_shape = config._get_mesh()
+        assert mesh_dim_names == ("dp_shard", "ep")
+        assert mesh_shape == (2, 4)
+
+        sizes = dict(zip(mesh_dim_names, mesh_shape))
+        submesh_tp_size = sizes.get("tp", 1)
+        submesh_cp_size = sizes.get("cp", 1)
+        submesh_ep_size = sizes.get("ep", 1)
+        submesh_fsdp_size = sizes.get("dp_shard", 1)
+        submesh_dp_size = sizes.get("dp_replicate", 1)
+
+        remapped_indices = [
+            process_index // (submesh_tp_size * submesh_cp_size * submesh_ep_size) for process_index in range(8)
+        ]
+        assert remapped_indices == [0, 0, 0, 0, 1, 1, 1, 1]
+        assert submesh_fsdp_size * submesh_dp_size == 2


### PR DESCRIPTION
## What does this PR do?

`ParallelismConfig` had `dp_replicate`, `dp_shard`, `tp`, `cp`, and `sp`, but no expert-parallel axis. A 2-way FSDP × 4-way EP layout on 8 GPUs could not be expressed, and every downstream stack had to invent its own mesh.

This adds `ep_size` (env `PARALLELISM_CONFIG_EP_SIZE`, CLI `--parallelism_config_ep_size`, `accelerate config` when FSDP2 parallelism is enabled). Default is `1`.

- `total_size` and `non_data_parallel_size` include `ep_size`
- `"ep"` is in `non_dp_dim_names` when `ep_size > 1` (same batch on every EP rank, like TP/CP)
- `"ep"` is **not** in `fsdp_dim_names` / `dp_shard_cp_dim_names`, so FSDP2 does not double-shard expert weights
- Mesh order: `dp_replicate`, `dp_shard`, `cp`, `sp`, `ep`, `tp` (only enabled dims appear)
- `prepare_data_loader` treats EP like TP/CP when mapping ranks onto data-parallel groups

Expert placement stays with the model. Accelerate only builds `accelerator.torch_device_mesh["ep"]`.

```python
cfg = ParallelismConfig(dp_shard_size=2, ep_size=4)
accelerator = Accelerator(
    fsdp_plugin=FullyShardedDataParallelPlugin(fsdp_version=2),
    parallelism_config=cfg,
)
# mesh["ep"] is the expert group; mesh["dp_shard"] is the FSDP group
```

Fixes #4200. Config/mesh half of the FSDP2 × EP work around #4178 / huggingface/transformers#48204 / huggingface/trl#6869.

Not in this PR: token-choice dispatch, FSDP2 wrap-heuristic changes, USP (CP+SP).

## Tests

- Mesh shapes for EP-only, FSDP+EP, FSDP+EP+TP, HSDP+EP
- EP is not flattened into FSDP dims
- Env `PARALLELISM_CONFIG_EP_SIZE`
- `ep_size=0` raises
- Default `ep_size=1` does not change existing CP/TP meshes
- `dp_replicate>1` + `ep>1` is allowed
- DataLoader rank mapping keeps one batch per EP group

## Who can review?

@SunMarc @qgallouedec