### PR TITLE
Fix metric padding removal after skip_first_batches

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -641,6 +641,8 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
     @property
     def total_batch_size(self):
         batch_sampler = self.sampler if isinstance(self.sampler, BatchSampler) else self.batch_sampler
+        while isinstance(batch_sampler, SkipBatchSampler):
+            batch_sampler = batch_sampler.batch_sampler
         return (
             batch_sampler.batch_size
             if getattr(batch_sampler, "split_batches", False)
@@ -1457,6 +1459,7 @@ def skip_first_batches(dataloader, num_batches=0):
             device=dataloader.device,
             rng_types=dataloader.rng_types,
             synchronized_generator=dataloader.synchronized_generator,
+            _drop_last=dataloader._drop_last,
             iteration=dataloader.iteration,
             **kwargs,
         )

--- a/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
+++ b/src/accelerate/test_utils/scripts/test_distributed_data_loop.py
@@ -369,9 +369,37 @@ def test_stateful_dataloader_save_state(accelerator):
     _test_stateful_dataloader_save_state_resume(accelerator, iterable=False)
 
 
+def test_skip_first_batches_preserves_metric_samples():
+    for split_batches in (False, True):
+        accelerator = Accelerator(
+            dataloader_config=DataLoaderConfiguration(split_batches=split_batches, dispatch_batches=False)
+        )
+        for batch_size in (2 * accelerator.num_processes, 4 * accelerator.num_processes):
+            total_batch_size = batch_size if split_batches else batch_size * accelerator.num_processes
+            for num_items in (3 * total_batch_size, 3 * total_batch_size + 1):
+                for drop_last in (False, True):
+                    for skips in ((0,), (1,), (1, 1)):
+                        dataloader = accelerator.prepare(
+                            DataLoader(range(num_items), batch_size=batch_size, drop_last=drop_last)
+                        )
+                        for skip in skips:
+                            dataloader = accelerator.skip_first_batches(dataloader, skip)
+                        gathered = []
+                        for batch in dataloader:
+                            gathered.extend(accelerator.gather_for_metrics(batch).tolist())
+                        stop = num_items - num_items % total_batch_size if drop_last else num_items
+                        expected = list(range(sum(skips) * total_batch_size, stop))
+                        assert gathered == expected, (
+                            f"split_batches={split_batches}, drop_last={drop_last}, skips={skips}: "
+                            f"expected {expected}, got {gathered}"
+                        )
+
+
 def main():
     accelerator = create_accelerator()
     torch.manual_seed(accelerator.process_index)
+
+    test_skip_first_batches_preserves_metric_samples()
 
     accelerator.print("Test that even_batches variable ensures uniform batches across processes")
     test_default_ensures_even_batch_sizes()

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -614,6 +614,40 @@ class DataLoaderTester(AccelerateTestCase):
         new_dataloader = skip_first_batches(dataloader, num_batches=2)
         assert [t.tolist() for t in new_dataloader] == [[8, 9, 10, 11], [12, 13, 14, 15]]
 
+    @parameterized.expand(
+        [
+            (split, drop, skips, sampler_arg)
+            for split in (False, True)
+            for drop in (False, True)
+            for skips in ((0,), (1,), (1, 1))
+            for sampler_arg in (False, True)
+            if not (split and sampler_arg)  # batch_size=None does not support split_batches.
+        ]
+    )
+    def test_skip_first_batches_preserves_batch_metadata(self, split_batches, drop_last, skips, sampler_arg):
+        for rank in range(2):
+            dataset = torch.arange(26)
+            if sampler_arg:
+                dataloader = DataLoader(
+                    dataset, sampler=BatchSampler(range(26), batch_size=4, drop_last=drop_last), batch_size=None
+                )
+            else:
+                dataloader = DataLoader(dataset, batch_size=4, drop_last=drop_last)
+            original = prepare_data_loader(
+                dataloader,
+                num_processes=2,
+                process_index=rank,
+                split_batches=split_batches,
+            )
+            expected_batches = [batch.tolist() for batch in original][sum(skips) :]
+            expected_remainder = original.remainder
+            resumed = original
+            for skip in skips:
+                resumed = skip_first_batches(resumed, skip)
+            assert resumed.total_batch_size == original.total_batch_size
+            assert [batch.tolist() for batch in resumed] == expected_batches
+            assert resumed.remainder == expected_remainder
+
     def test_end_of_dataloader(self):
         dataloader = DataLoaderShard(list(range(16)), batch_size=4)
         for idx, _ in enumerate(dataloader):


### PR DESCRIPTION
## What does this PR do?

`skip_first_batches` wraps the batch sampler in `SkipBatchSampler`, which does not expose `batch_size`. This makes `DataLoaderShard.total_batch_size` raise; the suppressed exception leaves `remainder=-1`, so `gather_for_metrics` keeps duplicated padding samples in the final batch.

With 10 samples, two processes and a per-process batch size of 2, normal iteration gathers 10 samples. Calling `skip_first_batches(loader, 0)` instead gathers 12, including duplicated samples 0 and 1.

Unwrap skip samplers before reading the existing batch-size metadata, and preserve `_drop_last` when reconstructing the loader. This also handles nested skipping without changing sampling order.

## Validation

- 66 related tests passed, 16 skipped.
- All 18 new parameterized regressions fail on the baseline and pass with the fix.
- Actual CPU/Gloo testing: the expanded 48-case two-process matrix passed twice; the earlier 24-case three-process matrix also passed twice. Coverage includes split batches, different batch sizes, divisible and non-divisible dataset sizes, `drop_last`, and zero/one/nested skips.
- The distributed regression fails on the baseline.
- Full `make quality` and `git diff --check` pass.

GPU/TPU execution was not tested. Changes were prepared with AI assistance and reviewed by the contributor.

## Before submitting

- [x] Read the contribution guidelines.
- [x] Added regression tests.
- Prior issue discussion: none.
- Documentation changes: not needed; this restores existing behavior.
