### PR TITLE
Fix stateful dataloader checkpoint cache after loading

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -455,6 +455,7 @@ class DataLoaderAdapter:
 
     def load_state_dict(self, state_dict):
         self.base_dataloader.load_state_dict(state_dict)
+        self.dl_state_dict = state_dict
 
     @property
     def __class__(self):

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -728,6 +728,38 @@ class DataLoaderTester(AccelerateTestCase):
 
 
 class StatefulDataLoaderTester(AccelerateTestCase):
+    @parameterized.expand(
+        [
+            (cls.__name__, cls, workers, reuse)
+            for cls in (DataLoaderShard, DataLoaderDispatcher, SkipDataLoader)
+            for workers in (0, 2)
+            for reuse in (False, True)
+        ]
+    )
+    @require_torchdata_stateful_dataloader
+    def test_stateful_checkpoint_after_load(self, name, loader_cls, num_workers, reuse):
+        """Saving a loaded checkpoint before consuming a batch preserves its data cursor."""
+        source = StatefulDataLoader(range(24), batch_size=4, num_workers=num_workers)
+        source_iter = iter(source)
+        next(source_iter)
+        checkpoint = source.state_dict()
+        expected = torch.cat(list(source_iter))
+
+        loader = loader_cls(range(24), batch_size=4, num_workers=num_workers, use_stateful_dataloader=True)
+        if reuse:
+            iterator = iter(loader)
+            for _ in range(3):
+                next(iterator)
+            iterator.close()
+            if isinstance(loader, DataLoaderStateMixin):
+                loader.end()
+        loader.load_state_dict(checkpoint)
+
+        restored = StatefulDataLoader(range(24), batch_size=4, num_workers=num_workers)
+        restored.load_state_dict(loader.state_dict())
+        actual = torch.cat(list(restored))
+        torch.testing.assert_close(actual, expected)
+
     @require_torchdata_stateful_dataloader
     def test_skip_data_loader(self):
         dataloader = SkipDataLoader(list(range(16)), batch_size=4, skip_batches=2, use_stateful_dataloader=True)


### PR DESCRIPTION
Loading a stateful dataloader checkpoint updates the underlying loader but leaves the adapter's cached state unchanged. Saving again before reading another batch therefore writes the previous cursor. A fresh adapter can replay data; an adapter that had advanced further can skip data after restoration.

Refresh the cache after `load_state_dict` succeeds. The regression covers shard, dispatcher and skip loaders with zero or two workers, both fresh and reused adapters, and checks the actual remaining samples after another save/load.

Validation: the 12 new cases fail before the fix, and all 49 data-loader tests pass afterward. An `Accelerator.save_state`/`load_state` training check passes on CPU and eight H800 GPUs, matching data order and SGD momentum updates against uninterrupted training. Repository Ruff lint/format and applicable pre-commit checks pass.
