### PR TITLE
fix(data_loader): lazily capture stateful dataloader state (#4204)

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -440,8 +440,10 @@ class DataLoaderAdapter:
         else:
             self.base_dataloader = DataLoader(dataset, batch_sampler=batch_sampler, **kwargs)
 
+        # Capturing a stateful dataloader's state can create its iterator and consume sampler RNG.
+        # Defer that capture until iteration (after distributed RNG synchronization) or an explicit checkpoint.
         if hasattr(self.base_dataloader, "state_dict"):
-            self.dl_state_dict = self.base_dataloader.state_dict()
+            self.dl_state_dict = None
 
     def __getattr__(self, name):
         # Avoid infinite recursion if we try to access a nonexistent base_dataloader attribute.
@@ -451,6 +453,8 @@ class DataLoaderAdapter:
         return getattr(self.base_dataloader, name)
 
     def state_dict(self):
+        if self.dl_state_dict is None:
+            self.dl_state_dict = self.base_dataloader.state_dict()
         return self.dl_state_dict
 
     def load_state_dict(self, state_dict):

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -784,6 +784,27 @@ class StatefulDataLoaderTester(AccelerateTestCase):
         for d1, d2 in zip(data1, data2):
             assert torch.allclose(d1, d2)
 
+    @require_torchdata_stateful_dataloader
+    def test_stateful_dataloader_does_not_capture_state_during_initialization(self):
+        """Constructing a stateful adapter must not consume sampler RNG before iteration synchronizes it."""
+        generator = torch.Generator().manual_seed(1234)
+        rng_before = generator.get_state()
+        dataloader = DataLoaderShard(
+            list(range(32)),
+            batch_size=4,
+            shuffle=True,
+            generator=generator,
+            use_stateful_dataloader=True,
+            num_workers=2,
+        )
+
+        assert dataloader.dl_state_dict is None
+        assert torch.equal(generator.get_state(), rng_before)
+
+        # An explicit checkpoint before the first batch still captures the initial state on demand.
+        assert dataloader.state_dict() is not None
+        assert len(list(dataloader)) == 8
+
     @parameterized.expand([0, 2], name_func=parameterized_custom_name_func)
     @require_torchdata_stateful_dataloader
     def test_dataloader_dispatcher_state_dict(self, num_workers):


### PR DESCRIPTION
Fixes #4204

## Summary

`DataLoaderAdapter.__init__` eagerly called `StatefulDataLoader.state_dict()`. With worker prefetching, that creates an iterator and consumes each rank's local sampler RNG before `DataLoaderShard.__iter__` synchronizes RNG states. Unseeded distributed runs could therefore produce duplicate and missing samples in epoch 0.

This change:
- defers state capture until iteration or an explicit `state_dict()` call;
- preserves checkpoint capture before the first batch;
- adds a regression covering lazy initialization and explicit initial checkpointing.

## Validation

- `PYTHONPATH=src python -m pytest -q tests/test_data_loader.py -k "stateful"`: 13 passed
- `PYTHONPATH=src python -m pytest -q tests/test_data_loader.py`: 38 passed
- `PYTHONPATH=src python -m pytest -q tests/test_accelerator.py -k "stateful_dataloader"`: 17 passed
- `python -m ruff check src/accelerate/data_loader.py tests/test_data_loader.py`: All checks passed
- Two-process CPU/Gloo reproduction using file rendezvous: fixed output `union=96/96, missing=0, duplicates=0`; restoring eager capture reproduced `union=73/96, missing=23, duplicates=23`.

The requested `torch.distributed.run --standalone` command could not start in this Windows environment because the installed CPU PyTorch was built without libuv and its static rendezvous unconditionally requested it. The equivalent two-process Gloo run exercised the same Accelerate path.

@SunMarc please review.
