### PR TITLE
Restore shuffle order when resuming a stateful DataLoader

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -333,6 +333,27 @@ def _restore_shuffle_state(batch_sampler, state):
         sampler.generator.set_state(state["generator_state"])
 
 
+def _replace_sampler_iter_state(state_dict, new_iter_state):
+    """Point a torchdata state_dict at the start of the next epoch's permutation."""
+    if not isinstance(state_dict, dict):
+        return
+    if "_sampler_iter_state" in state_dict:
+        state_dict["_sampler_iter_state"] = new_iter_state
+    if "_num_yielded" in state_dict:
+        state_dict["_num_yielded"] = 0
+    if "_sampler_iter_yielded" in state_dict:
+        state_dict["_sampler_iter_yielded"] = 0
+    index_state = state_dict.get("_index_sampler_state")
+    if isinstance(index_state, dict) and "samples_yielded" in index_state:
+        index_state["samples_yielded"] = 0
+    snapshot = state_dict.get("_snapshot")
+    if isinstance(snapshot, dict):
+        _replace_sampler_iter_state(snapshot, new_iter_state)
+        main = snapshot.get("_main_snapshot")
+        if isinstance(main, dict):
+            _replace_sampler_iter_state(main, new_iter_state)
+
+
 class _BatchSamplerShardIterator:
     """Stateful iterator over a `BatchSamplerShard`.
 
@@ -608,12 +629,22 @@ class DataLoaderAdapter:
             self.dl_state_dict = self.base_dataloader.state_dict()
             # Potentially modify the state_dict to adjust for prefetching
             self.adjust_state_dict_for_prefetch()
-            # Then tag if we are at the end of the dataloader
-            self.dl_state_dict["_iterator_finished"] = self.end_of_dataloader
-            # Persist the sampler epoch so a fresh loader does not restart at epoch 0.
             iteration = getattr(self, "iteration", 0)
-            if iteration:
-                self.dl_state_dict[_ACCELERATE_ITERATION] = iteration
+            if getattr(self, "end_of_dataloader", False):
+                # Last batch of this epoch: persist the *next* epoch. The finished
+                # iterator still holds the pre-epoch shuffle snapshot, which would
+                # replay the epoch that just ended.
+                self.dl_state_dict["_iterator_finished"] = False
+                self.dl_state_dict[_ACCELERATE_ITERATION] = iteration + 1
+                batch_sampler = getattr(self, "batch_sampler", None)
+                if batch_sampler is None:
+                    batch_sampler = getattr(self, "sampler", None)
+                post = _capture_shuffle_state(batch_sampler) if batch_sampler is not None else {}
+                _replace_sampler_iter_state(self.dl_state_dict, {"yielded": 0, "shuffle_state": post})
+            else:
+                self.dl_state_dict["_iterator_finished"] = False
+                if iteration:
+                    self.dl_state_dict[_ACCELERATE_ITERATION] = iteration
 
 
 class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -82,8 +82,10 @@ class SeedableRandomSampler(RandomSampler):
     Needed specifically in distributed cases, when the random generator for each GPU needs to start from the same seed
     and be fully reproducible on multiple iterations.
 
-    If a custom `generator` is passed, it will rely on its initial seed as well as the current iteration it is on
-    (stored in `self.epoch`).
+    The permutation for an epoch is `manual_seed(self.epoch + self.initial_seed)`. `set_epoch` only assigns
+    `self.epoch`; `__iter__` never increments it. Callers (including [`DataLoaderShard`]) must call `set_epoch`
+    between passes. An implicit increment during iteration would shift the next permutation when a completed-epoch
+    checkpoint is restored, because the restore path may replay one extra full sampler cycle.
     """
 
     def __init__(self, *args, **kwargs):
@@ -105,10 +107,9 @@ class SeedableRandomSampler(RandomSampler):
         # print("Setting seed at epoch", self.epoch, seed)
         self.generator.manual_seed(seed)
         yield from super().__iter__()
-        self.set_epoch(self.epoch + 1)
 
     def set_epoch(self, epoch: int):
-        "Sets the current iteration of the sampler."
+        "Sets the current iteration of the sampler. Does not increment; assignment only."
         self.epoch = epoch
 
 
