### PR TITLE
Fix boolean tensor memory accounting

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -162,7 +162,7 @@ def dtype_byte_size(dtype: torch.dtype):
     ```
     """
     if dtype == torch.bool:
-        return 1 / 8
+        return 1
     elif dtype == CustomDtype.INT2:
         return 1 / 4
     elif dtype == CustomDtype.INT4:

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -34,6 +34,7 @@ from accelerate.test_utils import (
     require_non_hpu,
     torch_device,
 )
+from accelerate.utils.dataclasses import CustomDtype
 from accelerate.utils.modeling import (
     align_module_device,
     check_device_map,
@@ -136,11 +137,14 @@ def sequential_model(num_layers):
 
 class ModelingUtilsTester(unittest.TestCase):
     def test_dtype_byte_size(self):
-        self.assertEqual(dtype_byte_size(torch.bool), 1 / 8)
+        self.assertEqual(dtype_byte_size(torch.bool), torch.empty((), dtype=torch.bool).element_size())
         self.assertEqual(dtype_byte_size(torch.float16), 2)
         self.assertEqual(dtype_byte_size(torch.bfloat16), 2)
         self.assertEqual(dtype_byte_size(torch.float32), 4)
         self.assertEqual(dtype_byte_size(torch.float64), 8)
+        self.assertEqual(dtype_byte_size(CustomDtype.INT2), 1 / 4)
+        self.assertEqual(dtype_byte_size(CustomDtype.INT4), 1 / 2)
+        self.assertEqual(dtype_byte_size(CustomDtype.FP8), 1)
         # All 1-byte FP8 dtypes available in this torch should report 1 byte.
         # Previously only e4m3fn/e5m2 were handled; the *fnuz and e8m0fnu
         # variants fell through to a regex with no trailing digit and raised.
@@ -409,6 +413,38 @@ class ModelingUtilsTester(unittest.TestCase):
         model.half()
         buffer_size = compute_module_total_buffer_size(model)
         assert buffer_size == 624
+
+    @parameterized.expand(
+        [
+            (size, persistent, dtype)
+            for size in (0, 1, 9)
+            for persistent in (False, True)
+            for dtype in (None, torch.float16, torch.bfloat16)
+        ]
+    )
+    def test_compute_module_sizes_bool_buffer(self, size, persistent, dtype):
+        model = nn.Module()
+        model.attention = nn.Linear(2, 2, bias=False)
+        model.attention.register_buffer("mask", torch.ones(size, dtype=torch.bool), persistent=persistent)
+        mask_bytes = model.attention.mask.numel() * model.attention.mask.element_size()
+        weight = model.attention.weight
+        weight_bytes = weight.numel() * torch.empty((), dtype=dtype or weight.dtype).element_size()
+        sizes = compute_module_sizes(model, dtype=dtype)
+        self.assertEqual(sizes["attention.mask"], mask_bytes)
+        self.assertEqual(sizes["attention"], weight_bytes + mask_bytes)
+        self.assertEqual(sizes[""], weight_bytes + mask_bytes)
+        self.assertEqual(compute_module_total_buffer_size(model, dtype=dtype), mask_bytes)
+        self.assertEqual(
+            compute_module_sizes(model, special_dtypes={"attention.mask": torch.bool})["attention.mask"],
+            mask_bytes,
+        )
+
+    @parameterized.expand([(8, "disk"), (63, "disk"), (64, "cpu"), (65, "cpu")])
+    def test_infer_auto_device_map_bool_buffer(self, budget, expected_device):
+        model = nn.Module()
+        model.register_buffer("mask", torch.ones(8, 8, dtype=torch.bool), persistent=False)
+        device_map = infer_auto_device_map(model, max_memory={"cpu": budget}, offload_buffers=True)
+        self.assertEqual(device_map, {"mask": expected_device})
 
     def test_check_device_map(self):
         model = ModelForTest()


### PR DESCRIPTION
`dtype_byte_size(torch.bool)` currently returns 1/8, but PyTorch boolean tensors use one byte per element. This undercounts boolean buffers in module-size estimates and can place tensors within a `max_memory` budget that is smaller than their actual storage.

Return 1 for `torch.bool`, reusing the existing sizing and placement paths. Keep the packed `CustomDtype` estimates unchanged.

A small randomly initialized GPT-2 using Transformers 4.57.6 has two 1 MiB boolean attention buffers. Before this change, Accelerate reports 511,496 bytes for a model with 2,346,504 bytes of parameters and buffers; after the change, the estimate matches. This demonstrates the storage-accounting issue, not a measured production OOM. GPT-2 in Transformers 5.15.1 no longer has these registered buffers.

Validation:
- New/updated regression selection: 15 failures and 8 passes before the fix; all pass after.
- Modeling utilities: 57 passed, 9 skipped (plus 4 passing subtests).
- Big modeling: 11 passed, 26 skipped on CPU.
- Covers empty and non-empty buffers, persistence, dtype overrides, nested totals, and automatic placement at budget boundaries.
- Full `make quality` and `git diff --check` pass.

Scope: this corrects boolean tensor accounting. The existing module-splitting path can separately omit a module's own buffers when `no_split_module_classes` is not supplied; this patch does not address that behavior or guarantee a hard runtime memory bound.
