### PR TITLE
Fix FSDP2/ PEFT/`FULL_STATE_DICT` dropping every rank's adapter shard except rank 0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ extras["test_dev"] = [
     "datasets",
     "diffusers",
     "evaluate",
+    "peft",
     "torchdata>=0.8.0",
     "torchpippy>=0.2.0",
     "transformers",

--- a/src/accelerate/test_utils/testing.py
+++ b/src/accelerate/test_utils/testing.py
@@ -58,6 +58,7 @@ from ..utils import (
     is_neuron_available,
     is_npu_available,
     is_pandas_available,
+    is_peft_available,
     is_pippy_available,
     is_pytest_available,
     is_schedulefree_available,
@@ -257,6 +258,13 @@ def require_fp8(test_case):
 
 def require_fsdp2(test_case):
     return unittest.skipUnless(is_torch_version(">=", "2.5.0"), "test requires FSDP2 (torch >= 2.5.0)")(test_case)
+
+
+def require_peft(test_case):
+    """
+    Decorator marking a test that requires PEFT. These tests are skipped when PEFT isn't installed.
+    """
+    return unittest.skipUnless(is_peft_available(), "test requires PEFT")(test_case)
 
 
 def require_mlu(test_case):

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -20,6 +20,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import nullcontext
+from dataclasses import replace
 from pathlib import Path
 from typing import Callable, Union
 
@@ -55,6 +56,13 @@ def disable_fsdp_ram_efficient_loading():
 
 def _get_model_state_dict(model, adapter_only=False, sd_options=None):
     if adapter_only and is_peft_model(model):
+        if sd_options is not None and sd_options.full_state_dict:
+            from torch.distributed.checkpoint.state_dict import get_model_state_dict
+
+            # NOTE: Under FSDP2 `get_peft_model_state_dict` returns sharded `DTensor`s
+            #  that it has no handling for.
+            return get_model_state_dict(model, options=replace(sd_options, ignore_frozen_params=True))
+
         from peft import get_peft_model_state_dict
 
         return get_peft_model_state_dict(model, adapter_name=model.active_adapter)
@@ -70,6 +78,12 @@ def _get_model_state_dict(model, adapter_only=False, sd_options=None):
 
 def _set_model_state_dict(model, state_dict, adapter_only=False, sd_options=None):
     if adapter_only and is_peft_model(model):
+        # Invariant: `sd_options` is not None only for FSDP2
+        if sd_options is not None and sd_options.full_state_dict:
+            from torch.distributed.checkpoint.state_dict import set_model_state_dict
+
+            return set_model_state_dict(model, state_dict, options=replace(sd_options, strict=False))
+
         from peft import set_peft_model_state_dict
 
         return set_peft_model_state_dict(model, state_dict, adapter_name=model.active_adapter)

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -59,8 +59,6 @@ def _get_model_state_dict(model, adapter_only=False, sd_options=None):
         if sd_options is not None and sd_options.full_state_dict:
             from torch.distributed.checkpoint.state_dict import get_model_state_dict
 
-            # NOTE: Under FSDP2 `get_peft_model_state_dict` returns sharded `DTensor`s
-            #  that it has no handling for.
             return get_model_state_dict(model, options=replace(sd_options, ignore_frozen_params=True))
 
         from peft import get_peft_model_state_dict

--- a/src/accelerate/utils/fsdp_utils.py
+++ b/src/accelerate/utils/fsdp_utils.py
@@ -76,7 +76,6 @@ def _get_model_state_dict(model, adapter_only=False, sd_options=None):
 
 def _set_model_state_dict(model, state_dict, adapter_only=False, sd_options=None):
     if adapter_only and is_peft_model(model):
-        # Invariant: `sd_options` is not None only for FSDP2
         if sd_options is not None and sd_options.full_state_dict:
             from torch.distributed.checkpoint.state_dict import set_model_state_dict
 

--- a/tests/fsdp/peft_checkpointing.py
+++ b/tests/fsdp/peft_checkpointing.py
@@ -1,4 +1,4 @@
-# Copyright 2025 The HuggingFace Team. All rights reserved.
+# Copyright 2026 The HuggingFace Team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/fsdp/peft_checkpointing.py
+++ b/tests/fsdp/peft_checkpointing.py
@@ -1,0 +1,122 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Checks that `save_fsdp_model`/`load_fsdp_model` round-trip a PEFT adapter without losing any rank's shard.
+
+Every rank fills its *local* shard of every adapter parameter with a rank-distinctive constant, so that a shard that
+was gathered from the wrong rank (or never restored at all) is unambiguous. The freshly built model is zeroed before
+loading, otherwise a value that was simply never overwritten would look like a successful load.
+"""
+
+import argparse
+
+import torch
+from peft import LoraConfig, get_peft_model
+from torch import nn
+from torch.distributed.tensor import DTensor
+
+from accelerate import Accelerator
+from accelerate.utils import load_fsdp_model, save_fsdp_model
+
+
+DIM = 64
+
+
+class Block(nn.Module):
+    def __init__(self, dim):
+        super().__init__()
+        self.lin1 = nn.Linear(dim, dim)
+        self.lin2 = nn.Linear(dim, dim)
+
+    def forward(self, x):
+        return self.lin2(torch.relu(self.lin1(x)))
+
+
+class TinyModel(nn.Module):
+    def __init__(self, dim, num_blocks=2):
+        super().__init__()
+        self.blocks = nn.ModuleList([Block(dim) for _ in range(num_blocks)])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+def build(accelerator):
+    model = get_peft_model(TinyModel(DIM), LoraConfig(r=8, lora_alpha=16, target_modules=["lin1", "lin2"]))
+    optimizer = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=1e-3)
+    # FSDP2 requires the model and the optimizer to be prepared together
+    return accelerator.prepare(model, optimizer)
+
+
+def adapter_parameters(model):
+    for name, param in model.named_parameters():
+        if "lora_A" in name or "lora_B" in name:
+            yield name, param
+
+
+def local(param):
+    return param.to_local() if isinstance(param.data, DTensor) else param.data
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output_dir", type=str, required=True)
+    parser.add_argument("--adapter_only", action="store_true")
+    args = parser.parse_args()
+
+    accelerator = Accelerator()
+    fsdp_plugin = accelerator.state.fsdp_plugin
+    kwargs = {"adapter_only": True} if args.adapter_only else {}
+    # a value no rank shares with another, so that a mixed-up shard is detectable
+    fill_value = 1.0 + accelerator.process_index
+
+    model, optimizer = build(accelerator)
+    with torch.no_grad():
+        for _, param in adapter_parameters(model):
+            local(param).fill_(fill_value)
+
+    save_fsdp_model(fsdp_plugin, accelerator, model, args.output_dir, **kwargs)
+    accelerator.wait_for_everyone()
+
+    del model, optimizer
+    model, optimizer = build(accelerator)
+    with torch.no_grad():
+        for _, param in adapter_parameters(model):
+            local(param).zero_()
+
+    load_fsdp_model(fsdp_plugin, accelerator, model, args.output_dir, **kwargs)
+    accelerator.wait_for_everyone()
+
+    num_checked = 0
+    for name, param in adapter_parameters(model):
+        shard = local(param)
+        if shard.numel() == 0:
+            # this rank holds no slice of this parameter
+            continue
+        num_checked += 1
+        assert torch.allclose(shard, torch.full_like(shard, fill_value)), (
+            f"rank {accelerator.process_index} did not get its shard of {name} back: expected {fill_value}, "
+            f"got values in [{shard.min().item()}, {shard.max().item()}]"
+        )
+    assert num_checked > 0, f"rank {accelerator.process_index} checked no adapter parameter"
+
+    accelerator.wait_for_everyone()
+    if accelerator.is_main_process:
+        print(f"**PEFT {'adapter-only ' if args.adapter_only else ''}checkpointing round-trip is correct**")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -33,6 +33,7 @@ from accelerate.test_utils.testing import (
     require_multi_device,
     require_non_cpu,
     require_non_torch_xla,
+    require_peft,
     run_first,
     slow,
 )
@@ -925,3 +926,32 @@ class FSDP2IntegrationTest(FSDPIntegrationTest):
     def setUp(self):
         super().setUp()
         self.current_fsdp_version = 2
+
+    @require_fsdp2
+    @require_peft
+    def test_peft_checkpointing(self):
+        """Every rank's shard of the adapter must survive a `save_fsdp_model`/`load_fsdp_model` round-trip."""
+        test_file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "peft_checkpointing.py")
+        cmd = get_launch_command(
+            num_processes=2,
+            num_machines=1,
+            machine_rank=0,
+            use_fsdp=True,
+            fsdp_version=2,
+            fsdp_auto_wrap_policy="TRANSFORMER_BASED_WRAP",
+            fsdp_transformer_layer_cls_to_wrap="Block",
+        )
+        cmd.append("--fsdp_reshard_after_forward=true")
+
+        for state_dict_type in FSDP2_STATE_DICT_TYPE:
+            # `transformers.Trainer` always passes `adapter_only=True`, but the flag is optional for other callers
+            for adapter_only in (True, False):
+                cmd_config = cmd + [
+                    f"--fsdp_state_dict_type={state_dict_type}",
+                    test_file_path,
+                    f"--output_dir={os.path.join(self.tmpdir, state_dict_type, str(adapter_only))}",
+                ]
+                if adapter_only:
+                    cmd_config.append("--adapter_only")
+                with patch_environment(omp_num_threads=1):
+                    execute_subprocess_async(cmd_config)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -46,7 +46,12 @@ from accelerate.utils.constants import (
     FSDP_STATE_DICT_TYPE,
 )
 from accelerate.utils.dataclasses import FullyShardedDataParallelPlugin
