### PR TITLE
Fix `estimate-memory` for timm>=1.0.29 by adding the `hf-hub:` prefix

### DIFF
--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -17,7 +17,7 @@ from typing import Optional
 
 import torch
 from huggingface_hub import model_info
-from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+from huggingface_hub.utils import EntryNotFoundError, GatedRepoError, RepositoryNotFoundError
 
 from accelerate import init_empty_weights
 from accelerate.commands.utils import CustomArgumentParser
@@ -52,7 +52,13 @@ def check_has_model(error):
     Checks what library spawned `error` when a model is not found
     """
     message = str(error)
-    if is_timm_available() and isinstance(error, RuntimeError) and "Unknown model" in message:
+    # `timm.create_model("hf-hub:...")` reads `config.json` from the Hub without wrapping the errors: a missing file
+    # raises `EntryNotFoundError` and a `config.json` from another library has no `architecture` key (`KeyError`)
+    if is_timm_available() and (
+        (isinstance(error, RuntimeError) and "Unknown model" in message)
+        or isinstance(error, EntryNotFoundError)
+        or (isinstance(error, KeyError) and "architecture" in message)
+    ):
         return "timm"
     elif (
         is_transformers_available()
@@ -62,6 +68,21 @@ def check_has_model(error):
         return "transformers"
     else:
         return "unknown"
+
+
+def add_timm_hub_prefix(model_name: str) -> str:
+    """
+    Adds the `hf-hub:` source prefix that `timm.create_model` needs to load `model_name` from the Hub. Bare
+    architecture names from the `timm` registry (such as `resnet50`) are returned unchanged. So are names that already
+    carry a source prefix (such as `hf-hub:timm/resnet50.a1_in1k`), which only direct callers can pass: `verify_on_hub`
+    in `create_empty_model` rejects them before this function runs.
+
+    `timm>=1.0.29` refuses a Hub repo id without the prefix. Earlier versions dropped the repo owner and resolved the
+    rest of the name through the registry.
+    """
+    if ":" in model_name or "/" not in model_name:
+        return model_name
+    return f"hf-hub:{model_name}"
 
 
 def create_empty_model(
@@ -136,7 +157,7 @@ def create_empty_model(
             )
         print(f"Loading pretrained config for `{model_name}` from `timm`...")
         with init_empty_weights():
-            model = timm.create_model(model_name, pretrained=False)
+            model = timm.create_model(add_timm_hub_prefix(model_name), pretrained=False)
     else:
         raise ValueError(
             f"Library `{library_name}` is not supported yet, please open an issue on GitHub for us to add support."
@@ -263,7 +284,7 @@ def gather_data(args):
         model = create_empty_model(
             args.model_name, library_name=args.library_name, trust_remote_code=args.trust_remote_code
         )
-    except (RuntimeError, OSError, ValueError) as e:
+    except (RuntimeError, OSError, ValueError, KeyError) as e:
         library = check_has_model(e)
         if library != "unknown":
             raise RuntimeError(

--- a/src/accelerate/commands/estimate.py
+++ b/src/accelerate/commands/estimate.py
@@ -52,8 +52,6 @@ def check_has_model(error):
     Checks what library spawned `error` when a model is not found
     """
     message = str(error)
