### PR TITLE
Restore dataloader state when iteration ends early

### DIFF
--- a/src/accelerate/data_loader.py
+++ b/src/accelerate/data_loader.py
@@ -578,37 +578,37 @@ class DataLoaderShard(DataLoaderAdapter, DataLoaderStateMixin):
         if self.rng_types is not None:
             synchronize_rng_states(self.rng_types, self.synchronized_generator)
         self.begin()
-
-        self.set_epoch(self.iteration)
-        dataloader_iter = self.base_dataloader.__iter__()
-        # We iterate one batch ahead to check when we are at the end
         try:
-            current_batch = next(dataloader_iter)
-        except StopIteration:
-            self.end()
-            return
-
-        batch_index = 0
-        while True:
+            self.set_epoch(self.iteration)
+            dataloader_iter = self.base_dataloader.__iter__()
+            # We iterate one batch ahead to check when we are at the end
             try:
-                # But we still move it to the device so it is done before `StopIteration` is reached
-                if self.device is not None:
-                    current_batch = send_to_device(current_batch, self.device, non_blocking=self._non_blocking)
-                self._update_state_dict()
-                next_batch = next(dataloader_iter)
-                if batch_index >= self.skip_batches:
-                    yield current_batch
-                batch_index += 1
-                current_batch = next_batch
+                current_batch = next(dataloader_iter)
             except StopIteration:
-                self.end_of_dataloader = True
-                self._update_state_dict()
-                if batch_index >= self.skip_batches:
-                    yield current_batch
-                break
+                return
 
