### PR TITLE
Capture stateful dataloader state lazily so prepare() does not draw the shuffle permutation

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -441,7 +441,9 @@ class DataLoaderAdapter:
             self.base_dataloader = DataLoader(dataset, batch_sampler=batch_sampler, **kwargs)
 
         if hasattr(self.base_dataloader, "state_dict"):
-            self.dl_state_dict = self.base_dataloader.state_dict()
+            # Captured lazily in `_update_state_dict`: with `num_workers > 0`, calling `state_dict()` here would
+            # build the iterator and draw the sampler permutation before the RNG is synchronized across processes.
+            self.dl_state_dict = None
 
     def __getattr__(self, name):
         # Avoid infinite recursion if we try to access a nonexistent base_dataloader attribute.
@@ -451,6 +453,8 @@ class DataLoaderAdapter:
         return getattr(self.base_dataloader, name)
 
     def state_dict(self):
+        if self.dl_state_dict is None:
+            return self.base_dataloader.state_dict()
         return self.dl_state_dict
 
     def load_state_dict(self, state_dict):

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -312,6 +312,21 @@ def _test_stateful_dataloader_resume(accelerator, iterable):
         accelerator.dataloader_config = old_dataloader_config
 
 
+def test_stateful_dataloader_with_workers(accelerator):
+    """
+    With `num_workers > 0`, capturing the state dict at prepare time used to build the iterator and draw the epoch-0
+    permutation before the RNG was synchronized across processes, so each rank sharded a different permutation.
+    """
+    old_dataloader_config = accelerator.dataloader_config
+    try:
+        accelerator.dataloader_config = DataLoaderConfiguration(use_stateful_dataloader=True)
+        torch.manual_seed(accelerator.process_index)
+        loader = DataLoader(DummyDataset(), shuffle=True, batch_size=BATCH_SIZE, num_workers=NUM_WORKERS)
+        test_data_loader(loader, accelerator)
+    finally:
+        accelerator.dataloader_config = old_dataloader_config
+
+
 def test_stateful_dataloader(accelerator):
     """
     Tests that a stateful dataloader can be iterated over, saved after a few batches using `load_state_dict`, and then
@@ -419,6 +434,8 @@ def main():
     sampler = BatchSampler(RandomSampler(dataset), batch_size=BATCH_SIZE, drop_last=False)
     loader = DataLoader(dataset, sampler=sampler, batch_size=None, collate_fn=default_collate, num_workers=NUM_WORKERS)
     test_data_loader(loader, accelerator)
+    accelerator.print("Test stateful DataLoader with num_workers > 0")
+    test_stateful_dataloader_with_workers(accelerator)
     test_stateful_dataloader(accelerator)
     test_stateful_dataloader_save_state(accelerator)
 

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -757,6 +757,25 @@ class StatefulDataLoaderTester(AccelerateTestCase):
         for idx, _ in enumerate(dataloader):
             assert dataloader.end_of_dataloader == (idx == 3)
 
+    @require_torchdata_stateful_dataloader
+    def test_dataloader_shuffle_seeded_after_init(self):
+        # With `num_workers > 0`, capturing the state dict at init builds the iterator and draws the shuffle
+        # permutation right away, before `synchronize_rng_states` gets to run at the start of `__iter__`.
+        def epoch(init_seed):
+            generator = torch.Generator().manual_seed(init_seed)
+            dataloader = DataLoaderShard(
+                list(range(16)),
+                batch_size=4,
+                shuffle=True,
+                generator=generator,
+                use_stateful_dataloader=True,
+                num_workers=2,
+            )
+            generator.manual_seed(0)
+            return torch.cat(list(dataloader))
+
+        assert torch.equal(epoch(1), epoch(2))
+
     @parameterized.expand([0, 2], name_func=parameterized_custom_name_func)
     @require_torchdata_stateful_dataloader
     def test_dataloader_state_dict(self, num_workers):


### PR DESCRIPTION
# What does this PR do?

Fixes #4204

This is the lazy capture I proposed on the issue on Sep 2.

`DataLoaderAdapter.__init__` calls `base_dataloader.state_dict()` right after building the `StatefulDataLoader`. With `num_workers > 0` that builds the iterator and draws the sampler permutation at `prepare()` time, before `synchronize_rng_states` runs in `__iter__`, so each rank shards a different epoch-0 permutation.

Capture it lazily instead: `dl_state_dict` starts as `None` and `_update_state_dict` fills it once iteration starts. `state_dict()` falls back to the base dataloader if nothing was captured yet, so checkpointing before the first batch works as before.

Added a single-process test (shuffle order follows the seed set after init) and a 2-process `num_workers > 0` case in `test_distributed_data_loop.py`. Both fail on main.

## Before submitting
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? #4204
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
