### PR TITLE
Fix `save_model` dropping root-level parameters and buffers for offloaded models

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1750,8 +1750,8 @@ def get_state_dict_offloaded_model(model: nn.Module):
     state_dict = {}
     placeholders = set()
     for name, module in model.named_modules():
-        if name == "":
-            continue
+        # the root module is included so that parameters and buffers registered directly on it are saved
+        prefix = f"{name}." if name else ""
 
         try:
             with align_module_device(module, "cpu"):
@@ -1762,10 +1762,10 @@ def get_state_dict_offloaded_model(model: nn.Module):
         for key in module_state_dict:
             # ignore placeholder parameters that are still on the meta device
             if module_state_dict[key].device == torch.device("meta"):
-                placeholders.add(name + f".{key}")
+                placeholders.add(prefix + key)
                 continue
             params = module_state_dict[key]
-            state_dict[name + f".{key}"] = params.to("cpu")  # move buffers to cpu
+            state_dict[prefix + key] = params.to("cpu")  # move buffers to cpu
     for key in placeholders.copy():
         if key in state_dict:
             placeholders.remove(key)
@@ -2156,6 +2156,21 @@ def get_grad_scaler(distributed_type: DistributedType = None, **kwargs):
             return torch.cuda.amp.GradScaler(**kwargs)
 
 
+def _get_offload_hook(module: torch.nn.Module):
+    """
+    Returns the `AlignDevicesHook` that offloads `module`, or `None` if there is none. Hooks chained on a module are
+    wrapped in a `SequentialHook`, which is what `cpu_offload`, `disk_offload` and `dispatch_model` attach to the root
+    module, so the wrapper is unpacked before looking for the offloading hook.
+    """
+    from ..hooks import AlignDevicesHook, SequentialHook  # avoid circular import
+
+    hook = getattr(module, "_hf_hook", None)
+    for candidate in hook.hooks if isinstance(hook, SequentialHook) else (hook,):
+        if isinstance(candidate, AlignDevicesHook) and candidate.offload:
+            return candidate
+    return None
+
+
 def has_offloaded_params(module: torch.nn.Module) -> bool:
     """
     Checks if a module has offloaded parameters by checking if the given module has a AlignDevicesHook attached with
@@ -2167,9 +2182,7 @@ def has_offloaded_params(module: torch.nn.Module) -> bool:
     Returns:
         bool: `True` if the module has an offload hook and offloading is enabled, `False` otherwise.
     """
-    from ..hooks import AlignDevicesHook  # avoid circular import
-
-    return hasattr(module, "_hf_hook") and isinstance(module._hf_hook, AlignDevicesHook) and module._hf_hook.offload
+    return _get_offload_hook(module) is not None
 
 
 @contextlib.contextmanager
