### PR TITLE
Fix accelerate env never reading the MPS chip name

### DIFF
--- a/src/accelerate/commands/env.py
+++ b/src/accelerate/commands/env.py
@@ -17,6 +17,7 @@
 import argparse
 import os
 import platform
+import subprocess
 from shutil import which
 
 import numpy as np

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,31 +53,6 @@ class EnvCommandTester(unittest.TestCase):
 
         self.assertEqual(info["`accelerate` bash location"], "Not found")
 
-    def test_mps_type_reads_the_cpu_brand_string(self):
-        """On MPS the chip name comes from sysctl, with `platform.processor()` only as a fallback."""
-        args = accelerate_env_cmd.env_command_parser().parse_args([])
-
-        with (
-            patch.multiple(
-                accelerate_env_cmd,
-                is_xpu_available=lambda: False,
-                is_mlu_available=lambda: False,
-                is_sdaa_available=lambda: False,
-                is_musa_available=lambda: False,
-                is_npu_available=lambda: False,
-                is_neuron_available=lambda: False,
-                is_mps_available=lambda: True,
-            ),
-            patch("torch.cuda.is_available", return_value=False),
-            # platform.processor() shells out as well, so pin the fallback to something distinct
-            patch("accelerate.commands.env.platform.processor", return_value="fallback"),
-            patch("subprocess.check_output", return_value="Apple M2 Pro\n") as check_output,
-        ):
-            info = accelerate_env_cmd.env_command(args)
-
-        check_output.assert_any_call(["sysctl", "-n", "machdep.cpu.brand_string"], text=True)
-        self.assertEqual(info["MPS type"], "Apple M2 Pro")
-
 
 class AccelerateLauncherTester(unittest.TestCase):
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,31 @@ class EnvCommandTester(unittest.TestCase):
 
         self.assertEqual(info["`accelerate` bash location"], "Not found")
 
+    def test_mps_type_reads_the_cpu_brand_string(self):
+        """On MPS the chip name comes from sysctl, with `platform.processor()` only as a fallback."""
+        args = accelerate_env_cmd.env_command_parser().parse_args([])
+
+        with (
+            patch.multiple(
+                accelerate_env_cmd,
+                is_xpu_available=lambda: False,
+                is_mlu_available=lambda: False,
+                is_sdaa_available=lambda: False,
+                is_musa_available=lambda: False,
+                is_npu_available=lambda: False,
+                is_neuron_available=lambda: False,
+                is_mps_available=lambda: True,
+            ),
+            patch("torch.cuda.is_available", return_value=False),
+            # platform.processor() shells out as well, so pin the fallback to something distinct
+            patch("accelerate.commands.env.platform.processor", return_value="fallback"),
+            patch("subprocess.check_output", return_value="Apple M2 Pro\n") as check_output,
+        ):
+            info = accelerate_env_cmd.env_command(args)
+
+        check_output.assert_any_call(["sysctl", "-n", "machdep.cpu.brand_string"], text=True)
+        self.assertEqual(info["MPS type"], "Apple M2 Pro")
+
 
 class AccelerateLauncherTester(unittest.TestCase):
     """


### PR DESCRIPTION
# What does this PR do?

#4158 added an MPS branch to `accelerate env`:

```python
elif pt_mps_available:
    try:
        mps_type = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip()
    except Exception:
        mps_type = platform.processor() or "Apple Silicon"
    info["MPS type"] = mps_type
```

`subprocess` is never imported in `src/accelerate/commands/env.py`. The call raises `NameError`, the surrounding `except Exception` swallows it, and the reported chip name is always the `platform.processor()` fallback. The `sysctl` lookup that #4158 added has never run.

`ruff check` catches it, so `make quality` is currently red on `main` for this one line:

```
src/accelerate/commands/env.py:114:24: F821 Undefined name `subprocess`
Found 1 error.
```

Adding the import is the whole change.

## Testing

`tests/test_cli.py::EnvCommandTester::test_mps_type_reads_the_cpu_brand_string` forces the MPS branch and checks that the `sysctl` call actually happens. On `main` it fails, and the captured output shows the fallback being reported:

```
- MPS type: fallback
E   Expected: check_output(['sysctl', '-n', 'machdep.cpu.brand_string'], text=True)
```

The test pins the call rather than only the returned string on purpose: `platform.processor()` shells out as well, so mocking `subprocess.check_output` alone makes both branches return the same value and the test passes either way. The fallback is pinned to a distinct value for the same reason.

- `pytest tests/test_cli.py -k mps_type`: fails on `main`, passes here.
- `pytest tests/test_cli.py`: 37 passed, 3 skipped, 1 failed. The failure is `test_accelerate_test`, which fails the same way on `main` on this machine (it shells out to `accelerate-launch`, which is not on PATH here).
- `ruff check .` and `ruff format --check .` with the 0.13.1 pinned in `setup.py`: clean here, one F821 on `main`.

Ran on Python 3.13, torch 2.11.0, Linux, CPU.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