@@ -649,10 +650,16 @@ class DataLoaderAdapter:
                 if isinstance(batch_sampler, BatchSamplerShard):
                     # The finished shard iterator still holds the pre-epoch
                     # shuffle snapshot; rewrite it to the post-epoch state.
+                    # SeedableRandomSampler.__iter__ no longer auto-increments,
+                    # so persist the *next* epoch explicitly. Otherwise restore
+                    # would replay the permutation that just finished.
+                    shuffle_state = _capture_shuffle_state(batch_sampler)
+                    if "epoch" in shuffle_state:
+                        shuffle_state["epoch"] = iteration + 1
                     self.dl_state_dict["_iterator_finished"] = False
                     _replace_sampler_iter_state(
                         self.dl_state_dict,
-                        {"yielded": 0, "shuffle_state": _capture_shuffle_state(batch_sampler)},
+                        {"yielded": 0, "shuffle_state": shuffle_state},
                     )
                 else:
                     # Leave torchdata's iterator schema intact so a plain

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -333,11 +333,21 @@ def _restore_shuffle_state(batch_sampler, state):
         sampler.generator.set_state(state["generator_state"])
 
 
+def _is_accelerate_sampler_iter_state(state):
+    return isinstance(state, dict) and "yielded" in state and "shuffle_state" in state
+
+
 def _replace_sampler_iter_state(state_dict, new_iter_state):
-    """Point a torchdata state_dict at the start of the next epoch's permutation."""
+    """Point a *BatchSamplerShard* iterator snapshot at the start of the next epoch.
+
+    Only overwrite `_sampler_iter_state` when it is already Accelerate's
+    `{yielded, shuffle_state}` payload. Torchdata's own iterator uses
+    `{samples_yielded, ...}`; replacing that schema makes `load_state_dict`
+    raise `KeyError: 'samples_yielded'`.
+    """
     if not isinstance(state_dict, dict):
         return
-    if "_sampler_iter_state" in state_dict:
+    if _is_accelerate_sampler_iter_state(state_dict.get("_sampler_iter_state")):
         state_dict["_sampler_iter_state"] = new_iter_state
     if "_num_yielded" in state_dict:
         state_dict["_num_yielded"] = 0
@@ -631,16 +641,23 @@ class DataLoaderAdapter:
             self.adjust_state_dict_for_prefetch()
             iteration = getattr(self, "iteration", 0)
             if getattr(self, "end_of_dataloader", False):
-                # Last batch of this epoch: persist the *next* epoch. The finished
-                # iterator still holds the pre-epoch shuffle snapshot, which would
-                # replay the epoch that just ended.
-                self.dl_state_dict["_iterator_finished"] = False
+                # Last batch of this epoch: persist the *next* epoch.
                 self.dl_state_dict[_ACCELERATE_ITERATION] = iteration + 1
                 batch_sampler = getattr(self, "batch_sampler", None)
-                if batch_sampler is None:
+                if not isinstance(batch_sampler, BatchSamplerShard):
                     batch_sampler = getattr(self, "sampler", None)
