### PR TITLE
Restore legacy JSON configuration discovery without changing YAML output

### DIFF
--- a/src/accelerate/commands/config/config_args.py
+++ b/src/accelerate/commands/config/config_args.py
@@ -30,7 +30,7 @@ hf_cache_home = os.path.expanduser(
     os.environ.get("HF_HOME", os.path.join(os.environ.get("XDG_CACHE_HOME", "~/.cache"), "huggingface"))
 )
 cache_dir = os.path.join(hf_cache_home, "accelerate")
-default_json_config_file = os.path.join(cache_dir, "default_config.yaml")
+default_json_config_file = os.path.join(cache_dir, "default_config.json")
 default_yaml_config_file = os.path.join(cache_dir, "default_config.yaml")
 
 # For backward compatibility: the default config is the json one if it's the only existing file.

--- a/src/accelerate/commands/config/default.py
+++ b/src/accelerate/commands/config/default.py
@@ -27,14 +27,14 @@ from ...utils import (
     is_sdaa_available,
     is_xpu_available,
 )
-from .config_args import ClusterConfig, default_json_config_file
+from .config_args import ClusterConfig, default_yaml_config_file
 from .config_utils import SubcommandHelpFormatter
 
 
 description = "Create a default config file for Accelerate with only a few flags set."
 
 
-def write_basic_config(mixed_precision="no", save_location: str = default_json_config_file):
+def write_basic_config(mixed_precision="no", save_location: str = default_yaml_config_file):
     """
     Creates and saves a basic cluster config to be used on a local machine with potentially multiple GPUs. Will also
     set CPU if it is a CPU-only machine.
@@ -42,7 +42,7 @@ def write_basic_config(mixed_precision="no", save_location: str = default_json_c
     Args:
         mixed_precision (`str`, *optional*, defaults to "no"):
             Mixed Precision to use. Should be one of "no", "fp16", or "bf16"
-        save_location (`str`, *optional*, defaults to `default_json_config_file`):
+        save_location (`str`, *optional*, defaults to `default_yaml_config_file`):
             Optional custom save location. Should be passed to `--config_file` when using `accelerate launch`. Default
             location is inside the huggingface cache folder (`~/.cache/huggingface`) but can be overridden by setting
             the `HF_HOME` environmental variable, followed by `accelerate/default_config.yaml`.
@@ -143,7 +143,7 @@ def default_command_parser(parser, parents):
     parser = parser.add_parser("default", parents=parents, help=description, formatter_class=SubcommandHelpFormatter)
     parser.add_argument(
         "--config_file",
-        default=default_json_config_file,
+        default=default_yaml_config_file,
         help=(
             "The path to use to store the config file. Will default to a file named default_config.yaml in the cache "
             "location, which is the content of the environment `HF_HOME` suffixed with 'accelerate', or if you don't have "

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+import sys
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
 import torch
@@ -235,6 +238,32 @@ class ClusterConfigTester(unittest.TestCase):
     """
 
     test_config_path = Path("tests/test_configs")
+
+    def test_default_config_file_selection(self):
+        # Resolve the cache in a fresh process without changing imported config defaults in this test process.
+        command = [
+            sys.executable,
+            "-c",
+            "from accelerate.commands.config.config_args import load_config_from_file; "
+            "print(load_config_from_file(None).mixed_precision)",
+        ]
+        for filenames, expected in [
+            (["default_config.json"], "no"),
+            (["default_config.yaml"], "bf16"),
+            (["default_config.json", "default_config.yaml"], "bf16"),
+        ]:
+            with self.subTest(filenames=filenames), TemporaryDirectory() as tmpdir:
+                config_dir = Path(tmpdir) / "accelerate"
+                config_dir.mkdir()
+                for filename in filenames:
+                    if filename.endswith(".json"):
+                        contents = json.dumps({"distributed_type": "NO", "mixed_precision": "no", "use_cpu": True})
+                    else:
+                        contents = "distributed_type: 'NO'\nmixed_precision: bf16\nuse_cpu: true\n"
+                    (config_dir / filename).write_text(contents, encoding="utf-8")
+                with patch_environment(hf_home=tmpdir):
+                    result = run_command(command, return_stdout=True)
+                self.assertEqual(result.strip(), expected)
 
     def test_base_config(self):
         # Tests that all the dataclasses can be initialized


### PR DESCRIPTION
# What does this PR do?

Restore discovery of an existing `default_config.json` while preserving YAML precedence and the documented YAML output path of the basic configuration API and CLI.

Both `default_json_config_file` and `default_yaml_config_file` pointed to `default_config.yaml`, so the existing backward-compatibility branch could never select a JSON-only cache. `load_config_from_file(None)` then raised `FileNotFoundError`, and launcher's existence check ignored that legacy configuration.

The JSON constant now points to its named file. The basic-config writer and CLI explicitly retain `default_yaml_config_file`, so fixing discovery does not change where newly generated basic configurations are written. A regression covers JSON-only, YAML-only, and both-files precedence in isolated child processes. No new runtime dependencies.

No existing issue is linked. Exact-symbol and configuration-related issue/PR searches did not identify a matching open fix. This has not received prior issue or forum approval.

## Validation

Linux x86_64, Python 3.11.15, PyTorch 2.8.0; CPU configuration parsing/writing only, no model downloads or distributed/GPU training.

- Standalone reproduction against base `fd132822ff0aea945786a263a49e6730249917cb`: a JSON-only isolated `HF_HOME` raised `FileNotFoundError` for `default_config.yaml`.
- Identical fixed scenario: JSON-only and YAML-only discovery passed; YAML won when both existed; `ClusterConfig.from_json_file()` retained its JSON behavior; both `write_basic_config` and `accelerate config default` wrote the documented YAML path and produced readable configurations.
- `PYTHONPATH=src CUDA_VISIBLE_DEVICES='' ACCELERATE_USE_CPU=true python -m pytest -q tests/test_cli.py::ClusterConfigTester`: **4 passed, 3 subtests passed**.
- `make style`: passed with Ruff 0.13.1; 117 Python files in the sparse checkout remained unchanged.
- `make quality`: passed with Ruff 0.13.1.
- Full editable `.[dev]` setup completed in an isolated Python 3.11 environment; `uv pip check` passed for all 92 installed packages. The configuration regression and API/CLI smoke were then rerun successfully in that complete environment: **4 passed, 3 subtests passed**, and all five discovery/output scenarios passed.

No full distributed, model, GPU, or integration suite is claimed.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case). Not applicable: behavioral bug fix.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? No prior approval; this is a newly identified narrow bug.
- [x] Did you make sure to update the documentation with your changes? The function docstring names the correct YAML constant; public documentation remains accurate because the output path is preserved.
- [x] Did you write any new necessary tests?

## Who can review?

Configuration/CLI maintainers.

## AI assistance and draft status

The investigation, patch, regression test, and this description were prepared with AI assistance. The baseline/fixed scenarios, focused regression tests, and style/quality commands above were executed locally. AI assistance is separate from the account owner's human review recorded below. This remains a draft for the normal project review and CI process.


Human review (account owner, code patch in commit `24eeec2f12857f79cfd0748b0e56c6961d34b156`): this has been manually reviewed. The owner authorized this draft.
