### PR TITLE
fix(security): reject checkpoint shard paths that escape the checkpoint folder (CVE-2026-69112)

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1818,6 +1818,9 @@ def _resolve_shard_file(checkpoint_folder: str, shard_file: str) -> str:
     an untrusted checkpoint. `os.path.join` follows `..` segments and drops the folder entirely when
     given an absolute path, so the name has to be checked before it is joined.
 
+    A shard that names an existing path which is not a regular file is refused as well: opening a
+    FIFO blocks until a writer connects, which hangs the load indefinitely.
+
     Args:
         checkpoint_folder: The folder the index file was found in.
         shard_file: A shard name taken from the index's `weight_map`.
@@ -1826,7 +1829,8 @@ def _resolve_shard_file(checkpoint_folder: str, shard_file: str) -> str:
         The path to the shard, guaranteed to sit inside `checkpoint_folder`.
 
     Raises:
-        ValueError: If `shard_file` is absolute or points outside `checkpoint_folder`.
+        ValueError: If `shard_file` is absolute, points outside `checkpoint_folder`, or names an
+            existing path that is not a regular file.
     """
     if os.path.isabs(shard_file):
         raise ValueError(
@@ -1842,6 +1846,12 @@ def _resolve_shard_file(checkpoint_folder: str, shard_file: str) -> str:
         raise ValueError(
             f"Checkpoint index contains a shard path that points outside the checkpoint folder ({shard_file})."
         )
+
+    # A missing shard is left to the loader below, which reports it in context. Something that
+    # exists but is not a regular file -- a FIFO above all, whose `open` blocks forever -- never
+    # names a usable checkpoint, so refuse it here.
+    if os.path.exists(resolved) and not os.path.isfile(resolved):
+        raise ValueError(f"Checkpoint index contains a shard path that is not a regular file ({shard_file}).")
     return resolved
 
 

--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -1811,6 +1811,40 @@ def get_state_dict_from_offload(
     return state_dict
 
 
+def _resolve_shard_file(checkpoint_folder: str, shard_file: str) -> str:
+    """Join a shard name from a checkpoint index onto its folder, refusing to escape that folder.
+
+    The shard names come from the checkpoint's own `*.index.json`, which is attacker-controlled for
+    an untrusted checkpoint. `os.path.join` follows `..` segments and drops the folder entirely when
+    given an absolute path, so the name has to be checked before it is joined.
+
+    Args:
+        checkpoint_folder: The folder the index file was found in.
+        shard_file: A shard name taken from the index's `weight_map`.
+
+    Returns:
+        The path to the shard, guaranteed to sit inside `checkpoint_folder`.
+
+    Raises:
+        ValueError: If `shard_file` is absolute or points outside `checkpoint_folder`.
+    """
+    if os.path.isabs(shard_file):
+        raise ValueError(
+            f"Checkpoint index contains an absolute shard path ({shard_file}). Shard paths must be relative to the "
+            "checkpoint folder."
+        )
+
+    folder = os.path.normpath(checkpoint_folder) if checkpoint_folder else "."
+    resolved = os.path.normpath(os.path.join(folder, shard_file))
+    # Compare the normalized strings rather than `realpath`, so that legitimately symlinked
+    # checkpoints (as laid out by the Hugging Face hub cache) keep working.
+    if resolved != folder and not resolved.startswith(folder.rstrip(os.sep) + os.sep):
+        raise ValueError(
+            f"Checkpoint index contains a shard path that points outside the checkpoint folder ({shard_file})."
+        )
+    return resolved
+
+
 def load_checkpoint_in_model(
     model: nn.Module,
     checkpoint: Union[str, os.PathLike],
@@ -1938,7 +1972,7 @@ def load_checkpoint_in_model(
         if "weight_map" in index:
             index = index["weight_map"]
         checkpoint_files = sorted(list(set(index.values())))
-        checkpoint_files = [os.path.join(checkpoint_folder, f) for f in checkpoint_files]
+        checkpoint_files = [_resolve_shard_file(checkpoint_folder, f) for f in checkpoint_files]
 
     # Logic for missing/unexpected keys goes here.
 

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -15,6 +15,7 @@
 import json
 import os
 import tempfile
+import threading
 import unittest
 import warnings
 from collections import OrderedDict
@@ -519,6 +520,34 @@ class ModelingUtilsTester(unittest.TestCase):
                 json.dump(index, f)
 
             load_checkpoint_in_model(model, snapshot_dir)
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires os.mkfifo")
+    def test_load_checkpoint_in_model_rejects_shard_paths_that_are_not_regular_files(self):
+        # A shard pointing at a FIFO reaches `torch.load`, whose `open` blocks until a writer
+        # connects and so hangs the load forever. The shard is refused before it is opened.
+        model = ModelForTest()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.mkfifo(os.path.join(tmp_dir, "checkpoint.bin"))
+            index = dict.fromkeys(model.state_dict(), "checkpoint.bin")
+            with open(os.path.join(tmp_dir, "weight_map.index.json"), "w") as f:
+                json.dump(index, f)
+
+            # Load off-thread so that a regression fails this test instead of hanging the suite.
+            raised = []
+
+            def load():
+                try:
+                    load_checkpoint_in_model(model, tmp_dir)
+                except BaseException as e:  # noqa: BLE001 - handed back to the calling thread
+                    raised.append(e)
+
+            thread = threading.Thread(target=load, daemon=True)
+            thread.start()
+            thread.join(timeout=60)
+
+            self.assertFalse(thread.is_alive(), "loading a FIFO shard blocked instead of raising")
+            self.assertEqual(len(raised), 1)
+            self.assertIsInstance(raised[0], ValueError)
 
     @require_non_cpu
     def test_load_checkpoint_in_model_one_gpu(self):

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -478,6 +478,48 @@ class ModelingUtilsTester(unittest.TestCase):
             self.shard_test_model(model, tmp_dir)
             load_checkpoint_in_model(model, tmp_dir)
 
+    def test_load_checkpoint_in_model_rejects_shard_paths_outside_folder(self):
+        # The `weight_map` of a sharded checkpoint is attacker-controlled for an untrusted
+        # checkpoint. Shard names that escape the checkpoint folder must be refused rather
+        # than opened.
+        model = ModelForTest()
+        for escaping_name in ["../outside.bin", "sub/../../outside.bin", os.path.join(os.sep, "tmp", "outside.bin")]:
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                index = dict.fromkeys(model.state_dict(), escaping_name)
+                with open(os.path.join(tmp_dir, "weight_map.index.json"), "w") as f:
+                    json.dump(index, f)
+
+                with self.assertRaises(ValueError):
+                    load_checkpoint_in_model(model, tmp_dir)
+
+    def test_load_checkpoint_in_model_allows_shard_paths_inside_folder(self):
+        # Nested shard names and symlinked shards (as laid out by the Hugging Face hub cache)
+        # stay inside the checkpoint folder and must keep loading.
+        model = ModelForTest()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.makedirs(os.path.join(tmp_dir, "shards"))
+            shard_name = os.path.join("shards", "checkpoint.bin")
+            torch.save(model.state_dict(), os.path.join(tmp_dir, shard_name))
+            index = dict.fromkeys(model.state_dict(), shard_name)
+            with open(os.path.join(tmp_dir, "weight_map.index.json"), "w") as f:
+                json.dump(index, f)
+
+            load_checkpoint_in_model(model, tmp_dir)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            blob_dir = os.path.join(tmp_dir, "blobs")
+            snapshot_dir = os.path.join(tmp_dir, "snapshot")
+            os.makedirs(blob_dir)
+            os.makedirs(snapshot_dir)
+            blob = os.path.join(blob_dir, "deadbeef")
+            torch.save(model.state_dict(), blob)
+            os.symlink(os.path.relpath(blob, snapshot_dir), os.path.join(snapshot_dir, "checkpoint.bin"))
+            index = dict.fromkeys(model.state_dict(), "checkpoint.bin")
+            with open(os.path.join(snapshot_dir, "weight_map.index.json"), "w") as f:
+                json.dump(index, f)
+
+            load_checkpoint_in_model(model, snapshot_dir)
+
     @require_non_cpu
     def test_load_checkpoint_in_model_one_gpu(self):
         device_map = {"linear1": 0, "batchnorm": "cpu", "linear2": "cpu"}


### PR DESCRIPTION
# What does this PR do?

Fix for CVE-2026-69112 / GHSA-4j2p-28q2-5m79, reported in #4067.


This is a follow-up to #4138, which fixed the path traversal in `load_checkpoint_in_model` but was closed by the stale bot. 

**Problem:**
  - `load_checkpoint_in_model` joins `weight_map` values from a checkpoint's `*.index.json` straight onto the checkpoint folder                                                                                                                                    
  - Those values come from the checkpoint author; `os.path.join` follows `..` and discards the folder entirely for an absolute path                                                                                                                                
  - A crafted checkpoint can make the loader open files anywhere on disk; a shard pointing at a FIFO hangs `torch.load` forever                                                                                                                                    
  - Reachable via plain `load_checkpoint_in_model(model, "<dir>")` and `load_checkpoint_and_dispatch(...)`

**Fix:**
* Commit 1: Adds `_resolve_shard_file`, rejecting absolute names and paths that normalize outside the checkpoint folder
  * cherry picked from #4138 by @AbdullahRasheed45
* Commit 2:  rejects shards that exist but are not regular files, 
  * Fixes the FIFO half of #4067 missing from #4138.

**For reviewers**                                                                                                                                                                                                                                 
  - Containment is checked with normalized path strings, *not* `realpath` -- the HF hub cache stores `snapshots/<rev>/model.safetensors` as a symlink into `../../blobs/<sha>`, so a `realpath` check resolves outside the snapshot dir and breaks every cached     
  checkpoint. Test covers that layout                                                                                                                                                                                                                              
  - 3 tests added: escaping names, layouts that must keep working, FIFO                                                                                                                                                                                            
  - The FIFO test loads off-thread with a join timeout so a regression fails rather than hangs CI -- verified it blocks without the fix                                                                                                                             
  - `tests/test_modeling_utils.py` passes; `ruff format` clean  

AI assistance was used in preparing this PR

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @qgallouedec please could you take a look?
