### PR TITLE
Fix circular import between accelerate.state and accelerate.utils

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -17,7 +17,9 @@ import inspect
 import torch
 
 from .state import AcceleratorState, GradientState
-from .utils import DistributedType, honor_type, is_lomo_available, is_torch_xla_available
+from .utils.dataclasses import DistributedType
+from .utils.imports import is_lomo_available, is_torch_xla_available
+from .utils.operations import honor_type
 
 
 if is_torch_xla_available():

--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -25,15 +25,18 @@ from typing import Any, Callable
 
 import torch
 
-from .utils import (
-    DistributedType,
-    DynamoBackend,
-    GradientAccumulationPlugin,
+from .utils.dataclasses import DistributedType, DynamoBackend, GradientAccumulationPlugin, SageMakerDistributedType
+from .utils.environment import (
     check_cuda_fp8_capability,
     check_cuda_p2p_ib_support,
-    deepspeed_required,
     get_cpu_distributed_information,
     get_int_from_env,
+    parse_choice_from_env,
+    parse_flag_from_env,
+    set_numa_affinity,
+)
+from .utils.imports import (
+    deepspeed_required,
     is_datasets_available,
     is_deepspeed_available,
     is_fp8_available,
@@ -48,11 +51,7 @@ from .utils import (
     is_torch_xla_available,
     is_xccl_available,
     is_xpu_available,
-    parse_choice_from_env,
-    parse_flag_from_env,
-    set_numa_affinity,
 )
-from .utils.dataclasses import SageMakerDistributedType
 
 
 if is_torch_xla_available():

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import ast
 import subprocess
 import sys
+import unittest
+from pathlib import Path
 
+import accelerate
 from accelerate.test_utils import require_transformer_engine
 from accelerate.test_utils.testing import TempDirTestCase, require_import_timer
 from accelerate.utils import is_import_timer_available
@@ -98,3 +102,38 @@ class LazyImportTester(TempDirTestCase):
         output = run_import_time("import accelerate, accelerate.utils.transformer_engine")
 
         self.assertFalse(" transformer_engine" in output, "`transformer_engine` should not be imported on import")
+
+
+def _top_level_relative_imports(module_path):
+    """Returns the set of module names imported with `from .name import ...` at the top of `module_path`."""
+    tree = ast.parse(Path(module_path).read_text())
+    names = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+            names.add(node.module)
+    return names
+
+
+class CircularImportTester(unittest.TestCase):
+    """
+    Test suite which statically checks that modules which several `accelerate.utils` submodules import back from
+    (such as `accelerate.state`) are not themselves importing the aggregating `accelerate.utils` package.
+
+    `accelerate.utils.operations`, `accelerate.utils.modeling`, `accelerate.utils.other`, `accelerate.utils.tqdm`
+    and `accelerate.utils.random` all do `from ..state import ...`. Since `accelerate/utils/__init__.py` eagerly
+    imports all of them, anything that does `from .utils import ...` from within `accelerate.state` (or another
+    module `accelerate.utils` submodules import back from) creates a circular import. This resolves by accident
+    in a normal single-threaded import because of a fixed import order, but breaks as soon as two threads import
+    different `accelerate` submodules at the same time, see huggingface/accelerate#4173 for the same bug in
+    `accelerate.utils.bnb`.
+    """
+
+    def test_state_does_not_import_utils_package(self):
+        src_dir = Path(accelerate.__file__).parent
+        imported = _top_level_relative_imports(src_dir / "state.py")
+        self.assertNotIn("utils", imported)
+
+    def test_optimizer_does_not_import_utils_package(self):
+        src_dir = Path(accelerate.__file__).parent
+        imported = _top_level_relative_imports(src_dir / "optimizer.py")
+        self.assertNotIn("utils", imported)


### PR DESCRIPTION
Fixes #4215

`accelerate/state.py` and `accelerate/optimizer.py` imported from the aggregating `accelerate.utils` package. A handful of submodules that `accelerate/utils/__init__.py` eagerly loads (`operations.py`, `modeling.py`, `other.py`, `tqdm.py`, `random.py`) import `AcceleratorState` or `PartialState` back from `accelerate.state`, so `state.py` depending on the whole `utils` package created a real circular import, the same shape as the `utils <-> big_modeling` cycle from #4173.

It resolves fine in a normal single threaded import because `accelerate/__init__.py` always finishes loading `accelerator.py`, and with it the full `utils` package, before it reaches `state.py`. That ordering stops protecting you once two threads import different `accelerate` submodules at the same time.

## Changes

- `state.py` now imports `DistributedType`, `DynamoBackend`, `GradientAccumulationPlugin` and `SageMakerDistributedType` from `utils.dataclasses`, the environment helpers from `utils.environment`, and the availability checks from `utils.imports`, instead of the aggregating `utils` package.
- `optimizer.py` now imports `DistributedType` from `utils.dataclasses`, `is_lomo_available`/`is_torch_xla_available` from `utils.imports`, and `honor_type` from `utils.operations`, instead of the aggregating `utils` package.

Both are self-contained leaf modules with no import back to `accelerate.state` or `accelerate.optimizer`, so this removes the cycle without changing what either file actually uses.

## Tests

Added `CircularImportTester` to `tests/test_imports.py`. It statically parses `state.py` and `optimizer.py` and asserts neither one imports the `utils` package directly, so a future PR reintroducing `from .utils import ...` in either file will fail this test. I checked it against the pre-fix source and it fails there, and passes after this change.

Also ran the existing `tests/test_optimizer.py` and `tests/test_scheduler.py` suites and a CPU-only smoke test that prepares a model, optimizer and scheduler through `Accelerator` and runs a training step, both pass.
