### PR TITLE
Do not import torch.distributed in model_has_dtensor on a non-distributed build

### DIFF
--- a/src/accelerate/utils/other.py
+++ b/src/accelerate/utils/other.py
@@ -239,6 +239,13 @@ def model_has_dtensor(model: torch.nn.Module) -> bool:
     Returns:
         `bool`: Whether the model has DTensor parameters.
     """
+    if not is_torch_distributed_available():
+        # DTensor lives under `torch.distributed`, so a torch build without a distributed backend
+        # cannot hold DTensor parameters, and importing it raises rather than returning False.
+        # AMD's Windows ROCm wheels are such a build: `torch.distributed` imports, but
+        # `torch.distributed.is_available()` is False and `torch._C._distributed_c10d` is absent.
+        return False
+
     if is_torch_version(">=", "2.5.0"):
         from torch.distributed.tensor import DTensor
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import builtins
 import os
 import pickle
 import tempfile
@@ -53,6 +54,7 @@ from accelerate.utils import (
     has_offloaded_params,
     is_torch_xla_available,
     listify,
+    model_has_dtensor,
     pad_across_processes,
     pad_input_tensors,
     patch_environment,
@@ -291,6 +293,27 @@ class UtilsTester(unittest.TestCase):
             assert ctx.records[0].levelname == "WARNING"
             assert "5.4.0" in ctx.records[0].msg
             assert "5.5.0" in ctx.records[0].msg
+
+    def test_model_has_dtensor_false_without_a_distributed_build(self):
+        # A torch build compiled without a distributed backend cannot hold DTensor parameters, and
+        # importing torch.distributed.tensor on one raises instead of returning False. AMD's Windows
+        # ROCm wheels are such a build. Reproduce that by making the import fail the way it does
+        # there, so this fails loudly if the availability guard is ever dropped.
+        real_import = builtins.__import__
+
+        def refuse_dtensor_import(name, *args, **kwargs):
+            if name in ("torch.distributed.tensor", "torch.distributed._tensor"):
+                raise ModuleNotFoundError("No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package")
+            return real_import(name, *args, **kwargs)
+
+        with patch("accelerate.utils.other.is_torch_distributed_available", return_value=False):
+            with patch.object(builtins, "__import__", refuse_dtensor_import):
+                assert model_has_dtensor(nn.Linear(4, 4)) is False
+
+    def test_model_has_dtensor_still_inspects_params_with_a_distributed_build(self):
+        # The guard must not short-circuit the real check on a normal build.
+        with patch("accelerate.utils.other.is_torch_distributed_available", return_value=True):
+            assert model_has_dtensor(nn.Linear(4, 4)) is False
 
     @require_non_torch_xla
     def test_save_safetensor_shared_memory(self):


### PR DESCRIPTION
# What does this PR do?

`model_has_dtensor()` imports `torch.distributed.tensor` unconditionally. On a PyTorch build compiled without a distributed backend that import raises rather than returning `False`, and since v1.15.0 every `prepare_model()` call reaches it:

```
accelerator.py:1802   device_placement = (... and not model_has_dtensor(model))
utils/other.py:243    from torch.distributed.tensor import DTensor
...
torch/distributed/distributed_c10d.py:25
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
```

AMD's official Windows ROCm wheels are exactly that build: `torch.distributed` imports, `torch.distributed.is_available()` is `False`, and `torch._C._distributed_c10d` does not exist. So all training on AMD GPUs on Windows dies at trainer start.

In 1.14.0 the sole call site (`accelerator.py:1878`) sat behind `if self.multi_device and not (...)`, so a single-GPU run never reached it. The second call site added in #4181 is unguarded, and that is what turned a multi-device-only path into one every run executes.

**Why guard the function rather than restore the guard on the new call site.** The invariant belongs to `model_has_dtensor` itself: DTensor lives under `torch.distributed`, so a build without a distributed backend cannot hold DTensor parameters at all, and the honest answer there is `False` rather than an exception. That also covers any future call site without anyone having to remember.

`is_torch_distributed_available()` is the existing idiom for this. It is already imported in this same file and already used as a guard ~70 lines further down, and `accelerator.py:2958` already computes `is_dtensor_available = torch.distributed.is_available() and is_torch_version(">=", DTENSOR_PYTORCH_VERSION)`, so the "DTensor requires a distributed build" relationship is established in the codebase.

**Tests.** Two added. The first reproduces the reported failure rather than stubbing it: it patches the import to raise the way it does on those wheels, so it fails against unpatched sources with the bug report's own error.

```
ModuleNotFoundError: No module named 'torch._C._distributed_c10d'; 'torch._C' is not a package
```

The second pins that the guard does not short-circuit the real check on a normal build.

`tests/test_utils.py`: 48 passed, 4 skipped. `ruff check` and `ruff format` clean.

I do not have one of the affected wheels, so the AMD-on-Windows end-to-end path is not something I verified directly. The unit test reproduces the exact import failure from the traceback, and the reporter has the hardware.

Fixes #4249

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/accelerate/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (#4249)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/accelerate/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/accelerate/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