-                post = _capture_shuffle_state(batch_sampler) if batch_sampler is not None else {}
-                _replace_sampler_iter_state(self.dl_state_dict, {"yielded": 0, "shuffle_state": post})
+                if isinstance(batch_sampler, BatchSamplerShard):
+                    # The finished shard iterator still holds the pre-epoch
+                    # shuffle snapshot; rewrite it to the post-epoch state.
+                    self.dl_state_dict["_iterator_finished"] = False
+                    _replace_sampler_iter_state(
+                        self.dl_state_dict,
+                        {"yielded": 0, "shuffle_state": _capture_shuffle_state(batch_sampler)},
+                    )
+                else:
+                    # Leave torchdata's iterator schema intact so a plain
+                    # DataLoaderShard/Dispatcher can start a fresh pass.
+                    self.dl_state_dict["_iterator_finished"] = True
             else:
                 self.dl_state_dict["_iterator_finished"] = False
                 if iteration:

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -43,6 +43,11 @@ from .utils import (
 
 logger = get_logger(__name__)
 
+# Extra key stored in DataLoaderAdapter.state_dict so a fresh loader can resume
+# the same sampler epoch after a completed pass. Omitted when iteration == 0
+# to keep adapter state_dicts comparable to a raw StatefulDataLoader.
+_ACCELERATE_ITERATION = "_accelerate_iteration"
+
 # kwargs of the DataLoader in min version 2.0
 _PYTORCH_DATALOADER_KWARGS = {
     "batch_size": 1,
@@ -186,6 +191,9 @@ class BatchSamplerShard(BatchSampler):
             return length + 1 if self.process_index < len(self.batch_sampler) % self.num_processes else length
 
     def __iter__(self):
+        return _BatchSamplerShardIterator(self)
+
+    def _raw_iter(self):
         return self._iter_with_split() if self.split_batches else self._iter_with_no_split()
 
     def _iter_with_split(self):
@@ -269,6 +277,97 @@ class BatchSamplerShard(BatchSampler):
                         cycle_index = end_index
                     batch = []
                     idx += 1
+
+
+def _make_torch_generator():
+    device = torch.get_default_device() if hasattr(torch, "get_default_device") else "cpu"
+    generator = torch.Generator(device=device)
+    seed = int(torch.empty((), dtype=torch.int64).random_().item())
+    generator.manual_seed(seed)
+    return generator
+
+
+def _get_inner_index_sampler(batch_sampler):
+    """Return the sampler that produces dataset indices, unwrapping BatchSamplerShard."""
+    inner_batch_sampler = getattr(batch_sampler, "batch_sampler", None)
+    if inner_batch_sampler is not None:
+        inner_sampler = getattr(inner_batch_sampler, "sampler", None)
+        if inner_sampler is not None:
+            return inner_sampler
+    return getattr(batch_sampler, "sampler", None)
+
+
+def _capture_shuffle_state(batch_sampler):
+    """Snapshot the state needed to regenerate the current epoch's permutation."""
+    sampler = _get_inner_index_sampler(batch_sampler)
+    if sampler is None:
+        return {}
+    state = {}
+    if isinstance(sampler, SeedableRandomSampler):
+        state["epoch"] = sampler.epoch
+        state["initial_seed"] = sampler.initial_seed
+    if isinstance(sampler, RandomSampler):
+        # RandomSampler(generator=None) draws from the global RNG each epoch, which
+        # cannot be restored. Attach a dedicated generator so the permutation is
+        # a function of serializable state. SeedableRandomSampler reseeds from
+        # (epoch, initial_seed) and should not consume extra global RNG here.
+        if sampler.generator is None and not isinstance(sampler, SeedableRandomSampler):
+            sampler.generator = _make_torch_generator()
+        if sampler.generator is not None:
+            state["generator_state"] = sampler.generator.get_state()
+    return state
+
+
+def _restore_shuffle_state(batch_sampler, state):
+    sampler = _get_inner_index_sampler(batch_sampler)
+    if sampler is None or not state:
+        return
+    if isinstance(sampler, SeedableRandomSampler):
+        if "initial_seed" in state:
+            sampler.initial_seed = state["initial_seed"]
+        if "epoch" in state:
+            sampler.set_epoch(state["epoch"])
+    if "generator_state" in state and isinstance(sampler, RandomSampler):
+        if sampler.generator is None:
+            sampler.generator = _make_torch_generator()
+        sampler.generator.set_state(state["generator_state"])
+
+
+class _BatchSamplerShardIterator:
+    """Stateful iterator over a `BatchSamplerShard`.
+
+    `StatefulDataLoader` will persist this object's `state_dict` as
+    `_sampler_iter_state` when the iterator implements the torchdata Stateful
+    protocol. That lets a freshly constructed loader restore both the shuffle
+    permutation (generator / SeedableRandomSampler epoch) and the cursor.
+    """
+
+    def __init__(self, shard: "BatchSamplerShard"):
+        self.shard = shard
+        # Snapshot *before* iterating the inner sampler, which consumes the generator.
+        self._snapshot = _capture_shuffle_state(shard)
+        self._inner = shard._raw_iter()
+        self._yielded = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        batch = next(self._inner)
+        self._yielded += 1
+        return batch
+
+    def state_dict(self):
+        return {"yielded": self._yielded, "shuffle_state": self._snapshot}
+
+    def load_state_dict(self, state_dict):
+        self._snapshot = state_dict.get("shuffle_state", {})
+        _restore_shuffle_state(self.shard, self._snapshot)
+        self._inner = self.shard._raw_iter()
+        self._yielded = 0
+        for _ in range(state_dict.get("yielded", 0)):
+            next(self._inner)
+            self._yielded += 1
 
 
 class IterableDatasetShard(IterableDataset):
@@ -454,6 +553,12 @@ class DataLoaderAdapter:
         return self.dl_state_dict
 
     def load_state_dict(self, state_dict):
+        state_dict = dict(state_dict)
+        iteration = state_dict.pop(_ACCELERATE_ITERATION, None)
+        if iteration is not None and hasattr(self, "set_epoch"):
+            self.set_epoch(iteration)
+        elif iteration is not None and hasattr(self, "iteration"):
+            self.iteration = iteration
         self.base_dataloader.load_state_dict(state_dict)
 
     @property
@@ -505,6 +610,10 @@ class DataLoaderAdapter:
             self.adjust_state_dict_for_prefetch()
             # Then tag if we are at the end of the dataloader
             self.dl_state_dict["_iterator_finished"] = self.end_of_dataloader
+            # Persist the sampler epoch so a fresh loader does not restart at epoch 0.
+            iteration = getattr(self, "iteration", 0)
+            if iteration:
+                self.dl_state_dict[_ACCELERATE_ITERATION] = iteration
 
 
 class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
@@ -1324,6 +1433,16 @@ def prepare_data_loader(
 
     if isinstance(sampler, SeedableRandomSampler) and use_seedable_sampler:
         dataloader.set_sampler(sampler)
+        # DataLoaderAdapter may have already created a StatefulDataLoader iterator
+        # (to snapshot the initial state_dict) against the original RandomSampler.
+        # Drop it so the first epoch uses SeedableRandomSampler.
+        if use_stateful_dataloader:
+            base = getattr(dataloader, "base_dataloader", None)
+            if base is not None and hasattr(base, "state_dict"):
+                base._iterator = None
+                if hasattr(base, "_initial_iter_for_state_dict"):
+                    base._initial_iter_for_state_dict = False
+                dataloader.dl_state_dict = base.state_dict()
     if state.distributed_type == DistributedType.XLA:
         return MpDeviceLoaderWrapper(dataloader, device)
     return dataloader

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -685,6 +685,37 @@ class DataLoaderTester(AccelerateTestCase):
         test_sampler_epoch(DataLoaderShard)
         test_sampler_epoch(DataLoaderDispatcher)
 
+    def test_seedable_random_sampler_set_epoch_only_assigns(self):
+        """`set_epoch` must only assign. `__iter__` must not auto-increment.
+
+        A completed-epoch restore can replay one extra full sampler cycle. If
+        `__iter__` increments `self.epoch`, that extra cycle shifts the next
+        permutation by one epoch.
+        """
+        dataset = list(range(16))
+        sampler = SeedableRandomSampler(dataset, data_seed=1234)
+        first = list(sampler)
+        assert sampler.epoch == 0
+        second = list(sampler)
+        assert first == second
+        sampler.set_epoch(1)
+        assert sampler.epoch == 1
+        third = list(sampler)
+        assert sampler.epoch == 1
+        assert first != third
+
+    def test_seedable_sampler_epochs_still_advance_via_dataloader_set_epoch(self):
+        """DataLoaderShard must keep changing the permutation across epochs via `set_epoch`."""
+        dataset = TensorDataset(torch.arange(32))
+        sampler = SeedableRandomSampler(dataset, data_seed=1234)
+        loader = DataLoaderShard(dataset, sampler=sampler, batch_size=4)
+        epoch0 = [batch[0].tolist() for batch in loader]
+        epoch1 = [batch[0].tolist() for batch in loader]
+        assert epoch0 != epoch1
+        loader.set_epoch(0)
+        replay = [batch[0].tolist() for batch in loader]
+        assert replay == epoch0
+
     @require_datasets
     def test_iterable_dataset_native_sharding_when_n_shards_equals_num_processes(self):
         """When n_shards == num_processes, native HF dataset sharding should be used."""
@@ -1086,9 +1117,23 @@ class StatefulDataLoaderTester(AccelerateTestCase):
             use_seedable_sampler=use_seedable_sampler,
         )
 
+    @staticmethod
+    def _consume_extra_rng():
+        """Draw from the global RNG the way a real resume would (init, eval, augments).
+
+        Without persisted sampler state, torchdata rebuilds the permutation from
+        the global RNG. A same-seed resume with no other consumers can match by
+        coincidence; these draws make that path fail.
+        """
+        _ = torch.randn(32, 32)
+        eval_loader = DataLoader(TensorDataset(torch.arange(16)), batch_size=4, shuffle=True)
+        list(eval_loader)
+        _ = torch.randperm(64)
+
     def _assert_fresh_loader_resume_matches(
         self, remaining, state_dict, process_index, use_seedable_sampler, seed=9999
     ):
+        self._consume_extra_rng()
         resumed_loader = self._make_shuffled_stateful_loader(
             process_index, use_seedable_sampler=use_seedable_sampler, seed=seed
         )
@@ -1255,7 +1300,71 @@ class StatefulDataLoaderTester(AccelerateTestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             save_accelerator_state(tmpdir, [], [], [], [loader], process_index=0, step=0)
             remaining = [self._batch_values(batch) for batch in iterator]
+            self._consume_extra_rng()
             resumed_loader = self._make_shuffled_stateful_loader(0, seed=9999)
             load_accelerator_state(tmpdir, [], [], [], [resumed_loader], process_index=0)
         resumed = [self._batch_values(batch) for batch in resumed_loader]
         assert resumed == remaining
+
+    @parameterized.expand(
+        [
+            (0, False, "mid_epoch_0"),
+            (1, False, "mid_epoch_0"),
+            (0, True, "mid_epoch_0"),
+            (1, True, "mid_epoch_0"),
+            (0, False, "mid_epoch_n"),
+            (1, False, "mid_epoch_n"),
+            (0, True, "mid_epoch_n"),
+            (1, True, "mid_epoch_n"),
+            (0, False, "epoch_boundary"),
+            (1, False, "epoch_boundary"),
+            (0, True, "epoch_boundary"),
+            (1, True, "epoch_boundary"),
+        ]
+    )
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_matches_uninterrupted_reference(
+        self, process_index, use_seedable_sampler, checkpoint
+    ):
+        """Resumed batches must match a never-interrupted reference stream bit-for-bit.
+
+        Covers the four restore bars under simulated DDP (`num_processes=2`):
+        mid-epoch-0, mid-epoch-N (N=1), completed-epoch N→N+1, and resume
+        without the caller re-seeding torch.
+        """
+        n_mid = 3
+        ref_loader = self._make_shuffled_stateful_loader(
+            process_index, use_seedable_sampler=use_seedable_sampler, seed=1234
+        )
+        epoch0 = [self._batch_values(batch) for batch in ref_loader]
+        epoch1 = [self._batch_values(batch) for batch in ref_loader]
+        reference = epoch0 + epoch1
+        assert len(epoch0) > n_mid
+
+        loader = self._make_shuffled_stateful_loader(
+            process_index, use_seedable_sampler=use_seedable_sampler, seed=1234
+        )
+        if checkpoint == "mid_epoch_0":
+            iterator = iter(loader)
+            consumed = [self._batch_values(next(iterator)) for _ in range(n_mid)]
+            state_dict = loader.state_dict()
+        elif checkpoint == "mid_epoch_n":
+            consumed = [self._batch_values(batch) for batch in loader]
+            iterator = iter(loader)
+            consumed.extend(self._batch_values(next(iterator)) for _ in range(n_mid))
+            state_dict = loader.state_dict()
+        elif checkpoint == "epoch_boundary":
+            consumed = [self._batch_values(batch) for batch in loader]
+            state_dict = loader.state_dict()
+        else:
+            raise AssertionError(checkpoint)
+
+        self._consume_extra_rng()
+        resumed_loader = self._make_shuffled_stateful_loader(
+            process_index, use_seedable_sampler=use_seedable_sampler, seed=None
+        )
+        resumed_loader.load_state_dict(state_dict)
+        resumed = [self._batch_values(batch) for batch in resumed_loader]
+        if checkpoint == "mid_epoch_0":
+            resumed.extend(self._batch_values(batch) for batch in resumed_loader)
+        assert consumed + resumed == reference

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 
 import random
+import tempfile
 import weakref
 
 import pytest
 import torch
 from parameterized import parameterized
-from torch.utils.data import BatchSampler, DataLoader, IterableDataset
+from torch.utils.data import BatchSampler, DataLoader, IterableDataset, RandomSampler, TensorDataset
 
 from accelerate import Accelerator, PartialState
+from accelerate.checkpointing import load_accelerator_state, save_accelerator_state
 from accelerate.data_loader import (
     BatchSamplerShard,
     DataLoaderDispatcher,
@@ -1064,3 +1066,129 @@ class StatefulDataLoaderTester(AccelerateTestCase):
 
         gradient_state = GradientState()
         assert gradient_state.active_dataloader is None
+
+    @staticmethod
+    def _batch_values(batch):
+        tensor = batch[0] if isinstance(batch, (list, tuple)) else batch
+        return tensor.detach().cpu().tolist()
+
+    @staticmethod
+    def _make_shuffled_stateful_loader(process_index, use_seedable_sampler=False, seed=1234):
+        if seed is not None:
+            torch.manual_seed(seed)
+        dataset = TensorDataset(torch.arange(64))
+        dataloader = DataLoader(dataset, batch_size=4, shuffle=True, num_workers=0)
+        return prepare_data_loader(
+            dataloader,
+            num_processes=2,
+            process_index=process_index,
+            use_stateful_dataloader=True,
+            use_seedable_sampler=use_seedable_sampler,
+        )
+
+    def _assert_fresh_loader_resume_matches(
+        self, remaining, state_dict, process_index, use_seedable_sampler, seed=9999
+    ):
+        resumed_loader = self._make_shuffled_stateful_loader(
+            process_index, use_seedable_sampler=use_seedable_sampler, seed=seed
+        )
+        resumed_loader.load_state_dict(state_dict)
+        resumed = [self._batch_values(batch) for batch in resumed_loader]
+        assert resumed == remaining
+
+    @parameterized.expand([(0, False), (1, False), (0, True), (1, True)])
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_after_epoch_boundary(self, process_index, use_seedable_sampler):
+        """Fresh-loader resume after a full epoch plus N batches of the next epoch.
+
+        Regression test for https://github.com/huggingface/accelerate/issues/4195:
+        the cursor was restored but the shuffle permutation was not.
+        """
+        loader = self._make_shuffled_stateful_loader(process_index, use_seedable_sampler=use_seedable_sampler)
+        list(loader)
+        iterator = iter(loader)
+        for _ in range(3):
+            next(iterator)
+        state_dict = loader.state_dict()
+        remaining = [self._batch_values(batch) for batch in iterator]
+        assert remaining, "expected leftover batches in the second epoch"
+        self._assert_fresh_loader_resume_matches(remaining, state_dict, process_index, use_seedable_sampler)
+
+    @parameterized.expand([(0, False), (1, False), (0, True), (1, True)])
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_mid_first_epoch(self, process_index, use_seedable_sampler):
+        loader = self._make_shuffled_stateful_loader(process_index, use_seedable_sampler=use_seedable_sampler)
+        iterator = iter(loader)
+        for _ in range(3):
+            next(iterator)
+        state_dict = loader.state_dict()
+        remaining = [self._batch_values(batch) for batch in iterator]
+        self._assert_fresh_loader_resume_matches(remaining, state_dict, process_index, use_seedable_sampler)
+
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_orders_differ_across_ranks(self):
+        batches_by_rank = []
+        for process_index in (0, 1):
+            loader = self._make_shuffled_stateful_loader(process_index)
+            batches_by_rank.append([self._batch_values(batch) for batch in loader])
+        assert batches_by_rank[0] != batches_by_rank[1]
+
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_without_reseed(self):
+        """Resume must not depend on the caller re-seeding torch before building the new loader."""
+        loader = self._make_shuffled_stateful_loader(0, seed=1234)
+        iterator = iter(loader)
+        for _ in range(3):
+            next(iterator)
+        state_dict = loader.state_dict()
+        remaining = [self._batch_values(batch) for batch in iterator]
+
+        torch.manual_seed(42)
+        resumed_loader = self._make_shuffled_stateful_loader(0, seed=None)
+        resumed_loader.load_state_dict(state_dict)
+        resumed = [self._batch_values(batch) for batch in resumed_loader]
+        assert resumed == remaining
+
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_random_sampler_generator_none(self):
+        dataset = TensorDataset(torch.arange(64))
+        sampler = RandomSampler(dataset)
+        assert sampler.generator is None
+        batch_sampler = BatchSamplerShard(
+            BatchSampler(sampler, batch_size=4, drop_last=False),
+            num_processes=2,
+            process_index=0,
+        )
+        loader = DataLoaderShard(dataset, batch_sampler=batch_sampler, use_stateful_dataloader=True)
+        iterator = iter(loader)
+        for _ in range(3):
+            next(iterator)
+        state_dict = loader.state_dict()
+        remaining = [self._batch_values(batch) for batch in iterator]
+
+        sampler2 = RandomSampler(dataset)
+        assert sampler2.generator is None
+        batch_sampler2 = BatchSamplerShard(
+            BatchSampler(sampler2, batch_size=4, drop_last=False),
+            num_processes=2,
+            process_index=0,
+        )
+        resumed_loader = DataLoaderShard(dataset, batch_sampler=batch_sampler2, use_stateful_dataloader=True)
+        resumed_loader.load_state_dict(state_dict)
+        resumed = [self._batch_values(batch) for batch in resumed_loader]
+        assert resumed == remaining
+
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_via_accelerator_save_state(self):
+        loader = self._make_shuffled_stateful_loader(0)
+        list(loader)
+        iterator = iter(loader)
+        for _ in range(3):
+            next(iterator)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            save_accelerator_state(tmpdir, [], [], [], [loader], process_index=0, step=0)
+            remaining = [self._batch_values(batch) for batch in iterator]
+            resumed_loader = self._make_shuffled_stateful_loader(0, seed=9999)
+            load_accelerator_state(tmpdir, [], [], [], [resumed_loader], process_index=0)
+        resumed = [self._batch_values(batch) for batch in resumed_loader]
+        assert resumed == remaining

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1116,6 +1116,29 @@ class StatefulDataLoaderTester(AccelerateTestCase):
 
     @parameterized.expand([(0, False), (1, False), (0, True), (1, True)])
     @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_after_completed_epoch(self, process_index, use_seedable_sampler):
+        """Checkpointing after `list(loader)` must resume at the *next* epoch's permutation."""
+        loader = self._make_shuffled_stateful_loader(process_index, use_seedable_sampler=use_seedable_sampler)
+        list(loader)
+        state_dict = loader.state_dict()
+        next_epoch = [self._batch_values(batch) for batch in loader]
+        assert next_epoch, "expected a second epoch of batches"
+        self._assert_fresh_loader_resume_matches(next_epoch, state_dict, process_index, use_seedable_sampler)
+
+    @parameterized.expand([(0, False), (1, False), (0, True), (1, True)])
+    @require_torchdata_stateful_dataloader
+    def test_stateful_shuffle_resume_on_last_batch_of_second_epoch(self, process_index, use_seedable_sampler):
+        """A last-batch snapshot of epoch 1 must resume at epoch 2, not replay epoch 1."""
+        loader = self._make_shuffled_stateful_loader(process_index, use_seedable_sampler=use_seedable_sampler)
+        list(loader)
+        list(loader)
+        state_dict = loader.state_dict()
+        third_epoch = [self._batch_values(batch) for batch in loader]
+        assert third_epoch, "expected a third epoch of batches"
+        self._assert_fresh_loader_resume_matches(third_epoch, state_dict, process_index, use_seedable_sampler)
+
+    @parameterized.expand([(0, False), (1, False), (0, True), (1, True)])
+    @require_torchdata_stateful_dataloader
     def test_stateful_shuffle_resume_mid_first_epoch(self, process_index, use_seedable_sampler):
         loader = self._make_shuffled_stateful_loader(process_index, use_seedable_sampler=use_seedable_sampler)
         iterator = iter(loader)

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1137,6 +1137,50 @@ class StatefulDataLoaderTester(AccelerateTestCase):
         assert third_epoch, "expected a third epoch of batches"
         self._assert_fresh_loader_resume_matches(third_epoch, state_dict, process_index, use_seedable_sampler)
 
+    @require_torchdata_stateful_dataloader
+    def test_completed_epoch_resume_plain_dataloader_shard(self):
+        """A finished `DataLoaderShard(batch_size=...)` must not smash torchdata's iterator schema."""
+
+        def make():
+            return DataLoaderShard(list(range(64)), batch_size=4, use_stateful_dataloader=True)
+
+        loader = make()
+        first = [self._batch_values(batch) for batch in loader]
+        state_dict = loader.state_dict()
+        second = [self._batch_values(batch) for batch in loader]
+        assert first == second
+        resumed = make()
+        resumed.load_state_dict(state_dict)
+        assert [self._batch_values(batch) for batch in resumed] == second
+
+    @require_torchdata_stateful_dataloader
+    def test_completed_epoch_resume_plain_shuffled_dataloader_shard(self):
+        """Same public constructor with `shuffle=True` must load without KeyError."""
+
+        def make():
+            return DataLoaderShard(list(range(64)), batch_size=4, shuffle=True, use_stateful_dataloader=True)
+
+        loader = make()
+        list(loader)
+        state_dict = loader.state_dict()
+        resumed = make()
+        resumed.load_state_dict(state_dict)
+        assert sum(1 for _ in resumed) == 16
+
+    @require_torchdata_stateful_dataloader
+    def test_completed_epoch_resume_dataloader_dispatcher(self):
+        def make():
+            return DataLoaderDispatcher(list(range(64)), batch_size=4, use_stateful_dataloader=True)
+
+        loader = make()
+        first = [self._batch_values(batch) for batch in loader]
+        state_dict = loader.state_dict()
+        second = [self._batch_values(batch) for batch in loader]
+        assert first == second
+        resumed = make()
+        resumed.load_state_dict(state_dict)
+        assert [self._batch_values(batch) for batch in resumed] == second
+
     @parameterized.expand([(0, False), (1, False), (0, True), (1, True)])
     @require_torchdata_stateful_dataloader
     def test_stateful_shuffle_resume_mid_first_epoch(self, process_index, use_seedable_sampler):


### PR DESCRIPTION
## What does this PR do?

`use_stateful_dataloader=True` restored how far the loader had walked, but not the shuffle permutation. After a completed epoch, a fresh loader rebuilt `RandomSampler` at epoch 0 and then skipped N batches of the *wrong* order. Mid-epoch resume on a new process had the same failure when the sampler's generator was not serialized.

This persists the state needed to rebuild the current epoch's permutation:

- `BatchSamplerShard` now yields a stateful iterator. `StatefulDataLoader` stores that as `_sampler_iter_state` (generator snapshot taken *before* the inner sampler consumes it, plus how many batches were yielded).
- `RandomSampler(generator=None)` gets a dedicated generator so the permutation is not tied to the caller's global RNG.
- `SeedableRandomSampler` epoch / `initial_seed` are restored.
- `DataLoaderAdapter.state_dict` also records `_accelerate_iteration` after a completed pass so `set_epoch` is applied on load.

A new loader + `load_state_dict` (or `Accelerator.save_state` / `load_state`) then sees the same remaining batches.

Fixes #4195. Related: #4196 takes a similar iterator snapshot but does not cover the epoch-boundary case or `Accelerator.save_state`.

## Tests

All under `@require_torchdata_stateful_dataloader`, using `prepare_data_loader(..., num_processes=2)` (no GPU):

- Full epoch 0, checkpoint after 3 batches of epoch 1, resume into a **new** loader — ranks 0 and 1, with and without `use_seedable_sampler`
- Mid-first-epoch resume, same matrix
- Rank 0 and rank 1 see different orders
- Resume does not depend on re-seeding torch
- `RandomSampler.generator is None`
- `save_accelerator_state` / `load_accelerator_state`

Existing stateful DataLoader tests still pass.

## Who can review?

@SunMarc