### PR TITLE
Stop dtype_byte_size returning zero for sub-byte torch dtypes

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -185,7 +185,10 @@ def dtype_byte_size(dtype: torch.dtype):
     if bit_search is None:
         raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")
     bit_size = int(bit_search.groups()[0])
-    return bit_size // 8
+    # torch has no sub-byte storage: torch.uint4, torch.int4, torch.float4_e2m1fn_x2 and the rest of
+    # the sub-byte dtypes all report element_size() == 1. Without the floor they divide down to zero
+    # bytes, and a module holding them measures as free.
+    return max(bit_size // 8, 1)
 
 
 def id_tensor_storage(tensor: torch.Tensor) -> tuple[torch.device, int, int]:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -153,6 +153,27 @@ class ModelingUtilsTester(unittest.TestCase):
         ):
             if hasattr(torch, name):
                 self.assertEqual(dtype_byte_size(getattr(torch, name)), 1, msg=name)
+        # Sub-byte dtypes occupy a whole byte per element in torch (element_size() == 1), so they
+        # must not floor to zero bytes, which would make a module holding them measure as free.
+        for name in (
+            "uint1",
+            "uint2",
+            "uint3",
+            "uint4",
+            "uint5",
+            "uint6",
+            "uint7",
+            "int1",
+            "int2",
+            "int3",
+            "int4",
+            "int5",
+            "int6",
+            "int7",
+            "float4_e2m1fn_x2",
+        ):
+            if hasattr(torch, name):
+                self.assertEqual(dtype_byte_size(getattr(torch, name)), 1, msg=name)
 
     def check_set_module_tensor_for_device(self, model, device1, device2):
         assert model.linear1.weight.device == torch.device(device1)


### PR DESCRIPTION
### What is wrong

`dtype_byte_size` ends its regex fallback with `bit_size // 8`, so every torch dtype narrower than a byte floors to **0**. On torch 2.11 that is twenty dtypes: `uint1`-`uint7`, `int1`-`int7`, `float4_e2m1fn_x2`, `bits2x4`, `bits4x2`, `quint2x4`, `quint4x2`.

`compute_module_sizes` multiplies `tensor.numel()` by that, so a module holding 4-bit weights measures as **0 bytes**. `infer_auto_device_map` and `get_balanced_memory` then treat it as free and can pack the whole model onto one device.

The function already returns fractions elsewhere (`torch.bool` -> 1/8, `CustomDtype.INT4` -> 1/2), so the floor is inconsistent with its own contract: accelerate's own INT4 placeholder reports 1/2 a byte while torch's native `torch.uint4` reports 0.

### What changed

```python
bit_size = int(bit_search.groups()[0])
return max(bit_size // 8, 1)
```

torch has no sub-byte storage: all twenty of these dtypes report `element_size() == 1`, so one byte is the right floor. Nothing at 8 bits or wider changes.

### Test

Extended `ModelingUtilsTester.test_dtype_byte_size` with the sub-byte dtypes, guarded by `hasattr` for older torch.

```
$ pytest tests/test_modeling_utils.py -k test_dtype_byte_size -q
# on main:   1 failed   -> AssertionError: 0 != 1 : uint1
# with this: 1 passed
```

`pytest tests/test_modeling_utils.py -q` gives 39 passed / 3 failed either way; the three `infer_auto_device_map_with_buffer*` failures are present on main and unrelated. `ruff format --check` is clean and `ruff check` reports the same count before and after.