-from accelerate.utils.fsdp_utils import disable_fsdp_ram_efficient_loading, enable_fsdp_ram_efficient_loading
+from accelerate.utils.fsdp_utils import (
+    _get_model_state_dict,
+    _set_model_state_dict,
+    disable_fsdp_ram_efficient_loading,
+    enable_fsdp_ram_efficient_loading,
+)
 
 
 set_seed(42)
@@ -62,6 +67,65 @@ if is_fp16_available():
     dtypes.append(FP16)
 if is_bf16_available():
     dtypes.append(BF16)
+
+
+@require_fsdp2
+@require_peft
+class FSDP2PeftStateDictTest(AccelerateTestCase):
+    """
+    The FSDP2 adapter-only path must go *through* `sd_options`, not around it.
+
+    Runs single-process on CPU, so it cannot check that each rank's shard survives -- that needs two
+    devices and lives in `peft_checkpointing.py`. What it does lock down is the regression itself: the PEFT
+    branch used to return before the `sd_options` gather, which under FSDP2 meant rank 0's shard was written
+    as if it were the whole tensor.
+    """
+
+    def _peft_model(self):
+        from peft import LoraConfig, get_peft_model
+
+        class Tiny(torch.nn.Module):
+            def __init__(self, dim=32):
+                super().__init__()
+                self.lin1 = torch.nn.Linear(dim, dim)
+                self.lin2 = torch.nn.Linear(dim, dim)
+
+        return get_peft_model(Tiny(), LoraConfig(r=4, target_modules=["lin1", "lin2"]))
+
+    @staticmethod
+    def _fill_adapter(model, value):
+        with torch.no_grad():
+            for name, param in model.named_parameters():
+                if "lora_" in name:
+                    param.fill_(value)
+
+    def test_adapter_state_dict_is_keyed_by_model_fqns(self):
+        """If the PEFT branch returns early, the adapter name is stripped and these no longer match."""
+        from torch.distributed.checkpoint.state_dict import StateDictOptions
+
+        model = self._peft_model()
+        state_dict = _get_model_state_dict(model, adapter_only=True, sd_options=StateDictOptions(full_state_dict=True))
+        trainable = {name for name, param in model.named_parameters() if param.requires_grad}
+        assert state_dict.keys() == trainable
+
+    def test_adapter_state_dict_round_trip(self):
+        """An adapter-only state dict doesn't cover the frozen base weights, so loading it can't be strict."""
+        from torch.distributed.checkpoint.state_dict import StateDictOptions
+
+        sd_options = StateDictOptions(full_state_dict=True)
+        model = self._peft_model()
+        self._fill_adapter(model, 0.5)
+
+        # a real checkpoint goes through disk; clone to break the aliasing with the live parameters
+        state_dict = {
+            key: value.detach().clone()
+            for key, value in _get_model_state_dict(model, adapter_only=True, sd_options=sd_options).items()
+        }
+        self._fill_adapter(model, 0.0)
+        _set_model_state_dict(model, state_dict, adapter_only=True, sd_options=sd_options)
+
+        restored = {float(param.detach().flatten()[0]) for name, param in model.named_parameters() if "lora_" in name}
+        assert restored == {0.5}
 
 
 @require_non_cpu


