### PR TITLE
Fix stateful dataloader losing shuffle order on multi-process resume (#4195)

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -454,6 +454,14 @@ class DataLoaderAdapter:
         return self.dl_state_dict
 
     def load_state_dict(self, state_dict):
+        # `_iteration` holds the epoch counter that seeds the (seedable) sampler's shuffle. Restore it
+        # before the base dataloader rebuilds its sampler iterator, so a mid-training checkpoint resumes
+        # on the current epoch's permutation instead of epoch 0's. See #4195.
+        if "_iteration" in state_dict:
+            state_dict = dict(state_dict)
+            iteration = state_dict.pop("_iteration")
+            if hasattr(self, "set_epoch"):
+                self.set_epoch(iteration)
         self.base_dataloader.load_state_dict(state_dict)
 
     @property
@@ -505,6 +513,9 @@ class DataLoaderAdapter:
             self.adjust_state_dict_for_prefetch()
             # Then tag if we are at the end of the dataloader
             self.dl_state_dict["_iterator_finished"] = self.end_of_dataloader
+            # Persist the epoch counter so a shuffled sampler resumes on the correct permutation (see #4195).
+            if hasattr(self, "iteration"):
+                self.dl_state_dict["_iteration"] = self.iteration
 
 
 class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
@@ -1250,6 +1261,13 @@ def prepare_data_loader(
                     seed = int(torch.empty((), dtype=torch.int64).random_().item())
                     sampler.generator.manual_seed(seed)
                 synchronized_generator = sampler.generator
+                if use_stateful_dataloader and num_processes > 1:
+                    logger.warning_once(
+                        "Checkpointing a shuffled stateful dataloader across multiple processes only restores the "
+                        "batch cursor, not the sampler's shuffle order: resuming replays the first epoch's "
+                        "permutation from that position. Pass `use_seedable_sampler=True` for an exactly resumable "
+                        "shuffle order."
+                    )
             batch_sampler = dataloader.sampler if sampler_is_batch_sampler else dataloader.batch_sampler
             new_batch_sampler = BatchSamplerShard(
                 batch_sampler,

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -897,6 +897,14 @@ class StatefulDataLoaderTester(AccelerateTestCase):
         dl_shard_state_dict = dl_shard.state_dict()
         dl_dispatcher_state_dict = dl_dispatcher.state_dict()
 
+        # DataLoaderShard / DataLoaderDispatcher additionally persist the sampler epoch counter
+        # (`_iteration`) so a shuffled sampler resumes on the correct permutation (see #4195). torchdata's
+        # StatefulDataLoader has no such field, so drop it before comparing the shared state.
+        assert "_iteration" in dl_shard_state_dict
+        assert "_iteration" in dl_dispatcher_state_dict
+        dl_shard_state_dict.pop("_iteration")
+        dl_dispatcher_state_dict.pop("_iteration")
+
         assert expected_state_dict == skip_dl_state_dict
         assert expected_state_dict == dl_shard_state_dict
         assert expected_state_dict == dl_dispatcher_state_dict
@@ -1007,6 +1015,14 @@ class StatefulDataLoaderTester(AccelerateTestCase):
         skip_dl_state_dict = skip_dl.state_dict()
         dl_shard_state_dict = dl_shard.state_dict()
         dl_dispatcher_state_dict = dl_dispatcher.state_dict()
+
+        # DataLoaderShard / DataLoaderDispatcher additionally persist the sampler epoch counter
+        # (`_iteration`) so a shuffled sampler resumes on the correct permutation (see #4195). torchdata's
+        # StatefulDataLoader has no such field, so drop it before comparing the shared state.
+        assert "_iteration" in dl_shard_state_dict
+        assert "_iteration" in dl_dispatcher_state_dict
+        dl_shard_state_dict.pop("_iteration")
+        dl_dispatcher_state_dict.pop("_iteration")
 
         assert expected_state_dict == skip_dl_state_dict
         assert expected_state_dict == dl_shard_state_dict


### PR DESCRIPTION
## What this fixes

Closes #4195 — under multi-process training, a shuffled stateful dataloader resumes on **epoch 0's permutation at the restored cursor position** instead of continuing the current epoch's order.

## Root cause

In the sharded stateful path, the shuffle order for a given `__iter__` is seeded by `DataLoaderShard`/`DataLoaderDispatcher.iteration` (the epoch counter), which `set_epoch()` propagates down to the sampler (`SeedableRandomSampler.epoch`, or the sampler generator). That counter is **never part of the checkpoint**: `DataLoaderStateMixin.state_dict()` returns only the underlying torchdata `StatefulDataLoader` state, and `load_state_dict()` forwards it verbatim.

So on resume a fresh process starts at `iteration == 0`, `__iter__` calls `set_epoch(0)`, and torchdata's fast-forward (`itertools.islice(iter(index_sampler), sampler_iter_yielded, None)`) re-iterates the sampler from epoch 0 — restoring the batch **position** but the epoch‑0 **order**. (Single-process is unaffected: there the sampler iterator state torchdata already serializes carries the permutation.)

## The fix

- Persist the epoch counter as `_iteration` in the dataloader `state_dict`, and restore it in `load_state_dict()` (via `set_epoch`) **before** the base dataloader rebuilds its sampler iterator. With `use_seedable_sampler=True` the shuffle order then resumes exactly.
- The plain-`RandomSampler` multi-process path has no recoverable per-epoch seed across a process restart (its generator seed is drawn fresh each launch), so exact shuffle-resume isn't achievable there — emit a one-time warning pointing at `use_seedable_sampler=True`. This is the issue's option 2.

The adapter `state_dict` now carries one extra key beyond torchdata's `StatefulDataLoader`; loading a state without `_iteration` (old checkpoints, or a torchdata dict) is a no-op, and the two `*_equivalent_to_torchdata_stateful_dataloader` tests drop that key before comparing the shared state.

## Verification

Against `main` @ `f13f7c13`, the issue's reproducer (`torchrun --nproc_per_node=2`, `use_seedable_sampler=True`):

| | before | after |
|---|---|---|
| resumed == true continuation | ❌ (both ranks replay epoch‑0 order) | ✅ both ranks |

Verified for both `DataLoaderShard` and `DataLoaderDispatcher` (`dispatch_batches=True`), on 2 processes. Existing `StatefulDataLoaderTester` suite passes (12 passed) with the equivalence tests updated.

I did **not** add an automated regression test: the bug only manifests across a genuine process restart (a fresh loader at `iteration=0`), which the current in-process dataloader test harness doesn't simulate — the existing `_test_stateful_dataloader_resume` checkpoints within epoch 0 and so never exercises it. Happy to add one in whatever form you prefer (e.g. a two-launch save/resume in `test_distributed_data_loop.py`).

---

*Disclosure: I'm an AI agent working under the maintainer's GitHub account. The diagnosis and fix were verified at the code level against today's `main` as described above; please review on the merits and tell me if anything's off — I'll follow up.*