-        self.iteration += 1
-        self.end()
+            batch_index = 0
+            while True:
+                try:
+                    # But we still move it to the device so it is done before `StopIteration` is reached
+                    if self.device is not None:
+                        current_batch = send_to_device(current_batch, self.device, non_blocking=self._non_blocking)
+                    self._update_state_dict()
+                    next_batch = next(dataloader_iter)
+                    if batch_index >= self.skip_batches:
+                        yield current_batch
+                    batch_index += 1
+                    current_batch = next_batch
+                except StopIteration:
+                    self.end_of_dataloader = True
+                    self._update_state_dict()
+                    if batch_index >= self.skip_batches:
+                        yield current_batch
+                    break
+
+            self.iteration += 1
+        finally:
+            self.end()
 
     def __reduce__(self):
         """
@@ -871,79 +871,81 @@ class DataLoaderDispatcher(DataLoaderAdapter, DataLoaderStateMixin):
 
     def __iter__(self):
         self.begin()
-        self.set_epoch(self.iteration)
-        main_iterator = None
-        if is_torch_version(">=", "2.0.1"):
-            # NOTE PyTorch DataLoader adds forward compatibilities for DataPipes, which broadcasts
-            # shared seed to all dist processes. Thus, we need to create iterator for all dist processes.
-            # But, we only iterate through the DataLoader on process 0.
-            main_iterator = self.base_dataloader.__iter__()
-        elif self.state.process_index == 0:
-            main_iterator = self.base_dataloader.__iter__()
-        stop_iteration = False
-        self._stop_iteration = False
-        first_batch = None
-        next_batch, next_batch_info = self._fetch_batches(main_iterator)
-        batch_index = 0
-        while not stop_iteration:
-            batch, batch_info = next_batch, next_batch_info
+        try:
+            self.set_epoch(self.iteration)
+            main_iterator = None
+            if is_torch_version(">=", "2.0.1"):
+                # NOTE PyTorch DataLoader adds forward compatibilities for DataPipes, which broadcasts
+                # shared seed to all dist processes. Thus, we need to create iterator for all dist processes.
+                # But, we only iterate through the DataLoader on process 0.
+                main_iterator = self.base_dataloader.__iter__()
+            elif self.state.process_index == 0:
+                main_iterator = self.base_dataloader.__iter__()
+            stop_iteration = False
+            self._stop_iteration = False
+            first_batch = None
+            next_batch, next_batch_info = self._fetch_batches(main_iterator)
+            batch_index = 0
+            while not stop_iteration:
+                batch, batch_info = next_batch, next_batch_info
 
-            if self.state.process_index != 0:
-                # Initialize tensors on other processes than process 0.
-                batch = initialize_tensors(batch_info[0])
-            batch = send_to_device(batch, self.state.device, non_blocking=self._non_blocking)
-            # Broadcast the batch before splitting it.
-            batch = broadcast(batch, from_process=0)
+                if self.state.process_index != 0:
+                    # Initialize tensors on other processes than process 0.
+                    batch = initialize_tensors(batch_info[0])
+                batch = send_to_device(batch, self.state.device, non_blocking=self._non_blocking)
+                # Broadcast the batch before splitting it.
+                batch = broadcast(batch, from_process=0)
 
-            if not self._drop_last and first_batch is None:
-                # We keep at least num processes elements of the first batch to be able to complete the last batch
-                first_batch = self.slice_fn(
+                if not self._drop_last and first_batch is None:
+                    # We keep at least num processes elements of the first batch to be able to complete the last batch
+                    first_batch = self.slice_fn(
+                        batch,
+                        slice(0, self.state.num_processes),
+                        process_index=self.state.process_index,
+                        num_processes=self.state.num_processes,
+                    )
+
+                if batch is None:
+                    raise ValueError(
+                        f"Batch does not contain any data (`{batch}`). At the end of all iterable data available before expected stop iteration."
+                    )
+
+                observed_batch_size = find_batch_size(batch)
+                batch_size = observed_batch_size // self.state.num_processes
+
+                stop_iteration = self._stop_iteration
+                if not stop_iteration:
+                    # We may still be at the end of the dataloader without knowing it yet: if there is nothing left in
+                    # the dataloader since the number of batches is a round multiple of the number of processes.
+                    next_batch, next_batch_info = self._fetch_batches(main_iterator)
+                    # next_batch_info[0] is None when there are no more batches, otherwise we still need to process them.
+                    if self._stop_iteration and next_batch_info[0] is None:
+                        stop_iteration = True
+
+                if not self._drop_last and stop_iteration and observed_batch_size % self.state.num_processes != 0:
+                    # If the last batch is not complete, let's add the first batch to it.
+                    batch = concatenate([batch, first_batch], dim=0)
+                    # Batch size computation above is wrong, it's off by 1 so we fix it.
+                    batch_size += 1
+
+                data_slice = slice(self.state.process_index * batch_size, (self.state.process_index + 1) * batch_size)
+                batch = self.slice_fn(
                     batch,
-                    slice(0, self.state.num_processes),
+                    data_slice,
                     process_index=self.state.process_index,
                     num_processes=self.state.num_processes,
                 )
 
-            if batch is None:
-                raise ValueError(
-                    f"Batch does not contain any data (`{batch}`). At the end of all iterable data available before expected stop iteration."
-                )
-
-            observed_batch_size = find_batch_size(batch)
-            batch_size = observed_batch_size // self.state.num_processes
-
-            stop_iteration = self._stop_iteration
-            if not stop_iteration:
-                # We may still be at the end of the dataloader without knowing it yet: if there is nothing left in
-                # the dataloader since the number of batches is a round multiple of the number of processes.
-                next_batch, next_batch_info = self._fetch_batches(main_iterator)
-                # next_batch_info[0] is None when there are no more batches, otherwise we still need to process them.
-                if self._stop_iteration and next_batch_info[0] is None:
-                    stop_iteration = True
-
-            if not self._drop_last and stop_iteration and observed_batch_size % self.state.num_processes != 0:
-                # If the last batch is not complete, let's add the first batch to it.
-                batch = concatenate([batch, first_batch], dim=0)
-                # Batch size computation above is wrong, it's off by 1 so we fix it.
-                batch_size += 1
-
-            data_slice = slice(self.state.process_index * batch_size, (self.state.process_index + 1) * batch_size)
-            batch = self.slice_fn(
-                batch,
-                data_slice,
-                process_index=self.state.process_index,
-                num_processes=self.state.num_processes,
-            )
-
-            if stop_iteration:
-                self.end_of_dataloader = True
-                self._update_state_dict()
-                self.remainder = observed_batch_size
-            if batch_index >= self.skip_batches:
-                yield batch
-            batch_index += 1
-        self.iteration += 1
-        self.end()
+                if stop_iteration:
+                    self.end_of_dataloader = True
+                    self._update_state_dict()
+                    self.remainder = observed_batch_size
+                if batch_index >= self.skip_batches:
+                    yield batch
+                batch_index += 1
+            self.iteration += 1
+        finally:
+            self.end()
 
     def set_epoch(self, epoch: int):
         # In case it is manually passed in, the user can set it to what they like

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -20,7 +20,7 @@ import torch
 from parameterized import parameterized
 from torch.utils.data import BatchSampler, DataLoader, IterableDataset
 
-from accelerate import Accelerator, PartialState
+from accelerate import Accelerator, DataLoaderConfiguration, PartialState
 from accelerate.data_loader import (
     BatchSamplerShard,
     DataLoaderDispatcher,
@@ -631,6 +631,98 @@ class DataLoaderTester(AccelerateTestCase):
         # Test it also works on the second iteration
         for idx, _ in enumerate(dataloader):
             assert dataloader.end_of_dataloader == (idx == 3)
+
+    @parameterized.expand(
+        [
+            (dispatch, exit_mode)
+            for dispatch in (False, True)
+            for exit_mode in ("complete", "first", "last", "close", "error")
+        ]
+    )
+    def test_interrupted_validation_preserves_accumulation(self, dispatch, exit_mode):
+        accelerator = Accelerator(
+            cpu=True,
+            gradient_accumulation_steps=2,
+            dataloader_config=DataLoaderConfiguration(dispatch_batches=dispatch),
+        )
+        model = torch.nn.Linear(1, 1, bias=False)
+        with torch.no_grad():
+            model.weight.fill_(1.0)
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+        training = DataLoader(torch.ones(5, 1), batch_size=1)
+        validation = DataLoader(torch.ones(2, 1), batch_size=1)
+        model, optimizer, training, validation = accelerator.prepare(model, optimizer, training, validation)
+        sync_steps = []
+        updates = 0
+        validation_error = RuntimeError("validation failed")
+
+        for index, batch in enumerate(training):
+            with accelerator.accumulate(model):
+                accelerator.backward(model(batch).square().mean())
+                before = model.weight.detach().clone()
+                optimizer.step()
+                optimizer.zero_grad()
+                sync_steps.append(accelerator.sync_gradients)
+                updates += not torch.equal(before, model.weight)
+
+            if index == 0:
+                with torch.no_grad():
+                    if exit_mode == "close":
+                        iterator = iter(validation)
+                        model(next(iterator))
+                        model(next(iterator))
+                        iterator.close()
+                    else:
+                        try:
+                            for val_index, val_batch in enumerate(validation):
+                                model(val_batch)
+                                if exit_mode == "first" or (exit_mode == "last" and val_index == 1):
+                                    break
+                                if exit_mode == "error":
+                                    raise validation_error
+                        except RuntimeError as error:
+                            assert error is validation_error
+
+        assert sync_steps == [False, True, False, True, True]
+        assert updates == 3
+        torch.testing.assert_close(model.weight, torch.tensor([[0.576]]))
+        assert not accelerator.gradient_state.in_dataloader
+        completed_epochs = int(exit_mode == "complete")
+        assert validation.iteration == completed_epochs
+        assert len(list(validation)) == 2
+        assert validation.iteration == completed_epochs + 1
+
+    @parameterized.expand([(False,), (True,)])
+    def test_dataloader_iterator_cleanup(self, dispatch):
+        accelerator = Accelerator(cpu=True, dataloader_config=DataLoaderConfiguration(dispatch_batches=dispatch))
+        dataloader = accelerator.prepare(DataLoader(range(4), batch_size=1))
+        iterator = iter(dataloader)
+        next(iterator)
+        assert accelerator.gradient_state.active_dataloader is dataloader
+        assert dataloader.iteration == 0
+        iterator.close()
+        assert not accelerator.gradient_state.in_dataloader
+        assert dataloader.iteration == 0
+        assert len(list(dataloader)) == 4
+        assert dataloader.iteration == 1
+
+        error = RuntimeError("dataset failed")
+
+        class FailingDataset(torch.utils.data.Dataset):
+            def __len__(self):
+                return 2
+
+            def __getitem__(self, index):
+                if index == 1:
+                    raise error
+                return index
+
+        dataloader = accelerator.prepare(DataLoader(FailingDataset(), batch_size=1))
+        with pytest.raises(RuntimeError) as caught:
+            next(iter(dataloader))
+        assert caught.value is error
+        assert not accelerator.gradient_state.in_dataloader
+        assert dataloader.iteration == 0
 
     def test_set_epoch_in_batch_sampler(self):
         # Ensure that set_epoch gets propagated to custom batch samplers that accept it


### PR DESCRIPTION
Closing a validation iterator early can leave it active in `GradientState`, causing the resumed training loop to skip or add optimizer updates during gradient accumulation. Run `end()` in `finally` for both `DataLoaderShard` and `DataLoaderDispatcher` so closing or failing iterators restore the active training loader.

Added regression coverage for update cadence and iterator cleanup; the dataloader, optimizer and scheduler tests pass on CPU (57 passed, 3 skipped).