### PR TITLE
Persist dataloader iteration and shuffle generator in save_state/load_state

### DIFF
--- a/docs/source/usage_guides/checkpoint.md
+++ b/docs/source/usage_guides/checkpoint.md
@@ -16,7 +16,8 @@ rendered properly in your Markdown viewer.
 # Checkpointing
 
 When training a PyTorch model with Accelerate, you may often want to save and continue a state of training. Doing so requires
-saving and loading the model, optimizer, RNG generators, and the GradScaler. Inside Accelerate are two convenience functions to achieve this quickly:
+saving and loading the model, optimizer, RNG generators, the GradScaler, and the epoch counter and shuffle generator of each
+prepared dataloader, so that a resumed run continues the shuffle sequence instead of replaying an earlier epoch. Inside Accelerate are two convenience functions to achieve this quickly:
 - Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location
 - Use [`~Accelerator.load_state`] for loading everything stored from an earlier `save_state`
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3620,7 +3620,8 @@ class Accelerator:
 
     def save_state(self, output_dir: str | None = None, safe_serialization: bool = True, **save_model_func_kwargs):
         """
-        Saves the current states of the model, optimizer, scaler, RNG generators, and registered objects to a folder.
+        Saves the current states of the model, optimizer, scaler, RNG generators, the epoch counter and shuffle
+        generator of each prepared dataloader, and registered objects to a folder.
 
         If a `ProjectConfiguration` was passed to the `Accelerator` object with `automatic_checkpoint_naming` enabled
         then checkpoints will be saved to `self.project_dir/checkpoints`. If the number of current saves is greater

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -60,6 +60,38 @@ from .state import PartialState
 logger = get_logger(__name__)
 
 
+def _get_dataloader_sampler_state(dataloader) -> Optional[dict]:
+    """
+    Collects what a prepared dataloader needs to resume its shuffle order: the number of epochs it has iterated
+    (`SeedableRandomSampler` derives its seed from it) and the state of the generator the sampler draws from, when it
+    has one. Returns `None` for dataloaders that were not prepared by Accelerate.
+    """
+    from .data_loader import get_shuffle_generator
+
+    # Under XLA the prepared dataloader is wrapped in an `MpDeviceLoaderWrapper`
+    dataloader = getattr(dataloader, "_loader", dataloader)
+    iteration = getattr(dataloader, "iteration", None)
+    if iteration is None:
+        return None
+    generator = get_shuffle_generator(dataloader)
+    return {
+        "iteration": iteration,
+        "generator_state": generator.get_state() if generator is not None else None,
+    }
+
+
+def _set_dataloader_sampler_state(dataloader, sampler_state: dict) -> None:
+    from .data_loader import get_shuffle_generator
+
+    dataloader = getattr(dataloader, "_loader", dataloader)
+    if sampler_state.get("iteration") is not None and hasattr(dataloader, "iteration"):
+        # `set_epoch` also forwards the epoch to the sampler and the dataset
+        dataloader.set_epoch(sampler_state["iteration"])
+    generator = get_shuffle_generator(dataloader)
+    if generator is not None and sampler_state.get("generator_state") is not None:
+        generator.set_state(sampler_state["generator_state"])
+
+
 def save_accelerator_state(
     output_dir: str,
     model_states: list[dict],
@@ -131,19 +163,15 @@ def save_accelerator_state(
     for i, dataloader in enumerate(dataloaders):
         sampler_name = f"{SAMPLER_NAME}.bin" if i == 0 else f"{SAMPLER_NAME}_{i}.bin"
         output_sampler_file = output_dir.joinpath(sampler_name)
-        # Only save if we have our custom sampler
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
-
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
+        sampler_state = _get_dataloader_sampler_state(dataloader)
+        if sampler_state is not None:
+            save(sampler_state, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
+            logger.info(f"Sampler state for dataloader {i} saved in {output_sampler_file}")
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             output_dataloader_state_dict_file = output_dir.joinpath(dataloader_state_dict_name)
             state_dict = dataloader.state_dict()
             torch.save(state_dict, output_dataloader_state_dict_file)
-        logger.info(f"Sampler state for dataloader {i} saved in {output_sampler_file}")
 
     # GradScaler state
     if scaler is not None:
@@ -267,13 +295,9 @@ def load_accelerator_state(
     for i, dataloader in enumerate(dataloaders):
         sampler_name = f"{SAMPLER_NAME}.bin" if i == 0 else f"{SAMPLER_NAME}_{i}.bin"
         input_sampler_file = input_dir.joinpath(sampler_name)
-        # Only load if we have our custom sampler
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
-
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                sampler = dataloader.set_sampler(load(input_sampler_file))
+        # Checkpoints written before the sampler state was tracked do not have this file
+        if input_sampler_file.exists():
+            _set_dataloader_sampler_state(dataloader, load(input_sampler_file, **load_kwargs))
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -995,6 +995,22 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
                 self.batch_sampler.batch_sampler.sampler = sampler
 
 
+def get_shuffle_generator(dataloader) -> Optional[torch.Generator]:
+    """
+    Returns the `torch.Generator` the shuffling of a prepared dataloader draws from, or `None` when it draws from the
+    global RNG. This is the generator `prepare_data_loader` synchronizes across processes when it created one, else the
+    one the user gave the sampler.
+    """
+    generator = getattr(dataloader, "synchronized_generator", None)
+    if generator is None:
+        # Walk `SkipBatchSampler` -> `BatchSamplerShard` -> `BatchSampler` down to the sampler
+        sampler = dataloader.sampler if isinstance(dataloader.sampler, BatchSampler) else dataloader.batch_sampler
+        while sampler is not None and not hasattr(sampler, "generator"):
+            sampler = getattr(sampler, "sampler", None) or getattr(sampler, "batch_sampler", None)
+        generator = getattr(sampler, "generator", None)
+    return generator if isinstance(generator, torch.Generator) else None
+
+
 def get_sampler(dataloader):
     """
     Get the sampler associated to the dataloader

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -17,6 +17,8 @@
 import contextlib
 import io
 import math