-    # `timm.create_model("hf-hub:...")` reads `config.json` from the Hub without wrapping the errors: a missing file
-    # raises `EntryNotFoundError` and a `config.json` from another library has no `architecture` key (`KeyError`)
     if is_timm_available() and (
         (isinstance(error, RuntimeError) and "Unknown model" in message)
         or isinstance(error, EntryNotFoundError)
@@ -72,13 +70,8 @@ def check_has_model(error):
 
 def add_timm_hub_prefix(model_name: str) -> str:
     """
-    Adds the `hf-hub:` source prefix that `timm.create_model` needs to load `model_name` from the Hub. Bare
-    architecture names from the `timm` registry (such as `resnet50`) are returned unchanged. So are names that already
-    carry a source prefix (such as `hf-hub:timm/resnet50.a1_in1k`), which only direct callers can pass: `verify_on_hub`
-    in `create_empty_model` rejects them before this function runs.
-
-    `timm>=1.0.29` refuses a Hub repo id without the prefix. Earlier versions dropped the repo owner and resolved the
-    rest of the name through the registry.
+    Adds the `hf-hub:` prefix that `timm.create_model` needs for Hub repo ids. Bare architecture names and names that
+    already have a source prefix are returned unchanged.
     """
     if ":" in model_name or "/" not in model_name:
         return model_name

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,11 +17,17 @@ from pathlib import Path
 from unittest.mock import patch
 
 import torch
-from huggingface_hub.utils import GatedRepoError
+from huggingface_hub.utils import EntryNotFoundError, GatedRepoError
 
 import accelerate.commands.test as accelerate_test_cmd
 from accelerate.commands.config.config_args import BaseConfig, ClusterConfig, SageMakerConfig, load_config_from_file
-from accelerate.commands.estimate import estimate_command, estimate_command_parser, gather_data
+from accelerate.commands.estimate import (
+    add_timm_hub_prefix,
+    check_has_model,
+    estimate_command,
+    estimate_command_parser,
+    gather_data,
+)
 from accelerate.commands.launch import _validate_launch_command, launch_command, launch_command_parser
 from accelerate.commands.to_fsdp2 import (
     convert_config_to_fsdp2,
@@ -452,6 +458,15 @@ class ModelEstimatorTester(unittest.TestCase):
             args = self.parser.parse_args(["muellerzr/dummy", "--library_name", "timm"])
             estimate_command(args)
 
+    @require_timm
+    def test_wrong_library_timm(self):
+        # A Hub repo whose `config.json` belongs to another library has no `architecture` key for `timm`
+        with self.assertRaisesRegex(
+            RuntimeError, "Tried to load `hf-internal-testing/tiny-random-bert` with `timm` but"
+        ):
+            args = self.parser.parse_args(["hf-internal-testing/tiny-random-bert", "--library_name", "timm"])
+            estimate_command(args)
+
     @require_transformers
     def test_invalid_model_name_transformers(self):
         with self.assertRaises(RuntimeError, msg="Tried to load `muellerzr/dummy` with `transformers` but"):
@@ -549,6 +564,25 @@ class ModelEstimatorTester(unittest.TestCase):
         assert total_size == output[0][2], (
             f"Calculation for total size in `fp32` is incorrect, expected {total_size} but received {output[0][2]}"
         )
+
+    def test_timm_hub_prefix(self):
+        # Bare architecture names come from the `timm` registry and must stay unchanged
+        assert add_timm_hub_prefix("resnet50") == "resnet50"
+        assert add_timm_hub_prefix("resnet50.a1_in1k") == "resnet50.a1_in1k"
+        # Hub repo ids need the `hf-hub:` source prefix that `timm>=1.0.29` requires
+        assert add_timm_hub_prefix("timm/resnet50.a1_in1k") == "hf-hub:timm/resnet50.a1_in1k"
+        # Names that already carry a source prefix must stay unchanged
+        assert add_timm_hub_prefix("hf-hub:timm/resnet50.a1_in1k") == "hf-hub:timm/resnet50.a1_in1k"
+        assert add_timm_hub_prefix("local-dir:/path/to/model") == "local-dir:/path/to/model"
+
+    @require_timm
+    def test_check_has_model_timm(self):
+        # Unknown architecture in the `timm` registry
+        assert check_has_model(RuntimeError("Unknown model (dummy)")) == "timm"
+        # Hub repo without a `timm` `config.json`, raised by `timm.create_model("hf-hub:...")`
+        assert check_has_model(EntryNotFoundError("Entry Not Found for url: .../config.json.")) == "timm"
+        # Hub repo whose `config.json` belongs to another library, raised by `timm.create_model("hf-hub:...")`
+        assert check_has_model(KeyError("architecture")) == "timm"
 
 
 class ToFSDP2Tester(unittest.TestCase):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,17 +17,11 @@ from pathlib import Path
 from unittest.mock import patch
 
 import torch
-from huggingface_hub.utils import EntryNotFoundError, GatedRepoError
+from huggingface_hub.utils import GatedRepoError
 
 import accelerate.commands.test as accelerate_test_cmd
 from accelerate.commands.config.config_args import BaseConfig, ClusterConfig, SageMakerConfig, load_config_from_file
-from accelerate.commands.estimate import (
-    add_timm_hub_prefix,
-    check_has_model,
-    estimate_command,
-    estimate_command_parser,
-    gather_data,
-)
+from accelerate.commands.estimate import add_timm_hub_prefix, estimate_command, estimate_command_parser, gather_data
 from accelerate.commands.launch import _validate_launch_command, launch_command, launch_command_parser
 from accelerate.commands.to_fsdp2 import (
     convert_config_to_fsdp2,
@@ -574,15 +568,6 @@ class ModelEstimatorTester(unittest.TestCase):
         # Names that already carry a source prefix must stay unchanged
         assert add_timm_hub_prefix("hf-hub:timm/resnet50.a1_in1k") == "hf-hub:timm/resnet50.a1_in1k"
         assert add_timm_hub_prefix("local-dir:/path/to/model") == "local-dir:/path/to/model"
-
-    @require_timm
-    def test_check_has_model_timm(self):
-        # Unknown architecture in the `timm` registry
-        assert check_has_model(RuntimeError("Unknown model (dummy)")) == "timm"
-        # Hub repo without a `timm` `config.json`, raised by `timm.create_model("hf-hub:...")`
-        assert check_has_model(EntryNotFoundError("Entry Not Found for url: .../config.json.")) == "timm"
-        # Hub repo whose `config.json` belongs to another library, raised by `timm.create_model("hf-hub:...")`
-        assert check_has_model(KeyError("architecture")) == "timm"
 
 
 class ToFSDP2Tester(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

`accelerate estimate-memory timm/resnet50.a1_in1k --library_name timm` fails with timm 1.0.29:

    ValueError: Model name 'timm/resnet50.a1_in1k' has no source prefix but looks like a Hugging Face Hub repo id or a local path. Use 'hf-hub:timm/resnet50.a1_in1k' to load from the Hub or 'local-dir:timm/resnet50.a1_in1k' to load from a local folder.

Since huggingface/pytorch-image-models#2727 (shipped in timm 1.0.29), timm needs a source prefix for anything that looks like a repo id. Older versions dropped the repo owner and looked the rest up in the registry, which only worked because timm names its Hub repos after the architecture. The two timm tests in tests/test_cli.py fail on main because of this, see https://github.com/huggingface/accelerate/actions/runs/33763859075/job/100676635381.

I now add the hf-hub: prefix before calling timm.create_model when the name looks like a repo id, and leave bare architecture names like resnet50 alone. With the prefix, timm reads config.json from the Hub and raises its own errors when the file is missing or belongs to another library. I map those to the existing "Tried to load ... with timm but ..." message, so the user sees the same error as with timm 1.0.28.

Note that timm names now resolve through the Hub config.json rather than the registry entry with the same name. That means user-owned timm repos work as well.

I tested with timm 1.0.28 and 1.0.29. I added unit tests for the prefix rule and the error mapping, and one end-to-end test for a repo whose config.json belongs to another library. No version pin is needed, timm has supported the hf-hub: prefix for a long time.

Fixes #4212


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Nothing user-facing changed, the documented `timm/resnet50.a1_in1k` example works as before.
- [x] Did you write any new necessary tests?


## Who can review?

@SunMarc (Command Line Interface)
