### PR TITLE
feat(examples): Add distributed image captioning example with BLIP-2

### DIFF
--- a/examples/inference/distributed/README.md
+++ b/examples/inference/distributed/README.md
@@ -16,12 +16,12 @@ pip install accelerate torch
 |--------|-------|-------------|
 | `phi2.py` | Microsoft Phi-2 | Basic distributed inference with Phi-2 |
 | `gemma_distributed.py` | Google Gemma 2B | Distributed inference with Gemma 2B-IT |
+| `image_captioning.py` | BLIP-2 | Distributed image captioning |
 | `stable_diffusion.py` | Stable Diffusion | Distributed image generation |
 | `distributed_image_generation.py` | Various | Image generation examples |
 | `distributed_speech_generation.py` | Various | Speech generation examples |
 | `florence2.py` | Florence-2 | Vision-language model inference |
 | `llava_next_video.py` | LLaVA-NeXT-Video | Video understanding |
-| `phi2.py` | Phi-2 | Original Phi-2 example |
 
 ## Running code
 
@@ -41,4 +41,10 @@ For the Gemma example:
 
 ```bash
 accelerate launch --num_processes {NUM_GPUS} gemma_distributed.py
+```
+
+For the image captioning example:
+
+```bash
+accelerate launch --num_processes {NUM_GPUS} image_captioning.py --data_path /path/to/images --output_path /path/to/output
 ```

--- a/examples/inference/distributed/README.md
+++ b/examples/inference/distributed/README.md
@@ -10,6 +10,19 @@ Load an entire model onto each GPU and sending chunks of a batch through each GP
 pip install accelerate torch
 ```
 
+## Examples
+
+| Script | Model | Description |
+|--------|-------|-------------|
+| `phi2.py` | Microsoft Phi-2 | Basic distributed inference with Phi-2 |
+| `gemma_distributed.py` | Google Gemma 2B | Distributed inference with Gemma 2B-IT |
+| `stable_diffusion.py` | Stable Diffusion | Distributed image generation |
+| `distributed_image_generation.py` | Various | Image generation examples |
+| `distributed_speech_generation.py` | Various | Speech generation examples |
+| `florence2.py` | Florence-2 | Vision-language model inference |
+| `llava_next_video.py` | LLaVA-NeXT-Video | Video understanding |
+| `phi2.py` | Phi-2 | Original Phi-2 example |
+
 ## Running code
 
 You can either use `torchrun` or the recommended way of `accelerate launch` (without needing to run `accelerate config`) on each script:
@@ -22,4 +35,10 @@ Or:
 
 ```bash
 torchrun --nproc-per-node {NUM_GPUS} phi2.py
