### PR TITLE
Stop accepting a split_batches argument Accelerator never reads

### DIFF
--- a/src/accelerate/accelerator.py
+++ b/src/accelerate/accelerator.py
@@ -175,12 +175,6 @@ except ImportError:
 
 logger = get_logger(__name__)
 
-# Sentinel values for defaults
-_split_batches = object()
-_dispatch_batches = object()
-_even_batches = object()
-_use_seedable_sampler = object()
-
 
 class Accelerator:
     """
@@ -280,7 +274,6 @@ class Accelerator:
     def __init__(
         self,
         device_placement: bool = True,
-        split_batches: bool = _split_batches,
         mixed_precision: PrecisionType | str | None = None,
         gradient_accumulation_steps: int = 1,
         cpu: bool = False,

--- a/tests/test_accelerator.py
+++ b/tests/test_accelerator.py
@@ -132,6 +132,18 @@ def parameterized_custom_name_func(func, param_num, param):
 
 
 class AcceleratorTester(AccelerateTestCase):
+    def test_split_batches_only_comes_from_the_dataloader_config(self):
+        # `split_batches` moved to `DataLoaderConfiguration` along with `dispatch_batches`,
+        # `even_batches` and `use_seedable_sampler`. Those three were dropped from `Accelerator`,
+        # so passing one now raises; `split_batches` stayed in the signature and was never read,
+        # which made `Accelerator(split_batches=True)` configure nothing and say nothing.
+        for removed in ("split_batches", "dispatch_batches", "even_batches", "use_seedable_sampler"):
+            with self.assertRaises(TypeError):
+                Accelerator(**{removed: True})
+
+        accelerator = Accelerator(dataloader_config=DataLoaderConfiguration(split_batches=True))
+        assert accelerator.split_batches is True
+
     def test_partial_state_after_reset(self):
         # Verifies that custom getattr errors will be thrown
         # if the state is reset, but only if trying to


### PR DESCRIPTION
## What breaks

`Accelerator(split_batches=True)` is accepted, configures nothing, and says nothing.

```python
>>> Accelerator(split_batches=True).split_batches
False
```

`accelerator.split_batches` keeps reporting the `DataLoaderConfiguration` default, so the caller believes they turned batch splitting on and they did not.

## Why

#2441 moved `split_batches`, `dispatch_batches`, `even_batches` and `use_seedable_sampler` into `DataLoaderConfiguration`. Three of the four were later dropped from `Accelerator.__init__` and now raise `TypeError`. `split_batches` was left in the signature bound to a sentinel:

```python
split_batches: bool = _split_batches,
```

and there is no reader for it anywhere in `__init__`. The four `_split_batches` / `_dispatch_batches` / `_even_batches` / `_use_seedable_sampler` sentinels at module scope have no reader either.

It is also positional slot 2, so `Accelerator(True, True)` puts the second argument somewhere that does nothing.

## What changed

Drop the parameter and the four dead sentinels. `Accelerator(split_batches=True)` now fails the same way `Accelerator(even_batches=True)` already does, and `DataLoaderConfiguration` stays the one route in. This is what `create_accelerator` in `test_distributed_data_loop.py` already does.

## Tests

`test_split_batches_only_comes_from_the_dataloader_config` asserts all four names raise `TypeError`, and that `DataLoaderConfiguration(split_batches=True)` still reaches `accelerator.split_batches`.

```
1 passed in 1.78s
```

On main it fails:

```
with self.assertRaises(TypeError):
E  AssertionError: TypeError not raised
```

No test in the suite passes `split_batches=` to `Accelerator`. `ruff` 0.13.1, the pin in `setup.py`, is clean on both files.

## One choice worth your call

The alternative is keeping it for a release behind a deprecation warning that forwards into the config. Happy to send that version instead. Removal is what the other three already do, and anyone passing it today is getting nothing anyway.