### PR DESCRIPTION
On FSDP2 with `fsdp_state_dict_type=FULL_STATE_DICT` and a PEFT model, `save_fsdp_model(..., adapter_only=True)` writes only rank 0's slice of each adapter tensor, and `load_fsdp_model(..., adapter_only=True)` restores nothing on the other ranks. 

On N GPUs, resuming reverts `(N-1)/N` of the adapter to its init — `lora_B` to zero, `lora_A` to random.

`transformers.Trainer` always hits this: `get_fsdp_ckpt_kwargs()` returns `{"adapter_only": True}` unconditionally whenever `save_fsdp_model` accepts it.

## Repro

LoRA `r=32`, `target_modules="all-linear"` on `trl-internal-testing/small-Qwen2ForCausalLM-2.5`, FSDP2, 2×H100. Instead of training, each rank fills its **own local slice** of every adapter tensor with a rank-specific value — rank 0 gets `lora_A=0.03`/`lora_B=0.01`, rank 1 gets `0.04`/`0.02` — so a slice restored from the wrong rank is unmistakable. 

Then: save → fresh model → zero the adapter → load → measure. The zeroing matters; without it a value that was simply never overwritten looks like a successful load.

| config | rank 0 after load | rank 1 after load | artifact | size | `lora_B` values in file |
|---|---|---|---|---|---|
| **FULL + `adapter_only`** ← what Trainer uses | 0.03 / 0.01 ✅ | **0.00 / 0.00** ❌ lost | `pytorch_model_fsdp.bin` | 191,949 B | **`[0.01]`** — rank 1's `0.02` absent |
| FULL, no flag | 0.03 / 0.01 ✅ | 0.04 / 0.02 ✅ | `pytorch_model_fsdp.bin` | 156,173,213 B | `[0.01, 0.02]` |
| SHARDED + `adapter_only` | 0.03 / 0.01 ✅ | 0.04 / 0.02 ✅ | `pytorch_model_fsdp_0/` (2 × `.distcp`) | 459,168 B | `[0.01, 0.02]` |
| SHARDED, no flag | 0.03 / 0.01 ✅ | 0.04 / 0.02 ✅ | `pytorch_model_fsdp_0/` | 156,363,611 B | `[0.01, 0.02]` |

