### PR TITLE
Read ACCELERATE_BYPASS_DEVICE_MAP case-insensitively, like every other boolean flag

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -1473,7 +1473,7 @@ class Accelerator:
                 isinstance(obj, torch.nn.Module)
                 and self.verify_device_map(obj)
                 and self.distributed_type != DistributedType.NO
-                and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true"
+                and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false").lower() != "true"
             ):
                 raise ValueError(
                     "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1814,7 +1814,7 @@ class Accelerator:
         if (
             self.verify_device_map(model)
             and self.distributed_type != DistributedType.NO
-            and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true"
+            and os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false").lower() != "true"
         ):
             raise ValueError(
                 "You can't train a model that has been loaded with `device_map='auto'` in any distributed mode."
@@ -1888,7 +1888,7 @@ class Accelerator:
                 if any(p.requires_grad for p in model.parameters()):
                     kwargs = self.ddp_handler.to_kwargs() if self.ddp_handler is not None else {}
                     # TODO: Look at enabling native TP training directly with a proper config
-                    if os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true":
+                    if os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false").lower() != "true":
                         if self.device.type == "hpu":
                             device_ids, output_device = [self.device.index], self.device.index
                         else:


### PR DESCRIPTION
# What does this PR do?

Reads `ACCELERATE_BYPASS_DEVICE_MAP` case-insensitively, the way every other boolean environment flag in the library is read.

All three sites compared the raw value, so `ACCELERATE_BYPASS_DEVICE_MAP=True` silently did nothing:

```python
# accelerator.py:1475, 1816, 1890 (before)
os.environ.get("ACCELERATE_BYPASS_DEVICE_MAP", "false") != "true"
```

It is the only one of eleven such flags read this way. `ACCELERATE_USE_FSDP`, `ACCELERATE_USE_DEEPSPEED`, `ACCELERATE_USE_MEGATRON_LM`, `ACCELERATE_USE_SAGEMAKER`, `ACCELERATE_USE_PARALLELISM_CONFIG`, `ACCELERATE_ALLOW_CP_STANDALONE`, `ACCELERATE_DEBUG_MODE`, `ACCELERATE_DEEPSPEED_ZERO3_SAVE_16BIT_MODEL`, `FSDP_OFFLOAD_PARAMS` and `PARALLELISM_CONFIG_SP_SEQ_LENGTH_IS_VARIABLE` all `.lower()` first.

```
value    BYPASS_DEVICE_MAP   USE_FSDP (sibling, same file)
'true'   True                True
'True'   False               True
'TRUE'   False               True
```

That inconsistency is what makes it a trap rather than merely strict. `True` is the spelling a Python user reaches for, and it works for the flag two hundred lines up. When it is ignored the user still hits the `device_map='auto'` `ValueError`, whose text does not mention the variable, so nothing points at the value as the cause; the DDP `device_ids` branch at 1890 takes the non-bypass path for the same reason.

Adding `.lower()` only widens acceptance to `True` and `TRUE`, so no value that works today changes meaning.

Fixes #4240

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case: #4240
- [ ] Did you make sure to update the documentation with your changes? The variable is undocumented today; I have not added docs for it here, but I am glad to if you would like it listed with the other environment variables.
- [ ] Did you write any new necessary tests?

On that last box, deliberately unticked: the three call sites need a distributed `Accelerator` and a model loaded with `device_map='auto'`, so a faithful test is heavier than the change. Happy to add one if you would rather have it, and equally happy to route these flags through `str_to_bool` instead, which would also make them accept `1`, `yes` and `on` like the library's own documented parser does. I kept that out of here because it is a wider blast radius than a bug fix.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
