### PR TITLE
Fix skipped-step detection for AMP-aware optimizers

### DIFF
--- a/src/accelerate/optimizer.py
+++ b/src/accelerate/optimizer.py
@@ -168,12 +168,18 @@ class AcceleratedOptimizer(torch.optim.Optimizer):
 
         if self.gradient_state.sync_gradients:
             if self.scaler is not None:
+                # AMP-aware optimizers can skip inside their kernel even when step() is called.
+                scale_before = (
+                    self.scaler.get_scale() if getattr(self.optimizer, "_step_supports_amp_scaling", False) else None
+                )
                 self.optimizer.step = self._optimizer_patched_step_method
 
                 self.scaler.step(self.optimizer, closure)
                 self.scaler.update()
 
-                if not self._accelerate_step_called:
+                if scale_before is not None:
+                    self._is_overflow = self.scaler.get_scale() < scale_before
+                elif not self._accelerate_step_called:
                     # If the optimizer step was skipped, gradient overflow was detected.
                     self._is_overflow = True
                 else:

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -17,12 +17,46 @@ import pickle
 import torch
 
 from accelerate import Accelerator
+from accelerate.optimizer import AcceleratedOptimizer
+from accelerate.scheduler import AcceleratedScheduler
 from accelerate.test_utils import require_cpu, require_fp16, require_non_cpu
 from accelerate.test_utils.testing import AccelerateTestCase
 
 
 @require_cpu
 class CPUOptimizerTester(AccelerateTestCase):
+    def test_amp_overflow_keeps_optimizer_and_scheduler_in_sync(self):
+        Accelerator(cpu=True)
+        for fused in (False, True):
+            with self.subTest(fused=fused):
+                parameter = torch.nn.Parameter(torch.ones(4))
+                raw_optimizer = torch.optim.AdamW([parameter], lr=0.1, fused=fused)
+                scaler = torch.amp.GradScaler("cpu", growth_interval=2)
+                optimizer = AcceleratedOptimizer(raw_optimizer, scaler=scaler)
+                scheduler = AcceleratedScheduler(
+                    torch.optim.lr_scheduler.LambdaLR(raw_optimizer, lambda _: 1.0),
+                    optimizer,
+                    split_batches=True,
+                )
+
+                # Include consecutive overflows, recovery, and a successful scale-growth step.
+                for overflow in (False, True, True, False, False):
+                    optimizer.zero_grad()
+                    scaler.scale(parameter.sum()).backward()
+                    if overflow:
+                        parameter.grad[0] = torch.inf
+                    before = parameter.detach().clone()
+                    step_before = float(raw_optimizer.state.get(parameter, {}).get("step", 0))
+                    scheduler_before = scheduler.scheduler.last_epoch
+
+                    optimizer.step()
+                    scheduler.step()
+
+                    self.assertEqual(optimizer.step_was_skipped, overflow)
+                    self.assertEqual(torch.equal(parameter, before), overflow)
+                    self.assertEqual(float(raw_optimizer.state[parameter]["step"]), step_before + (not overflow))
+                    self.assertEqual(scheduler.scheduler.last_epoch, scheduler_before + (not overflow))
+
     def test_accelerated_optimizer_pickling(self):
         model = torch.nn.Linear(10, 10)
         optimizer = torch.optim.SGD(model.parameters(), 0.1)


### PR DESCRIPTION
## Summary

Detect skipped AMP-aware optimizer steps from the GradScaler scale backoff. Fused AdamW calls its Python `step()` even when the kernel skips the update, so the existing call marker reports success and allows the scheduler to advance.

The extra scale reads are limited to optimizers that handle AMP scaling themselves; other optimizers keep the existing detection path.

Fixes #4242.

## Validation

- `python -m pytest -q tests/test_optimizer.py tests/test_scheduler.py`: 10 passed, 2 skipped on PyTorch 2.13.0+cpu. The two skipped tests require accelerator hardware.
- The new regression fails on unmodified `f13f7c13` for fused AdamW. It checks the parameter update, optimizer step counter, skip flag, and scheduler together, including consecutive overflows, recovery, scale growth, and unfused AdamW.
- Ruff 0.13.1 lint and format checks, and `git diff --check`, pass for the changed files.

The CUDA reproduction is documented in the linked issue; CUDA tests were not rerun on this branch.
