### PR TITLE
Fix accelerate launch --cpu never setting the KMP variables

### DIFF
--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -40,7 +40,6 @@ from ..utils import (
 from ..utils.constants import DEEPSPEED_MULTINODE_LAUNCHERS
 from ..utils.other import get_free_port, is_port_in_use, merge_dicts
 from ..utils.versions import compare_versions
-from . import parse_flag_from_env
 from .dataclasses import DistributedType, SageMakerDistributedType
 
 
@@ -161,7 +160,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> tuple[list[str]
     if (num_processes is not None and num_processes > 1) or num_machines > 1:
         current_env["MASTER_ADDR"] = args.main_process_ip if args.main_process_ip is not None else "127.0.0.1"
         current_env["MASTER_PORT"] = str(args.main_process_port) if args.main_process_port is not None else "29500"
-    if parse_flag_from_env(current_env["ACCELERATE_USE_CPU"], False):
+    if args.cpu or args.use_cpu:
         current_env["KMP_AFFINITY"] = "granularity=fine,compact,1,0"
         current_env["KMP_BLOCKTIME"] = str(1)
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -160,7 +160,7 @@ def prepare_simple_launcher_cmd_env(args: argparse.Namespace) -> tuple[list[str]
     if (num_processes is not None and num_processes > 1) or num_machines > 1:
         current_env["MASTER_ADDR"] = args.main_process_ip if args.main_process_ip is not None else "127.0.0.1"
         current_env["MASTER_PORT"] = str(args.main_process_port) if args.main_process_port is not None else "29500"
-    if args.cpu or args.use_cpu:
+    if str_to_bool(current_env["ACCELERATE_USE_CPU"]):
         current_env["KMP_AFFINITY"] = "granularity=fine,compact,1,0"
         current_env["KMP_BLOCKTIME"] = str(1)
 

--- a/src/accelerate/utils/launch.py
+++ b/src/accelerate/utils/launch.py
@@ -40,6 +40,7 @@ from ..utils import (
 from ..utils.constants import DEEPSPEED_MULTINODE_LAUNCHERS
 from ..utils.other import get_free_port, is_port_in_use, merge_dicts
 from ..utils.versions import compare_versions
+from . import str_to_bool
 from .dataclasses import DistributedType, SageMakerDistributedType
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -159,6 +160,26 @@ class AccelerateLauncherTester(unittest.TestCase):
         self.assertEqual(len(python_script_cmd), 3)
         self.assertEqual(python_script_cmd[1], str(self.test_file_path))
         self.assertEqual(python_script_cmd[2], test_file_arg)
+
+    def test_cpu_launch_sets_kmp_env(self):
+        """
+        `accelerate launch --cpu` sets the Intel OpenMP variables, and a launch without it leaves them alone.
+        """
+        with patch.dict(os.environ):
+            os.environ.pop("KMP_AFFINITY", None)
+            os.environ.pop("KMP_BLOCKTIME", None)
+
+            args = self.parser.parse_args(["--cpu", str(self.test_file_path)])
+            args, _, _ = _validate_launch_command(args)
+            _, current_env = prepare_simple_launcher_cmd_env(args)
+            assert current_env["KMP_AFFINITY"] == "granularity=fine,compact,1,0"
+            assert current_env["KMP_BLOCKTIME"] == "1"
+
+            args = self.parser.parse_args([str(self.test_file_path)])
+            args, _, _ = _validate_launch_command(args)
+            _, current_env = prepare_simple_launcher_cmd_env(args)
+            assert "KMP_AFFINITY" not in current_env
+            assert "KMP_BLOCKTIME" not in current_env
 
     def test_validate_launch_command(self):
         """Test that the validation function combines args and defaults."""


### PR DESCRIPTION
# What does this PR do?

`accelerate launch --cpu` no longer sets `KMP_AFFINITY` and `KMP_BLOCKTIME`.

#3912 gated those two on CPU mode with:

```python
if parse_flag_from_env(current_env["ACCELERATE_USE_CPU"], False):
```

`parse_flag_from_env` takes an environment variable *name* and does `os.environ.get(key, str(default))`. Here it is handed the *value*, the string `"True"` or `"False"`, so it looks for an environment variable literally called `True`, does not find one, and returns the default. The guard is `False` on every launch.

Before #3912 the line was `if current_env["ACCELERATE_USE_CPU"]:`, which was always `True` because `"False"` is a non-empty string, so the variables were set on GPU launches too. That was the bug reported in #3911. The fix replaced one constant with the other.

On `main`, with `prepare_simple_launcher_cmd_env`:

```
accelerate launch --cpu      ACCELERATE_USE_CPU='True'   KMP_AFFINITY=None  KMP_BLOCKTIME=None
accelerate launch (no flag)  ACCELERATE_USE_CPU='False'  KMP_AFFINITY=None  KMP_BLOCKTIME=None
```

and the mechanism, which is easy to confirm directly:

```
>>> parse_flag_from_env("True", False)
False
>>> os.environ["True"] = "yes"       # an env var actually named "True"
>>> parse_flag_from_env("True", False)
True
```

With this PR:

```
accelerate launch --cpu      ACCELERATE_USE_CPU='True'   KMP_AFFINITY='granularity=fine,compact,1,0'  KMP_BLOCKTIME='1'
accelerate launch (no flag)  ACCELERATE_USE_CPU='False'  KMP_AFFINITY=None                            KMP_BLOCKTIME=None
```

The flag is now tested the same way the line two above it already tests it (`current_env["ACCELERATE_USE_CPU"] = str(args.cpu or args.use_cpu)`), and the rest of the launch code does the same thing (`commands/launch.py` uses `args.use_cpu` and `args.cpu` directly throughout). The import that #3912 added for the broken call has no other user in the file, so it goes with it.

## Testing

`tests/test_cli.py::AccelerateLauncherTester::test_cpu_launch_sets_kmp_env` covers both directions, so neither the original #3911 behaviour nor this one can come back. It fails on `main` with `KeyError: 'KMP_AFFINITY'` and passes here.

- `pytest tests/test_cli.py`: 37 passed, 3 skipped, 1 failed. The failure is `test_accelerate_test`, which fails identically on `main` on this machine with `FileNotFoundError: 'accelerate-launch'`, since I run from source rather than an installed console script.
- `ruff check .` and `ruff format --check .` with the 0.13.1 pinned in `setup.py`: clean for these files. `ruff check` also reports one unrelated F821 in `commands/env.py` on `main`, which #4221 fixes.

Ran on Python 3.13, torch 2.11.0, Linux, CPU.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
