### PR TITLE
Fix shape metadata when copying tensors across devices

### DIFF
--- a/src/accelerate/test_utils/scripts/test_ops.py
+++ b/src/accelerate/test_utils/scripts/test_ops.py
@@ -150,12 +150,13 @@ def test_op_checker(state):
 def test_copy_tensor_to_devices(state):
     if state.distributed_type not in [DistributedType.MULTI_GPU, DistributedType.XLA]:
         return
-    if state.is_main_process:
-        tensor = torch.tensor([1, 2, 3], dtype=torch.int).to(state.device)
-    else:
-        tensor = None
-    tensor = copy_tensor_to_devices(tensor)
-    assert torch.allclose(tensor, torch.tensor([1, 2, 3], dtype=torch.int, device=state.device))
+    for source in (0, state.num_processes - 1):
+        for shape in [(2, 3), (), (0, 3), (2, 0, 3)]:
+            for dtype in [torch.float32, torch.bfloat16, torch.int64]:
+                expected = torch.full(shape, 3, dtype=dtype, device=state.device)
+                tensor = expected.clone() if state.process_index == source else None
+                tensor = copy_tensor_to_devices(tensor)
+                torch.testing.assert_close(tensor, expected)
 
 
 def _mp_fn(index):

--- a/src/accelerate/utils/operations.py
+++ b/src/accelerate/utils/operations.py
@@ -559,25 +559,18 @@ def gather_tensor_shape(tensor):
     """
     Grabs the shape of `tensor` only available on one process and returns a tensor of its shape
     """
-    # Allocate 80 bytes to store the shape
+    # Store the rank and dtype before the dimensions so zero-sized axes are preserved.
     max_tensor_dimension = 2**20
     state = PartialState()
-    base_tensor = torch.empty(max_tensor_dimension, dtype=torch.int, device=state.device)
+    base_tensor = torch.zeros(max_tensor_dimension, dtype=torch.int, device=state.device)
 
-    # Since PyTorch can't just send a tensor to another GPU without
-    # knowing its size, we store the size of the tensor with data
-    # in an allocation
     if tensor is not None:
-        shape = tensor.shape
-        tensor_dtype = TENSOR_TYPE_TO_INT[tensor.dtype]
-        base_tensor[: len(shape) + 1] = torch.tensor(list(shape) + [tensor_dtype], dtype=int)
-    # Perform a reduction to copy the size data onto all GPUs
+        metadata = [tensor.ndim, TENSOR_TYPE_TO_INT[tensor.dtype], *tensor.shape]
+        base_tensor[: len(metadata)] = torch.tensor(metadata, dtype=torch.int, device=state.device)
+    # Only the source contributes metadata to the sum.
     base_tensor = reduce(base_tensor, reduction="sum")
-    base_tensor = base_tensor[base_tensor.nonzero()]
-    # The last non-zero data contains the coded dtype the source tensor is
-    dtype = int(base_tensor[-1:][0])
-    base_tensor = base_tensor[:-1]
-    return base_tensor, dtype
+    ndim, dtype = base_tensor[:2].tolist()
+    return base_tensor[2 : ndim + 2], dtype
 
 
 def copy_tensor_to_devices(tensor=None) -> torch.Tensor:
@@ -593,7 +586,7 @@ def copy_tensor_to_devices(tensor=None) -> torch.Tensor:
     state = PartialState()
     shape, dtype = gather_tensor_shape(tensor)
     if tensor is None:
-        tensor = torch.zeros(shape, dtype=TENSOR_INT_TO_DTYPE[dtype]).to(state.device)
+        tensor = torch.zeros(tuple(shape.tolist()), dtype=TENSOR_INT_TO_DTYPE[dtype], device=state.device)
     return reduce(tensor, reduction="sum")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -61,7 +61,7 @@ from accelerate.utils import (
     save,
     send_to_device,
 )
-from accelerate.utils.operations import is_namedtuple
+from accelerate.utils.operations import TENSOR_INT_TO_DTYPE, gather_tensor_shape, is_namedtuple
 
 
 if is_torch_xla_available():
@@ -76,6 +76,26 @@ class UtilsTester(unittest.TestCase):
     def setUp(self):
         # logging requires initialized state
         PartialState()
+
+    @unittest.skipUnless(hasattr(torch.utils, "deterministic"), "requires deterministic memory filling")
+    def test_gather_tensor_shape_preserves_metadata(self):
+        enabled = torch.are_deterministic_algorithms_enabled()
+        warn_only = torch.is_deterministic_algorithms_warn_only_enabled()
+        fill = torch.utils.deterministic.fill_uninitialized_memory
+        try:
+            torch.use_deterministic_algorithms(True)
+            torch.utils.deterministic.fill_uninitialized_memory = True
+            for shape in [(2, 3), (), (0, 3), (2, 0, 3)]:
+                for dtype in [torch.float32, torch.bfloat16, torch.int64]:
+                    with self.subTest(shape=shape, dtype=dtype):
+                        tensor = torch.ones(shape, dtype=dtype, device=PartialState().device)
+                        actual_shape, actual_dtype = gather_tensor_shape(tensor)
+                        self.assertEqual(actual_shape.numel(), len(shape))
+                        self.assertEqual(actual_shape.flatten().tolist(), list(shape))
+                        self.assertEqual(TENSOR_INT_TO_DTYPE[actual_dtype], dtype)
+        finally:
+            torch.utils.deterministic.fill_uninitialized_memory = fill
+            torch.use_deterministic_algorithms(enabled, warn_only=warn_only)
 
     def test_send_to_device(self):
         tensor = torch.randn(5, 2)


### PR DESCRIPTION
`copy_tensor_to_devices`, used by pipeline inference with `gather_output=True`, reduces a shape buffer whose unused entries and non-source ranks are uninitialized. Those values can become dimensions or an invalid dtype. Filtering metadata with `nonzero()` also loses zero-sized axes, and the receiver passes a tensor where `torch.zeros` expects a size tuple.

Initialize the metadata buffer to zero, prefix the dimensions with their count and dtype, and construct receiver tensors from the decoded size tuple. The existing collective and dtype mapping are retained.

Tests cover deterministic uninitialized-memory filling, scalars, empty dimensions, three dtypes, and either the first or last rank as source. All 12 metadata subcases fail on the original code and pass with the fix; the utilities module reports 46 passed and 5 skipped. The distributed operations script passes on eight H800 GPUs, and an eight-stage `prepare_pippy(gather_output=True)` model matches the unpartitioned reference on every rank. Ruff lint/format and pre-commit pass. XLA and multi-node inference were not tested.
