### PR TITLE
Fix dtype_byte_size reporting zero bytes for sub-byte and packed dtypes

### DIFF
--- a/src/accelerate/utils/modeling.py
+++ b/src/accelerate/utils/modeling.py
@@ -169,18 +169,9 @@ def dtype_byte_size(dtype: torch.dtype):
         return 1 / 2
     elif dtype == CustomDtype.FP8:
         return 1
-    elif is_torch_version(">=", "2.1.0") and dtype in [
-        getattr(torch, name)
-        for name in (
-            "float8_e4m3fn",
-            "float8_e5m2",
-            "float8_e4m3fnuz",
-            "float8_e5m2fnuz",
-            "float8_e8m0fnu",
-        )
-        if hasattr(torch, name)
-    ]:
-        return 1
+    elif is_torch_version(">=", "2.1.0"):
+        # The name regex below misreads FP8 and sub-byte dtypes such as `uint4` and `float4_e2m1fn_x2`
+        return dtype.itemsize
     bit_search = re.search(r"[^\d](\d+)$", str(dtype))
     if bit_search is None:
         raise ValueError(f"`dtype` is not a valid dtype: {dtype}.")

--- a/tests/test_modeling_utils.py
+++ b/tests/test_modeling_utils.py
@@ -153,6 +153,10 @@ class ModelingUtilsTester(unittest.TestCase):
         ):
             if hasattr(torch, name):
                 self.assertEqual(dtype_byte_size(getattr(torch, name)), 1, msg=name)
+        # Sub-byte and packed dtypes still occupy one byte per element in storage.
+        for name in ("uint4", "float4_e2m1fn_x2"):
+            if hasattr(torch, name):
+                self.assertEqual(dtype_byte_size(getattr(torch, name)), 1, msg=name)
 
     def check_set_module_tensor_for_device(self, model, device1, device2):
         assert model.linear1.weight.device == torch.device(device1)


### PR DESCRIPTION
# What does this PR do?

`dtype_byte_size` falls back to reading the trailing digits of the dtype name:

```python
bit_search = re.search(r"[^\d](\d+)$", str(dtype))
return int(bit_search.groups()[0]) // 8
```

For torch's sub-byte and packed dtypes that trailing number is not the storage size, and the integer division turns it into zero:

```
uint4              -> 0   (torch stores one element per byte)
uint1              -> 0
float4_e2m1fn_x2   -> 0   (two values packed in one byte, itemsize 1)
```

`compute_module_sizes` and therefore `infer_auto_device_map` then count such parameters as free, so a device map can overcommit a device by the whole size of those weights.

torch has exposed `dtype.itemsize` since 2.1, the same version that already gates the FP8 branch. This PR returns `itemsize` under that gate, which also replaces the hardcoded FP8 name list. The regex stays as the fallback for torch 2.0. `torch.bool` and the `CustomDtype` values keep their explicit sizes.

The `float8_e8m0fnu` and sub-byte cases in `test_dtype_byte_size` fail on `main` with `0 != 1` and pass with the change. `tests/test_modeling_utils.py` passes locally (torch 2.14, CPU).

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? No change needed.
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc
