### PR TITLE
Fix split_between_processes raising TypeError when padding a tuple

### DIFF
--- a/src/accelerate/state.py
+++ b/src/accelerate/state.py
@@ -487,7 +487,10 @@ class PartialState:
                             tensorized_result, pad_index=send_to_device(inputs[-1], self.device)
                         )
                     else:
-                        result += [inputs[-1]] * (num_samples_per_process + (1 if num_extras > 0 else 0) - len(result))
+                        num_padding = num_samples_per_process + (1 if num_extras > 0 else 0) - len(result)
+                        # `result` is a slice of `inputs`, so it keeps the input's own sequence type.
+                        # Build the padding to match it: `tuple + list` raises, even when it is empty.
+                        result = result + type(result)([inputs[-1]] * num_padding)
                 return result
             elif isinstance(inputs, dict):
                 for key in inputs.keys():

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -679,10 +679,13 @@ def test_split_between_processes_list():
 
     even_data = list(range(0, (2 * state.num_processes)))
     odd_data = list(range(0, (2 * state.num_processes) - 1))
-    for data in [odd_data, even_data]:
-        expected_output = data
+    for data in [odd_data, even_data, tuple(odd_data), tuple(even_data)]:
+        expected_output = list(data)
 
         with state.split_between_processes(data, apply_padding=True) as results:
+            assert type(results) is type(data), (
+                f"Padding changed the input type. Process index: {state.process_index}; Expected: {type(data)}; Got: {type(results)}"
+            )
             num_samples_per_device = math.ceil(len(data) / state.num_processes)
             # Test all processes gets the correct number of item(s)
             assert len(results) == num_samples_per_device, (


### PR DESCRIPTION
### What is wrong

`split_between_processes(..., apply_padding=True)` raises `TypeError` for a tuple, which all three public wrappers document as an accepted input type.

```
rank 0 list  -> ['a', 'b']
rank 1 list  -> ['c', 'c']
rank 0 tuple -> TypeError: can only concatenate tuple (not "list") to tuple
rank 1 tuple -> TypeError: can only concatenate tuple (not "list") to tuple
```

`_split_values` slices the input, so `result` keeps the input's own sequence type, and then pads with `result += [inputs[-1]] * n`. For a list that works. For a tuple it is `tuple + list`, which raises, and it raises on ranks needing no padding too since `tuple + []` raises as well. `apply_padding=False` already returns tuples fine, so only the padding path is broken.

### What changed

Build the padding with the same type as the slice.

```python
num_padding = num_samples_per_process + (1 if num_extras > 0 else 0) - len(result)
result = result + type(result)([inputs[-1]] * num_padding)
```

Lists are unchanged (`list([...])` is a list) and tuples now come back as tuples.

### Test

`test_split_between_processes_list` now also runs its odd and even cases as tuples and asserts the padding does not change the input type.

```
torchrun --nproc_per_node 2   # test_split_between_processes_list, cpu=True
  on main:    TypeError: can only concatenate tuple (not "list") to tuple   (both ranks)
  with this:  passes on both ranks
```

The sibling `split_between_processes` tests for dict, tensor and the evenly case pass on both ranks before and after. `ruff check` and `ruff format --check` (0.13.1, the pinned version) report the same results on both files before and after.
