### PR TITLE
Treat MPS out-of-memory errors as OOM in find_executable_batch_size

### DIFF
--- a/src/accelerate/utils/memory.py
+++ b/src/accelerate/utils/memory.py
@@ -99,7 +99,7 @@ def release_memory(*objects) -> list:
 
 def should_reduce_batch_size(exception: Exception) -> bool:
     """
-    Checks if `exception` relates to CUDA out-of-memory, XPU out-of-memory, CUDNN not supported, or CPU out-of-memory
+    Checks if `exception` relates to CUDA, XPU, MPS or CPU out-of-memory, or CUDNN not supported
 
     Args:
         exception (`Exception`):
@@ -107,6 +107,7 @@ def should_reduce_batch_size(exception: Exception) -> bool:
     """
     _statements = [
         " out of memory.",  # OOM for CUDA, HIP, XPU
+        "MPS backend out of memory",  # MPS OOM
         "cuDNN error: CUDNN_STATUS_NOT_SUPPORTED.",  # CUDNN SNAFU
         "DefaultCPUAllocator: can't allocate memory",  # CPU OOM
         "FATAL ERROR :: MODULE:PT_DEVMEM Allocation failed",  # HPU OOM

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -126,24 +126,6 @@ class MemoryTest(unittest.TestCase):
         ]
         assert [bs, arg1] == [8, "hello"]
 
-    def test_mps_out_of_memory(self):
-        batch_sizes = []
-
-        @find_executable_batch_size(starting_batch_size=16)
-        def mock_training_loop_function(batch_size):
-            nonlocal batch_sizes
-            batch_sizes.append(batch_size)
-            if batch_size != 8:
-                # Message raised by the MPS allocator, which has no trailing period after "out of memory".
-                raise RuntimeError(
-                    "MPS backend out of memory (MPS allocated: 8.00 GB, other allocations: 384.00 KB, max allowed: "
-                    "9.07 GB). Tried to allocate 2.00 GB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 "
-                    "to disable upper limit for memory allocations (may cause system failure)."
-                )
-
-        mock_training_loop_function()
-        assert batch_sizes == [16, 14, 12, 10, 9, 8]
-
     def test_start_zero(self):
         @find_executable_batch_size(starting_batch_size=0)
         def mock_training_loop_function(batch_size):

--- a/tests/test_memory_utils.py
+++ b/tests/test_memory_utils.py
@@ -126,6 +126,24 @@ class MemoryTest(unittest.TestCase):
         ]
         assert [bs, arg1] == [8, "hello"]
 
+    def test_mps_out_of_memory(self):
+        batch_sizes = []
+
+        @find_executable_batch_size(starting_batch_size=16)
+        def mock_training_loop_function(batch_size):
+            nonlocal batch_sizes
+            batch_sizes.append(batch_size)
+            if batch_size != 8:
+                # Message raised by the MPS allocator, which has no trailing period after "out of memory".
+                raise RuntimeError(
+                    "MPS backend out of memory (MPS allocated: 8.00 GB, other allocations: 384.00 KB, max allowed: "
+                    "9.07 GB). Tried to allocate 2.00 GB on private pool. Use PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.0 "
+                    "to disable upper limit for memory allocations (may cause system failure)."
+                )
+
+        mock_training_loop_function()
+        assert batch_sizes == [16, 14, 12, 10, 9, 8]
+
     def test_start_zero(self):
         @find_executable_batch_size(starting_batch_size=0)
         def mock_training_loop_function(batch_size):


### PR DESCRIPTION
Fixes #4226

`should_reduce_batch_size` matches OOM errors on `" out of memory."` with a trailing period. The MPS allocator raises `RuntimeError("MPS backend out of memory (MPS allocated: ...). Tried to allocate ...")`, so nothing matched and `find_executable_batch_size` re-raised on the first attempt on Apple silicon. This adds the MPS message to `_statements`, as #3405 did for HIP, plus a test that uses the allocator's real message.

Checked on macOS arm64 with torch 2.14.0 and `PYTORCH_MPS_HIGH_WATERMARK_RATIO=0.02` to force the OOM early. Before: the decorated function raised at batch size 32. After: it stepped from 32 down to 7 and succeeded. On CPU the sequence is unchanged. Over 12 sample exception messages (CUDA, HIP, XPU, CPU, HPU, cuDNN, two MPS variants, the test helper's string, an unrelated `RuntimeError`, a `ValueError`, and a two-arg `RuntimeError`) only the two MPS messages change, from `False` to `True`.

```
pytest tests/test_memory_utils.py -q   # 8 passed; the new test fails on main
make quality                            # clean
```

Drafted with Claude Opus / Fable 5.1. Reviewed by Muse Spark 1.3 and GLM 5.3 as judges before submission.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc @BenjaminBossan
