### PR TITLE
Resume a mid-epoch checkpoint on the same permutation

### DIFF
--- a/docs/source/usage_guides/checkpoint.md
+++ b/docs/source/usage_guides/checkpoint.md
@@ -72,6 +72,13 @@ accelerator.load_state("my/save/path/checkpointing/checkpoint_0")
 After resuming from a checkpoint, it may also be desirable to resume from a particular point in the active `DataLoader` if 
 the state was saved during the middle of an epoch. You can use [`~Accelerator.skip_first_batches`] to do so. 
 
+`save_state` records where each prepared dataloader is in its shuffle sequence. A checkpoint taken inside an epoch resumes on the
+same permutation when the shuffle comes from a `torch.Generator`: `use_seedable_sampler=True`, a `generator` passed to the
+`DataLoader`, or the default sampler in a multi-process run with `dispatch_batches=False`, with or without
+`use_stateful_dataloader`. When the permutation comes from the global RNG (the default sampler with no generator in a single
+process, or with `dispatch_batches=True`) the interrupted epoch is redrawn on resume, and only checkpoints taken at an epoch
+boundary line up.
+
 ```python
 from accelerate import Accelerator
 

--- a/docs/source/usage_guides/checkpoint.md
+++ b/docs/source/usage_guides/checkpoint.md
@@ -16,7 +16,8 @@ rendered properly in your Markdown viewer.
 # Checkpointing
 
 When training a PyTorch model with Accelerate, you may often want to save and continue a state of training. Doing so requires
-saving and loading the model, optimizer, RNG generators, and the GradScaler. Inside Accelerate are two convenience functions to achieve this quickly:
+saving and loading the model, optimizer, RNG generators, the GradScaler, and the epoch counter and shuffle generator of each
+prepared dataloader, so that a resumed run continues the shuffle sequence instead of replaying an earlier epoch. Inside Accelerate are two convenience functions to achieve this quickly:
 - Use [`~Accelerator.save_state`] for saving everything mentioned above to a folder location
 - Use [`~Accelerator.load_state`] for loading everything stored from an earlier `save_state`
 

--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -3620,7 +3620,8 @@ class Accelerator:
 
     def save_state(self, output_dir: str | None = None, safe_serialization: bool = True, **save_model_func_kwargs):
         """
-        Saves the current states of the model, optimizer, scaler, RNG generators, and registered objects to a folder.
+        Saves the current states of the model, optimizer, scaler, RNG generators, the epoch counter and shuffle
+        generator of each prepared dataloader, and registered objects to a folder.
 
         If a `ProjectConfiguration` was passed to the `Accelerator` object with `automatic_checkpoint_naming` enabled
         then checkpoints will be saved to `self.project_dir/checkpoints`. If the number of current saves is greater

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -74,16 +74,26 @@ def _get_dataloader_sampler_state(dataloader) -> Optional[dict]:
     if iteration is None:
         return None
     generator = get_shuffle_generator(dataloader)
-    return {
-        "iteration": iteration,
-        "generator_state": generator.get_state() if generator is not None else None,
-    }
+    epoch_start = getattr(dataloader, "_generator_state_at_epoch_start", None)
+    inside_epoch = epoch_start is not None and epoch_start[0] == iteration
+    if inside_epoch and getattr(dataloader, "end_of_dataloader", False):
+        # The last batch was already handed out: from the sampler's point of view the epoch is complete, only the
+        # bookkeeping after the final `yield` has not run yet
+        iteration += 1
+        inside_epoch = False
+    generator_state = None
+    if generator is not None:
+        # Inside an epoch the permutation was already drawn, resume must draw it again: use the state it was drawn from
+        generator_state = epoch_start[1] if inside_epoch else generator.get_state()
+    return {"iteration": iteration, "generator_state": generator_state}
 
 
 def _set_dataloader_sampler_state(dataloader, sampler_state: dict) -> None:
     from .data_loader import get_shuffle_generator
 
     dataloader = getattr(dataloader, "_loader", dataloader)
+    # Whatever this process iterated before loading is not where the checkpoint was taken
+    dataloader._generator_state_at_epoch_start = None
     if sampler_state.get("iteration") is not None and hasattr(dataloader, "iteration"):
         # `set_epoch` also forwards the epoch to the sampler and the dataset
         dataloader.set_epoch(sampler_state["iteration"])

--- a/src/accelerate/checkpointing.py
+++ b/src/accelerate/checkpointing.py
@@ -60,6 +60,38 @@ from .state import PartialState
 logger = get_logger(__name__)
 
 
+def _get_dataloader_sampler_state(dataloader) -> Optional[dict]:
+    """
+    Collects what a prepared dataloader needs to resume its shuffle order: the number of epochs it has iterated
+    (`SeedableRandomSampler` derives its seed from it) and the state of the generator the sampler draws from, when it
+    has one. Returns `None` for dataloaders that were not prepared by Accelerate.
+    """
+    from .data_loader import get_shuffle_generator
+
+    # Under XLA the prepared dataloader is wrapped in an `MpDeviceLoaderWrapper`
+    dataloader = getattr(dataloader, "_loader", dataloader)
+    iteration = getattr(dataloader, "iteration", None)
+    if iteration is None:
+        return None
+    generator = get_shuffle_generator(dataloader)
+    return {
+        "iteration": iteration,
+        "generator_state": generator.get_state() if generator is not None else None,
+    }
+
+
+def _set_dataloader_sampler_state(dataloader, sampler_state: dict) -> None:
+    from .data_loader import get_shuffle_generator
+
+    dataloader = getattr(dataloader, "_loader", dataloader)
+    if sampler_state.get("iteration") is not None and hasattr(dataloader, "iteration"):
+        # `set_epoch` also forwards the epoch to the sampler and the dataset
+        dataloader.set_epoch(sampler_state["iteration"])
+    generator = get_shuffle_generator(dataloader)
+    if generator is not None and sampler_state.get("generator_state") is not None:
+        generator.set_state(sampler_state["generator_state"])
+
+
 def save_accelerator_state(
     output_dir: str,
     model_states: list[dict],
@@ -131,19 +163,15 @@ def save_accelerator_state(
     for i, dataloader in enumerate(dataloaders):
         sampler_name = f"{SAMPLER_NAME}.bin" if i == 0 else f"{SAMPLER_NAME}_{i}.bin"
         output_sampler_file = output_dir.joinpath(sampler_name)
-        # Only save if we have our custom sampler
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
-
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                save(sampler, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
+        sampler_state = _get_dataloader_sampler_state(dataloader)
+        if sampler_state is not None:
+            save(sampler_state, output_sampler_file, save_on_each_node=save_on_each_node, safe_serialization=False)
+            logger.info(f"Sampler state for dataloader {i} saved in {output_sampler_file}")
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             output_dataloader_state_dict_file = output_dir.joinpath(dataloader_state_dict_name)
             state_dict = dataloader.state_dict()
             torch.save(state_dict, output_dataloader_state_dict_file)
-        logger.info(f"Sampler state for dataloader {i} saved in {output_sampler_file}")
 
     # GradScaler state
     if scaler is not None:
@@ -267,13 +295,9 @@ def load_accelerator_state(
     for i, dataloader in enumerate(dataloaders):
         sampler_name = f"{SAMPLER_NAME}.bin" if i == 0 else f"{SAMPLER_NAME}_{i}.bin"
         input_sampler_file = input_dir.joinpath(sampler_name)
-        # Only load if we have our custom sampler
-        from .data_loader import IterableDatasetShard, SeedableRandomSampler
-
-        if isinstance(dataloader.dataset, IterableDatasetShard):
-            sampler = dataloader.get_sampler()
-            if isinstance(sampler, SeedableRandomSampler):
-                sampler = dataloader.set_sampler(load(input_sampler_file))
+        # Checkpoints written before the sampler state was tracked do not have this file
+        if input_sampler_file.exists():
+            _set_dataloader_sampler_state(dataloader, load(input_sampler_file, **load_kwargs))
         if getattr(dataloader, "use_stateful_dataloader", False):
             dataloader_state_dict_name = "dl_state_dict.bin" if i == 0 else f"dl_state_dict_{i}.bin"
             input_dataloader_state_dict_file = input_dir.joinpath(dataloader_state_dict_name)

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -995,6 +995,22 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
                 self.batch_sampler.batch_sampler.sampler = sampler
 
 
+def get_shuffle_generator(dataloader) -> Optional[torch.Generator]:
+    """
+    Returns the `torch.Generator` the shuffling of a prepared dataloader draws from, or `None` when it draws from the
+    global RNG. This is the generator `prepare_data_loader` synchronizes across processes when it created one, else the
+    one the user gave the sampler.
+    """
+    generator = getattr(dataloader, "synchronized_generator", None)
+    if generator is None:
+        # Walk `SkipBatchSampler` -> `BatchSamplerShard` -> `BatchSampler` down to the sampler
+        sampler = dataloader.sampler if isinstance(dataloader.sampler, BatchSampler) else dataloader.batch_sampler
+        while sampler is not None and not hasattr(sampler, "generator"):
+            sampler = getattr(sampler, "sampler", None) or getattr(sampler, "batch_sampler", None)
+        generator = getattr(sampler, "generator", None)
+    return generator if isinstance(generator, torch.Generator) else None
+
+
 def get_sampler(dataloader):
     """
     Get the sampler associated to the dataloader

--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -399,6 +399,40 @@ class DataLoaderStateMixin:
         self.end_of_dataloader = False
         self.remainder = -1
 
+    def _record_epoch_start(self):
+        """
+        Marks the start of an epoch and keeps the generator state its permutation is drawn from (if any), so a
+        checkpoint taken inside the epoch is attributed to it and the resumed run draws the same permutation. Shared
+        with the dataloader `skip_first_batches` was built from, since `save_state` only sees that one.
+        """
+        generator = get_shuffle_generator(self)
+        self._generator_state_at_epoch_start = (
+            self.iteration,
+            generator.get_state() if generator is not None else None,
+        )
+        source_dataloader = getattr(self, "_source_dataloader", None)
+        if source_dataloader is not None:
+            source_dataloader._generator_state_at_epoch_start = self._generator_state_at_epoch_start
+
+    def _mark_end_of_dataloader(self):
+        "Flags the last batch, also on the dataloader `skip_first_batches` was built from"
+        self.end_of_dataloader = True
+        source_dataloader = getattr(self, "_source_dataloader", None)
+        if source_dataloader is not None:
+            source_dataloader.end_of_dataloader = True
+
+    def _finish_epoch(self):
+        """
+        Counts the completed epoch, also on the dataloader `skip_first_batches` was built from. That one is assumed
+        not to be iterated or `set_epoch`-ed while the skipping dataloader is in use: it holds the epoch being resumed.
+        """
+        self.iteration += 1
+        self._generator_state_at_epoch_start = None
+        source_dataloader = getattr(self, "_source_dataloader", None)
+        if source_dataloader is not None and source_dataloader.iteration == self.iteration - 1:
+            source_dataloader.iteration = self.iteration
+            source_dataloader._generator_state_at_epoch_start = None
+
     def begin(self):
         "Prepares the gradient state for the current dataloader"
         self.reset()
@@ -580,6 +614,7 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         self.begin()
 
         self.set_epoch(self.iteration)
+        self._record_epoch_start()
         dataloader_iter = self.base_dataloader.__iter__()
         # We iterate one batch ahead to check when we are at the end
         try:
@@ -601,13 +636,13 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
                 batch_index += 1
                 current_batch = next_batch
             except StopIteration:
-                self.end_of_dataloader = True
+                self._mark_end_of_dataloader()
                 self._update_state_dict()
                 if batch_index >= self.skip_batches:
                     yield current_batch
                 break
 
-        self.iteration += 1
+        self._finish_epoch()
         self.end()
 
     def __reduce__(self):
@@ -936,13 +971,13 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
             )
 
             if stop_iteration:
-                self.end_of_dataloader = True
+                self._mark_end_of_dataloader()
                 self._update_state_dict()
                 self.remainder = observed_batch_size
             if batch_index >= self.skip_batches:
                 yield batch
             batch_index += 1
-        self.iteration += 1
+        self._finish_epoch()
         self.end()
 
     def set_epoch(self, epoch: int):
@@ -1418,6 +1453,8 @@ def skip_first_batches(dataloader, num_batches=0):
         device = dataloader.device
         dataloader = dataloader.dataloader
 
+    # Chain through an already-skipping dataloader so that nested calls all report to the original one
+    source_dataloader = getattr(dataloader, "_source_dataloader", dataloader)
     dataset = dataloader.dataset
     sampler_is_batch_sampler = False
     if isinstance(dataset, IterableDataset):
@@ -1482,6 +1519,11 @@ def skip_first_batches(dataloader, num_batches=0):
             dataloader = SkipDataLoader(dataset, skip_batches=num_batches, **kwargs)
         else:
             dataloader = DataLoader(dataset, batch_sampler=new_batch_sampler, **kwargs)
+
+    if isinstance(dataloader, (DataLoaderShard, DataLoaderDispatcher)):
+        # Epochs completed through the skipping dataloader count for the original one too, which is the one
+        # `save_state` checkpoints and the training loop goes back to after the resumed epoch.
+        dataloader._source_dataloader = source_dataloader
 
     if state.distributed_type == DistributedType.XLA:
         dataloader = MpDeviceLoaderWrapper(dataloader, device)

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -17,6 +17,8 @@
 import contextlib
 import io
 import math
+import shutil
+import tempfile
 import time
 from copy import deepcopy
 from pathlib import Path
@@ -32,6 +34,7 @@ from accelerate.test_utils import RegressionDataset, RegressionModel, are_the_sa
 from accelerate.utils import (
     DataLoaderConfiguration,
     DistributedType,
+    broadcast_object_list,
     gather,
     gather_object,
     is_bf16_available,
@@ -379,6 +382,49 @@ def check_seedable_sampler():
             new_items.append(batch["x"])
     new_items = torch.cat(new_items)
     assert torch.allclose(original_items, new_items), "Did not obtain the same items with the same seed and epoch."
+
+
+def check_dataloader_resume_order(use_seedable_sampler=False):
+    """
+    `load_state` must restore the shuffle position of a prepared dataloader on every process, so a resumed run
+    continues with the order it would have produced instead of replaying epoch 0 (accelerate#3996).
+    """
+
+    def epoch_order(dataloader):
+        return [sample for batch in dataloader for sample in batch["x"].tolist()]
+
+    def make_dataloader(accelerator):
+        set_seed(42)
+        train_set = RegressionDataset(length=32, seed=42)
+        return accelerator.prepare(DataLoader(train_set, batch_size=4, shuffle=True))
+
+    config = DataLoaderConfiguration(use_seedable_sampler=use_seedable_sampler)
+    accelerator = Accelerator(dataloader_config=config)
+    tmpdir = [tempfile.mkdtemp() if accelerator.is_main_process else None]
+    tmpdir = broadcast_object_list(tmpdir)[0]
+    try:
+        train_dl = make_dataloader(accelerator)
+        first_epoch = epoch_order(train_dl)
+        epoch_order(train_dl)
+        accelerator.save_state(tmpdir)
+        expected_continuation = epoch_order(train_dl)
+        assert expected_continuation != first_epoch, "The dataset is too small to tell epochs apart"
+
+        accelerator = Accelerator(dataloader_config=config)
+        train_dl = make_dataloader(accelerator)
+        accelerator.load_state(tmpdir)
+        resumed = epoch_order(train_dl)
+    finally:
+        accelerator.wait_for_everyone()
+        if accelerator.is_main_process:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    replayed_epoch_0 = gather_object([resumed == first_epoch])
+    continued = gather_object([resumed == expected_continuation])
+    assert not any(replayed_epoch_0), (
+        f"Resumed dataloader replayed the epoch-0 shuffle order on processes {replayed_epoch_0}"
+    )
+    assert all(continued), f"Resumed dataloader did not continue with the expected order on processes {continued}"
 
 
 def check_seedable_sampler_in_batch_sampler_shard():
@@ -880,6 +926,8 @@ def main():
         custom_sampler_check()
         check_seedable_sampler()
         check_seedable_sampler_with_data_seed()
+        check_dataloader_resume_order(use_seedable_sampler=False)
+        check_dataloader_resume_order(use_seedable_sampler=True)
 
     if state.num_processes > 1:
         check_seedable_sampler_in_batch_sampler_shard()

--- a/src/accelerate/test_utils/scripts/test_script.py
+++ b/src/accelerate/test_utils/scripts/test_script.py
@@ -44,6 +44,7 @@ from accelerate.utils import (
     is_hpu_available,
     is_mps_available,
     is_pytest_available,
+    is_torchdata_stateful_dataloader_available,
     set_seed,
     synchronize_rng_states,
 )
@@ -384,7 +385,7 @@ def check_seedable_sampler():
     assert torch.allclose(original_items, new_items), "Did not obtain the same items with the same seed and epoch."
 
 
-def check_dataloader_resume_order(use_seedable_sampler=False):
+def check_dataloader_resume_order(use_seedable_sampler=False, use_stateful_dataloader=False):
     """
     `load_state` must restore the shuffle position of a prepared dataloader on every process, so a resumed run
     continues with the order it would have produced instead of replaying epoch 0 (accelerate#3996).
@@ -398,22 +399,66 @@ def check_dataloader_resume_order(use_seedable_sampler=False):
         train_set = RegressionDataset(length=32, seed=42)
         return accelerator.prepare(DataLoader(train_set, batch_size=4, shuffle=True))
 
-    config = DataLoaderConfiguration(use_seedable_sampler=use_seedable_sampler)
+    config = DataLoaderConfiguration(
+        use_seedable_sampler=use_seedable_sampler, use_stateful_dataloader=use_stateful_dataloader
+    )
     accelerator = Accelerator(dataloader_config=config)
+    skip_batches = 3
     tmpdir = [tempfile.mkdtemp() if accelerator.is_main_process else None]
     tmpdir = broadcast_object_list(tmpdir)[0]
     try:
         train_dl = make_dataloader(accelerator)
+        # The default sampler draws from the global RNG when `prepare` attached no private generator (single process,
+        # `dispatch_batches`). Only the epoch-boundary resume is exact there, the interrupted epoch is redrawn.
+        mid_epoch_exact = use_seedable_sampler or getattr(train_dl, "synchronized_generator", None) is not None
         first_epoch = epoch_order(train_dl)
         epoch_order(train_dl)
         accelerator.save_state(tmpdir)
         expected_continuation = epoch_order(train_dl)
         assert expected_continuation != first_epoch, "The dataset is too small to tell epochs apart"
+        if mid_epoch_exact:
+            # Checkpoint inside an epoch; a stateful dataloader is positioned by `load_state`, a plain one by
+            # `skip_first_batches`
+            train_dl_iter = iter(train_dl)
+            for _ in range(skip_batches):
+                next(train_dl_iter)
+            accelerator.save_state(f"{tmpdir}/mid_epoch")
+            expected_mid_epoch_continuation = [sample for batch in train_dl_iter for sample in batch["x"].tolist()]
+            expected_following_epoch = epoch_order(train_dl)
+
+        continued_after_last_batch = True
+        if not use_stateful_dataloader:
+            # Checkpoint while handling the last batch of an epoch: the next run must start the following epoch
+            for step, batch in enumerate(train_dl):
+                if step == len(train_dl) - 1:
+                    accelerator.save_state(f"{tmpdir}/last_batch")
+            expected_after_last_batch = epoch_order(train_dl)
 
         accelerator = Accelerator(dataloader_config=config)
         train_dl = make_dataloader(accelerator)
         accelerator.load_state(tmpdir)
         resumed = epoch_order(train_dl)
+
+        if not use_stateful_dataloader:
+            accelerator = Accelerator(dataloader_config=config)
+            train_dl = make_dataloader(accelerator)
+            accelerator.load_state(f"{tmpdir}/last_batch")
+            continued_after_last_batch = epoch_order(train_dl) == expected_after_last_batch
+
+        continued_mid_epoch = True
+        if mid_epoch_exact:
+            accelerator = Accelerator(dataloader_config=config)
+            train_dl = make_dataloader(accelerator)
+            accelerator.load_state(f"{tmpdir}/mid_epoch")
+            if use_stateful_dataloader:
+                resumed_mid_epoch = epoch_order(train_dl)
+            else:
+                resumed_mid_epoch = epoch_order(accelerator.skip_first_batches(train_dl, skip_batches))
+            resumed_following_epoch = epoch_order(train_dl)
+            continued_mid_epoch = (
+                resumed_mid_epoch == expected_mid_epoch_continuation
+                and resumed_following_epoch == expected_following_epoch
+            )
     finally:
         accelerator.wait_for_everyone()
         if accelerator.is_main_process:
@@ -421,10 +466,19 @@ def check_dataloader_resume_order(use_seedable_sampler=False):
 
     replayed_epoch_0 = gather_object([resumed == first_epoch])
     continued = gather_object([resumed == expected_continuation])
+    continued_mid_epoch = gather_object([continued_mid_epoch])
+    continued_after_last_batch = gather_object([continued_after_last_batch])
     assert not any(replayed_epoch_0), (
         f"Resumed dataloader replayed the epoch-0 shuffle order on processes {replayed_epoch_0}"
     )
     assert all(continued), f"Resumed dataloader did not continue with the expected order on processes {continued}"
+    assert all(continued_mid_epoch), (
+        "Dataloader resumed from a mid-epoch checkpoint did not continue with the expected order (rest of the epoch, then "
+        f"the next one) on processes {continued_mid_epoch}"
+    )
+    assert all(continued_after_last_batch), (
+        f"Dataloader resumed from a checkpoint taken on the last batch replayed that epoch on processes {continued_after_last_batch}"
+    )
 
 
 def check_seedable_sampler_in_batch_sampler_shard():
@@ -931,6 +985,9 @@ def main():
 
     if state.num_processes > 1:
         check_seedable_sampler_in_batch_sampler_shard()
+        if state.distributed_type != DistributedType.XLA and is_torchdata_stateful_dataloader_available():
+            # The default sampler only resumes mid-epoch when `prepare` attached a private generator (multi-process)
+            check_dataloader_resume_order(use_seedable_sampler=False, use_stateful_dataloader=True)
 
     # Trainings are not exactly the same in DeepSpeed and CPU mode
     if state.distributed_type == DistributedType.DEEPSPEED:

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -40,6 +40,7 @@ from accelerate.utils import (
     DataLoaderConfiguration,
     DistributedType,
     ProjectConfiguration,
+    is_torchdata_stateful_dataloader_available,
     patch_environment,
     set_seed,
 )
@@ -130,12 +131,75 @@ class CheckpointTest(AccelerateTestCase):
             accelerator.save_state(safe_serialization=self.use_safetensors)
             assert len(os.listdir(accelerator.project_dir)) == 1
 
-    @parameterized.expand([(True,), (False,)], name_func=lambda f, n, p: f"{f.__name__}_seedable_{p.args[0]}")
+    # No default-sampler case beyond the epoch boundary: in a single process it draws from the global RNG (or, with
+    # `use_stateful_dataloader`, from torchdata's own generator), which `load_state` restores as of the checkpoint, so
+    # the interrupted epoch is redrawn. `test_script.py` covers the multi-process default sampler, where `prepare`
+    # attaches a private generator.
+    @parameterized.expand(
+        [(True, False, False), (True, True, False), (False, False, False), (True, True, True)],
+        name_func=lambda f, n, p: f"{f.__name__}_seedable_{p.args[0]}_mid_epoch_{p.args[1]}_stateful_{p.args[2]}",
+    )
     @require_non_torch_xla
-    def test_resume_restores_dataloader_shuffle_order(self, use_seedable_sampler):
+    def test_resume_restores_dataloader_shuffle_order(self, use_seedable_sampler, mid_epoch, use_stateful_dataloader):
         """
         After `load_state`, a shuffled dataloader must continue with the order it would have produced had training not
-        been interrupted, not replay epoch 0 (https://github.com/huggingface/accelerate/issues/3996).
+        been interrupted, not replay epoch 0 (https://github.com/huggingface/accelerate/issues/3996). A checkpoint
+        taken inside an epoch is resumed with `skip_first_batches` (a stateful dataloader is positioned by `load_state`
+        itself), and the epoch after that one must follow too.
+        """
+        if use_stateful_dataloader and not is_torchdata_stateful_dataloader_available():
+            self.skipTest("torchdata.stateful_dataloader is not available")
+        skip_batches, batch_size = 3, 4
+
+        def make_dataloader(accelerator):
+            dataloader = DataLoader(TensorDataset(torch.arange(32)), batch_size=batch_size, shuffle=True)
+            return accelerator.prepare(dataloader)
+
+        def epoch_order(dataloader):
+            return [sample for batch in dataloader for sample in batch[0].tolist()]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            set_seed(42)
+            dataloader_config = DataLoaderConfiguration(
+                use_seedable_sampler=use_seedable_sampler, use_stateful_dataloader=use_stateful_dataloader
+            )
+            accelerator = Accelerator(dataloader_config=dataloader_config)
+            train_dataloader = make_dataloader(accelerator)
+            orders = [epoch_order(train_dataloader) for _ in range(2)]
+            if mid_epoch:
+                iterator = iter(train_dataloader)
+                for _ in range(skip_batches):
+                    next(iterator)
+                accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+                expected = [[sample for batch in iterator for sample in batch[0].tolist()]]
+            else:
+                accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+                expected = [epoch_order(train_dataloader)]
+            expected.append(epoch_order(train_dataloader))
+            assert expected[-1] != orders[0], "The dataset is too small to tell epochs apart"
+
+            # Resume from scratch, as a new script run would
+            set_seed(42)
+            accelerator = Accelerator(dataloader_config=dataloader_config)
+            train_dataloader = make_dataloader(accelerator)
+            accelerator.load_state(tmpdir)
+            if mid_epoch and not use_stateful_dataloader:
+                resumed = [epoch_order(accelerator.skip_first_batches(train_dataloader, skip_batches))]
+            else:
+                resumed = [epoch_order(train_dataloader)]
+            resumed.append(epoch_order(train_dataloader))
+
+            assert resumed[0] != orders[0][skip_batches * batch_size if mid_epoch else 0 :], (
+                "Resumed dataloader replayed the epoch-0 shuffle order"
+            )
+            assert resumed == expected
+
+    @parameterized.expand([(True,), (False,)], name_func=lambda f, n, p: f"{f.__name__}_seedable_{p.args[0]}")
+    @require_non_torch_xla
+    def test_resume_after_checkpoint_on_last_batch(self, use_seedable_sampler):
+        """
+        A checkpoint taken while processing the last batch of an epoch (what `checkpointing_steps` produces whenever it
+        divides the number of batches) must resume with the next epoch, not replay the one that just finished.
         """
 
         def make_dataloader(accelerator):
@@ -150,20 +214,23 @@ class CheckpointTest(AccelerateTestCase):
             dataloader_config = DataLoaderConfiguration(use_seedable_sampler=use_seedable_sampler)
             accelerator = Accelerator(dataloader_config=dataloader_config)
             train_dataloader = make_dataloader(accelerator)
-            orders = [epoch_order(train_dataloader) for _ in range(2)]
-            accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
-            expected_continuation = epoch_order(train_dataloader)
-            assert expected_continuation != orders[0], "The dataset is too small to tell epochs apart"
+            epoch_order(train_dataloader)
+            just_finished = []
+            for step, batch in enumerate(train_dataloader):
+                just_finished += batch[0].tolist()
+                if step == len(train_dataloader) - 1:
+                    accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+            expected_next_epoch = epoch_order(train_dataloader)
 
-            # Resume from scratch, as a new script run would
             set_seed(42)
             accelerator = Accelerator(dataloader_config=dataloader_config)
             train_dataloader = make_dataloader(accelerator)
             accelerator.load_state(tmpdir)
-            resumed = epoch_order(train_dataloader)
+            # The example computes a resume step of 0 for this checkpoint and still goes through `skip_first_batches`
+            resumed = epoch_order(accelerator.skip_first_batches(train_dataloader, 0))
 
-            assert resumed != orders[0], "Resumed dataloader replayed the epoch-0 shuffle order"
-            assert resumed == expected_continuation
+            assert resumed != just_finished, "Resumed dataloader replayed the epoch the checkpoint closed"
+            assert resumed == expected_next_epoch
 
     @require_non_torch_xla
     def test_resume_restores_user_generator(self):

--- a/tests/test_state_checkpointing.py
+++ b/tests/test_state_checkpointing.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 
 import pytest
 import torch
-from parameterized import parameterized_class
+from parameterized import parameterized, parameterized_class
 from torch import nn
 from torch.utils.data import DataLoader, TensorDataset
 
@@ -36,7 +36,13 @@ from accelerate.test_utils import (
     run_first,
 )
 from accelerate.test_utils.testing import AccelerateTestCase
-from accelerate.utils import DistributedType, ProjectConfiguration, patch_environment, set_seed
+from accelerate.utils import (
+    DataLoaderConfiguration,
+    DistributedType,
+    ProjectConfiguration,
+    patch_environment,
+    set_seed,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -123,6 +129,69 @@ class CheckpointTest(AccelerateTestCase):
             # Save second state
             accelerator.save_state(safe_serialization=self.use_safetensors)
             assert len(os.listdir(accelerator.project_dir)) == 1
+
+    @parameterized.expand([(True,), (False,)], name_func=lambda f, n, p: f"{f.__name__}_seedable_{p.args[0]}")
+    @require_non_torch_xla
+    def test_resume_restores_dataloader_shuffle_order(self, use_seedable_sampler):
+        """
+        After `load_state`, a shuffled dataloader must continue with the order it would have produced had training not
+        been interrupted, not replay epoch 0 (https://github.com/huggingface/accelerate/issues/3996).
+        """
+
+        def make_dataloader(accelerator):
+            dataloader = DataLoader(TensorDataset(torch.arange(32)), batch_size=4, shuffle=True)
+            return accelerator.prepare(dataloader)
+
+        def epoch_order(dataloader):
+            return [sample for batch in dataloader for sample in batch[0].tolist()]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            set_seed(42)
+            dataloader_config = DataLoaderConfiguration(use_seedable_sampler=use_seedable_sampler)
+            accelerator = Accelerator(dataloader_config=dataloader_config)
+            train_dataloader = make_dataloader(accelerator)
+            orders = [epoch_order(train_dataloader) for _ in range(2)]
+            accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+            expected_continuation = epoch_order(train_dataloader)
+            assert expected_continuation != orders[0], "The dataset is too small to tell epochs apart"
+
+            # Resume from scratch, as a new script run would
+            set_seed(42)
+            accelerator = Accelerator(dataloader_config=dataloader_config)
+            train_dataloader = make_dataloader(accelerator)
+            accelerator.load_state(tmpdir)
+            resumed = epoch_order(train_dataloader)
+
+            assert resumed != orders[0], "Resumed dataloader replayed the epoch-0 shuffle order"
+            assert resumed == expected_continuation
+
+    @require_non_torch_xla
+    def test_resume_restores_user_generator(self):
+        "A `generator` passed to the `DataLoader` is restored by `load_state`, so a resumed run keeps its shuffle order."
+
+        def make_dataloader(accelerator):
+            generator = torch.Generator().manual_seed(0)
+            dataloader = DataLoader(TensorDataset(torch.arange(32)), batch_size=4, shuffle=True, generator=generator)
+            return accelerator.prepare(dataloader)
+
+        def epoch_order(dataloader):
+            return [sample for batch in dataloader for sample in batch[0].tolist()]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            accelerator = Accelerator()
+            train_dataloader = make_dataloader(accelerator)
+            first_epoch = epoch_order(train_dataloader)
+            epoch_order(train_dataloader)
+            accelerator.save_state(tmpdir, safe_serialization=self.use_safetensors)
+            expected_continuation = epoch_order(train_dataloader)
+
+            accelerator = Accelerator()
+            train_dataloader = make_dataloader(accelerator)
+            accelerator.load_state(tmpdir)
+            resumed = epoch_order(train_dataloader)
+
+            assert resumed != first_epoch, "Resumed dataloader replayed the epoch-0 shuffle order"
+            assert resumed == expected_continuation
 
     def test_can_resume_training_with_folder(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Stacked on #4232, the first commit is that PR, only the second one is new here.

After #4232 an epoch-boundary checkpoint resumes fine, but one taken inside an epoch doesn't, with the default sampler. `RandomSampler` draws the permutation as soon as iteration starts, so by the time `save_state` runs mid-epoch, `synchronized_generator` already holds the state for the *next* epoch. Restore that, call `skip_first_batches(dl, n)`, and you skip `n` batches of a permutation you never trained on. The seedable sampler was already fine here, its seed is `initial_seed + epoch` and doesn't care when you saved.

Then there's a second thing I only noticed while testing this, and it hits both samplers. `skip_first_batches` builds a fresh `DataLoaderShard` with the source's `iteration` (that's #4071), but the source never hears that the epoch finished. Your loop goes back to the original loader for the next epoch, `__iter__` calls `set_epoch(k)` on it again, and you get permutation `k` twice in a row. `examples/by_feature/checkpointing.py` has exactly this shape.

What changed: `DataLoaderShard.__iter__` records `(iteration, generator.get_state())` right before it creates the base iterator, and `save_state` uses that pair as long as `iteration` still points at the same epoch, the live state otherwise. One case needed its own rule: saving while handling the *last* batch of an epoch. `iteration` only moves after the final `yield`, so that checkpoint looked like "inside epoch k" and resumed by replaying epoch k, with every later epoch off by one. The example hits it whenever `checkpointing_steps` divides the batches per epoch, and the checkpoint looks fine. `end_of_dataloader` is already set before that last batch is handed out, so `save_state` treats it as the end of the epoch. Test for it in both test files. `skip_first_batches` sets `_source_dataloader` on the loader it returns, `_finish_epoch` writes the incremented `iteration` back to the source, and `_record_epoch_start` mirrors the epoch-start state onto it, so crashing a second time inside the resumed epoch works too (I ran that one: save 3 batches in, resume, save 2 batches later, resume again, rest of the epoch and the next one match on both ranks). Nested `skip_first_batches` calls chain to the original loader. The write-back only happens when the source is still one epoch behind, and the recorded epoch-start state is dropped when an epoch completes and when `load_state` runs, so a `save_state` right after `load_state` writes what was loaded, not what this process happened to iterate before.

Nothing changes for a run that never resumes: `_record_epoch_start` only calls `get_state()`, it consumes no RNG, so an uninterrupted run produces the same order as before this PR, byte for byte. Only resumed runs move.

`use_stateful_dataloader=True` with the default sampler gets the same fix for free. torchdata fast-forwards the sampler by re-iterating it, so restoring the epoch-start generator state makes it redraw the same permutation, and then the rest of the epoch and the next one match on both ranks. On #4232 alone that path is wrong on both counts. That's the config the checkpointing example uses with `--use_stateful_dataloader`.

Still not exact, and left alone here: the paths where the permutation comes from a generator Accelerate doesn't hold, so the default sampler in a single process (global RNG, or torchdata's own generator with `use_stateful_dataloader`) and the default sampler with `dispatch_batches=True` (global RNG on the main process). `load_state` restores the global RNG as of the checkpoint, so a mid-epoch resume there gets a fresh permutation for the interrupted epoch, same as plain PyTorch. Epoch-boundary resume on those paths is fine after #4232. There are two more things on the dispatcher I'll send separately, both pre-existing: `skip_first_batches` on a `DataLoaderDispatcher` wraps the *unsharded* batch sampler, so it skips `n` global batches instead of `n` per-rank ones, and `DataLoaderDispatcher.set_epoch` only looks at `batch_sampler.sampler`, which a `SkipBatchSampler` doesn't have, so the seedable sampler's epoch never reaches the skipping loader. Either one makes the rest of a resumed epoch wrong under `dispatch_batches=True` (the following epoch is right).

Checked on CPU, torch 2.14.0, 2 processes over gloo: save after 3 batches of epoch 2, resume with `skip_first_batches(dl, 3)`, compare the rest of epoch 2 and all of epoch 3 against the uninterrupted run.

```
                                        rest of epoch 2   epoch 3
