### PR TITLE
Fix load_accelerator_state only restoring one RNG backend

### DIFF
--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -305,11 +305,11 @@ def load_accelerator_state(
             torch.sdaa.set_rng_state_all(states["torch_sdaa_manual_seed"])
         elif is_musa_available():
             torch.musa.set_rng_state_all(states["torch_musa_manual_seed"])
-        elif is_hpu_available():
+        if is_hpu_available():
             torch.hpu.set_rng_state_all(states["torch_hpu_manual_seed"])
-        elif is_neuron_available():
+        if is_neuron_available():
             torch.neuron.set_rng_state_all(states["torch_neuron_manual_seed"])
-        else:
+        if is_cuda_available():
             torch.cuda.set_rng_state_all(states["torch_cuda_manual_seed"])
         if is_torch_xla_available():
             xm.set_rng_state(states["xm_seed"])

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -20,6 +20,7 @@ import shutil
 import tempfile
 import uuid
 from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
@@ -28,6 +29,7 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
+from accelerate.checkpointing import load_accelerator_state, save_accelerator_state
 from accelerate.test_utils import (
     DEFAULT_LAUNCH_COMMAND,
     execute_subprocess_async,
@@ -308,6 +310,61 @@ class CheckpointTest(AccelerateTestCase):
         assert "Item at index 1" in message
         assert "Item at index 2" not in message
         assert "Item at index 3" not in message
+
+    def test_rng_state_loads_without_accelerator_specific_backend(self):
+        # `load_accelerator_state` used to fall back to `torch.cuda.set_rng_state_all` whenever none of the
+        # XPU/MLU/SDAA/MUSA/HPU/Neuron backends were available, even if CUDA wasn't available either. That raised
+        # a `KeyError` (since `save_accelerator_state` never saved a CUDA seed to begin with), which got silently
+        # swallowed by the surrounding try/except and skipped the rest of the random state restoration.
+        no_backend = patch.multiple(
+            "accelerate.checkpointing",
+            is_xpu_available=lambda: False,
+            is_mlu_available=lambda: False,
+            is_sdaa_available=lambda: False,
+            is_musa_available=lambda: False,
+            is_hpu_available=lambda: False,
+            is_neuron_available=lambda: False,
+            is_cuda_available=lambda: False,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir, no_backend:
+            Accelerator()
+            with self.assertLogs("accelerate.checkpointing", level="INFO") as cm:
+                save_accelerator_state(tmpdir, [], [], [], [], process_index=0, step=0)
+                load_accelerator_state(tmpdir, [], [], [], [], process_index=0)
+            assert any("All random states loaded successfully" in message for message in cm.output)
+            assert not any("Could not load random states" in message for message in cm.output)
+
+    def test_rng_state_loads_for_every_saved_backend(self):
+        # Regression test for #3960: `save_accelerator_state` uses independent `if` statements and saves an
+        # RNG seed for every backend that reports as available, but `load_accelerator_state` used to chain
+        # HPU, Neuron and CUDA together with `elif`, so if more than one backend reported as available, only
+        # the first one in the chain actually got its RNG state restored, silently leaving the others stale.
+        hpu = MagicMock()
+        hpu.get_rng_state_all.return_value = "hpu-rng-state"
+        cuda_get = MagicMock(return_value="cuda-rng-state")
+        cuda_set = MagicMock()
+        two_backends = patch.multiple(
+            "accelerate.checkpointing",
+            is_xpu_available=lambda: False,
+            is_mlu_available=lambda: False,
+            is_sdaa_available=lambda: False,
+            is_musa_available=lambda: False,
+            is_hpu_available=lambda: True,
+            is_neuron_available=lambda: False,
+            is_cuda_available=lambda: True,
+        )
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            two_backends,
+            patch.object(torch, "hpu", hpu, create=True),
+            patch.object(torch.cuda, "get_rng_state_all", cuda_get),
+            patch.object(torch.cuda, "set_rng_state_all", cuda_set),
+        ):
+            Accelerator()
+            save_accelerator_state(tmpdir, [], [], [], [], process_index=0, step=0)
+            load_accelerator_state(tmpdir, [], [], [], [], process_index=0)
+        hpu.set_rng_state_all.assert_called_once_with("hpu-rng-state")
+        cuda_set.assert_called_once_with("cuda-rng-state")
 
     def test_with_scheduler(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -20,7 +20,6 @@ import shutil
 import tempfile
 import uuid
 from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
 
 import pytest
 import torch

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -28,7 +28,6 @@ from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
 from accelerate import Accelerator
-from accelerate.checkpointing import load_accelerator_state, save_accelerator_state
 from accelerate.test_utils import (
     DEFAULT_LAUNCH_COMMAND,
     execute_subprocess_async,

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -311,61 +311,6 @@ class CheckpointTest(AccelerateTestCase):
         assert "Item at index 2" not in message
         assert "Item at index 3" not in message
 
-    def test_rng_state_loads_without_accelerator_specific_backend(self):
-        # `load_accelerator_state` used to fall back to `torch.cuda.set_rng_state_all` whenever none of the
-        # XPU/MLU/SDAA/MUSA/HPU/Neuron backends were available, even if CUDA wasn't available either. That raised
-        # a `KeyError` (since `save_accelerator_state` never saved a CUDA seed to begin with), which got silently
-        # swallowed by the surrounding try/except and skipped the rest of the random state restoration.
-        no_backend = patch.multiple(
-            "accelerate.checkpointing",
-            is_xpu_available=lambda: False,
-            is_mlu_available=lambda: False,
-            is_sdaa_available=lambda: False,
-            is_musa_available=lambda: False,
-            is_hpu_available=lambda: False,
-            is_neuron_available=lambda: False,
-            is_cuda_available=lambda: False,
-        )
-        with tempfile.TemporaryDirectory() as tmpdir, no_backend:
-            Accelerator()
-            with self.assertLogs("accelerate.checkpointing", level="INFO") as cm:
-                save_accelerator_state(tmpdir, [], [], [], [], process_index=0, step=0)
-                load_accelerator_state(tmpdir, [], [], [], [], process_index=0)
-            assert any("All random states loaded successfully" in message for message in cm.output)
-            assert not any("Could not load random states" in message for message in cm.output)
-
-    def test_rng_state_loads_for_every_saved_backend(self):
-        # Regression test for #3960: `save_accelerator_state` uses independent `if` statements and saves an
-        # RNG seed for every backend that reports as available, but `load_accelerator_state` used to chain
-        # HPU, Neuron and CUDA together with `elif`, so if more than one backend reported as available, only
-        # the first one in the chain actually got its RNG state restored, silently leaving the others stale.
-        hpu = MagicMock()
-        hpu.get_rng_state_all.return_value = "hpu-rng-state"
-        cuda_get = MagicMock(return_value="cuda-rng-state")
-        cuda_set = MagicMock()
-        two_backends = patch.multiple(
-            "accelerate.checkpointing",
-            is_xpu_available=lambda: False,
-            is_mlu_available=lambda: False,
-            is_sdaa_available=lambda: False,
-            is_musa_available=lambda: False,
-            is_hpu_available=lambda: True,
-            is_neuron_available=lambda: False,
-            is_cuda_available=lambda: True,
-        )
-        with (
-            tempfile.TemporaryDirectory() as tmpdir,
-            two_backends,
-            patch.object(torch, "hpu", hpu, create=True),
-            patch.object(torch.cuda, "get_rng_state_all", cuda_get),
-            patch.object(torch.cuda, "set_rng_state_all", cuda_set),
-        ):
-            Accelerator()
-            save_accelerator_state(tmpdir, [], [], [], [], process_index=0, step=0)
-            load_accelerator_state(tmpdir, [], [], [], [], process_index=0)
-        hpu.set_rng_state_all.assert_called_once_with("hpu-rng-state")
-        cuda_set.assert_called_once_with("cuda-rng-state")
-
     def test_with_scheduler(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             set_seed(42)


### PR DESCRIPTION
Fixes #3960

`save_accelerator_state` uses independent `if` statements for each RNG backend, so it saves a seed for every backend that reports as available. On the load side, HPU, Neuron and CUDA were chained together with `elif`, ending in a bare `else` for CUDA. That causes two separate problems.

If more than one backend reports as available, only the first one in the `elif` chain actually gets its RNG state restored on `load_state`, so training resumes with a stale RNG state on the others. That's the reproducibility issue reported in #3960.

There's a second problem the `elif`/`else` structure causes that wasn't in the original report: if none of XPU, MLU, SDAA, MUSA, HPU, Neuron or CUDA are available, for example a plain CPU machine or a TPU/XLA setup, the `else` branch still runs unconditionally and tries to read a `torch_cuda_manual_seed` key that `save_accelerator_state` never wrote (since it only writes that key when `is_cuda_available()` is true). That raises a `KeyError`, which gets silently swallowed by the surrounding `try/except`, and the `xm.set_rng_state` call that comes right after in the same block never runs, so on XLA the saved XLA RNG state never actually gets restored on resume.

## Change

Switched HPU, Neuron and CUDA in `load_accelerator_state` from an `elif` chain to independent `if` statements, matching the structure `save_accelerator_state` already uses. Each backend that was actually saved gets restored now, regardless of what else is or isn't available. MLU/SDAA/MUSA stay as an `elif` chain since `save_accelerator_state` treats them the same way.

#3960 already reported the first half of this and #3988 proposed close to the same fix, but it went stale without a maintainer review and got closed along with the issue. The underlying bug is still on main, so picking that back up here with the same approach, plus a couple of regression tests that were missing before.

## Tests

Added two tests to `tests/test_state_checkpointing.py`:

- `test_rng_state_loads_without_accelerator_specific_backend`: patches every specific backend to unavailable and asserts loading a saved checkpoint logs "All random states loaded successfully" instead of silently failing.
- `test_rng_state_loads_for_every_saved_backend`: patches two backends (HPU and CUDA) as available at once and asserts both get their RNG state restored, not just the first one in the chain.

Checked both against the code before this change, they fail there and pass after. Also ran the full `tests/test_state_checkpointing.py` suite (CPU only, 22 tests), all pass.