@@ -2184,18 +2197,19 @@ def align_module_device(module: torch.nn.Module, execution_device: Optional[torc
             If provided, overrides the module's execution device within the context. Otherwise, use hook execution
             device or pass
     """
-    if has_offloaded_params(module):
+    offload_hook = _get_offload_hook(module)
+    if offload_hook is not None:
         if execution_device is not None:
-            original_device = module._hf_hook.execution_device
-            module._hf_hook.execution_device = execution_device
+            original_device = offload_hook.execution_device
+            offload_hook.execution_device = execution_device
 
         try:
-            module._hf_hook.pre_forward(module)
+            offload_hook.pre_forward(module)
             yield
         finally:
-            module._hf_hook.post_forward(module, None)
+            offload_hook.post_forward(module, None)
             if execution_device is not None:
-                module._hf_hook.execution_device = original_device
+                offload_hook.execution_device = original_device
 
     elif execution_device is not None:
         devices = {name: param.device for name, param in module.named_parameters(recurse=False)}

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -47,6 +47,7 @@ from accelerate.utils.modeling import (
     get_module_size_with_ties,
     get_non_persistent_buffers,
     get_state_dict_offloaded_model,
+    has_offloaded_params,
     infer_auto_device_map,
     load_checkpoint_in_model,
     load_state_dict,
@@ -78,6 +79,19 @@ class NestedModelForTest(nn.Module):
 
     def forward(self, x):
         return self.model(x)
+
+
+class ModelWithRootTensorsForTest(nn.Module):
+    """Registers a parameter and a buffer on the root module, as vision models do for `cls_token`/`pos_embed`."""
+
+    def __init__(self):
+        super().__init__()
+        self.cls_token = nn.Parameter(torch.randn(1, 1, 3))
+        self.register_buffer("pos_embed", torch.randn(3))
+        self.model = ModelForTest()
+
+    def forward(self, x):
+        return self.model(x + self.cls_token + self.pos_embed)
 
 
 class LinearWithNonPersistentBuffers(nn.Module):
@@ -1094,7 +1108,7 @@ class ModelingUtilsTester(unittest.TestCase):
             convert_file_size_to_int("-1GB")
 
     def test_get_state_dict_offloaded_model(self):
-        for model_cls in (ModelForTest, NestedModelForTest):
+        for model_cls in (ModelForTest, NestedModelForTest, ModelWithRootTensorsForTest):
             model = model_cls()
             execution_device = torch.device(torch_device)
             original_state_dict = model.state_dict()
@@ -1152,6 +1166,18 @@ class ModelingUtilsTester(unittest.TestCase):
         assert model.linear1.weight.device == offload_device
         assert model.batchnorm.weight.device == offload_device
         assert model.linear2.weight.device == offload_device
+
+    def test_align_module_device_offloaded_root(self):
+        # offloading attaches a SequentialHook to the root module, which must still be recognized as offloaded
+        model = ModelWithRootTensorsForTest()
+        cpu_offload(model, execution_device=torch.device(torch_device), offload_buffers=True)
+
+        assert has_offloaded_params(model)
+        with align_module_device(model, execution_device="cpu"):
+            assert model.cls_token.device == torch.device("cpu")
+            assert model.pos_embed.device == torch.device("cpu")
+        assert model.cls_token.device == torch.device("meta")
+        assert model.pos_embed.device == torch.device("meta")
 
     def test_align_module_device_offloaded_nested(self):
         model = NestedModelForTest()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,7 +26,13 @@ import torch
 from torch import nn
 
 from accelerate.big_modeling import cpu_offload_with_hook
-from accelerate.hooks import attach_align_device_hook, remove_hook_from_module
+from accelerate.hooks import (
+    AlignDevicesHook,
+    SequentialHook,
+    add_hook_to_module,
+    attach_align_device_hook,
+    remove_hook_from_module,
+)
 from accelerate.state import PartialState
 from accelerate.test_utils.testing import (
     require_huggingface_suite,
@@ -441,6 +447,13 @@ class UtilsTester(unittest.TestCase):
 
         remove_hook_from_module(model)
         attach_align_device_hook(model, offload=True)
+        assert has_offloaded_params(model)
+
+        # the offloading hook is still found when chained with another hook into a SequentialHook
+        remove_hook_from_module(model)
+        attach_align_device_hook(model, offload=True)
+        add_hook_to_module(model, AlignDevicesHook(io_same_device=True), append=True)
+        assert isinstance(model._hf_hook, SequentialHook)
         assert has_offloaded_params(model)
 
     def test_concatenate(self):


### PR DESCRIPTION
# What does this PR do?

`get_state_dict_offloaded_model` skips the root module (`if name == "": continue`), so parameters and buffers registered directly on it are collected by nobody and vanish. `Accelerator.save_model` routes to this function for any offloaded model, so it writes an incomplete checkpoint with no warning. On a module with `cls_token`/`pos_embed` on the root, after `disk_offload`:

```
expected: ['blocks.0.bias', 'blocks.0.weight', 'cls_token', 'head.bias', 'head.weight', 'pos_embed']
saved   : ['blocks.0.bias', 'blocks.0.weight', 'head.bias', 'head.weight']
```

Including the root exposes a second bug. Offloading appends an `io_same_device` hook, so the root carries a `SequentialHook`; `has_offloaded_params` returns `False` for it and `align_module_device` then raises `ValueError: cls_token is on the meta device`. Both now resolve the offloading `AlignDevicesHook` through one helper that unwraps `SequentialHook`.

Keys and values now round-trip exactly for `cpu_offload`, `disk_offload` and `dispatch_model`. `ModelForTest` and `NestedModelForTest` register nothing on the root, which is why the existing test could not catch this, so I added a model that does.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [x] Did you write any new necessary tests?

The three new/extended tests fail on `main` and pass here. `tests/test_modeling_utils.py`, `test_utils.py`, `test_offload.py`, `test_big_modeling.py`, `test_hooks.py` and `test_accelerator.py` give the same 7 failures before and after (unrelated local toolchain issues), 151 passed before and 152 after.

## Who can review?

@SunMarc @BenjaminBossan

🤖 Generated with [Claude Code](https://claude.com/claude-code)