+```
+
+For the Gemma example:
+
+```bash
+accelerate launch --num_processes {NUM_GPUS} gemma_distributed.py
 ```

--- a/examples/inference/distributed/gemma_distributed.py
+++ b/examples/inference/distributed/gemma_distributed.py
@@ -1,0 +1,101 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Distributed inference example using Google Gemma 2B with Accelerate.
+
+This example demonstrates how to run distributed inference on multiple GPUs
+using the `PartialState` API for simple data-parallel inference.
+
+Run with:
+    accelerate launch --num_processes {NUM_GPUS} gemma_distributed.py
+
+Or:
+    torchrun --nproc-per-node {NUM_GPUS} gemma_distributed.py
+"""
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from accelerate import PartialState
+from accelerate.utils import gather_object
+
+
+# Start up the distributed environment without needing the Accelerator.
+distributed_state = PartialState()
+
+# Use Google Gemma 2B - a small but capable model good for demo purposes.
+model_name = "google/gemma-2b-it"
+model = AutoModelForCausalLM.from_pretrained(
+    model_name, device_map=distributed_state.device, torch_dtype=torch.bfloat16
+)
+
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+tokenizer.pad_token = tokenizer.eos_token
+
+# Example prompts covering different tasks
+prompts = [
+    "Explain quantum computing in simple terms:",
+    "Write a Python function to compute fibonacci numbers:",
+    "Translate to French: The weather is nice today.",
+    "Summarize the benefits of distributed computing:",
+    "What is the capital of Australia?",
+]
+
+# Configure batching - adjust based on your GPU memory
+batch_size = 2
+pad_to_multiple_of = 8
+
+# Split prompts into batches
+formatted_prompts = [prompts[i : i + batch_size] for i in range(0, len(prompts), batch_size)]
+
+# Apply padding on the left for generation
+padding_side_default = tokenizer.padding_side
+tokenizer.padding_side = "left"
+tokenized_prompts = [
+    tokenizer(
+        formatted_prompt, padding=True, pad_to_multiple_of=pad_to_multiple_of, return_tensors="pt"
+    )
+    for formatted_prompt in formatted_prompts
+]
+tokenizer.padding_side = padding_side_default
+
+completions_per_process = []
+
+# Distribute batches across processes
+# Each process gets a subset of batches; apply_padding ensures equal batch counts
+with distributed_state.split_between_processes(tokenized_prompts, apply_padding=True) as batched_prompts:
+    for batch in batched_prompts:
+        batch = batch.to(distributed_state.device)
+        # Generate with temperature for more natural responses
+        outputs = model.generate(
+            **batch, max_new_tokens=50, temperature=0.7, do_sample=True, top_p=0.9
+        )
+        generated_text = tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        completions_per_process.extend(generated_text)
+
+# Gather results from all processes
+completions_gather = gather_object(completions_per_process)
+
+# Remove duplicates from apply_padding
+completions = completions_gather[: len(prompts)]
+
+# Print results from main process
+distributed_state.print("=== Distributed Inference Results ===")
+for i, (prompt, completion) in enumerate(zip(prompts, completions)):
+    distributed_state.print(f"\n--- Prompt {i+1} ---")
+    distributed_state.print(f"Prompt: {prompt}")
+    distributed_state.print(f"Completion: {completion}")
+
+distributed_state.print("\n✅ Distributed inference completed successfully!")

--- a/examples/inference/distributed/image_captioning.py
+++ b/examples/inference/distributed/image_captioning.py
@@ -1,0 +1,212 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Distributed image captioning example using BLIP-2 with Accelerate.
+
+This example demonstrates how to run distributed image captioning on multiple GPUs
+using the `PartialState` API for simple data-parallel inference.
+
+Run with:
+    accelerate launch --num_processes {NUM_GPUS} image_captioning.py
+
+Or:
+    torchrun --nproc-per-node {NUM_GPUS} image_captioning.py
+
+Requirements:
+    pip install transformers accelerate torch Pillow
+"""
+
+import json
+import os
+import pathlib
+import queue
+from concurrent.futures import ThreadPoolExecutor
+from typing import Union
+
+import fire
+import torch
+from PIL import Image
+from transformers import AutoProcessor, Blip2ForConditionalGeneration
+
+from accelerate import PartialState
+from accelerate.utils import tqdm
+
+
+def main(
+    data_path: str,
+    output_path: str,
+    batch_size: int = 8,
+    num_workers: int = 2,
+    model_name: str = "Salesforce/blip2-opt-2.7b",
+    max_new_tokens: int = 50,
+    num_beams: int = 3,
+):
+    """
+    Distributed image captioning with BLIP-2.
+
+    Args:
+        data_path: Path to directory containing images or a single image file
+        output_path: Output directory for captions and metadata
+        batch_size: Batch size per GPU
+        num_workers: Number of workers for saving results
+        model_name: BLIP-2 model to use
+        max_new_tokens: Maximum new tokens for caption generation
+        num_beams: Number of beams for beam search
+    """
+    output_dir = pathlib.Path(output_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    distributed_state = PartialState()
+
+    # Load model and processor
+    model = Blip2ForConditionalGeneration.from_pretrained(
+        model_name,
+        device_map=distributed_state.device,
+        torch_dtype=torch.float16,
+    )
+
+    processor = AutoProcessor.from_pretrained(model_name)
+
+    def find_images(root: Union[str, pathlib.Path]):
+        """Find all image files in directory recursively."""
+        image_extensions = {".jpg", ".jpeg", ".png", ".bmp", ".webp", ".tiff"}
+        root = pathlib.Path(root)
+        if root.is_file() and root.suffix.lower() in image_extensions:
+            return [root]
+        return [
+            p for p in root.rglob("*")
+            if p.is_file() and p.suffix.lower() in image_extensions
+        ]
+
+    image_files = find_images(data_path)
+    if not image_files:
+        raise ValueError(f"No image files found in {data_path}")
+
+    # Filter already processed images
+    processed_hashes = set()
+    if output_dir.exists():
+        for f in output_dir.glob("*_caption.json"):
+            processed_hashes.add(f.stem.replace("_caption", ""))
+
+    def get_file_hash(path: pathlib.Path) -> str:
+        """Generate a hash for the file path to use as unique identifier."""
+        import hashlib
+        return hashlib.md5(str(path).encode()).hexdigest()[:12]
+
+    # Filter out already processed
+    image_files = [
+        img for img in image_files
+        if get_file_hash(img) not in processed_hashes
+    ]
+
+    distributed_state.print(f"Found {len(image_files)} images to process")
+
+    if not image_files:
+        distributed_state.print("All images already processed!")
+        return
+
+    def preprocess_batch(batch_images, processor):
+        """Preprocess a batch of images."""
+        images = [Image.open(img).convert("RGB") for img in batch_images]
+        inputs = processor(
+            images=images,
+            return_tensors="pt",
+            padding=True,
+        )
+        return inputs, images
+
+    def save_results(output_queue: queue.Queue, output_dir: pathlib.Path, processor):
+        """Save results in a separate thread to not block GPU."""
+        while True:
+            try:
+                item = output_queue.get(timeout=5)
+                if item is None:
+                    break
+                captions, image_paths, images = item
+                for caption, img_path, image in zip(captions, image_paths, images):
+                    file_hash = get_file_hash(img_path)
+
+                    # Save image
+                    img_save_path = output_dir / f"{file_hash}.jpg"
+                    image.save(img_save_path)
+
+                    # Save caption metadata
+                    metadata = {
+                        "original_path": str(img_path),
+                        "caption": caption,
+                        "model": model_name,
+                        "max_new_tokens": max_new_tokens,
+                        "num_beams": num_beams,
+                    }
+                    meta_path = output_dir / f"{file_hash}_caption.json"
+                    with meta_path.open("w") as f:
+                        json.dump(metadata, f, indent=2)
+            except queue.Empty:
+                continue
+
+    # Create batches
+    batches = [
+        image_files[i:i + batch_size]
+        for i in range(0, len(image_files), batch_size)
+    ]
+
+    # Distribute batches across processes
+    if distributed_state.num_processes > 1:
+        chunk_size = len(batches) // distributed_state.num_processes
+        start_idx = distributed_state.process_index * chunk_size
+        end_idx = (
+            start_idx + chunk_size
+            if distributed_state.process_index < distributed_state.num_processes - 1
+            else len(batches)
+        )
+        batches = batches[start_idx:end_idx]
+
+    output_queue = queue.Queue()
+    save_thread = ThreadPoolExecutor(max_workers=num_workers)
+    save_future = save_thread.submit(save_results, output_queue, output_dir, processor)
+
+    try:
+        for batch_images in tqdm(
+            batches,
+            desc="Generating captions",
+            disable=not distributed_state.is_main_process,
+        ):
+            inputs, images = preprocess_batch(batch_images, processor)
+            inputs = {k: v.to(distributed_state.device) for k, v in inputs.items()}
+
+            with torch.no_grad():
+                generated_ids = model.generate(
+                    **inputs,
+                    max_new_tokens=max_new_tokens,
+                    num_beams=num_beams,
+                )
+
+            captions = processor.batch_decode(
+                generated_ids,
+                skip_special_tokens=True
+            )
+
+            output_queue.put((captions, batch_images, images))
+
+    finally:
+        output_queue.put(None)
+        save_thread.shutdown(wait=True)
+
+    save_future.result()
+    distributed_state.print(f"\n✅ Captioning completed! Results saved to {output_dir}")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)


### PR DESCRIPTION
Add a new example for distributed image captioning using BLIP-2 model. This addresses the request in #3078 for image captioning examples.

**The example includes:**
- Data-parallel inference using 
-  for non-blocking artifact serialization (saves to disk without blocking GPU)
- Support for common image formats (jpg, png, bmp, webp, tiff)
- Resume capability via output file tracking
- Configurable batch size, beam search, and token limits

**Files changed:**
-  (new)
-  (updated with new example)

Closes #3078