### PR TITLE
Fix MLFLOW_NESTED_RUN never being able to turn nesting off

### DIFF
--- a/src/accelerate/tracking.py
+++ b/src/accelerate/tracking.py
@@ -40,6 +40,7 @@ from .utils import (
     is_trackio_available,
     is_wandb_available,
     listify,
+    str_to_bool,
 )
 
 
@@ -738,6 +739,8 @@ class MLflowTracker(GeneralTracker):
             tags = json.loads(tags)
 
         nested_run = os.environ.get("MLFLOW_NESTED_RUN", nested_run)
+        if isinstance(nested_run, str):
+            nested_run = str_to_bool(nested_run) == 1
 
         self.experiment_name = experiment_name
         self.logging_dir = logging_dir

--- a/tests/test_tracking.py
+++ b/tests/test_tracking.py
@@ -237,6 +237,18 @@ class MLflowTrackingTest(unittest.TestCase):
         fig = plt.figure(figsize=(6, 4))
         return fig
 
+    def test_nested_run_env_var_is_read_as_a_bool(self):
+        """MLFLOW_NESTED_RUN takes priority over the argument, so it has to be able to turn nesting off too."""
+        for value in ("False", "false", "0", "no", "off"):
+            with mock.patch.dict(os.environ, {"MLFLOW_NESTED_RUN": value}):
+                tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
+            self.assertIs(tracker.nested_run, False, f"MLFLOW_NESTED_RUN={value} should disable nesting")
+
+        for value in ("True", "true", "1", "yes", "on"):
+            with mock.patch.dict(os.environ, {"MLFLOW_NESTED_RUN": value}):
+                tracker = MLflowTracker(experiment_name="test_exp", logging_dir=self.tmpdir.name)
+            self.assertIs(tracker.nested_run, True, f"MLFLOW_NESTED_RUN={value} should enable nesting")
+
     def test_log(self):
         import mlflow
 


### PR DESCRIPTION
# What does this PR do?

`MLflowTracker.__init__` reads the environment variable and hands the result straight to `mlflow.start_run`:

```python
nested_run = os.environ.get("MLFLOW_NESTED_RUN", nested_run)
...
self.active_run = mlflow.start_run(..., nested=self.nested_run, ...)
```

When the variable is set, the value is a string, and every non-empty string is truthy. So `MLFLOW_NESTED_RUN` can only turn nesting on:

```
MLFLOW_NESTED_RUN='False'  -> nested_run='False'  bool=True
MLFLOW_NESTED_RUN='false'  -> nested_run='false'  bool=True
MLFLOW_NESTED_RUN='0'      -> nested_run='0'      bool=True
MLFLOW_NESTED_RUN='no'     -> nested_run='no'     bool=True
MLFLOW_NESTED_RUN='True'   -> nested_run='True'   bool=True
unset                      -> nested_run=False    bool=False
```

The docstring says the variable has priority over the argument, so passing `nested_run=False` in code cannot win either. Setting the variable to any value at all enables nesting, which is the opposite of what someone writing `MLFLOW_NESTED_RUN=0` expects.

`tags` two lines above already converts its string form:

```python
tags = os.environ.get("MLFLOW_TAGS", tags)
if isinstance(tags, str):
    tags = json.loads(tags)
```

so the conversion is the only thing missing here. `str_to_bool` is what the rest of the library uses for boolean environment variables, and it accepts the usual spellings on both sides. After the change:

```
MLFLOW_NESTED_RUN='False'  -> nested_run=False
MLFLOW_NESTED_RUN='no'     -> nested_run=False
MLFLOW_NESTED_RUN='True'   -> nested_run=True
MLFLOW_NESTED_RUN='1'      -> nested_run=True
unset                      -> nested_run=False
```

## Testing

`tests/test_tracking.py::MLflowTrackingTest::test_nested_run_env_var_is_read_as_a_bool` walks both sets of spellings and asserts the attribute is the actual boolean. It fails on `main` on the first one with `MLFLOW_NESTED_RUN=False should disable nesting` and passes here. It only constructs the tracker, so it needs no tracking backend.

- `pytest tests/test_tracking.py -k MLflow`: 7 failed, 1 passed on `main`; 7 failed, 2 passed here, the extra pass being the new test. The 7 are the same on both sides and unrelated: mlflow 3.15.2 rejects the file store that `setUp` configures unless `MLFLOW_ALLOW_FILE_STORE=true` is set.
- `ruff check .` and `ruff format --check .` with the 0.13.1 pinned in `setup.py`: clean.

Ran on Python 3.13, torch 2.11.0, mlflow 3.15.2, Linux, CPU.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