+import shutil
+import tempfile
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -32,6 +34,7 @@ from accelerate.test_utils import RegressionDataset, RegressionModel, are_the_sa
 from accelerate.utils import (
     DataLoaderConfiguration,
     DistributedType,
+    broadcast_object_list,
     gather,
     gather_object,
     is_bf16_available,
@@ -379,6 +382,49 @@ def check_seedable_sampler():
             new_items.append(batch["x"])
     new_items = torch.cat(new_items)
     assert torch.allclose(original_items, new_items), "Did not obtain the same items with the same seed and epoch."
+
+
+def check_dataloader_resume_order(use_seedable_sampler=False):
+    """
+    `load_state` must restore the shuffle position of a prepared dataloader on every process, so a resumed run
+    continues with the order it would have produced instead of replaying epoch 0 (accelerate#3996).
+    """
+
+    def epoch_order(dataloader):
+        return [sample for batch in dataloader for sample in batch["x"].tolist()]
+
+    def make_dataloader(accelerator):
+        set_seed(42)
+        train_set = RegressionDataset(length=32, seed=42)
+        return accelerator.prepare(DataLoader(train_set, batch_size=4, shuffle=True))
+
+    config = DataLoaderConfiguration(use_seedable_sampler=use_seedable_sampler)
+    accelerator = Accelerator(dataloader_config=config)
+    tmpdir = [tempfile.mkdtemp() if accelerator.is_main_process else None]
+    tmpdir = broadcast_object_list(tmpdir)[0]
+    try:
+        train_dl = make_dataloader(accelerator)
+        first_epoch = epoch_order(train_dl)
+        epoch_order(train_dl)
+        accelerator.save_state(tmpdir)
+        expected_continuation = epoch_order(train_dl)
+        assert expected_continuation != first_epoch, "The dataset is too small to tell epochs apart"
+
+        accelerator = Accelerator(dataloader_config=config)
+        train_dl = make_dataloader(accelerator)
+        accelerator.load_state(tmpdir)
+        resumed = epoch_order(train_dl)
+    finally:
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    replayed_epoch_0 = gather_object([resumed == first_epoch])
+    continued = gather_object([resumed == expected_continuation])
+    assert not any(replayed_epoch_0), (
+        f"Resumed dataloader replayed the epoch-0 shuffle order on processes {replayed_epoch_0}"
+    )
+    assert all(continued), f"Resumed dataloader did not continue with the expected order on processes {continued}"
 
 
 def check_seedable_sampler_in_batch_sampler_shard():
@@ -880,6 +926,8 @@ def main():
         custom_sampler_check()
         check_seedable_sampler()
         check_seedable_sampler_with_data_seed()
+        check_dataloader_resume_order(use_seedable_sampler=False)
+        check_dataloader_resume_order(use_seedable_sampler=True)
 
     if state.num_processes > 1:
         check_seedable_sampler_in_batch_sampler_shard()

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 
 import pytest
 import torch
-from parameterized import parameterized_class
+from parameterized import parameterized, parameterized_class
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -36,7 +36,13 @@ from accelerate.test_utils import (
     run_first,
 )
 from accelerate.test_utils.testing import AccelerateTestCase
-from accelerate.utils import DistributedType, ProjectConfiguration, patch_environment, set_seed
+from accelerate.utils import (
+    DataLoaderConfiguration,
+    DistributedType,
+    ProjectConfiguration,
+    patch_environment,
+    set_seed,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -123,6 +129,69 @@ class CheckpointTest(AccelerateTestCase):
             # Save second state
             accelerator.save_state(safe_serialization=self.use_safetensors)
             assert len(os.listdir(accelerator.project_dir)) == 1
+
+    @parameterized.expand([(True,), (False,)], name_func=lambda f, n, p: f"{f.__name__}_seedable_{p.args[0]}")
+    @require_non_torch_xla
+    def test_resume_restores_dataloader_shuffle_order(self, use_seedable_sampler):
+        """
+        After `load_state`, a shuffled dataloader must continue with the order it would have produced had training not
+        been interrupted, not replay epoch 0 (https://github.com/huggingface/accelerate/issues/3996).
+        """
+
+        def make_dataloader(accelerator):
+            dataloader = DataLoader(TensorDataset(torch.arange(32)), batch_size=4, shuffle=True)
+            return accelerator.prepare(dataloader)
+
+        def epoch_order(dataloader):
+            return [sample for batch in dataloader for sample in batch[0].tolist()]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            set_seed(42)
+            dataloader_config = DataLoaderConfiguration(use_seedable_sampler=use_seedable_sampler)
+            accelerator = Accelerator(dataloader_config=dataloader_config)
+            train_dataloader = make_dataloader(accelerator)
+            orders = [epoch_order(train_dataloader) for _ in range(2)]
+            accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+            expected_continuation = epoch_order(train_dataloader)
+            assert expected_continuation != orders[0], "The dataset is too small to tell epochs apart"
+
+            # Resume from scratch, as a new script run would
+            set_seed(42)
+            accelerator = Accelerator(dataloader_config=dataloader_config)
+            train_dataloader = make_dataloader(accelerator)
+            accelerator.load_state(tmpdir)
+            resumed = epoch_order(train_dataloader)
+
+            assert resumed != orders[0], "Resumed dataloader replayed the epoch-0 shuffle order"
+            assert resumed == expected_continuation
+
+    @require_non_torch_xla
+    def test_resume_restores_user_generator(self):
+        "A `generator` passed to the `DataLoader` is restored by `load_state`, so a resumed run keeps its shuffle order."
+
+        def make_dataloader(accelerator):
+            generator = torch.Generator().manual_seed(0)
+            dataloader = DataLoader(TensorDataset(torch.arange(32)), batch_size=4, shuffle=True, generator=generator)
+            return accelerator.prepare(dataloader)
+
+        def epoch_order(dataloader):
+            return [sample for batch in dataloader for sample in batch[0].tolist()]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            accelerator = Accelerator()
+            train_dataloader = make_dataloader(accelerator)
+            first_epoch = epoch_order(train_dataloader)
+            epoch_order(train_dataloader)
+            accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+            expected_continuation = epoch_order(train_dataloader)
+
+            accelerator = Accelerator()
+            train_dataloader = make_dataloader(accelerator)
+            accelerator.load_state(tmpdir)
+            resumed = epoch_order(train_dataloader)
+
+            assert resumed != first_epoch, "Resumed dataloader replayed the epoch-0 shuffle order"
+            assert resumed == expected_continuation
 
     def test_can_resume_training_with_folder(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fixes #3996

Resuming from `save_state` / `load_state` replays the epoch-0 shuffle order. I hit it with the reporter's scripts on `main` @ 0f7e35f, then with a 2-process gloo run on CPU, same result both ways.

The sampler branch in `checkpointing.py:137` (and `:273` on load) only fires when the dataset is an `IterableDatasetShard` *and* the sampler is a `SeedableRandomSampler`. Those two never happen together, an iterable shard sits on `_InfiniteConstantSampler`, so nothing has been written for dataloaders since #2080. What's missing is two small things:

- with `use_seedable_sampler=True`, the seed is `initial_seed + epoch` (`data_loader.py:99-101`) and `__iter__` sets that epoch from `self.iteration` (`:582`, `:874` for the dispatcher). `iteration` is never saved, so a resumed loader starts at epoch 0 again. That's also why #4019 couldn't fix it by saving the sampler object, the next `__iter__` overwrites the epoch anyway.
- with the default sampler and `num_processes > 1`, `prepare_data_loader` hands the sampler a private generator (`data_loader.py:1247-1252`) and keeps it as `synchronized_generator`. Its state is never saved, so `prepare()` recreates the same sequence on resume.

So `save_state` now writes `{"iteration", "generator_state"}` per prepared dataloader into the `sampler{_i}.bin` slot that already existed, and `load_state` puts both back when the file is there, through `set_epoch` so the sampler and dataset hear about it too. The generator is whichever one the sampler draws from: the private one `prepare` attached, or a `generator=` the user passed to the `DataLoader`, which covers the plain PyTorch reproducibility recipe in a single process as well (that one replayed too, generator state was never written). One file from the main process is enough, the generator state is the same on every rank after `synchronize_rng_states`, same as the optimizer and scheduler files. Old checkpoints don't have the file and load as before. With `use_stateful_dataloader=True` the file is written and read as well, next to torchdata's `dl_state_dict.bin`; the torchdata branch itself is untouched. I unwrap XLA's `MpDeviceLoaderWrapper` too but couldn't run XLA here.

One thing this doesn't cover: a checkpoint taken inside an epoch still resumes that epoch on the next permutation. #4233 stacks on this one and handles that.

Before, the resumed order equals epoch 0's in both configurations. After, it equals the recorded continuation on every rank. torch 2.14.0, Python 3.13.12, CPU. #3242 is the same report from 2024 on 2 GPUs.

I also ran `examples/by_feature/checkpointing.py` end to end (bert-base-cased, MRPC cut to 256 train / 64 eval so it finishes on CPU, 2 processes, `--checkpointing_steps epoch`, the example's default sampler). Uninterrupted run, rank-0 loss sum per epoch: 5.152098, 4.962221, 4.925249. Resume from `epoch_0` with this branch: 4.962221, 4.925249, same numbers. Resume from the same checkpoint on `main`: 5.068580, 4.844967, so it trained epochs 1 and 2 on a different order.

```
pytest tests/test_state_checkpointing.py -q     # 24 passed, the 2 seedable cases and the user-generator case fail on main
torchrun --nproc_per_node 2 test_script.py     # check_dataloader_resume_order passes, on main it fails with
                                               #   "replayed the epoch-0 shuffle order on processes [True, True]"
pytest tests/test_data_loader.py tests/test_accelerator.py tests/test_utils.py tests/test_big_modeling.py -q   # 154 passed, 24 skipped
make quality                                   # clean on ruff 0.13.1
```

Drafted with Claude Opus / Fable 5.1. Reviewed by Muse Spark 1.3 and GLM 5.3 as judges before submission.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
