### PR TITLE
docs: fix three dead links left by the docs restructure

### DIFF
--- a/docs/source/package_reference/logging.md
+++ b/docs/source/package_reference/logging.md
@@ -15,7 +15,7 @@ rendered properly in your Markdown viewer.
 
 # Logging
 
-Refer to the [Troubleshooting guide](../usage_guides/troubleshooting#logging) or to the example below to learn 
+Refer to the [Troubleshooting guide](../basic_tutorials/troubleshooting#logging) or to the example below to learn 
 how to use Accelerate's logger. 
 
 [[autodoc]] logging.get_logger

--- a/docs/source/package_reference/utilities.md
+++ b/docs/source/package_reference/utilities.md
@@ -103,7 +103,7 @@ These are classes which can be configured and passed through to the appropriate 
 
 These are environmental variables that can be enabled for different use cases
 
-* `ACCELERATE_DEBUG_MODE` (`str`): Whether to run accelerate in debug mode. More info available [here](../usage_guides/debug.md).
+* `ACCELERATE_DEBUG_MODE` (`str`): Whether to run accelerate in debug mode. More info available [here](../basic_tutorials/troubleshooting#hanging-code-and-timeout-errors).
 
 
 

--- a/docs/source/usage_guides/deepspeed.md
+++ b/docs/source/usage_guides/deepspeed.md
@@ -69,7 +69,7 @@ Inference:
 
 1. DeepSpeed ZeRO Inference supports ZeRO stage 3 with ZeRO-Infinity. It uses the same ZeRO protocol as training, but
    it doesn't use an optimizer and a lr scheduler and only stage 3 is relevant. For more details see:
-   [deepspeed-zero-inference](#deepspeed-zero-inference).
+   [ZeRO Inference](#zero-inference).
 
 
 ## How it works?


### PR DESCRIPTION
Three broken links in `docs/source/`, all fallout from the troubleshooting guide moving to `basic_tutorials/`:

- `package_reference/utilities.md`: debug-mode link → `../usage_guides/debug.md` (absent) now points at the `Hanging code and timeout errors` section of `basic_tutorials/troubleshooting.md`
- `package_reference/logging.md`: `../usage_guides/troubleshooting#logging` → `../basic_tutorials/troubleshooting#logging` (heading verified)
- `usage_guides/deepspeed.md`: in-page anchor `#deepspeed-zero-inference` matched no heading → `#zero-inference` (the `## ZeRO Inference` section)