The saved entries are ungathered `DTensor`s holding just the local half:

```
FULL + adapter_only:  ...layers.0.self_attn.q_proj.lora_B.weight
    type=DTensor  shape=(128, 32)  placements=(Shard(dim=0),)  to_local().shape=(64, 32)  distinct=[0.01]
FULL + no flag:       ...layers.0.self_attn.q_proj.lora_B.default.weight
    type=Tensor   shape=(128, 32)                                                         distinct=[0.01, 0.02]
```

`load_fsdp_model` even reports the failure in-band and it gets thrown away: rank 1 lists every
`lora_A`/`lora_B` key as missing while rank 0 lists only base-model keys. No caller looks at the
returned `_IncompatibleKeys`.

## The fix
- **Save** — `ignore_frozen_params=True` drops the frozen weights and gathers the rest. In a LoRA run the trainable tensors *are* the adapter.
- **Load** — `strict=False` because the file holds the adapter only. Torch broadcasts from rank 0 and re-slices on every rank.
- `ignore_frozen_params` filters *before* the gather, so the frozen base model is never materialized on rank 0.

All five runs (the four above plus the no-zeroing resume) now come back correct on both ranks, the file holds `[0.01, 0.02]`, and `load_fsdp_model` reports no missing LoRA keys on either rank.

## Tests

Two layers: one cheap enough to run on every PR, one that needs 2 GPUs.

- **`FSDP2PeftStateDictTest`** (`tests/fsdp/test_fsdp.py`) — single process, CPU, runs on every PR. Can't check sharding, but asserts the adapter state dict is keyed by the model's own FQNs, which is only true if the `sd_options` path was taken. A second test round-trips the adapter, which guards `strict=False`. Reverting only `fsdp_utils.py` turns the pair from 2 passed into 1 failed.
- **`tests/fsdp/peft_checkpointing.py`** — the only test that proves each rank's shard survives, since the bug can't appear on one rank. Every rank fills its own slice with a distinct value, saves, rebuilds, zeroes, loads, and checks it got its own value back. `FSDP2IntegrationTest.test_peft_checkpointing` runs it across both state-dict types × `adapter_only` on/off. `@slow` + `@require_multi_device` like the FSDP tests around it, so it runs in the nightly `multi_gpu` job. Against the unpatched code: `rank 1 did not get its shard of ...lora_A.default.weight back: expected 2.0, got values in [0.0, 0.0]`.
- `peft` is the only added dependency, test-only, in `test_dev`. Unavoidable — the branch is gated on `is_peft_model`, so a test has to build a real `PeftModel` to reach it.
- Heads up: the nightly job installs with `--no-deps` and gets its dependencies from the prebuilt GPU image, so both tests skip until that image is rebuilt with the new extra.