main + #4232, default                   no                no
main + #4232, seedable                  yes               no
main + #4232, default + stateful        no                no
this PR, default and seedable           yes               yes
this PR, default + stateful             yes               yes
this PR, seedable + dispatch            no (skip bugs)    yes
this PR, default + dispatch             no (global RNG)   no
this PR, save on the last batch         next epoch        yes

pytest tests/test_state_checkpointing.py -q     # 32 passed; the mid-epoch and last-batch cases fail on #4232 alone
python test_script.py                            # single process, passes (the mid-epoch part is gated on a private generator)
torchrun --nproc_per_node 2 test_script.py       # check_dataloader_resume_order walks the mid-epoch path on both ranks, stateful too
make quality                                      # clean on ruff 0.13.1
```

One design question rather than a change: the single-process default path could get the same private generator `prepare_data_loader` already attaches in the multi-process branch. Every non-dispatch path would then resume exactly and the gate in the tests would go away. The cost is that a single-process run's epoch-0 order would change versus earlier releases, since the seed would be drawn at `prepare` instead of the first `__iter__`. I didn't do it here because of that; happy to if you'd rather have one code path.

Drafted with Claude Opus / Fable 5.1. Reviewed by Muse Spark 1.3 and GLM 5.3 as judges before submission.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-documentation---specification).
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
